### PR TITLE
性能(连接轮询门控): 仅可见+连接页时裁剪/推送连接快照 (P1/P2/P3/P4)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -936,7 +936,10 @@ if (gotTheLock) {
     statsService = new StatsService(
       (stats) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_STATS_UPDATED, stats),
       clashApiClient,
-      (snap) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, snap)
+      (snap) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, snap),
+      // P1/P2：窗口可见才轮询——隐藏（macOS hide / minimizeToTray）/销毁（轻量模式）时无 UI 消费者，
+      // 跳过整轮 clash_api fetch+parse+trim+广播。读模块级 mainWindow 当前值（创建/销毁会变）。
+      () => !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
     );
     // 杀核前静默 clash_api 客户端：停 StatsService 轮询（client.agent 的 RST 由 stopSingBoxProcess 的
     // destroyClashApiAgent→client.destroyAgent 统一负责，单一 destroy 路径，P0-2 治本不变）。

--- a/src/main/ipc/handlers/proxy-handlers.ts
+++ b/src/main/ipc/handlers/proxy-handlers.ts
@@ -68,6 +68,15 @@ export function registerProxyHandlers(
     return { ok: res.ok };
   });
 
+  // 连接页订阅/退订（P1 watcher 引用计数）：仅连接页打开时主进程才裁剪+推送连接快照，
+  // 「代理连着但没盯连接页」稳态下省掉全量裁剪与大包广播。fire-and-forget（渲染端不关心返回值）。
+  registerIpcHandler<void, void>(IPC_CHANNELS.CONNECTIONS_WATCH, async () => {
+    statsService?.addConnectionsWatcher();
+  });
+  registerIpcHandler<void, void>(IPC_CHANNELS.CONNECTIONS_UNWATCH, async () => {
+    statsService?.removeConnectionsWatcher();
+  });
+
   // 启动代理
   registerIpcHandler<UserConfig, void>(
     IPC_CHANNELS.PROXY_START,

--- a/src/main/services/StatsService.ts
+++ b/src/main/services/StatsService.ts
@@ -57,6 +57,10 @@ export class StatsService {
   };
   private connections: ConnectionEntry[] = [];
   private tick = 0;
+  // P1：连接页 watcher 引用计数（连接页 mount→+1 / unmount→-1，经 CONNECTIONS_WATCH/UNWATCH IPC）。
+  // 仅 >0 时才 trimConnection + 推送连接快照——「代理连着但没盯连接页」最常见稳态下省掉全量裁剪与大包广播。
+  // 计数泄漏（渲染端硬崩漏 unwatch）fail-safe：退化为始终推送 = 原行为，不破功能。
+  private connectionsWatchers = 0;
   /**
    * @param onUpdate 每次拿到新快照时回调（广播给渲染端）
    * @param clashApi clash_api(9090) 客户端（T15：与 ProxyManager 共用单一 agent，替代本服务原私有 agent + getJson）
@@ -65,12 +69,19 @@ export class StatsService {
   constructor(
     private readonly onUpdate: (stats: TrafficStats) => void,
     private readonly clashApi: ClashApiClient,
-    private readonly onConnections?: (snap: ConnectionsSnapshot) => void
+    private readonly onConnections?: (snap: ConnectionsSnapshot) => void,
+    // P2：窗口可见性谓词。无可见窗口（macOS hide / minimizeToTray / 轻量销毁 / 普通最小化）= 无任何 UI 消费者
+    // → 整轮跳过 fetch/parse/trim/广播（含首页 stats，非仅连接列表；与只门控连接列表的 P1 watcher 不同）。
+    // 缺省（未注入，如单测）= 不门控、保持原行为，与 onConnections 缺省语义对称。
+    private readonly isWindowVisible?: () => boolean
   ) {}
 
   start(): void {
     if (this.timer) return;
     this.last = null;
+    // 停核→重启时连接页可能仍 mount 着（connectionsWatchers>0，无 0→1 跃迁不经 addConnectionsWatcher 对齐）：
+    // 与 mount 对齐逻辑一致，让重启后首轮 poll 即推连接快照（否则 stop() 置 tick=0 致首帧慢一拍 ~1s）。
+    if (this.connectionsWatchers > 0) this.tick = CONNECTIONS_PUSH_DIVIDER - 1;
     this.timer = setInterval(() => void this.poll(), POLL_INTERVAL_MS);
   }
 
@@ -101,7 +112,26 @@ export class StatsService {
     return { connections: this.connections, at: Date.now() };
   }
 
+  /** 连接页订阅：引用计数 +1。0→1 时把 tick 对齐到下一轮即推，连接页 mount 后 ≤1s 见数据（不等满 divider）。 */
+  addConnectionsWatcher(): void {
+    this.connectionsWatchers++;
+    if (this.connectionsWatchers === 1) {
+      this.tick = CONNECTIONS_PUSH_DIVIDER - 1;
+    }
+  }
+
+  /** 连接页退订：引用计数 -1（钳制 ≥0，防 over-unwatch）。归 0 后下轮 poll 不再 trim/推送。 */
+  removeConnectionsWatcher(): void {
+    if (this.connectionsWatchers > 0) this.connectionsWatchers--;
+  }
+
   private async poll(): Promise<void> {
+    // P2：无可见窗口（hide / 最小化 / 轻量销毁）→ 无任何 UI 消费者，整轮跳过 fetch+parse+trim+广播（含首页 stats）。
+    // 重置 last 让窗口恢复后首轮干净再基线（避免跨隐藏窗口的大 dt 算出失真速率）。
+    if (this.isWindowVisible && !this.isWindowVisible()) {
+      this.last = null;
+      return;
+    }
     try {
       const data = await this.clashApi.getJson<{
         uploadTotal?: number;
@@ -122,17 +152,23 @@ export class StatsService {
       this.last = { up, down, at: now };
       this.snapshot.totalUpload = up;
       this.snapshot.totalDownload = down;
+      // activeConnections 只取 length（廉价、无需 trim）→ 首页连接数恒可用，与连接列表门控解耦
       this.snapshot.activeConnections = Array.isArray(data.connections)
         ? data.connections.length
         : 0;
       this.onUpdate({ ...this.snapshot });
 
-      // 连接快照：复用本次已取到的 data.connections，裁剪后按 divider 节奏推送（全局唯一 poller）
-      this.connections = Array.isArray(data.connections)
-        ? data.connections.map(trimConnection)
-        : [];
-      if (++this.tick % CONNECTIONS_PUSH_DIVIDER === 0) {
-        this.onConnections?.({ connections: this.connections, at: now });
+      // 连接列表：仅连接页有 watcher 时才 trim + 按 divider 推送（P1 主门控）。trim 移进 divider 分支
+      // （P4：消除「每 1s 裁剪但每 2s 才推」的半浪费）；无 watcher 时零裁剪、清陈旧缓存。
+      if (this.connectionsWatchers > 0) {
+        if (++this.tick % CONNECTIONS_PUSH_DIVIDER === 0) {
+          this.connections = Array.isArray(data.connections)
+            ? data.connections.map(trimConnection)
+            : [];
+          this.onConnections?.({ connections: this.connections, at: now });
+        }
+      } else if (this.connections.length > 0) {
+        this.connections = []; // 无 watcher：清缓存（CONNECTIONS_GET 回填得空，watch 后下轮即 fill）
       }
     } catch {
       /* 静默：核心未运行 / 连接被拒 */

--- a/src/main/services/__tests__/stats-service-gating.test.ts
+++ b/src/main/services/__tests__/stats-service-gating.test.ts
@@ -1,0 +1,225 @@
+/**
+ * StatsService「连接轮询门控」单测：覆盖 P1/P2 两道门控——
+ *  1) 窗口可见性谓词（isWindowVisible）：无可见窗口整轮跳过 fetch/parse/广播。
+ *  2) 连接页 watcher 引用计数：仅 connectionsWatchers>0 时才 trim + 按 CONNECTIONS_PUSH_DIVIDER(=2) 推连接快照。
+ *     addConnectionsWatcher 0→1 把 tick 对齐到 DIVIDER-1，使下一轮 poll 立即满足 divider 即推首帧。
+ * poll() 为私有 async，直接经 (service as any).poll() 驱动（跟随 proxy-manager 测试的 (svc as any) 直调私有方法风格），
+ * 避免 fake timer 驱动 async poll 的 microtask flush 复杂度。ClashApiClient 用 { getJson: jest.fn() } stub 强转注入。
+ */
+import { StatsService } from '../StatsService';
+import type { TrafficStats, ConnectionsSnapshot } from '../../../shared/types';
+
+// 对照 sing-box clash_api GET /connections 单条连接结构（含隐私/扩展字段，验 trim 字段裁剪）
+const RAW_CONN = {
+  id: 'conn-1',
+  upload: 12345,
+  download: 67890,
+  start: '2026-06-13T10:00:00.000Z',
+  chains: ['proxy-selector', 'hk-node'],
+  rule: 'rule_set=>proxy',
+  rulePayload: '',
+  metadata: {
+    network: 'tcp',
+    type: 'Tun',
+    sourceIP: '192.168.1.10',
+    destinationIP: '93.184.216.34',
+    sourcePort: '54321',
+    destinationPort: '443',
+    host: 'example.com',
+    processPath: '/usr/bin/curl',
+  },
+};
+
+/** clash_api /connections 响应体（带累计 totals + 一条连接）。 */
+function makeData(connections: unknown[] = [RAW_CONN]) {
+  return { uploadTotal: 1000, downloadTotal: 2000, connections };
+}
+
+/** ClashApiClient stub：getJson 返回预设响应，记录调用。强转注入（参考 proxy-manager 测试的 client as any 风格）。 */
+function makeClashApi(data: unknown = makeData()) {
+  return { getJson: jest.fn().mockResolvedValue(data) };
+}
+
+/**
+ * 组装一个 StatsService 及其回调 spy。
+ * @param withVisible 是否注入 isWindowVisible 谓词
+ * @param visible      谓词返回值（仅 withVisible 时有效）
+ * @param data         getJson 响应体
+ */
+function setup(opts: { withVisible?: boolean; visible?: boolean; data?: unknown } = {}) {
+  const onUpdate = jest.fn<void, [TrafficStats]>();
+  const onConnections = jest.fn<void, [ConnectionsSnapshot]>();
+  const clashApi = makeClashApi(opts.data ?? makeData());
+  const isWindowVisible = opts.withVisible ? jest.fn(() => opts.visible ?? true) : undefined;
+  const service = new StatsService(onUpdate, clashApi as any, onConnections, isWindowVisible);
+  return { service, onUpdate, onConnections, clashApi, isWindowVisible };
+}
+
+/** 直接驱动一轮私有 async poll（替代 fake timer，规避 microtask flush）。 */
+async function poll(service: StatsService): Promise<void> {
+  await (service as any).poll();
+}
+
+describe('StatsService 连接轮询门控', () => {
+  describe('可见性门控（isWindowVisible）', () => {
+    it('isWindowVisible 返回 false 时，一次 poll 不调 getJson / onUpdate / onConnections', async () => {
+      const { service, onUpdate, onConnections, clashApi } = setup({
+        withVisible: true,
+        visible: false,
+      });
+      service.addConnectionsWatcher(); // 即便有 watcher，不可见也整轮跳过
+
+      await poll(service);
+
+      expect(clashApi.getJson).not.toHaveBeenCalled();
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(onConnections).not.toHaveBeenCalled();
+    });
+
+    it('不可见 poll 会把 last 重置为 null（恢复后首轮干净再基线）', async () => {
+      const { service } = setup({ withVisible: true, visible: false });
+      (service as any).last = { up: 1, down: 1, at: Date.now() };
+
+      await poll(service);
+
+      expect((service as any).last).toBeNull();
+    });
+  });
+
+  describe('无 watcher（connectionsWatchers===0）', () => {
+    it('可见 + 无 watcher：poll 调 onUpdate（totals）但不调 onConnections', async () => {
+      const { service, onUpdate, onConnections } = setup({ withVisible: true, visible: true });
+
+      await poll(service);
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      const stats = onUpdate.mock.calls[0][0];
+      expect(stats.totalUpload).toBe(1000);
+      expect(stats.totalDownload).toBe(2000);
+      expect(stats.activeConnections).toBe(1); // 取 connections.length，与连接列表门控解耦
+      expect(onConnections).not.toHaveBeenCalled();
+    });
+
+    it('无 watcher：getConnectionsSnapshot() 返回空 connections', async () => {
+      const { service } = setup({ withVisible: true, visible: true });
+
+      await poll(service);
+
+      expect(service.getConnectionsSnapshot().connections).toEqual([]);
+    });
+  });
+
+  describe('有 watcher（addConnectionsWatcher）', () => {
+    it('addConnectionsWatcher 后下一次 poll 立即推 onConnections（0→1 tick 对齐，≤1 次 poll 即推首帧）', async () => {
+      const { service, onConnections } = setup({ withVisible: true, visible: true });
+
+      service.addConnectionsWatcher();
+      await poll(service); // 因 tick 已对齐到 DIVIDER-1，本轮 ++tick%DIVIDER===0 立即推
+
+      expect(onConnections).toHaveBeenCalledTimes(1);
+    });
+
+    it('推送的 snapshot.connections 是 trim 后的（字段裁剪正确：id / metadata.host 等带出）', async () => {
+      const { service, onConnections } = setup({ withVisible: true, visible: true });
+
+      service.addConnectionsWatcher();
+      await poll(service);
+
+      const snap = onConnections.mock.calls[0][0];
+      expect(snap.connections).toHaveLength(1);
+      const e = snap.connections[0];
+      expect(e.id).toBe('conn-1');
+      expect(e.metadata?.host).toBe('example.com');
+      expect(e.metadata?.destinationIP).toBe('93.184.216.34');
+      expect(e.metadata?.sourceIP).toBe('192.168.1.10');
+      expect(e.metadata?.processPath).toBe('/usr/bin/curl');
+      expect(e.upload).toBe(12345);
+      expect(e.download).toBe(67890);
+      expect(e.start).toBe('2026-06-13T10:00:00.000Z');
+      // 与 getConnectionsSnapshot 缓存一致
+      expect(service.getConnectionsSnapshot().connections).toHaveLength(1);
+    });
+
+    it('连续两次 poll 至少推一次连接快照（首帧 ≤1 次 poll 即到）', async () => {
+      const { service, onConnections } = setup({ withVisible: true, visible: true });
+
+      service.addConnectionsWatcher();
+      await poll(service);
+      await poll(service);
+
+      expect(onConnections.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('divider 节奏（CONNECTIONS_PUSH_DIVIDER=2）', () => {
+    it('0→1 立即推首帧后，后续按每 2 次 poll 推一次', async () => {
+      const { service, onConnections } = setup({ withVisible: true, visible: true });
+
+      service.addConnectionsWatcher();
+      await poll(service); // 第1轮：tick 1→2，%2===0 → 推（首帧）         累计 1
+      expect(onConnections).toHaveBeenCalledTimes(1);
+
+      await poll(service); // 第2轮：tick 2→3，%2!==0 → 不推                累计 1
+      expect(onConnections).toHaveBeenCalledTimes(1);
+
+      await poll(service); // 第3轮：tick 3→4，%2===0 → 推                  累计 2
+      expect(onConnections).toHaveBeenCalledTimes(2);
+
+      await poll(service); // 第4轮：tick 4→5，%2!==0 → 不推                累计 2
+      expect(onConnections).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('计数钳制（removeConnectionsWatcher）', () => {
+    it('计数为 0 时 remove 后仍为 0（不变负，避免 >0 误判）', () => {
+      const { service } = setup({ withVisible: true, visible: true });
+
+      service.removeConnectionsWatcher();
+      service.removeConnectionsWatcher();
+
+      expect((service as any).connectionsWatchers).toBe(0);
+    });
+
+    it('add 后 remove 归 0，再 poll 不推连接快照（间接断言钳制未误判 >0）', async () => {
+      const { service, onConnections } = setup({ withVisible: true, visible: true });
+
+      service.addConnectionsWatcher();
+      service.removeConnectionsWatcher(); // 归 0
+      service.removeConnectionsWatcher(); // 钳制：仍 0，不应变负
+      expect((service as any).connectionsWatchers).toBe(0);
+
+      await poll(service);
+      await poll(service);
+
+      expect(onConnections).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('缺省行为不变（未注入 isWindowVisible 且无 watcher）', () => {
+    it('缺省（无谓词 + 无 watcher）：totals 推、连接列表不推', async () => {
+      const onUpdate = jest.fn<void, [TrafficStats]>();
+      const onConnections = jest.fn<void, [ConnectionsSnapshot]>();
+      const clashApi = makeClashApi(makeData());
+      // 不注入 isWindowVisible（第 4 参数省略）= 不门控、保持原行为
+      const service = new StatsService(onUpdate, clashApi as any, onConnections);
+
+      await poll(service);
+
+      expect(clashApi.getJson).toHaveBeenCalledTimes(1); // 无谓词 → 不跳过 fetch
+      expect(onUpdate).toHaveBeenCalledTimes(1); // totals 推
+      expect(onConnections).not.toHaveBeenCalled(); // 无 watcher → 连接列表不推
+    });
+
+    it('缺省 + 加 watcher：下一轮仍按 0→1 对齐立即推（谓词缺省不影响 watcher 门控）', async () => {
+      const onUpdate = jest.fn<void, [TrafficStats]>();
+      const onConnections = jest.fn<void, [ConnectionsSnapshot]>();
+      const clashApi = makeClashApi(makeData());
+      const service = new StatsService(onUpdate, clashApi as any, onConnections);
+
+      service.addConnectionsWatcher();
+      await poll(service);
+
+      expect(onConnections).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/renderer/components/connections/connections-table.tsx
+++ b/src/renderer/components/connections/connections-table.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import {
   Table,
   TableBody,
@@ -61,6 +69,130 @@ function ruleActionVariant(action: string): 'secondary' | 'destructive' | 'defau
   return 'default';
 }
 
+/** 稳定的零速率引用：speeds 无此 id 时传入，使 ConnectionRow memo 的 speed 比较恒定（不每帧新建对象）。 */
+const ZERO_SPEED: ConnSpeed = { up: 0, down: 0 };
+
+/**
+ * 全表共享秒级 tick（P3）：时长列每秒刷新原本随父组件 setNow 触发整表 reconcile（重跑 visible.map + diff ≤500 行）。
+ * 改为模块级外部 store + useSyncExternalStore：1s tick 只重渲订阅它的各 DurationCell（纯文本），不穿透
+ * ConnectionRow 的 memo → 整行/整表不因时长刷新而 reconcile。仅有订阅者时跑 interval（无连接页=零开销）；
+ * 暂停由表 setDurationTicking(false) 冻结（与快照冻结一致）。单连接页实例，模块级状态安全。
+ */
+let durationNow = Date.now();
+let durationTimer: ReturnType<typeof setInterval> | null = null;
+let durationTicking = true;
+const durationListeners = new Set<() => void>();
+function subscribeDuration(cb: () => void): () => void {
+  durationListeners.add(cb);
+  if (!durationTimer) {
+    durationTimer = setInterval(() => {
+      if (!durationTicking) return;
+      durationNow = Date.now();
+      durationListeners.forEach((l) => l());
+    }, 1000);
+  }
+  return () => {
+    durationListeners.delete(cb);
+    if (durationListeners.size === 0 && durationTimer) {
+      clearInterval(durationTimer);
+      durationTimer = null;
+    }
+  };
+}
+function getDurationNow(): number {
+  return durationNow;
+}
+function setDurationTicking(v: boolean): void {
+  durationTicking = v;
+}
+
+/** 时长单元（P3）：订阅共享秒 tick 独立自刷新，使整行不因时长每秒变化而 reconcile（绕过 ConnectionRow memo）。 */
+const DurationCell = memo(function DurationCell({ start }: { start?: string }) {
+  const now = useSyncExternalStore(subscribeDuration, getDurationNow, getDurationNow);
+  return <>{fmtDuration(durationSec({ start } as ConnectionEntry, now))}</>;
+});
+
+interface ConnectionRowProps {
+  conn: ConnectionEntry;
+  speed: ConnSpeed;
+  onClose: (id: string) => void;
+  closeLabel: string;
+}
+
+/**
+ * 单连接行（P3）：memo 按「会变的展示字段」比较——对固定连接 id，仅上下行累计(traffic)与速率会变，
+ * 其余(规则/目标/源/链/进程)在 clash 连接创建时即定型恒不变。故 id+upload+download+speed 相等 ⇒ 整行视图不变、
+ * 跳过 reconcile（2s 快照下 idle 连接行不再无谓重渲）。时长由内嵌 DurationCell 经共享 tick 自刷新，不入本比较。
+ */
+const ConnectionRow = memo(
+  function ConnectionRow({ conn: c, speed: s, onClose, closeLabel }: ConnectionRowProps) {
+    const m = c.metadata || {};
+    const proc = m.processPath || '-';
+    const procName = proc === '-' ? '-' : proc.split(/[/\\]/).pop() || proc;
+    const rv = parseRule(c.rule, c.rulePayload);
+    return (
+      <TableRow>
+        <TableCell className="py-2">
+          <button
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+            title={closeLabel}
+            onClick={() => onClose(c.id)}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </TableCell>
+        <TableCell className="py-2 text-xs">{typeOf(c)}</TableCell>
+        <TableCell className="py-2 font-mono text-xs">{sourceOf(c)}</TableCell>
+        <TableCell className="max-w-[220px] truncate py-2 text-xs" title={destOf(c)}>
+          {destOf(c)}
+        </TableCell>
+        <TableCell className="max-w-[200px] py-2 text-xs" title={rv.full || undefined}>
+          {rv.action ? (
+            <span className="flex items-center gap-1.5">
+              {rv.type && <span className="truncate text-muted-foreground">{rv.type}</span>}
+              <Badge
+                variant={ruleActionVariant(rv.action)}
+                className="shrink-0 px-1.5 py-0 text-[10px] font-normal"
+              >
+                {rv.action}
+              </Badge>
+            </span>
+          ) : (
+            <span className="block truncate">{rv.full || '-'}</span>
+          )}
+        </TableCell>
+        <TableCell className="max-w-[160px] truncate py-2 text-xs" title={chainOf(c)}>
+          {chainOf(c)}
+        </TableCell>
+        <TableCell className="whitespace-nowrap py-2 text-xs">
+          <span className="text-success">↓ {formatBytes(s.down)}/s</span>
+          <span className="ml-2 text-info">↑ {formatBytes(s.up)}/s</span>
+        </TableCell>
+        <TableCell className="whitespace-nowrap py-2 text-xs text-muted-foreground">
+          ↓ {formatBytes(c.download ?? 0)} / ↑ {formatBytes(c.upload ?? 0)}
+        </TableCell>
+        <TableCell className="whitespace-nowrap py-2 text-xs">
+          <DurationCell start={c.start} />
+        </TableCell>
+        <TableCell className="max-w-[180px] truncate py-2 text-xs" title={proc}>
+          {procName}
+        </TableCell>
+      </TableRow>
+    );
+  },
+  // memo 比较：只比会变的展示字段。**契约**：对固定 conn.id，chains/rule/rulePayload/metadata（→ chainOf/parseRule/
+  // destOf/sourceOf/typeOf/processPath）在 clash 连接生命周期内不可变（切节点创建新连接、不改已有 id），故不入比较。
+  // ⚠️ 若上游（trimConnection / sing-box）改为对已有 id 回填/修正这些字段，须把对应字段纳入比较，否则行静默不更新。
+  (prev, next) =>
+    prev.onClose === next.onClose &&
+    prev.closeLabel === next.closeLabel &&
+    prev.conn.id === next.conn.id &&
+    (prev.conn.upload ?? 0) === (next.conn.upload ?? 0) &&
+    (prev.conn.download ?? 0) === (next.conn.download ?? 0) &&
+    prev.speed.up === next.speed.up &&
+    prev.speed.down === next.speed.down
+);
+
 export function ConnectionsTable() {
   const { t } = useTranslation();
   const proxyRunning = useAppStore((s) => s.connectionStatus?.proxyCore?.running ?? false);
@@ -72,7 +204,6 @@ export function ConnectionsTable() {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [speeds, setSpeeds] = useState<Map<string, ConnSpeed>>(new Map());
   const [confirmCloseAll, setConfirmCloseAll] = useState(false);
-  const [now, setNow] = useState(Date.now());
 
   // 暂停态用 ref 让订阅回调读到最新值（订阅只挂一次，不随 paused 重订阅）。
   const pausedRef = useRef(paused);
@@ -83,6 +214,9 @@ export function ConnectionsTable() {
   // 数据：挂载 CONNECTIONS_GET 回填 + 订阅 EVENT_CONNECTIONS_UPDATED。暂停时冻结（不更新表 + 不推进速率基准）。
   useEffect(() => {
     let mounted = true;
+    // P1：通知 main「连接页已打开」→ 仅此时主进程才裁剪 + 推送连接快照（watcher 引用计数 +1）。
+    // fire-and-forget：失败不影响订阅（main 无 watcher 时退化为不推送，空态由 proxyRunning gate 兜底）。
+    void api.connections.watch().catch(() => {});
     const apply = (snap: ConnectionsSnapshot) => {
       if (pausedRef.current) return; // 本地冻结：保留当前帧
       const { speeds: s, next } = computeConnSpeeds(snap.connections, rateRef.current, snap.at);
@@ -104,17 +238,16 @@ export function ConnectionsTable() {
     return () => {
       mounted = false;
       unsub();
+      // P1：连接页关闭 → watcher 引用计数 -1，归 0 后 main 停止裁剪 + 推送（省「没盯连接页」稳态无效工作）。
+      void api.connections.unwatch().catch(() => {});
     };
   }, []);
 
-  // 时长列实时刷新与高频快照解耦：每 1s 推进 now（秒级精度足够），暂停时冻结。原随每帧快照 setNow 会把时长
-  // 刷新频率绑死在快照频率上、放大整表重渲染（LOW-B）；改为固定 1s tick，配合 filtered 不依赖 now（见上）。
+  // 时长列刷新与整表 reconcile 解耦（P3）：秒级 tick 下沉到模块级共享 store，仅 DurationCell 订阅、
+  // 自刷新文本，不再随 setNow 重跑 visible.map + reconcile ≤500 行。暂停时冻结 tick（与快照冻结一致）。
   useEffect(() => {
-    const id = setInterval(() => {
-      if (!pausedRef.current) setNow(Date.now());
-    }, 1000);
-    return () => clearInterval(id);
-  }, []);
+    setDurationTicking(!paused);
+  }, [paused]);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -193,19 +326,23 @@ export function ConnectionsTable() {
     }
   };
 
-  const handleClose = async (id: string) => {
-    try {
-      const { ok } = await api.connections.close(id);
-      if (ok) {
-        // 乐观移除：下一帧快照若仍在会再回填（极少见），但即时反馈更顺手
-        setConnections((prev) => prev.filter((c) => c.id !== id));
-      } else {
+  // useCallback 稳定引用：作为 ConnectionRow 的 onClose prop，避免每次父渲染新建函数使 memo 失效。
+  const handleClose = useCallback(
+    async (id: string) => {
+      try {
+        const { ok } = await api.connections.close(id);
+        if (ok) {
+          // 乐观移除：下一帧快照若仍在会再回填（极少见），但即时反馈更顺手
+          setConnections((prev) => prev.filter((c) => c.id !== id));
+        } else {
+          toast.error(t('connections.closeFailed'));
+        }
+      } catch {
         toast.error(t('connections.closeFailed'));
       }
-    } catch {
-      toast.error(t('connections.closeFailed'));
-    }
-  };
+    },
+    [t]
+  );
 
   const handleCloseAll = async () => {
     setConfirmCloseAll(false);
@@ -315,64 +452,15 @@ export function ConnectionsTable() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {visible.map((c) => {
-                const s = speeds.get(c.id) || { up: 0, down: 0 };
-                const m = c.metadata || {};
-                const proc = m.processPath || '-';
-                const procName = proc === '-' ? '-' : proc.split(/[/\\]/).pop() || proc;
-                const rv = parseRule(c.rule, c.rulePayload);
-                return (
-                  <TableRow key={c.id}>
-                    <TableCell className="py-2">
-                      <button
-                        className="rounded p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                        title={t('connections.close')}
-                        onClick={() => handleClose(c.id)}
-                      >
-                        <X className="h-4 w-4" />
-                      </button>
-                    </TableCell>
-                    <TableCell className="py-2 text-xs">{typeOf(c)}</TableCell>
-                    <TableCell className="py-2 font-mono text-xs">{sourceOf(c)}</TableCell>
-                    <TableCell className="max-w-[220px] truncate py-2 text-xs" title={destOf(c)}>
-                      {destOf(c)}
-                    </TableCell>
-                    <TableCell className="max-w-[200px] py-2 text-xs" title={rv.full || undefined}>
-                      {rv.action ? (
-                        <span className="flex items-center gap-1.5">
-                          {rv.type && (
-                            <span className="truncate text-muted-foreground">{rv.type}</span>
-                          )}
-                          <Badge
-                            variant={ruleActionVariant(rv.action)}
-                            className="shrink-0 px-1.5 py-0 text-[10px] font-normal"
-                          >
-                            {rv.action}
-                          </Badge>
-                        </span>
-                      ) : (
-                        <span className="block truncate">{rv.full || '-'}</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="max-w-[160px] truncate py-2 text-xs" title={chainOf(c)}>
-                      {chainOf(c)}
-                    </TableCell>
-                    <TableCell className="whitespace-nowrap py-2 text-xs">
-                      <span className="text-success">↓ {formatBytes(s.down)}/s</span>
-                      <span className="ml-2 text-info">↑ {formatBytes(s.up)}/s</span>
-                    </TableCell>
-                    <TableCell className="whitespace-nowrap py-2 text-xs text-muted-foreground">
-                      ↓ {formatBytes(c.download ?? 0)} / ↑ {formatBytes(c.upload ?? 0)}
-                    </TableCell>
-                    <TableCell className="whitespace-nowrap py-2 text-xs">
-                      {fmtDuration(durationSec(c, now))}
-                    </TableCell>
-                    <TableCell className="max-w-[180px] truncate py-2 text-xs" title={proc}>
-                      {procName}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
+              {visible.map((c) => (
+                <ConnectionRow
+                  key={c.id}
+                  conn={c}
+                  speed={speeds.get(c.id) ?? ZERO_SPEED}
+                  onClose={handleClose}
+                  closeLabel={t('connections.close')}
+                />
+              ))}
               {filtered.length > MAX_VISIBLE_ROWS && (
                 <TableRow>
                   <TableCell

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -370,6 +370,14 @@ export const connectionsApi = {
   onUpdated(listener: (snap: ConnectionsSnapshot) => void): () => void {
     return ipcClient.on(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, listener);
   },
+  /** 连接页 mount 时订阅：通知 main 开始裁剪+推送连接快照（watcher 引用计数 +1）。fire-and-forget。 */
+  async watch(): Promise<void> {
+    return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_WATCH);
+  },
+  /** 连接页 unmount 时退订：watcher 引用计数 -1，归 0 后 main 停止裁剪+推送。fire-and-forget。 */
+  async unwatch(): Promise<void> {
+    return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_UNWATCH);
+  },
   /** 关单条连接（main 经 9090 DELETE /connections/{id}；渲染端无 secret）。 */
   async close(id: string): Promise<{ ok: boolean }> {
     return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_CLOSE, { id });

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -71,6 +71,8 @@ export const IPC_CHANNELS = {
   CONNECTIONS_GET: 'connections:get',
   CONNECTIONS_CLOSE: 'connections:close', // 关单条连接（main 经 9090 DELETE /connections/{id}）
   CONNECTIONS_CLOSE_ALL: 'connections:closeAll', // 关全部连接（main 经 9090 DELETE /connections，触发 ResetNetwork）
+  CONNECTIONS_WATCH: 'connections:watch', // 连接页 mount：watcher 引用计数 +1，main 开始裁剪+推送连接快照
+  CONNECTIONS_UNWATCH: 'connections:unwatch', // 连接页 unmount：watcher 引用计数 -1，归 0 后 main 停止裁剪+推送
 
   // 出口 IP 信息（本地直连出口 / 代理出口）
   IP_INFO_GET: 'ipinfo:get',


### PR DESCRIPTION
## 概要
连接轮询门控（P1/P2/P3/P4）性能优化：消除"代理连着但没盯连接页/窗口不可见"稳态下的无效 fetch+trim+IPC 广播。独立审计两轮收敛，无 HIGH/MED。

## 改动
- **P1 watcher 引用计数门控**：连接页 mount→`CONNECTIONS_WATCH`(+1)/unmount→`UNWATCH`(-1)，`connectionsWatchers>0` 才 trim+推送连接快照。fail-safe：漏 unwatch 退化为原行为。
- **P2 窗口可见性门控**：`isWindowVisible` 谓词，无可见窗口整轮跳过 fetch/parse/trim/广播（含首页 stats）。
- **P3 连接表行级 memo**：`ConnectionRow`/`DurationCell` memo + 共享秒 tick 订阅 + `ZERO_SPEED` 稳定引用，整表 reconcile→仅变化行。
- **P4**：trim 移进 divider 分支；`activeConnections` 取廉价 length 与列表门控解耦。

## 验证
- tsc main+renderer exit 0；jest stats-service-gating 12/12（隔离态实测，PR 内容自洽不依赖别分支）。
- 独立审计两轮收敛（无 HIGH/MED）；真机 RSS/IPC profiling 建议 reviewer 复测。

## 范围
- 与 #65（Windows 提权/分流/UI 修复）**文件域零重叠**，可独立合并。
- 不含 CoreUpdateService 改动（别会话，独立 PR）。

Generated with [Claude Code](https://claude.com/claude-code)
