### PR TITLE
fix(naive): stop sending unsupported alpn/insecure to sing-box naive outbound

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1457,16 +1457,17 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       outbound.password = server.password;
 
       // NaiveProxy specific configuration
-      // 1. Force TLS enabled (NaiveProxy usually uses H2/TLS)
-      // 2. Default server_name to server address if not specified
+      // sing-box 的 naive outbound 由 Cronet 自管 TLS，仅支持 server_name / certificate /
+      // certificate_path / ech。下发 alpn 或 insecure:true 会让 sing-box 拒启：
+      //   FATAL: initialize outbound: alpn is not supported on naive outbound
+      //   FATAL: initialize outbound: insecure is not supported on naive outbound
+      // 故这里只下发 server_name（用户在节点上设置的 alpn / allowInsecure 对 naive 无效，忽略）。
+      // 参考：https://sing-box.sagernet.org/configuration/outbound/naive/ （TLS 字段限制）
+      //       SagerNet/sing-box protocol/naive/outbound.go (v1.13.x) ~L47 的 ALPN/insecure 校验
       outbound.tls = {
         enabled: true,
         server_name: server.tlsSettings?.serverName || server.address,
-        insecure: server.tlsSettings?.allowInsecure || false,
-        alpn: server.tlsSettings?.alpn || undefined,
       };
-
-      // 3. Naive handles its own fingerprint/transport, typically does not use uTLS settings
     }
 
     // SOCKS 特定配置


### PR DESCRIPTION
## Problem

FlowZ builds the `naive` outbound's TLS block with `alpn` and `insecure`:

```ts
outbound.tls = {
  enabled: true,
  server_name: server.tlsSettings?.serverName || server.address,
  insecure: server.tlsSettings?.allowInsecure || false,
  alpn: server.tlsSettings?.alpn || undefined,
};
```

But sing-box's `naive` outbound uses Cronet, which manages its own TLS, and **only `server_name` / `certificate` / `certificate_path` / `ech` are supported**. Passing `alpn`, or `insecure: true`, makes sing-box **hard-fail at startup**:

```
FATAL: initialize outbound: alpn is not supported on naive outbound
FATAL: initialize outbound: insecure is not supported on naive outbound
```

So a naive node that carries an ALPN (e.g. from an imported subscription) or has "allow insecure" enabled causes the core to refuse to start. Reproduced with the bundled `sing-box check` (1.13.3): `alpn:["h3"]` → `alpn is not supported on naive outbound`; `insecure:true` → `insecure is not supported on naive outbound`; `server_name`-only → accepted.

## Fix

Emit only `server_name` for the naive outbound TLS. The `alpn` / `allowInsecure` the user may have set on the node are ignored, since sing-box's naive cannot honour them anyway (and the docs explicitly advise against self-signed certs for naive).

## References

- sing-box docs — Naive outbound TLS supports only `server_name` / `certificate` / `certificate_path` / `ech`: <https://sing-box.sagernet.org/configuration/outbound/naive/>
- sing-box source — `protocol/naive/outbound.go` (v1.13.x), ~L47: `if len(options.TLS.ALPN) > 0 { return nil, E.New("alpn is not supported on naive outbound") }` (plus the analogous `insecure` check).

## Testing

`tsc -p tsconfig.main.json`, `eslint`, `prettier` clean; the post-fix naive outbound (`server_name` only) validated by the bundled `sing-box check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)