### PR TITLE
feat(proxy): 节点列表加「直连」项实现 proxifier（默认直连+仅规则走代理，不新增模式）

### DIFF
--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -27,6 +27,7 @@ import {
   protocolRequirementError,
 } from '../../shared/server-completeness';
 import { isAccountBasedProtocol } from '../../shared/endpoint-routes';
+import { isDirectSelection } from '../../shared/direct-selection';
 
 export interface IConfigManager {
   loadConfig(): Promise<UserConfig>;
@@ -456,8 +457,8 @@ export class ConfigManager implements IConfigManager {
       );
     }
 
-    // 验证 selectedServerId
-    if (config.selectedServerId !== null) {
+    // 验证 selectedServerId（'__direct__' 哨兵=全局直连，非真实节点，豁免存在性校验，见 shared/direct-selection）
+    if (config.selectedServerId !== null && !isDirectSelection(config.selectedServerId)) {
       if (typeof config.selectedServerId !== 'string') {
         throw new Error('selectedServerId must be a string or null');
       }

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -28,6 +28,7 @@ import { type ISystemProxyManager, SystemProxyBase } from './SystemProxyManager'
 import { type ISystemDnsManager } from './SystemDnsManager';
 import { localProxyPort, controlApiPort } from '../../shared/proxy-ports';
 import { effectiveBypassLan } from '../../shared/system-proxy-bypass';
+import { isDirectSelection, resolveGlobalExitTag } from '../../shared/direct-selection';
 import {
   isIpv4Host,
   isIpv6Host,
@@ -383,9 +384,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       throw new Error('No server selected');
     }
 
-    // 查找选中的服务器
-    const selectedServer = config.servers.find((s) => s.id === config.selectedServerId);
-    if (!selectedServer) {
+    // 查找选中的服务器（'__direct__' 哨兵=全局直连，无真实节点，跳过存在性校验）
+    const isDirect = isDirectSelection(config.selectedServerId);
+    const selectedServer = isDirect
+      ? undefined
+      : config.servers.find((s) => s.id === config.selectedServerId);
+    if (!isDirect && !selectedServer) {
       throw new Error('Selected server not found');
     }
 
@@ -994,13 +998,14 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     const puts: { selectorTag: string; memberTag: string }[] = [];
     let globalChanged = false;
 
-    // 全局节点变化
+    // 全局节点变化（含切到/切出"直连"哨兵：memberTag=direct，direct 恒是 proxy-selector 成员→可热切换不重启）
     if (old.selectedServerId !== newConfig.selectedServerId && newConfig.selectedServerId) {
-      // 目标节点必须已存在于运行中的 selector（= 启动时 servers），否则 PUT 指向不存在的成员
-      if (!old.servers.some((s) => s.id === newConfig.selectedServerId)) {
+      const toDirect = isDirectSelection(newConfig.selectedServerId);
+      // 目标节点必须已存在于运行中的 selector（= 启动时 servers），否则 PUT 指向不存在的成员；direct 豁免（恒为成员）
+      if (!toDirect && !old.servers.some((s) => s.id === newConfig.selectedServerId)) {
         return { kind: 'none', puts: [] };
       }
-      const targetTag = this.currentIdToTagMap?.get(newConfig.selectedServerId);
+      const targetTag = resolveGlobalExitTag(newConfig.selectedServerId, this.currentIdToTagMap);
       if (!targetTag) return { kind: 'none', puts: [] };
       puts.push({ selectorTag: 'proxy-selector', memberTag: targetTag });
       globalChanged = true;
@@ -1657,13 +1662,19 @@ done
    * 生成 sing-box 配置（sing-box 1.12.x / 1.13.x 兼容格式）
    */
   generateSingBoxConfig(config: UserConfig, resolvedIps?: Record<string, string>): SingBoxConfig {
-    const selectedServer = config.servers.find((s) => s.id === config.selectedServerId);
-    if (!selectedServer) {
-      throw new Error('Selected server not found');
-    }
-    // 选中节点不可用（naive 缺 libcronet）→ 明确报错，不静默切到别的节点（修 review M1）
-    if (!isNodeUsable(selectedServer)) {
-      throw new Error(this.naiveUnavailableReason(selectedServer));
+    // 全局直连哨兵（#73 proxifier）：无真实选中节点，proxy-selector default=direct（在 buildOutbounds 内置）。
+    const isDirect = isDirectSelection(config.selectedServerId);
+    const selectedServer = isDirect
+      ? null
+      : (config.servers.find((s) => s.id === config.selectedServerId) ?? null);
+    if (!isDirect) {
+      if (!selectedServer) {
+        throw new Error('Selected server not found');
+      }
+      // 选中节点不可用（naive 缺 libcronet）→ 明确报错，不静默切到别的节点（修 review M1）
+      if (!isNodeUsable(selectedServer)) {
+        throw new Error(this.naiveUnavailableReason(selectedServer));
+      }
     }
 
     // 获取用户数据目录用于缓存文件

--- a/src/main/services/TrayManager.ts
+++ b/src/main/services/TrayManager.ts
@@ -10,6 +10,7 @@ import {
 import { LogManager } from './LogManager';
 import { ServerConfig, ProxyMode, ProxyModeType, SubscriptionConfig } from '../../shared/types';
 import { groupServersBySubscription } from '../../shared/server-grouping';
+import { DIRECT_SERVER_ID, isDirectSelection } from '../../shared/direct-selection';
 
 // 托盘菜单状态圆点（macOS 系统色，18px 抗锯齿）——替代旧的 emoji 大圆圈，更克制现代。
 const STATUS_DOT_PNG: Record<'connected' | 'disconnected' | 'error', string> = {
@@ -327,6 +328,15 @@ export class TrayManager implements ITrayManager {
         click: () => this.handleSelectServer(server.id),
       };
     };
+
+    // 「直连」置顶项（全局直连哨兵，#73）：与首页节点选择同概念、同步；选中即 proxy-selector→direct（热切换）。
+    serverSubmenu.push({
+      label: this.t('直连', 'Direct'),
+      type: 'radio' as const,
+      checked: isDirectSelection(data.selectedServerId),
+      click: () => this.handleSelectServer(DIRECT_SERVER_ID),
+    });
+    serverSubmenu.push({ type: 'separator' });
 
     if (data.servers.length === 0) {
       serverSubmenu.push({

--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -220,6 +220,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -883,6 +884,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -1501,6 +1503,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -2149,6 +2152,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -2749,6 +2753,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -3336,6 +3341,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -3897,6 +3903,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -4529,6 +4536,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -5153,6 +5161,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -5807,6 +5816,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -6424,6 +6434,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "WG-US",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -7026,6 +7037,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -7698,6 +7710,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -8278,6 +8291,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -8881,6 +8895,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -9461,6 +9476,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HTTPUpgrade",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -10071,6 +10087,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "Naive",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -10687,6 +10704,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -11303,6 +11321,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -11905,6 +11924,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -12545,6 +12565,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "SSH",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -13147,6 +13168,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "HK",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -13774,6 +13796,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "outbounds": [
           "WS",
           "GRPC",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -14405,6 +14428,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "outbounds": [
           "Reality",
           "ShadowTLS",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -15109,6 +15133,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "AnyTLS",
           "SOCKS",
           "HTTP",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -15726,6 +15751,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "outbounds": [
           "香港",
           "日本",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",
@@ -16356,6 +16382,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "interrupt_exist_connections": false,
         "outbounds": [
           "AntiCensor",
+          "direct",
         ],
         "tag": "proxy-selector",
         "type": "selector",

--- a/src/main/services/__tests__/singbox-outbounds-build.test.ts
+++ b/src/main/services/__tests__/singbox-outbounds-build.test.ts
@@ -52,7 +52,7 @@ describe('buildOutbounds — 基础装配 + 载体', () => {
     expect(tags).toContain('block');
     const sel = r.outbounds.find((o) => o.tag === 'proxy-selector')!;
     expect(sel.type).toBe('selector');
-    expect(sel.outbounds).toEqual(['香港']);
+    expect(sel.outbounds).toEqual(['香港', 'direct']);
     expect(sel.default).toBe('香港');
     expect(r.pendingEndpoints).toEqual([]);
     expect(r.pendingRuleSelectors).toEqual([]);
@@ -67,8 +67,28 @@ describe('buildOutbounds — 基础装配 + 载体', () => {
       deps()
     );
     const sel = r.outbounds.find((o) => o.tag === 'proxy-selector')!;
-    expect(sel.outbounds).toEqual(['香港', '日本']);
+    expect(sel.outbounds).toEqual(['香港', '日本', 'direct']);
     expect(sel.default).toBe('日本');
+  });
+
+  it('全局直连哨兵 → proxy-selector 含 direct 成员、default=direct（#73）', () => {
+    const servers = [vless('s1', '香港')];
+    const r = buildOutbounds(
+      null,
+      cfg(servers, { selectedServerId: '__direct__' }),
+      idMap(servers),
+      deps()
+    );
+    const sel = r.outbounds.find((o) => o.tag === 'proxy-selector')!;
+    expect(sel.outbounds).toEqual(['香港', 'direct']);
+    expect(sel.default).toBe('direct');
+  });
+
+  it('全局直连 + 0 节点 → 不抛；proxy-selector=[direct]、default=direct', () => {
+    const r = buildOutbounds(null, cfg([], { selectedServerId: '__direct__' }), new Map(), deps());
+    const sel = r.outbounds.find((o) => o.tag === 'proxy-selector')!;
+    expect(sel.outbounds).toEqual(['direct']);
+    expect(sel.default).toBe('direct');
   });
 
   it('1.12 → 增 direct-loopback；1.13 → 无', () => {
@@ -151,7 +171,10 @@ describe('buildOutbounds — endpoint + 门控', () => {
       deps({ gateInvalidNodes: gate })
     );
     expect(r.outbounds.map((o) => o.tag)).not.toContain('香港');
-    expect(r.outbounds.find((o) => o.tag === 'proxy-selector')!.outbounds).toEqual(['日本']);
+    expect(r.outbounds.find((o) => o.tag === 'proxy-selector')!.outbounds).toEqual([
+      '日本',
+      'direct',
+    ]);
   });
 
   it('所有节点不可用 → 抛错', () => {

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -17,6 +17,7 @@ import {
   effectiveAppRules,
   getNodeResolverTag,
 } from './singbox-config-helpers';
+import { isDirectSelection, resolveGlobalExitTag } from '../../shared/direct-selection';
 
 /** 节点是否可用：naive 需要 libcronet 核心库，缺库时不可用（会被跳过、分流/选中回退到 selector）。 */
 export function isNodeUsable(server: ServerConfig): boolean {
@@ -599,7 +600,7 @@ function generateRuleSelectors(
  * （由 generateSingBoxConfig 回写 this.*，供顶层 endpoints[] 注入与 hotSwitch/clash_api 回读）。
  */
 export function buildOutbounds(
-  selectedServer: ServerConfig,
+  selectedServer: ServerConfig | null,
   config: UserConfig,
   idToTagMap: Map<string, string>,
   deps: OutboundsDeps
@@ -653,7 +654,7 @@ export function buildOutbounds(
       if (server.protocol.toLowerCase() === 'tailscale') {
         const ts = server.tailscaleSettings;
         const ready = !!ts?.authKey?.trim() || tailscaleStateExists(server.id);
-        if (server.id !== selectedServer.id && !ready) {
+        if (server.id !== selectedServer?.id && !ready) {
           deps.log('info', `Tailscale 节点「${server.name}」未就绪(需登录)且非选中，已跳过`);
           continue;
         }
@@ -740,15 +741,22 @@ export function buildOutbounds(
     // 开关决定（默认 false=优雅切换，现有连接保留至自然关闭）。clash_api `PUT /proxies/proxy-selector`
     // 据此热切换、无需重启 sing-box（详见 switchMode）。路由的 final 与「→代理」规则统一指向本 selector。
     // nodeTags 已在节点循环中按序累积（含 endpoint tag）；空=所有节点生成失败/不可用。
-    if (nodeTags.length === 0) {
+    // 全局直连哨兵（#73）：无真实选中节点，default=direct；direct 恒为 proxy-selector 成员，
+    // 支持 clash_api 热切换「直连↔节点」不重启。proxifier 时即便 0 节点也不抛（纯直连合法）。
+    const isDirect = isDirectSelection(config.selectedServerId);
+    if (nodeTags.length === 0 && !isDirect) {
       throw new Error('没有可用的代理节点出站（所有节点配置生成失败）');
     }
-    const selectedServerTag = idToTagMap.get(selectedServer.id) || 'proxy';
+    const selectedServerTag = resolveGlobalExitTag(config.selectedServerId, idToTagMap) || 'proxy';
     outbounds.push({
       type: 'selector',
       tag: 'proxy-selector',
-      outbounds: nodeTags,
-      default: nodeTags.includes(selectedServerTag) ? selectedServerTag : nodeTags[0],
+      outbounds: [...nodeTags, 'direct'],
+      default: isDirect
+        ? 'direct'
+        : nodeTags.includes(selectedServerTag)
+          ? selectedServerTag
+          : nodeTags[0],
       interrupt_exist_connections: config.interruptConnectionsOnSwitch === true,
     });
 
@@ -762,7 +770,7 @@ export function buildOutbounds(
     if ((config.proxyMode || 'smart').toLowerCase() === 'smart') {
       generateRuleSelectors(config, idToTagMap, nodeTags, outbounds, pendingRuleSelectors);
     }
-  } else {
+  } else if (selectedServer) {
     // Fallback if config is missing (shouldn't happen)
     outbounds.push(
       buildProxyOutbound(selectedServer, idToTagMap, getNodeResolverTag(config, 'dial'))
@@ -843,7 +851,7 @@ export function buildOutbounds(
       return undefined;
     };
     const selector = outbounds.find((o) => o.tag === 'proxy-selector');
-    const selectedTag = idToTagMap.get(selectedServer.id);
+    const selectedTag = selectedServer ? idToTagMap.get(selectedServer.id) : undefined;
     let mutated = false;
     // 反复扫描：剔一个引用方可能让别的 detour 链断裂，收敛到不再有死引用。
 

--- a/src/renderer/components/home/connection-status-card.tsx
+++ b/src/renderer/components/home/connection-status-card.tsx
@@ -8,6 +8,7 @@ import { Plus, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { deriveConnectionStatus } from './connection-status';
+import { isDirectSelection } from '@shared/direct-selection';
 
 export function ConnectionStatusCard() {
   const connectionStatus = useAppStore((state) => state.connectionStatus);
@@ -21,6 +22,8 @@ export function ConnectionStatusCard() {
   const servers = config?.servers || [];
   const selectedServerId = config?.selectedServerId;
   const selectedServer = servers.find((s) => s.id === selectedServerId);
+  // 全局直连哨兵（#73）：selectedServerId='__direct__' 时无真实节点，但不是「未选择」——需走当前选择分支显示「直连」。
+  const isDirect = isDirectSelection(selectedServerId);
   const { t } = useTranslation();
 
   const handleServerChange = async (serverId: string) => {
@@ -73,7 +76,7 @@ export function ConnectionStatusCard() {
         </div>
 
         {/* 服务器选择区域 */}
-        {servers.length === 0 ? (
+        {servers.length === 0 && !isDirect ? (
           <div className="space-y-3">
             <div className="p-4 border border-dashed border-muted-foreground/25 rounded-lg text-center">
               <p className="text-sm text-muted-foreground mb-3">{t('home.noServerConfig')}</p>
@@ -90,7 +93,7 @@ export function ConnectionStatusCard() {
               </div>
             </div>
           </div>
-        ) : !selectedServer ? (
+        ) : !selectedServer && !isDirect ? (
           <div className="space-y-3">
             <div className="p-4 border border-warning/50 bg-warning/10 rounded-lg">
               <p className="text-sm text-warning mb-3 flex items-center gap-1.5">
@@ -102,7 +105,7 @@ export function ConnectionStatusCard() {
                   <SelectValue placeholder={t('home.selectServer')} />
                 </SelectTrigger>
                 <SelectContent>
-                  <ServerSelectGroups servers={servers} />
+                  <ServerSelectGroups servers={servers} includeDirect />
                 </SelectContent>
               </Select>
             </div>
@@ -121,36 +124,45 @@ export function ConnectionStatusCard() {
                     <ServerSelectGroups
                       servers={servers}
                       selectedId={selectedServerId ?? undefined}
+                      includeDirect
                     />
                   </SelectContent>
                 </Select>
               </div>
             </div>
 
-            {/* 服务器详细信息 */}
-            <div className="space-y-2 pt-2 border-t">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">{t('home.protocol')}</span>
-                <Badge variant="outline" className="text-xs">
-                  {selectedServer.protocol}
-                </Badge>
+            {/* 全局直连：未命中规则的流量直连、仅按规则走代理（与「直连模式」不同，规则仍生效） */}
+            {isDirect ? (
+              <div className="space-y-2 pt-2 border-t">
+                <p className="text-xs text-muted-foreground">
+                  {t('home.directGlobalHint', '全局直连：未命中规则的流量直连，仅按规则走代理')}
+                </p>
               </div>
+            ) : selectedServer ? (
+              <div className="space-y-2 pt-2 border-t">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">{t('home.protocol')}</span>
+                  <Badge variant="outline" className="text-xs">
+                    {selectedServer.protocol}
+                  </Badge>
+                </div>
 
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">{t('home.address')}</span>
-                <span
-                  className="text-sm font-medium truncate max-w-[150px]"
-                  title={selectedServer.address}
-                >
-                  {selectedServer.address}
-                </span>
-              </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">{t('home.address')}</span>
+                  <span
+                    className="text-sm font-medium truncate max-w-[150px]"
+                    title={selectedServer.address}
+                  >
+                    {selectedServer.address}
+                  </span>
+                </div>
 
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">{t('home.port')}</span>
-                <span className="text-sm font-medium">{selectedServer.port}</span>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">{t('home.port')}</span>
+                  <span className="text-sm font-medium">{selectedServer.port}</span>
+                </div>
               </div>
-            </div>
+            ) : null}
           </div>
         )}
 

--- a/src/renderer/components/settings/server-select-groups.tsx
+++ b/src/renderer/components/settings/server-select-groups.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '@/store/app-store';
 import { useTranslation } from 'react-i18next';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { DIRECT_SERVER_ID } from '@shared/direct-selection';
 
 interface ServerSelectGroupsProps {
   servers: ServerConfig[];
@@ -19,6 +20,8 @@ interface ServerSelectGroupsProps {
   itemClassName?: string;
   /** 当前选中的节点 id：决定默认展开哪个分组（其余默认折叠），并天然定位当前节点 */
   selectedId?: string;
+  /** 顶部加「直连」项（仅首页全局节点选择用；应用分流/路由规则/detour 不传——它们有各自 action=直连） */
+  includeDirect?: boolean;
 }
 
 /**
@@ -36,6 +39,7 @@ export function ServerSelectGroups({
   valuePrefix = '',
   itemClassName,
   selectedId,
+  includeDirect,
 }: ServerSelectGroupsProps) {
   const { t } = useTranslation();
   const subscriptions = useAppStore((s) => s.config?.subscriptions || []);
@@ -46,6 +50,12 @@ export function ServerSelectGroups({
   );
   const groups = groupServersBySubscription(list, subscriptions);
   const val = (id: string) => `${valuePrefix}${id}`;
+  // 「直连」置顶项（全局直连哨兵，#73）：选中即 proxy-selector default=direct；不分组、恒第一项。
+  const directItem = includeDirect ? (
+    <SelectItem value={val(DIRECT_SERVER_ID)} className={itemClassName}>
+      {t('servers.directGlobal', '直连')}
+    </SelectItem>
+  ) : null;
 
   // 默认展开组：当前选中节点所在组；无则第一组。
   // 注意：ServerSelectGroups 挂在 radix Select 的常驻 Content 子树里，会在 config 加载完成前先挂载，
@@ -68,6 +78,7 @@ export function ServerSelectGroups({
   if (groups.length <= 1) {
     return (
       <>
+        {directItem}
         {list.map((s) => (
           <SelectItem key={s.id} value={val(s.id)} className={itemClassName}>
             {s.name}
@@ -79,6 +90,7 @@ export function ServerSelectGroups({
 
   return (
     <>
+      {directItem}
       {groups.map((g) => {
         const open = expanded.has(g.id);
         const label = g.isMesh

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -217,6 +217,7 @@
   "home": {
     "connectionStatus": "Connection Status",
     "currentServer": "Current Server",
+    "directGlobalHint": "Global Direct: unmatched traffic goes direct; only rule-matched traffic uses proxy",
     "selectServer": "Select Server",
     "connecting": "Connecting...",
     "proxyControl": "Proxy Control",
@@ -806,6 +807,7 @@
     "selectProtocol": "Select your proxy server protocol",
     "detour": "Proxy Chain (Detour)",
     "directConnection": "Direct (No Chain)",
+    "directGlobal": "Direct",
     "detourDesc": "Connect to this node through another proxy server (proxy chain)",
     "selectFingerprint": "Select TLS Fingerprint",
     "flowDesc": "XTLS flow control, Reality recommends xtls-rprx-vision",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -217,6 +217,7 @@
   "home": {
     "connectionStatus": "连接状态",
     "currentServer": "当前服务器",
+    "directGlobalHint": "全局直连：未命中规则的流量直连，仅按规则走代理",
     "selectServer": "选择服务器",
     "connecting": "连接中...",
     "proxyControl": "代理控制",
@@ -806,6 +807,7 @@
     "selectProtocol": "选择您的代理服务器协议类型",
     "detour": "前置代理 (Proxy Chain)",
     "directConnection": "直连 (Direct)",
+    "directGlobal": "直连",
     "detourDesc": "选择通过另一个代理服务器连接此节点（链式代理）",
     "selectFingerprint": "选择 TLS 指纹",
     "flowDesc": "XTLS 流控，Reality 推荐使用 xtls-rprx-vision",

--- a/src/shared/direct-selection.ts
+++ b/src/shared/direct-selection.ts
@@ -1,0 +1,28 @@
+/**
+ * 全局节点选择「直连」哨兵（#73 proxifier）。
+ *
+ * selectedServerId 取此值 = 全局出口走 direct（proxy-selector default=direct）。配 smart 模式即 proxifier：
+ * 未命中规则的流量直连，仅 custom/app `action=proxy`+指定目标节点的走代理。global 模式下=等同直连模式。
+ *
+ * **只作"全局节点选择"用**（首页 / 托盘「选择服务器」），不作 per-rule 目标（per-rule 直连用 action=direct）。
+ * 故不会进 rule-sel 目标解析；仅 generateSingBoxConfig/buildOutbounds/planHotSwitch 识别它。
+ */
+export const DIRECT_SERVER_ID = '__direct__';
+
+export function isDirectSelection(selectedServerId: string | null | undefined): boolean {
+  return selectedServerId === DIRECT_SERVER_ID;
+}
+
+/**
+ * 全局出口的 proxy-selector 成员 tag（单一真值，收口「selectedServerId → memberTag」）：直连哨兵→'direct'，
+ * 否则查 idToTagMap 得节点 tag。generate-time 的 selector default 与 hot-switch 的 PUT 目标共用此映射、锁步
+ * （改哨兵值 / direct tag 名只此一处）。未知节点返回 undefined，由调用方按场景兜底
+ * （buildOutbounds → nodeTags[0]/'proxy'；planHotSwitch → 退回重启）。
+ */
+export function resolveGlobalExitTag(
+  selectedServerId: string | null | undefined,
+  idToTagMap: Map<string, string> | null | undefined
+): string | undefined {
+  if (isDirectSelection(selectedServerId)) return 'direct';
+  return selectedServerId ? idToTagMap?.get(selectedServerId) : undefined;
+}


### PR DESCRIPTION
## 背景（#73）
proxifier 场景：默认大部分流量直连，仅用户明确指定的少数站点走代理（多 VPN 各走各的）。现有三模式都给不了——smart 的 final=代理使未列出的国外流量默认走代理；direct 模式又忽略用户规则。

## 方案（不新增模式）
在「选择服务器」列表（首页 + 托盘菜单）顶部加一个「直连」项：选中即 `selectedServerId='__direct__'` 哨兵 → proxy-selector default=direct → final=direct，复用 smart 模式整套规则引擎：
- 未命中规则的流量（含国外 IP/域名）直连；
- custom/app 规则中 `action=proxy` + 指定目标节点的仍走该节点（proxifier 语义）；
- clash_api 可热切换「直连↔节点」，不重启；
- 三大模式不改；global 模式 + 选直连 = 等同直连模式。

「直连」仅加在全局节点选择（首页/托盘「选择服务器」）；应用分流/路由规则的目标列表不加（它们已有 `action=直连`）。

## 改动
- 新增 `shared/direct-selection`（哨兵 `DIRECT_SERVER_ID` + `isDirectSelection` + `resolveGlobalExitTag` 单一真值，收口 selectedServerId→memberTag 映射）。
- `ConfigManager` 豁免哨兵的节点存在性校验。
- `ProxyManager`（generateSingBoxConfig / 启动前校验 / planHotSwitch）+ `buildOutbounds`：proxy-selector 恒含 `direct` 成员、哨兵 default=direct、0 节点不抛、selectedServer 可空。
- `ServerSelectGroups` 加 opt-in `includeDirect`；`ConnectionStatusCard` 直连态展示；`TrayManager`「选择服务器」置顶「直连」。
- i18n（zh-CN / en-US）。

## 验证
- 自动化：tsc(main+renderer) + 全量单测（含 buildOutbounds 直连/0 节点用例）+ config-snapshot（仅 +"direct" 成员）+ build 全绿。
- 完整性核查：25 处 `selectedServerId` 消费点全安全（DNS 不解析 selectedServer、route 用字面量、AutoSwitch/autoConnect/TUN/inbounds 优雅 no-op）。

Close #73