### PR TITLE
feat(tun): opt-in "Block QUIC" to fix proxy UDP-relay blackhole

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -2099,6 +2099,25 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           action: 'reject',
         } as any);
       }
+
+      // T2-4: 用户开启"阻止 QUIC"时 reject 入站 UDP 443，让浏览器 QUIC 立即回退 TCP，
+      // 消除节点 UDP relay 不通时的 QUIC 黑洞（网页打开一会卡死）。协议三分类：
+      //   - ssh/http/anytls：上面已全量 reject UDP，此处对其为冗余 no-op；
+      //   - hysteria2/tuic：节点自身走 QUIC dial-server，会因 strict_route 回流被这条 reject
+      //     误杀，必须按协议 guard 跳过；
+      //   - vless/vmess/trojan/shadowsocks/naive/socks：本条真正生效对象（均 TCP dial-server；
+      //     naive 在 sing-box 是 H2/TLS/TCP、不支持 h3/QUIC，故安全；若将来支持 naive-h3 需更新此表）。
+      const udpTransportProtocols = ['hysteria2', 'tuic'];
+      if (
+        config.blockQuic === true &&
+        !udpTransportProtocols.includes(selectedServer.protocol.toLowerCase())
+      ) {
+        rules.push({
+          network: ['udp'],
+          port: [443],
+          action: 'reject',
+        } as any);
+      }
     }
 
     return routeConfig;

--- a/src/renderer/components/settings/advanced-settings.tsx
+++ b/src/renderer/components/settings/advanced-settings.tsx
@@ -22,6 +22,12 @@ export function AdvancedSettings() {
   const [isLoading, setIsLoading] = useState(false);
   const { t } = useTranslation();
 
+  // 当前选中节点为 QUIC 协议(hy2/tuic)时，"阻止 QUIC"会误杀其传输，禁用该开关
+  const selectedProtocol = config?.servers
+    ?.find((s) => s.id === config?.selectedServerId)
+    ?.protocol?.toLowerCase();
+  const isQuicNode = selectedProtocol === 'hysteria2' || selectedProtocol === 'tuic';
+
   const handleSavePorts = async () => {
     if (!config) return;
 
@@ -297,6 +303,24 @@ export function AdvancedSettings() {
             </div>
             <p className="text-xs text-muted-foreground ml-6 mb-2">
               {t('settings.advanced.bypassLANDesc')}
+            </p>
+
+            <div className="flex items-center space-x-2 pt-2">
+              <Checkbox
+                id="blockQuic"
+                checked={config.blockQuic === true}
+                disabled={isQuicNode}
+                onCheckedChange={(checked) => {
+                  const updatedConfig = { ...config, blockQuic: checked as boolean };
+                  saveConfig(updatedConfig);
+                }}
+              />
+              <Label htmlFor="blockQuic" className="font-normal cursor-pointer">
+                {t('settings.advanced.blockQuic')}
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground ml-6 mb-2">
+              {t('settings.advanced.blockQuicDesc')}
             </p>
 
             {/* 自动换节点 */}

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -233,6 +233,8 @@
       "allowLanGatewayTip": "When used as a gateway (other devices set this computer as Gateway/DNS), please ensure TUN mode is enabled. This will automatically enable system IP forwarding and listen on port 53 for DNS services.",
       "bypassLAN": "Bypass LAN",
       "bypassLANDesc": "Force requests destined for the local network to bypass the proxy (disable to allow proxying for 192.168.x etc.)",
+      "blockQuic": "Block QUIC (force TCP)",
+      "blockQuicDesc": "Reject QUIC (UDP 443) so browsers fall back to TCP. Fixes pages stalling when the node's UDP relay is unreliable. Off by default; not applicable to Hysteria2/TUIC nodes.",
       "terminalProxy": "Terminal Proxy Settings",
       "terminalProxyDesc": "Copy the following commands to set proxy in terminal (proxy must be started first)",
       "gitProxy": "Git Proxy Settings",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -232,6 +232,8 @@
       "allowLanGatewayTip": "当作为网关使用（另一台设备设置此电脑为网关及 DNS）时，请务必开启 TUN 模式。该设置将自动开启系统 IP 转发并监听 53 端口提供 DNS 服务。",
       "bypassLAN": "绕过局域网 (Bypass LAN)",
       "bypassLANDesc": "默认将发往局域网的请求强制直连（关闭此选项后，192.168.x 等内网 IP 才可能走代理）",
+      "blockQuic": "阻止 QUIC（强制 TCP）",
+      "blockQuicDesc": "reject QUIC（UDP 443），让浏览器回退 TCP，解决节点 UDP relay 不通导致的网页卡顿/断流。默认关；对 Hysteria2/TUIC 节点不适用。",
       "terminalProxy": "终端代理设置",
       "terminalProxyDesc": "复制以下命令到终端中设置代理（需要先启动代理）",
       "gitProxy": "Git 代理设置",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -335,6 +335,7 @@ export interface UserConfig {
   mixedPort?: number; // 混合端口（可选，同时支持 HTTP 和 SOCKS5，0 或 undefined 表示禁用）
   allowLan?: boolean; // 局域网共享代理（允许其他设备连接）
   bypassLAN?: boolean; // 绕过局域网（将内网 IP 设置为直连）
+  blockQuic?: boolean; // 阻止 QUIC（reject 入站 UDP 443 强制浏览器回退 TCP）；默认关；hy2/tuic 节点自动跳过
   bypassProcesses?: string[]; // 排除进程（指定进程直连，不走代理）
 
   // 日志设置


### PR DESCRIPTION
## Problem

In smart/global TUN mode, browser QUIC (UDP 443) to non-CN domains is routed to the proxy `final`. When the selected node's UDP relay is unreliable (common for cheap nodes / restrictive networks), those QUIC connections hang instead of failing fast, so pages "load for a second then stall" — a TUN-mode "断流" symptom.

## Fix

A **default-off** `blockQuic` setting (Advanced settings). When enabled, inbound QUIC (UDP 443) is `reject`ed so browsers immediately fall back to TCP/HTTP2 (reliable through the proxy). Opt-in, so users whose UDP relay works keep HTTP/3.

### Why it's safe (protocol guard)
`strict_route` forces the **node's own** outbound (to its server) back through the route engine unless the server IP is in `route_exclude_address` (which, for domain nodes, only happens on Windows). So a blanket UDP-443 reject would kill the transport of a node that itself dials its server over QUIC. The rule is therefore **skipped for `hysteria2`/`tuic`** (the only QUIC-dial-server protocols in FlowZ). A UDP-443 reject **cannot match a TCP-transport node** even if its traffic loops back, so every other protocol is safe — including `naive`, which FlowZ runs through sing-box's `naive` outbound (H2/TLS/TCP; sing-box has no h3/QUIC naive and rejects `network: udp`/`alpn`). This sidesteps the need for cross-platform node-IP exclusion.

The rule is placed after the CN-direct / node-direct / custom / app-policy / geosite rules, so it only rejects UDP 443 that would otherwise fall through to the proxy. The Advanced-settings toggle is **disabled when the selected node is hysteria2/tuic** (the guard makes it a no-op there).

## Testing
`tsc` (main + renderer), `eslint`, `prettier`, i18n JSON all clean; a representative smart-mode TUN config with the reject rule validated by the bundled `sing-box check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)