### PR TITLE
测速延迟改用 warm TTFB（对齐 mihomo unified-delay），消除握手 RTT 导致的虚高

### DIFF
--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -1,6 +1,8 @@
 /**
- * 速度测试服务（真实测速）：**所有协议**统一经临时 sing-box 的各自 HTTP 代理出口、GET generate_204 测 urltest TTFB，
- * 验证完整链路（连接+鉴权+中继+响应），等价 mihomo/clash 的 `/proxies/{name}/delay`。
+ * 速度测试服务（真实测速）：**所有协议**统一经临时 sing-box 的各自 HTTP 代理出口、CONNECT 隧道上发两次 GET 测
+ * urltest TTFB，验证完整链路（连接+鉴权+中继+响应）。计时对齐 mihomo `unified-delay`：在同一条已建立的隧道上**只计
+ * 第二次**请求往返——即不含建连/握手的「实际请求时间」，跨协议可比（旧实现每次新建连接、把到代理的握手 RTT
+ * 计进延迟，数值虚高且协议越重越偏，等价 mihomo `unified-delay:false`）。
  * 关键:端口通≠代理可用——裸 TCP ping 只测到入口的 RTT、测不出鉴权/协议/中继失败,故不再用于真实测速。
  *
  * 出站由 index.ts 注入 ProxyManager.buildSpeedTestOutbound 构造（全协议）。未注入（单测/兜底）时退回旧的 TCP ping + UDP 代理拆分。
@@ -30,9 +32,13 @@ export interface SpeedTestResult {
 export class SpeedTestService {
   private logManager: LogManager;
   private readonly MAX_CONCURRENT = 5; // TCP 并发数（仅兜底裸 ping 路径）
-  /** 经代理 urltest 的预热/正式测速并发上限：大订阅时分波，避免 N 路握手同时打出→请求风暴假超时。
-   *  小订阅(≤此值)等价全并行、零额外延迟；32=轻量 204 + sing-box 惰性拨号下的舒适区。 */
-  private static readonly PROXY_TEST_CONCURRENCY = 32;
+  /** 经代理 urltest 的测速并发上限：大订阅时分波，避免 N 路握手同时打出→请求风暴假超时。
+   *  小订阅(≤此值)等价全并行、零额外延迟。取 16=并发与稳健的折中（warm 计量已把握手挪出上报值，并发主要影响
+   *  总测速时长与争用、非延迟数值）；调大更快、调小更稳。 */
+  private static readonly PROXY_TEST_CONCURRENCY = 16;
+  /** 单节点测速总超时（ms）：覆盖冷建连(CONNECT+到代理/目标握手)+两次 GET；上报值只取第二次 warm RTT，与此无关。
+   *  取 8s 给大订阅并发冷启动留足头寸，超时即判该节点不可达(null)。 */
+  private static readonly MEASURE_TIMEOUT_MS = 8000;
   /**
    * 出站构造器（由 index.ts 注入 ProxyManager.buildSpeedTestOutbound）：注入后**所有协议**统一走「临时 sing-box
    * 经代理 urltest」真实测速（端口通≠代理可用，裸 TCP ping 测不出鉴权/中继失败）；返回 null=该节点不可用（如 naive
@@ -205,8 +211,9 @@ export class SpeedTestService {
   // ═══════════════════════════════════════════════════════════════
 
   /**
-   * 经临时 sing-box 真实测速（全协议）：每个可用节点起独立 HTTP 入站 → 该节点出站，GET 测速端点（默认 generate_204，
-   * 可经 testUrl 自配，兼容 http/https）测 TTFB。不可用节点（naive 缺 libcronet 等）预先剔除为 null、不进临时核。
+   * 经临时 sing-box 真实测速（全协议）：每个可用节点起独立 HTTP 入站 → 该节点出站，经 CONNECT 隧道发两次 GET 测速端点
+   * （默认 generate_204，可经 testUrl 自配，兼容 http/https）量 warm TTFB（详见 measureViaTunnel）。不可用节点（naive
+   * 缺 libcronet 等）预先剔除为 null、不进临时核。
    * @param onResult 可选逐节点回调：每测完一个节点即回传（serverId, latency），供 UI 流式增量显示。
    * @param testUrl 可选测速端点 URL（非法回落默认 generate_204）。
    */
@@ -302,23 +309,20 @@ export class SpeedTestService {
         return results;
       }
 
-      // 6. 预热：建立连接 + DNS 缓存（冷启动开销不计入延迟）。并发上限见 PROXY_TEST_CONCURRENCY。
-      await this.runWithLimit(usable, SpeedTestService.PROXY_TEST_CONCURRENCY, async (u) => {
-        await this.sendProxyRequest(serverPortMap.get(u.server.id)!, 8000, target);
-      });
-
-      // 7. 正式测速：经各自代理出站测 urltest TTFB。并发上限避免大订阅 N 路握手同时打出→请求风暴假超时；
-      //    小订阅(≤上限)等价全并行、零额外延迟。每测完一个节点立即回调 onResult（UI 流式显示），不等队列。
+      // 6. 测速：每节点经各自 HTTP 代理建一条 CONNECT 隧道，在同一条隧道上发两次 GET、只计第二次（warm RTT）——
+      //    对齐 mihomo unified-delay：第一次承担建连+握手暖身（丢弃计时），第二次是不含握手的纯请求延迟＝「实际请求
+      //    时间」。冷握手挪到被丢弃的第一次，故 32 并发的争用也不污染上报值；measureViaTunnel 内部已暖身，无需独立
+      //    预热轮。并发上限避免大订阅 N 路握手同时打出→请求风暴假超时；小订阅(≤上限)等价全并行。
+      //    每测完一个节点立即回调 onResult（UI 流式显示），不等队列。
       await this.runWithLimit(usable, SpeedTestService.PROXY_TEST_CONCURRENCY, async (u) => {
         const port = serverPortMap.get(u.server.id)!;
-        try {
-          const latency = await this.sendProxyRequest(port, 5000, target);
-          results.set(u.server.id, latency);
-          report(u.server.id, latency);
-        } catch {
-          results.set(u.server.id, null);
-          report(u.server.id, null);
-        }
+        const latency = await this.measureViaTunnel(
+          port,
+          SpeedTestService.MEASURE_TIMEOUT_MS,
+          target
+        );
+        results.set(u.server.id, latency);
+        report(u.server.id, latency);
       });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -469,65 +473,21 @@ export class SpeedTestService {
   // ═══════════════════════════════════════════════════════════════
 
   /**
-   * 通过本地 HTTP 代理（临时 sing-box 各节点入站）请求测速端点，量 TTFB（请求发出 → 收到响应头）。
-   * - HTTP 端点：代理绝对 URI GET（`GET http://host/path`，代理按 Host 转发）。
-   * - HTTPS 端点：代理 CONNECT 隧道 → TLS 握手 → GET；测速仅量可达性+TTFB，rejectUnauthorized=false（与 HTTP 路径不校验等价）。
+   * 经本地 HTTP 代理（临时 sing-box 各节点入站）测单节点延迟，量「实际请求时间」（不含建连/握手）。
+   *
+   * 做法对齐 mihomo `unified-delay`：CONNECT 到测速目标建一条隧道（= 已建立的「代理+目标」连接，等价 mihomo dial
+   * 出来的 instance），https 目标先在隧道上做一次 TLS 握手；随后在**同一条**连接上发两次 GET——第一次暖身（承担
+   * 建连+握手+冷启动，丢弃计时），第二次只量请求往返（响应头收齐 = warm TTFB）。
+   * HTTP/HTTPS 走同一隧道路径：第二次请求是否 warm 不依赖 sing-box 入站是否复用出站（隧道本身就是那条已建立的连接），
+   * 避免赌核内部行为。返回 null = 不可达/超时/对端过早关闭；单一总超时 timeout 兜底。
    */
-  private sendProxyRequest(
-    proxyPort: number,
-    timeout: number,
-    target: SpeedTestTarget
-  ): Promise<number | null> {
-    return target.https
-      ? this.sendHttpsViaProxy(proxyPort, timeout, target)
-      : this.sendHttpViaProxy(proxyPort, timeout, target);
-  }
-
-  /** HTTP 端点经代理绝对 URI GET。 */
-  private sendHttpViaProxy(
+  private measureViaTunnel(
     proxyPort: number,
     timeout: number,
     target: SpeedTestTarget
   ): Promise<number | null> {
     return new Promise((resolve) => {
-      const start = Date.now();
-      const timer = setTimeout(() => resolve(null), timeout);
-      const req = http.get(
-        {
-          hostname: '127.0.0.1',
-          port: proxyPort,
-          path: target.absoluteUri, // 代理绝对 URI（http://host[:port]/path）
-          headers: { Host: target.hostHeader, Connection: 'close' },
-          timeout,
-        },
-        (res) => {
-          clearTimeout(timer);
-          const latency = Date.now() - start; // 收到响应头即刻计算（不等 body），与 NekoBox urltest 一致
-          res.resume(); // 排空响应体，防止内存泄漏
-          resolve(latency);
-        }
-      );
-      req.on('error', () => {
-        clearTimeout(timer);
-        resolve(null);
-      });
-      req.on('timeout', () => {
-        clearTimeout(timer);
-        req.destroy();
-        resolve(null);
-      });
-    });
-  }
-
-  /** HTTPS 端点经代理 CONNECT 隧道 + TLS GET。 */
-  private sendHttpsViaProxy(
-    proxyPort: number,
-    timeout: number,
-    target: SpeedTestTarget
-  ): Promise<number | null> {
-    return new Promise((resolve) => {
-      const start = Date.now();
-      // 持有所有已建立句柄，finish 时统一 destroy（防 fd/socket 泄漏：大订阅并发 32 + HTTPS 时累积）。
+      // 持有所有已建立句柄，finish 时统一 destroy（防 fd/socket 泄漏：大订阅并发 32 时累积）。
       let connectReq: http.ClientRequest | null = null;
       let tunnel: net.Socket | null = null;
       let tlsSock: tls.TLSSocket | null = null;
@@ -536,7 +496,6 @@ export class SpeedTestService {
         if (done) return;
         done = true;
         clearTimeout(timer);
-        // 统一清理：destroy 所有已建立的句柄（GET 已拿到 TTFB / 任何错误 / 超时均不应留挂起 socket）
         tlsSock?.destroy();
         tunnel?.destroy();
         connectReq?.destroy();
@@ -544,10 +503,8 @@ export class SpeedTestService {
       };
       const timer = setTimeout(() => finish(null), timeout);
 
-      // CONNECT 端口用 target.port（不能用 hostHeader 拼 443——非标端口如 8443 会变成 host:8443:443；
-      // 也不能用 hostHeader:443——非标 hostHeader 已含端口会双端口）。CONNECT 始终显式 host:port。
+      // CONNECT 始终显式 host:port（标准端口也带，避免非标端口拼接歧义）。
       const connectHost = `${target.host}:${target.port}`;
-      // 1. 向代理发 CONNECT 建立到 target 的 TCP 隧道
       connectReq = http.request({
         host: '127.0.0.1',
         port: proxyPort,
@@ -558,33 +515,79 @@ export class SpeedTestService {
       });
       connectReq.on('error', () => finish(null));
       connectReq.on('timeout', () => finish(null));
+      // CONNECT 非 2xx（如 502）实测仍走 'connect'（携带 statusCode），由下方 statusCode 判定兜 null；
+      // 'response' 仅兜「代理把 CONNECT 降级成普通 HTTP 响应」的边缘情况，避免挂到总超时。
+      connectReq.on('response', () => finish(null));
       connectReq.on('connect', (res, socket) => {
         if (res.statusCode !== 200) {
           finish(null); // finish 内统一 destroy socket
           return;
         }
         tunnel = socket;
-        // 2. 在隧道上 TLS 握手；测速仅量可达性+TTFB，不校验证书（自签/MITM 端点也能测，与 HTTP 路径等价）
-        tlsSock = tls.connect(
-          { socket, servername: target.host, rejectUnauthorized: false },
-          () => {
-            // 3. 握手完成，发 GET（首批响应 data 即响应头到达 = TTFB）
-            tlsSock?.write(
-              `GET ${target.path} HTTP/1.1\r\nHost: ${target.hostHeader}\r\nConnection: close\r\n\r\n`
-            );
-          }
-        );
-        let measured = false;
-        tlsSock.on('data', () => {
-          if (!measured) {
-            measured = true;
-            finish(Date.now() - start);
-          }
-        });
-        tlsSock.on('error', () => finish(null));
+        socket.setNoDelay(true); // 关 Nagle：小请求 TTFB 不被 delayed-ACK/合包拖慢
+        if (target.https) {
+          // 隧道上做一次 TLS 握手（仅一次，归入第一次暖身）；测速仅量可达性+TTFB，不校验证书（与 HTTP 路径等价）。
+          tlsSock = tls.connect(
+            { socket, servername: target.host, rejectUnauthorized: false },
+            () => this.measureWarmRtt(tlsSock!, target, finish)
+          );
+          tlsSock.on('error', () => finish(null));
+        } else {
+          this.measureWarmRtt(socket, target, finish);
+        }
       });
       connectReq.end();
     });
+  }
+
+  /**
+   * 在一条已建立的隧道（net.Socket 或隧道上的 tls.TLSSocket）上发两次 GET，只计第二次「响应头收齐」的耗时（warm RTT）。
+   *
+   * 按 HTTP 报文边界（`\r\n\r\n`）在**连续缓冲**上数两次响应，**不是**见字节就判定——否则第一次响应的跨 chunk 残余
+   * （TLS record/TCP 分段/CDN 多次 write）会被误当第二次首字节，使上报值塌成 ≈0ms（比虚高更危险，会误选坏节点）。
+   * 切到第二次前**整段清空 buf**（连第一次响应的 body 残余一并丢弃——第二次请求此刻才发出，残余绝不含第二次数据）；
+   * 计到第二次响应头收齐，与 mihomo `client.Do`（收齐响应头即返回）同口径。用 GET 而非 HEAD：默认端点 generate_204
+   * 为 GET 设计、204 规范无 body，连接可立即复用；HEAD 可能 405/行为不一。
+   * 请求用 origin-form（隧道直连 origin，路径非代理绝对 URI）。
+   */
+  private measureWarmRtt(
+    conn: net.Socket | tls.TLSSocket,
+    target: SpeedTestTarget,
+    finish: (v: number | null) => void
+  ): void {
+    const HEADER_END = '\r\n\r\n';
+    const request =
+      `GET ${target.path} HTTP/1.1\r\n` +
+      `Host: ${target.hostHeader}\r\n` +
+      `Connection: keep-alive\r\n\r\n`;
+    let buf = '';
+    let firstDone = false;
+    let start = 0;
+
+    conn.on('data', (chunk: Buffer) => {
+      // latin1 单字节编码：逐 chunk 拼接不会把多字节字符跨 chunk 错位，ASCII 的响应头与 \r\n\r\n 边界检测安全。
+      // 勿改 utf8（会引入跨 chunk 截断）。
+      buf += chunk.toString('latin1');
+      if (!firstDone) {
+        if (buf.indexOf(HEADER_END) < 0) return; // 第一次响应头未收齐，继续累积（跨 chunk 安全）
+        // 第一次（暖身）响应头收齐：整段清空 buf（含可能的 body 残余）。第二次请求此刻才发出（下行 write），
+        // 故残余绝不含第二次响应数据——只 slice 到响应头会让自配「非 204 带 body」端点的 body（含空行）污染
+        // 第二次判定、塌成 ≈0ms，故整段丢弃。计时发第二次。
+        firstDone = true;
+        buf = '';
+        start = Date.now();
+        conn.write(request);
+      } else {
+        // 第二次响应：从第二次状态行 `HTTP/` 锚定起判「响应头收齐」，跳过可能先于第二次响应到达的第一次 body 残余
+        // （自配非 204 端点 + header/body 分段时，body 残余会先入清空后的 buf；不从 HTTP/ 起算会把它误当第二次）。
+        const sl = buf.indexOf('HTTP/');
+        if (sl < 0 || buf.indexOf(HEADER_END, sl) < 0) return; // 第二次状态行/响应头未到齐
+        finish(Date.now() - start); // 收齐第二次响应头 = 不含握手的纯请求往返
+      }
+    });
+    conn.on('error', () => finish(null));
+    conn.on('end', () => finish(null)); // 对端在测完前关闭 → 失败
+    conn.write(request); // 第一次（暖身，丢弃计时）
   }
 
   /**

--- a/src/main/services/__tests__/speed-test-warm-ttfb.test.ts
+++ b/src/main/services/__tests__/speed-test-warm-ttfb.test.ts
@@ -1,0 +1,324 @@
+/**
+ * SpeedTestService.measureViaTunnel 集成单测（本地 mock CONNECT 代理 + 明文/TLS origin，无 sing-box）。
+ *
+ * 核心断言：计时对齐 mihomo `unified-delay`——同一条隧道发两次 GET，**只计第二次**的请求往返。
+ * 故意把 connectDelay（建连）/ firstDelay（第一次/含 TLS 握手）放大、secondDelay 放小，验证上报值≈secondDelay，
+ * 远小于 connectDelay+firstDelay（证明握手/建连/第一次均不计入 = 不再虚高）。另覆盖：第一次响应跨 chunk 残余不污染
+ * 第二次计时（防塌成 ≈0ms 的相位机缺陷）、CONNECT 失败 / 对端早关 / 超时三类失败返回 null。
+ */
+import * as net from 'net';
+import * as tls from 'tls';
+import { SpeedTestService } from '../SpeedTestService';
+import { resolveSpeedTestTarget } from '../../../shared/speed-test';
+
+// 测试专用自签证书（仅本进程 mock origin 用；客户端测速 rejectUnauthorized=false 不校验）。
+const TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCoDRoduamuz7oo
+JDqvXZbOAmrSm74Qd6uj8zpfrrIlp4lUg+pVU4STww4pZAQQb88FSfzXjjEjKyWV
+q70Wv0nXeo2wvr+/mAZA3YDeAQFCb9aSq+HKzJhY9P3CmjOEJqgLjJ9OBos8QkR2
+aSWQyUa7xR7N72MggqePfbRzG9qHRBolzfZQrtdVNB0V/gR+Hmcj/ZwB3M7Tdg7F
+pMZrltVvncVUghWjIpcS8JgSc4t2WxDCJc3JYgtzt9CJqWWmTQFQNmgLfHNsm727
+Y0tSE2c7EqvAYU7cQ59mpisbJc/P9Xcm+S3+9fe781wvZqlJTvdXGa1R0qpANYKz
+KI/BwQ67AgMBAAECggEAGu/mtMcS7ON9Onv8MCn3R1RZ3SJ7x9X23FPbkoTFJ4YA
+XFy8ziqSAMFuXrIaeKwDahye+8peE/4Rizk5GRFWe8S4O5GH2OU8c19ODcfpdMXK
+hj4o9kHvVasHlg7znQY5P4it7GreHK2encBi9h9dSDHjqyzpHcfzpeuHZkAbujys
+eF3QkNL6x1BmNUCro4TG0ulnTTQeyTgo3tr/gXDGW8dorYvEyykBf9MMpsuEfypO
+nYOMcpHRxCa/jJ1TcTagkH/T1OTuemdfIjV5qWDOwzkmIx58RXG7Qxf5mfn3omKQ
+i/bp5Ly98HXaUwbD6RvwdlhJe0M8O3mT96+di+RLsQKBgQDmzw+H2VkWK5mL6xXw
+WqjWRaIsrqLFkb/0iBEwPwKXTg5UVwH1WNdM4ifrWIZbZilu+1ru/mtC9833FTik
+7i+xli7qYk571QqmZ+R4/e7OIl003UlgmXcFIfhIiuOWlrymeh32R7wE/XK4gegt
+dBNr2ZYzQM3v2s99Y5VWZF8VswKBgQC6ZI3p7hkPZ8QBsHpYnJ0PbRt1yuTwS1Bu
+b67fGdULsooLa34rFmqpVSdpQFf90kaxQWQCGePKjl92lF4JJ/fWN9B08YN4Wf00
+bvHfWHHk6KeW5uFCwE0iOqhcUF9tcD46D0wZlFBgOw8uUWAxtFZvSbwdjAq1/gdD
+DmvvXfiu2QKBgF6Yhpj675Qykl/SHc/AmGoZZ/pAKN4oei/ShJjtejZg+2Z9soPH
+wZX1Kr8+LPLQ0DJ4OjCxfWyY+4VE4U5XgJycHOZbHCeMjSzeb7lW+cTqOKEuAKDi
+xPEJlyTEJ7rUVMU2T4lcpSa2aYpNU8ctR7hwGSswaDbhyyBs7AvYX1AZAoGANnBJ
+9ong7dvrpmapxRmw0aGXRJcGuJv2mNqro2ODEtCJev5hMipw6pYBVb9CM9LnbLvh
+fq+bFTzx6ss4j8oJm5pfmtgzAsKdrmO85vOJCEdfMzapkfpiTN3+8D9VL7x5oDF5
+k3r64rA9JdUEmF/IYuaRN7wAINlZu58JrTav/DkCgYAtUdo8N6Zusw3Y23t8gLl6
+EO1yYEncTo6hmlmsqEWGCi+Unrjja5tCU7qBl4tqn85qMGzynnSJhFiW5ZcPw0Nl
+1oVy9i6fO4pqv/B/aqQqBED0c9kUoe+VkQAwXBu8AFrwgtUNL0lZW2BUUbVlKBS7
+3QMAV0J/K1v4W5tNjSTb5g==
+-----END PRIVATE KEY-----`;
+
+const TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIUKsb6U3Icqun55FUl7UlKZ74eFFowDQYJKoZIhvcNAQEL
+BQAwGjEYMBYGA1UEAwwPc3BlZWR0ZXN0LmxvY2FsMCAXDTI2MDYxNTExNDcwOVoY
+DzIxMjYwNTIyMTE0NzA5WjAaMRgwFgYDVQQDDA9zcGVlZHRlc3QubG9jYWwwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCoDRoduamuz7ooJDqvXZbOAmrS
+m74Qd6uj8zpfrrIlp4lUg+pVU4STww4pZAQQb88FSfzXjjEjKyWVq70Wv0nXeo2w
+vr+/mAZA3YDeAQFCb9aSq+HKzJhY9P3CmjOEJqgLjJ9OBos8QkR2aSWQyUa7xR7N
+72MggqePfbRzG9qHRBolzfZQrtdVNB0V/gR+Hmcj/ZwB3M7Tdg7FpMZrltVvncVU
+ghWjIpcS8JgSc4t2WxDCJc3JYgtzt9CJqWWmTQFQNmgLfHNsm727Y0tSE2c7EqvA
+YU7cQ59mpisbJc/P9Xcm+S3+9fe781wvZqlJTvdXGa1R0qpANYKzKI/BwQ67AgMB
+AAGjUzBRMB0GA1UdDgQWBBSpVbrUvl6+TJr44KuK2RWu22A5rDAfBgNVHSMEGDAW
+gBSpVbrUvl6+TJr44KuK2RWu22A5rDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQAHGAmoH954ZahWSUO0Zb1OelTZkmnPft8dY5W+HTj0WlksrDHE
+LNszGo5AxlWVAHt55yJ0UcDnab+qAQKnt8KXpBLhAgrOrtgiwLcZ9u0nrjWXPCQE
+2MksJxq4CnQxXVcgKzvTFtSrfkGCHL6Re1J0onAdPXbG/Bqur1WhW8bRbo59/ZnQ
+uqqhVlXDQ53pa81ApTi+kbgra12ExUcXlrbmhPB2qxqKfAJ68H0a4sXdQS7n9Mwd
+8IZ4nh5nFrD/IU54o6+QXqOFICQhqcWgykXL5gGf9oxAhCjMeXxUkUcxqGXTZYRk
+xiWQ81eyG2tDO/dC57ooE2BY/n8AYwY19rHS
+-----END CERTIFICATE-----`;
+
+const mockLog = { addLog: () => {} } as unknown as ConstructorParameters<
+  typeof SpeedTestService
+>[0];
+
+interface MockOpts {
+  /** CONNECT 收齐后延迟多久才回 200（模拟建连慢）。 */
+  connectDelay?: number;
+  /** 第一次 GET 延迟多久回响应（模拟首请求/暖身慢）。 */
+  firstDelay?: number;
+  /** 第二次 GET 延迟多久回响应（= 期望被计入的 warm RTT）。 */
+  secondDelay?: number;
+  /** 第一次响应改为 200 + 该 body（自配非 204 端点；body 含空行时不应污染第二次计时）。 */
+  firstBody?: string;
+  /** 与 firstBody 配合：第一次响应的 header 与 body 分两段发送（body 后到，模拟 TCP 分段/TLS record）。 */
+  splitFirstHeaderBody?: boolean;
+  /** CONNECT 后是否升 TLS（模拟 https 目标）。 */
+  tls?: boolean;
+  /** 对 CONNECT 回非 200（不可达代理）。 */
+  failConnect?: boolean;
+  /** 第一次响应后立即关闭连接（不支持 keep-alive，第二次无连接可用）。 */
+  closeAfterFirst?: boolean;
+  /** 第一次响应头之后再补发的残余字节（独立 chunk，模拟分片/CDN 多次 write）；不应被当作第二次首字节计时。 */
+  firstTrailer?: string;
+}
+
+interface MockProxy {
+  port: number;
+  close: () => Promise<void>;
+}
+
+/** 在已建立的流（明文隧道或 TLS）上扮演 origin：按到达的 GET 计次，按 first/second 时延回响应。 */
+function serveOrigin(stream: net.Socket | tls.TLSSocket, opts: MockOpts): void {
+  let reqBuf = '';
+  let count = 0;
+  stream.on('error', () => {});
+  stream.on('data', (d: Buffer) => {
+    reqBuf += d.toString('latin1');
+    while (reqBuf.includes('\r\n\r\n')) {
+      reqBuf = reqBuf.slice(reqBuf.indexOf('\r\n\r\n') + 4);
+      count++;
+      const isFirst = count === 1;
+      const delay = isFirst ? (opts.firstDelay ?? 0) : (opts.secondDelay ?? 0);
+      const closeNow = isFirst && opts.closeAfterFirst;
+      setTimeout(() => {
+        try {
+          const body = isFirst ? opts.firstBody : undefined;
+          if (body && opts.splitFirstHeaderBody) {
+            // header 先发、body 后发（独立 chunk）：body 残余会先于第二次响应进入清空后的 buf。
+            stream.write(`HTTP/1.1 200 OK\r\nContent-Length: ${Buffer.byteLength(body)}\r\n\r\n`);
+            setTimeout(() => {
+              try {
+                stream.write(body);
+              } catch {
+                /* 连接可能已被客户端 destroy */
+              }
+            }, 10).unref();
+          } else {
+            stream.write(
+              body
+                ? `HTTP/1.1 200 OK\r\nContent-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`
+                : 'HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n'
+            );
+          }
+          if (isFirst && opts.firstTrailer) {
+            // 第一次响应头之后再发一段残余 chunk（模拟分片/CDN 多次 write）。
+            setTimeout(() => {
+              try {
+                stream.write(opts.firstTrailer!);
+              } catch {
+                /* 连接可能已被客户端 destroy */
+              }
+            }, 10).unref();
+          }
+          if (closeNow) stream.end();
+        } catch {
+          /* 连接可能已被客户端 destroy */
+        }
+      }, delay).unref(); // unref：测试提前结束时不吊住事件循环（如 firstDelay=5000 的超时用例）
+    }
+  });
+}
+
+function startMockProxy(opts: MockOpts): Promise<MockProxy> {
+  const live = new Set<net.Socket>();
+  const server = net.createServer((sock) => {
+    live.add(sock);
+    sock.on('close', () => live.delete(sock));
+    sock.on('error', () => {});
+    let buf = '';
+    const onConnectData = (d: Buffer) => {
+      buf += d.toString('latin1');
+      if (!buf.includes('\r\n\r\n')) return;
+      sock.removeListener('data', onConnectData); // 交棒：后续由 TLS server 或 origin 接管读取
+      const reply = (): void => {
+        if (opts.failConnect) {
+          sock.write('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+          return;
+        }
+        sock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        if (opts.tls) {
+          const tlsSock = new tls.TLSSocket(sock, {
+            isServer: true,
+            key: TEST_KEY,
+            cert: TEST_CERT,
+          });
+          serveOrigin(tlsSock, opts);
+        } else {
+          serveOrigin(sock, opts);
+        }
+      };
+      if (opts.connectDelay) setTimeout(reply, opts.connectDelay).unref();
+      else reply();
+    };
+    sock.on('data', onConnectData);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as net.AddressInfo).port;
+      resolve({
+        port,
+        close: () =>
+          new Promise<void>((r) => {
+            for (const s of live) s.destroy();
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+type Measurable = {
+  measureViaTunnel(
+    proxyPort: number,
+    timeout: number,
+    target: ReturnType<typeof resolveSpeedTestTarget>
+  ): Promise<number | null>;
+};
+
+const svc = new SpeedTestService(mockLog) as unknown as Measurable;
+
+const HTTP_TARGET = resolveSpeedTestTarget('http://speedtest.local/generate_204');
+const HTTPS_TARGET = resolveSpeedTestTarget('https://speedtest.local/generate_204');
+
+describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-delay）', () => {
+  it('HTTP：只计第二次请求，排除建连+第一次（warm≈secondDelay，远小于 connect+first）', async () => {
+    // connect 100 + first 250 → 若误计冷启动会是 ~350+；只计第二次应 ≈60。
+    const proxy = await startMockProxy({ connectDelay: 100, firstDelay: 250, secondDelay: 60 });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      expect(latency).not.toBeNull();
+      expect(latency!).toBeGreaterThanOrEqual(40); // 确在量第二次（secondDelay=60）
+      expect(latency!).toBeLessThan(200); // 远低于 connect(100)+first(250)，证明握手/暖身不计入
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('HTTPS：TLS 握手归入暖身、不计入；仍只计第二次请求', async () => {
+    const proxy = await startMockProxy({
+      connectDelay: 100,
+      firstDelay: 250,
+      secondDelay: 60,
+      tls: true,
+    });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTPS_TARGET);
+      expect(latency).not.toBeNull();
+      expect(latency!).toBeGreaterThanOrEqual(40);
+      expect(latency!).toBeLessThan(200); // TLS 握手 + connect + first 均排除
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('第一次响应跨 chunk 残余不污染第二次计时（防塌成 ≈0ms）', async () => {
+    // 第一次响应头后 10ms 再发一段无 \r\n\r\n 的残余 chunk；旧相位机会把它当第二次首字节 → latency≈10；
+    // 正确实现应忽略残余、计到真正的第二次响应（secondDelay=100）。
+    const proxy = await startMockProxy({
+      firstDelay: 20,
+      secondDelay: 100,
+      firstTrailer: 'X-Leftover: stray-bytes-without-header-end\r\n',
+    });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      expect(latency).not.toBeNull();
+      expect(latency!).toBeGreaterThanOrEqual(50); // ≈secondDelay(100)，证明残余未被计为第二次
+      expect(latency!).toBeLessThan(260);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('自配非 204 端点（200 + body 含空行）不污染第二次计时（防 body 残余塌 0）', async () => {
+    // 第一次响应是 200 + body，且 body 内含 \r\n\r\n（HTML/JSON pretty-print 常见）。若把 body 残余当第二次响应头
+    // 会塌成 ≈firstDelay；正确实现整段清空 buf、只计真正的第二次（secondDelay=100）。
+    const proxy = await startMockProxy({
+      firstDelay: 20,
+      secondDelay: 100,
+      firstBody: 'part-a\r\n\r\npart-b',
+    });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      expect(latency).not.toBeNull();
+      expect(latency!).toBeGreaterThanOrEqual(50); // ≈secondDelay(100)，证明第一次 body 残余未被计入
+      expect(latency!).toBeLessThan(260);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('非 204 端点 header/body 分段、body 后到含空行：从 HTTP/ 锚定，仍只计第二次', async () => {
+    // 第一次 200 响应的 header 先到（触发清空 buf）、body（含 \r\n\r\n）10ms 后到，先于第二次响应入 buf。
+    // 若第二次不从状态行 HTTP/ 起算，会把该 body 残余误当第二次响应头 → 塌成 ≈firstDelay。
+    const proxy = await startMockProxy({
+      firstDelay: 20,
+      secondDelay: 100,
+      firstBody: 'part-a\r\n\r\npart-b',
+      splitFirstHeaderBody: true,
+    });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      expect(latency).not.toBeNull();
+      expect(latency!).toBeGreaterThanOrEqual(50); // ≈secondDelay(100)，证明后到的 body 残余未被计为第二次
+      expect(latency!).toBeLessThan(260);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('CONNECT 非 200（代理不可达）→ null', async () => {
+    const proxy = await startMockProxy({ failConnect: true });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 500, HTTP_TARGET);
+      expect(latency).toBeNull();
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('对端在第二次前关闭（不支持 keep-alive）→ null（不挂起）', async () => {
+    const proxy = await startMockProxy({ firstDelay: 10, closeAfterFirst: true });
+    try {
+      const latency = await svc.measureViaTunnel(proxy.port, 500, HTTP_TARGET);
+      expect(latency).toBeNull();
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('整体超时（请求迟迟不响应）→ null', async () => {
+    const proxy = await startMockProxy({ firstDelay: 5000 }); // 远超下方 timeout
+    try {
+      const start = Date.now();
+      const latency = await svc.measureViaTunnel(proxy.port, 200, HTTP_TARGET);
+      expect(latency).toBeNull();
+      expect(Date.now() - start).toBeLessThan(1500); // 在总超时附近返回，不等 5s
+    } finally {
+      await proxy.close();
+    }
+  });
+});

--- a/src/shared/__tests__/speed-test.test.ts
+++ b/src/shared/__tests__/speed-test.test.ts
@@ -2,8 +2,8 @@
  * parseSpeedTestUrl / resolveSpeedTestTarget 单测（纯函数，无网络/无 FS）：
  * 验证测速端点 URL → SpeedTestTarget 解析（http/https、host/port、path+query、非标准端口 Host 头、非法回落默认）。
  *
- * 这是「测速地址可设置」的后端核心：SpeedTestService.sendProxyRequest 据 target.https 分流（HTTP 绝对 URI GET /
- * HTTPS CONNECT 隧道+TLS）。FS/网络层（实际请求）属集成层、真机验证，不在此测。
+ * 这是「测速地址可设置」的后端核心：SpeedTestService.measureViaTunnel 据 target.https 决定 CONNECT 隧道上是否先
+ * 做 TLS 握手，再发两次 GET 只计第二次（warm RTT）。FS/网络层（实际请求）属集成层、真机验证，不在此测。
  */
 import { parseSpeedTestUrl, resolveSpeedTestTarget, DEFAULT_SPEED_TEST_URL } from '../speed-test';
 

--- a/src/shared/speed-test.ts
+++ b/src/shared/speed-test.ts
@@ -1,9 +1,9 @@
 /**
  * 节点测速目标 URL 解析（纯函数，主进程 SpeedTestService + 单测共用；不经网络）。
  *
- * 测速经临时 sing-box 的各节点 HTTP 代理出站、GET 端点量 TTFB（mihomo/clash 的 `/proxies/{name}/delay` 等价）。
- * 默认 generate_204（204 空响应、TTFB=真实全链路延迟）。用户可自配（如 cp.cloudflare.com/generate_204 或自建端点），
- * 兼容 HTTP（代理绝对 URI GET）与 HTTPS（CONNECT 隧道 + TLS GET）。非法/非 http(s)/无 host → 调用方回落默认。
+ * 测速经临时 sing-box 的各节点 HTTP 代理出站、CONNECT 隧道上发两次 GET 量 warm TTFB（mihomo `unified-delay` 等价）。
+ * 默认 generate_204（204 空响应、可立即复用连接）。用户可自配（如 cp.cloudflare.com/generate_204 或自建端点），
+ * HTTP/HTTPS 同走 CONNECT 隧道（https 目标先在隧道上 TLS 握手）。非法/非 http(s)/无 host → 调用方回落默认。
  */
 
 /** 默认测速端点：Google generate_204（与 mihomo/clash/NekoBox 默认 urltest 同款）。 */


### PR DESCRIPTION
## 问题
节点测速的 TTFB 数值偏高、不像实际请求时间。根因：原实现每次请求都新建连接（HTTP 路径 `Connection: close`、HTTPS 路径每次重 CONNECT+TLS），所谓“预热轮”的连接发完即关、从不复用 → 正式测量重新支付了到代理节点的 TCP + 协议/TLS 握手 RTT。这部分被计进延迟，导致数值虚高、且协议越重（TLS/Reality）越偏、跨协议不可比。等价于 mihomo 的 `unified-delay: false`（社区公认偏高）。

## 方案
对齐 mihomo `unified-delay: true` 的口径——在一条已建立的连接上量“第二次请求”的纯往返：
- 每个可用节点经其临时 HTTP 代理端口 `CONNECT` 到测速目标（默认 `http://www.gstatic.com/generate_204`）建一条隧道（= 已建立的「代理→节点 + 节点→目标」连接）；https 目标在隧道内做一次 TLS 握手。
- 在同一条连接上连发两次 GET：第一次暖身（承担建连+握手+冷启动，丢弃计时），**只计第二次**的请求往返 = 不含握手的“实际请求时间”，跨协议可比。
- 删除原独立的全局预热轮（每节点内已暖身），改为单趟测量，进度从首个节点即开始、无空窗。

## 健壮性（防上报值误塌成 ≈0ms）
手写 HTTP 帧解析按报文边界处理，避免“见字节即判定”被残余污染：
- 连续缓冲按 `\r\n\r\n` 数两次响应；第一次响应收齐后整段丢弃 buf；第二次从状态行 `HTTP/` 锚定起判响应头收齐——跳过跨 chunk 残余、以及自配“非 204 带 body”端点的 body 残余。
- 用 GET 而非 HEAD：`generate_204` 为 GET 设计、204 规范无 body 仍可复用连接，避免赌端点对 HEAD 的支持（可能 405/行为不一）。
- CONNECT 非 2xx / 对端在第二次前关闭（不支持 keep-alive）/ 总超时 → 一律 null。`setNoDelay(true)` 关 Nagle。

## 并发
测速并发上限 32 → 16：warm 计量后并发只影响总测速时长与争用、不影响延迟数值；16 在并发与稳健间折中（同时握手更少，对弱网/弱机友好）。

## 测试
新增 `speed-test-warm-ttfb` 单测（本地 mock CONNECT 代理 + 自签 TLS origin，无需 sing-box）：
- 只计第二次请求（排除建连/第一次/TLS 握手），覆盖 HTTP 与 HTTPS 两路径；
- 跨 chunk 残余、自配非 204 body（含 header/body 分段）均不塌成 ≈0ms；
- CONNECT 非 200 / 对端早关 / 总超时三类返回 null。
- 全量 jest 绿（42 套）。

## 行为
- 默认与常用端点（gstatic / cloudflare `generate_204`）路径不变，仅测得延迟更低、更稳、跨协议可比。
- 不影响正在使用的主代理：测速起独立临时 sing-box，用完即销毁。
