### PR TITLE
fix(update): 修复自动更新错配 + loose 形态原位更新（win便携/linux AppImage/mac .app）

### DIFF
--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -15,6 +15,12 @@ import { compareSemver } from '../../shared/version';
 import { ghMirrorUrl } from '../../shared/gh-proxy';
 import { createIdleTimeout, parseExpectedBytes } from './download-hardening';
 import { findSuitableUpdateAsset } from './update-asset';
+import {
+  buildWindowsUpdateVbs,
+  buildLinuxAppImageScript,
+  buildMacUpdateScript,
+  macAppBundleFromExe,
+} from './update-install-script';
 
 // 下载停滞超时：连接/下载 30s 无数据即视为卡死 → abort + 失败兜底（github 链接自动换镜像重试一次）。
 // 防永久挂起致更新永不 resolve（进度窗/对话框永久转圈）。正常下载持续有 data、不断重置、不会误触发。
@@ -201,20 +207,18 @@ export class UpdateService {
       }
 
       if (process.platform === 'win32') {
-        // Windows: 使用 VBScript 完全隐藏窗口运行安装程序
+        // Windows: 用 VBScript 隐藏窗口运行。便携态(PORTABLE_EXECUTABLE_FILE)=覆盖回原 exe 原位更新；
+        // 否则=跑 NSIS setup（注册表记住目录原位升级）。两者都只动产物、不碰 data。
         const { spawn } = require('child_process');
         const vbsPath = path.join(app.getPath('temp'), 'flowz_update.vbs');
 
-        // VBScript: 等待 2 秒确保应用完全退出，然后静默启动安装程序
-        // WScript.Shell.Run 的第二个参数 0 表示隐藏窗口，第三个参数 false 表示不等待
-        const vbsContent = [
-          'WScript.Sleep 2000',
-          `Set WshShell = CreateObject("WScript.Shell")`,
-          `WshShell.Run """${installerPath.replace(/\\/g, '\\\\')}""", 1, False`,
-          // 删除自身
-          `Set fso = CreateObject("Scripting.FileSystemObject")`,
-          `fso.DeleteFile WScript.ScriptFullName, True`,
-        ].join('\r\n');
+        const portableTarget = process.env.PORTABLE_EXECUTABLE_FILE || null;
+        this.logManager.addLog(
+          'info',
+          portableTarget ? '便携版：覆盖原 exe 原位更新' : 'NSIS：运行安装器原位升级',
+          'UpdateService'
+        );
+        const vbsContent = buildWindowsUpdateVbs({ installerPath, portableTarget });
 
         fs.writeFileSync(vbsPath, vbsContent, 'utf-8');
 
@@ -234,18 +238,17 @@ export class UpdateService {
           app.exit(0);
         }, 500);
       } else if (process.platform === 'darwin') {
-        // macOS: 打开 DMG 文件，用户需要手动拖拽安装
+        // macOS: 自动挂载 DMG → 原子替换 .app（定位到则自动；定位不到回退手动 open DMG）。只换 .app、不碰 data。
         const { spawn } = require('child_process');
-
-        // 创建一个 shell 脚本来处理更新
         const scriptPath = path.join(app.getPath('temp'), 'flowz_update.sh');
 
-        // 脚本内容：等待应用退出，挂载 DMG，复制新版本，卸载 DMG，启动新版本
-        const scriptContent = `#!/bin/bash
-sleep 2
-# 打开 DMG 文件让用户手动安装
-open "${installerPath}"
-`;
+        const appBundlePath = macAppBundleFromExe(app.getPath('exe'));
+        this.logManager.addLog(
+          'info',
+          appBundlePath ? `自动替换 .app: ${appBundlePath}` : '定位 .app 失败，回退手动拖拽',
+          'UpdateService'
+        );
+        const scriptContent = buildMacUpdateScript({ dmgPath: installerPath, appBundlePath });
 
         fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
 
@@ -263,9 +266,21 @@ open "${installerPath}"
           app.exit(0);
         }, 1000);
       } else {
-        // Linux: 直接打开安装包
-        await shell.openPath(installerPath);
-        this.logManager.addLog('info', '安装程序已启动，正在退出应用...', 'UpdateService');
+        // Linux: AppImage(loose, $APPIMAGE) → 覆盖原 AppImage 原位更新 + 重启（只换文件、不碰 ~/.config）；
+        // deb(installed) → 交 dpkg/GUI 安装器原位升级（openPath，原行为）。
+        const appImageTarget = process.env.APPIMAGE || null;
+        if (appImageTarget && installerPath.endsWith('.AppImage')) {
+          const { spawn } = require('child_process');
+          const scriptPath = path.join(app.getPath('temp'), 'flowz_update.sh');
+          const scriptContent = buildLinuxAppImageScript({ installerPath, appImageTarget });
+          fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
+          const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' });
+          child.unref();
+          this.logManager.addLog('info', `AppImage 原位更新: ${appImageTarget}`, 'UpdateService');
+        } else {
+          await shell.openPath(installerPath);
+          this.logManager.addLog('info', '安装程序已启动，正在退出应用...', 'UpdateService');
+        }
         setTimeout(() => {
           this.destroyTrayForExit();
           app.exit(0);
@@ -620,15 +635,16 @@ open "${installerPath}"
   }
 
   private findSuitableAsset(assets: any[]): any | null {
-    // 纯逻辑在 update-asset，此处仅注入 process 平台/架构 + 便携态（PORTABLE_EXECUTABLE_DIR
-    // 由 electron-builder portable 运行时注入，与 paths/ResourceManager 的便携判定同源），
-    // 使 Windows 便携/安装版各取对应 .exe（#72）。
-    return findSuitableUpdateAsset(
-      assets,
-      process.platform,
-      process.arch,
-      !!process.env.PORTABLE_EXECUTABLE_DIR
-    );
+    // 纯逻辑在 update-asset，此处仅注入 process 平台/架构 + 运行形态（loose vs installed），
+    // 使每平台各取对应包（#72）。loose 检测：win=PORTABLE_EXECUTABLE_DIR / linux=APPIMAGE
+    // （均 electron-builder 运行时注入，与 paths/ResourceManager 的便携判定同源）；mac 只有 DMG、不用。
+    const looseForm =
+      process.platform === 'win32'
+        ? !!process.env.PORTABLE_EXECUTABLE_DIR
+        : process.platform === 'linux'
+          ? !!process.env.APPIMAGE
+          : false;
+    return findSuitableUpdateAsset(assets, process.platform, process.arch, looseForm);
   }
 
   private isNewerVersion(latest: string, current: string): boolean {

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -14,6 +14,7 @@ import { system32 } from '../utils/win-system32';
 import { compareSemver } from '../../shared/version';
 import { ghMirrorUrl } from '../../shared/gh-proxy';
 import { createIdleTimeout, parseExpectedBytes } from './download-hardening';
+import { findSuitableUpdateAsset } from './update-asset';
 
 // 下载停滞超时：连接/下载 30s 无数据即视为卡死 → abort + 失败兜底（github 链接自动换镜像重试一次）。
 // 防永久挂起致更新永不 resolve（进度窗/对话框永久转圈）。正常下载持续有 data、不断重置、不会误触发。
@@ -619,27 +620,15 @@ open "${installerPath}"
   }
 
   private findSuitableAsset(assets: any[]): any | null {
-    const platform = process.platform;
-    const arch = process.arch;
-
-    if (platform === 'win32') {
-      const winAsset = assets.find((a: any) => a.name.endsWith('.exe') && a.name.includes('win'));
-      return winAsset || null;
-    } else if (platform === 'darwin') {
-      const archPattern = arch === 'arm64' ? 'mac-arm64' : 'mac-x64';
-      let asset = assets.find((a: any) => a.name.includes(archPattern) && a.name.endsWith('.dmg'));
-      if (!asset) {
-        asset = assets.find((a: any) => a.name.endsWith('.dmg'));
-      }
-      return asset || null;
-    } else if (platform === 'linux') {
-      let asset = assets.find((a: any) => a.name.endsWith('.AppImage'));
-      if (!asset) {
-        asset = assets.find((a: any) => a.name.endsWith('.deb'));
-      }
-      return asset || null;
-    }
-    return null;
+    // 纯逻辑在 update-asset，此处仅注入 process 平台/架构 + 便携态（PORTABLE_EXECUTABLE_DIR
+    // 由 electron-builder portable 运行时注入，与 paths/ResourceManager 的便携判定同源），
+    // 使 Windows 便携/安装版各取对应 .exe（#72）。
+    return findSuitableUpdateAsset(
+      assets,
+      process.platform,
+      process.arch,
+      !!process.env.PORTABLE_EXECUTABLE_DIR
+    );
   }
 
   private isNewerVersion(latest: string, current: string): boolean {

--- a/src/main/services/__tests__/update-asset.test.ts
+++ b/src/main/services/__tests__/update-asset.test.ts
@@ -1,5 +1,6 @@
 /**
- * findSuitableUpdateAsset 纯逻辑（#72）：Windows setup/portable 按运行形态消歧 + 跨平台不串台。
+ * findSuitableUpdateAsset 纯逻辑（#72）：按运行形态（loose vs installed）选对应包，跨平台不串台。
+ * looseForm = 当前是否以 loose 形态运行（win: 便携 / linux: AppImage；mac 不用）。
  */
 import { findSuitableUpdateAsset } from '../update-asset';
 
@@ -15,14 +16,16 @@ const RELEASE = [
 ];
 
 describe('findSuitableUpdateAsset — Windows setup/portable 消歧 (#72)', () => {
-  it('便携态 → 取 portable.exe（而非 setup）', () => {
-    const a = findSuitableUpdateAsset(RELEASE, 'win32', 'x64', true);
-    expect(a?.name).toBe('FlowZ-4.0.4-win-x64-portable.exe');
+  it('loose(便携) → portable.exe', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'win32', 'x64', true)?.name).toBe(
+      'FlowZ-4.0.4-win-x64-portable.exe'
+    );
   });
 
-  it('安装态(NSIS) → 取 setup.exe（而非 portable）', () => {
-    const a = findSuitableUpdateAsset(RELEASE, 'win32', 'x64', false);
-    expect(a?.name).toBe('FlowZ-4.0.4-win-x64-setup.exe');
+  it('installed(NSIS) → setup.exe', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'win32', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-win-x64-setup.exe'
+    );
   });
 
   it('选择与资产数组顺序无关（setup 在前也不误选）', () => {
@@ -35,14 +38,14 @@ describe('findSuitableUpdateAsset — Windows setup/portable 消歧 (#72)', () =
     );
   });
 
-  it('仅 setup 包：便携态退而取 setup（尽力而为）', () => {
+  it('仅 setup 包：loose 退而取 setup（尽力而为）', () => {
     const only = [A('FlowZ-4.0.4-win-x64-setup.exe')];
     expect(findSuitableUpdateAsset(only, 'win32', 'x64', true)?.name).toBe(
       'FlowZ-4.0.4-win-x64-setup.exe'
     );
   });
 
-  it('仅 portable 包：安装态退而取 portable', () => {
+  it('仅 portable 包：installed 退而取 portable', () => {
     const only = [A('FlowZ-4.0.4-win-x64-portable.exe')];
     expect(findSuitableUpdateAsset(only, 'win32', 'x64', false)?.name).toBe(
       'FlowZ-4.0.4-win-x64-portable.exe'
@@ -60,16 +63,47 @@ describe('findSuitableUpdateAsset — Windows setup/portable 消歧 (#72)', () =
   });
 
   it('畸形双词包（名含 setup 又含 portable）→ 行为按数组首个命中（钉死现状）', () => {
-    // electron-builder 不会产出这种名字；此处仅钉死 find 短路语义、防无声漂移。
     const malformed = [A('FlowZ-portable-setup.exe-win.exe'), A('FlowZ-win-x64-portable.exe')];
-    // 便携态：isPortable 先命中首个畸形包
     expect(findSuitableUpdateAsset(malformed, 'win32', 'x64', true)?.name).toBe(
       'FlowZ-portable-setup.exe-win.exe'
     );
   });
 });
 
-describe('findSuitableUpdateAsset — mac/linux 保持原行为', () => {
+describe('findSuitableUpdateAsset — Linux AppImage/deb 形态感知 (#72)', () => {
+  it('loose(AppImage 运行) → .AppImage', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'linux', 'x64', true)?.name).toBe(
+      'FlowZ-4.0.4-linux-x86_64.AppImage'
+    );
+  });
+
+  it('installed(deb) → .deb（修旧逻辑恒先 AppImage 致 deb 用户被错配）', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'linux', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-linux-amd64.deb'
+    );
+  });
+
+  it('loose 但无 AppImage → 回退 .deb', () => {
+    const debOnly = [A('FlowZ-4.0.4-linux-amd64.deb')];
+    expect(findSuitableUpdateAsset(debOnly, 'linux', 'x64', true)?.name).toBe(
+      'FlowZ-4.0.4-linux-amd64.deb'
+    );
+  });
+
+  it('installed 但无 deb → 回退 AppImage', () => {
+    const appOnly = [A('FlowZ-4.0.4-linux-x86_64.AppImage')];
+    expect(findSuitableUpdateAsset(appOnly, 'linux', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-linux-x86_64.AppImage'
+    );
+  });
+
+  it('无 linux 包 → null', () => {
+    const noLinux = [A('FlowZ-4.0.4-mac-arm64.dmg')];
+    expect(findSuitableUpdateAsset(noLinux, 'linux', 'x64', true)).toBeNull();
+  });
+});
+
+describe('findSuitableUpdateAsset — macOS（不分形态）', () => {
   it('darwin arm64 → mac-arm64 .dmg', () => {
     expect(findSuitableUpdateAsset(RELEASE, 'darwin', 'arm64', false)?.name).toBe(
       'FlowZ-4.0.4-mac-arm64.dmg'
@@ -86,19 +120,6 @@ describe('findSuitableUpdateAsset — mac/linux 保持原行为', () => {
   it('darwin x64 无 mac-x64 包 → 回退任意 .dmg', () => {
     expect(findSuitableUpdateAsset(RELEASE, 'darwin', 'x64', false)?.name).toBe(
       'FlowZ-4.0.4-mac-arm64.dmg'
-    );
-  });
-
-  it('linux → AppImage 优先', () => {
-    expect(findSuitableUpdateAsset(RELEASE, 'linux', 'x64', false)?.name).toBe(
-      'FlowZ-4.0.4-linux-x86_64.AppImage'
-    );
-  });
-
-  it('linux 无 AppImage → 回退 .deb', () => {
-    const debOnly = [A('FlowZ-4.0.4-linux-amd64.deb'), A('FlowZ-4.0.4-mac-arm64.dmg')];
-    expect(findSuitableUpdateAsset(debOnly, 'linux', 'x64', false)?.name).toBe(
-      'FlowZ-4.0.4-linux-amd64.deb'
     );
   });
 

--- a/src/main/services/__tests__/update-asset.test.ts
+++ b/src/main/services/__tests__/update-asset.test.ts
@@ -1,0 +1,108 @@
+/**
+ * findSuitableUpdateAsset 纯逻辑（#72）：Windows setup/portable 按运行形态消歧 + 跨平台不串台。
+ */
+import { findSuitableUpdateAsset } from '../update-asset';
+
+const A = (name: string) => ({ name, browser_download_url: `https://x/${name}` });
+
+// v4.0.4 真实 release 全量资产（混平台，验选择不串台）。
+const RELEASE = [
+  A('FlowZ-4.0.4-linux-amd64.deb'),
+  A('FlowZ-4.0.4-linux-x86_64.AppImage'),
+  A('FlowZ-4.0.4-mac-arm64.dmg'),
+  A('FlowZ-4.0.4-win-x64-portable.exe'),
+  A('FlowZ-4.0.4-win-x64-setup.exe'),
+];
+
+describe('findSuitableUpdateAsset — Windows setup/portable 消歧 (#72)', () => {
+  it('便携态 → 取 portable.exe（而非 setup）', () => {
+    const a = findSuitableUpdateAsset(RELEASE, 'win32', 'x64', true);
+    expect(a?.name).toBe('FlowZ-4.0.4-win-x64-portable.exe');
+  });
+
+  it('安装态(NSIS) → 取 setup.exe（而非 portable）', () => {
+    const a = findSuitableUpdateAsset(RELEASE, 'win32', 'x64', false);
+    expect(a?.name).toBe('FlowZ-4.0.4-win-x64-setup.exe');
+  });
+
+  it('选择与资产数组顺序无关（setup 在前也不误选）', () => {
+    const reordered = [A('FlowZ-4.0.4-win-x64-setup.exe'), A('FlowZ-4.0.4-win-x64-portable.exe')];
+    expect(findSuitableUpdateAsset(reordered, 'win32', 'x64', true)?.name).toBe(
+      'FlowZ-4.0.4-win-x64-portable.exe'
+    );
+    expect(findSuitableUpdateAsset(reordered, 'win32', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-win-x64-setup.exe'
+    );
+  });
+
+  it('仅 setup 包：便携态退而取 setup（尽力而为）', () => {
+    const only = [A('FlowZ-4.0.4-win-x64-setup.exe')];
+    expect(findSuitableUpdateAsset(only, 'win32', 'x64', true)?.name).toBe(
+      'FlowZ-4.0.4-win-x64-setup.exe'
+    );
+  });
+
+  it('仅 portable 包：安装态退而取 portable', () => {
+    const only = [A('FlowZ-4.0.4-win-x64-portable.exe')];
+    expect(findSuitableUpdateAsset(only, 'win32', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-win-x64-portable.exe'
+    );
+  });
+
+  it('无 Windows .exe → null', () => {
+    const noWin = [A('FlowZ-4.0.4-mac-arm64.dmg'), A('FlowZ-4.0.4-linux-amd64.deb')];
+    expect(findSuitableUpdateAsset(noWin, 'win32', 'x64', true)).toBeNull();
+  });
+
+  it('空资产 → null（守 winExe.length===0）', () => {
+    expect(findSuitableUpdateAsset([], 'win32', 'x64', true)).toBeNull();
+    expect(findSuitableUpdateAsset([], 'win32', 'x64', false)).toBeNull();
+  });
+
+  it('畸形双词包（名含 setup 又含 portable）→ 行为按数组首个命中（钉死现状）', () => {
+    // electron-builder 不会产出这种名字；此处仅钉死 find 短路语义、防无声漂移。
+    const malformed = [A('FlowZ-portable-setup.exe-win.exe'), A('FlowZ-win-x64-portable.exe')];
+    // 便携态：isPortable 先命中首个畸形包
+    expect(findSuitableUpdateAsset(malformed, 'win32', 'x64', true)?.name).toBe(
+      'FlowZ-portable-setup.exe-win.exe'
+    );
+  });
+});
+
+describe('findSuitableUpdateAsset — mac/linux 保持原行为', () => {
+  it('darwin arm64 → mac-arm64 .dmg', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'darwin', 'arm64', false)?.name).toBe(
+      'FlowZ-4.0.4-mac-arm64.dmg'
+    );
+  });
+
+  it('darwin x64 有 mac-x64 包 → 精确命中 mac-x64', () => {
+    const withX64 = [...RELEASE, A('FlowZ-4.0.4-mac-x64.dmg')];
+    expect(findSuitableUpdateAsset(withX64, 'darwin', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-mac-x64.dmg'
+    );
+  });
+
+  it('darwin x64 无 mac-x64 包 → 回退任意 .dmg', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'darwin', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-mac-arm64.dmg'
+    );
+  });
+
+  it('linux → AppImage 优先', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'linux', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-linux-x86_64.AppImage'
+    );
+  });
+
+  it('linux 无 AppImage → 回退 .deb', () => {
+    const debOnly = [A('FlowZ-4.0.4-linux-amd64.deb'), A('FlowZ-4.0.4-mac-arm64.dmg')];
+    expect(findSuitableUpdateAsset(debOnly, 'linux', 'x64', false)?.name).toBe(
+      'FlowZ-4.0.4-linux-amd64.deb'
+    );
+  });
+
+  it('未知平台 → null', () => {
+    expect(findSuitableUpdateAsset(RELEASE, 'freebsd' as NodeJS.Platform, 'x64', false)).toBeNull();
+  });
+});

--- a/src/main/services/__tests__/update-install-script.test.ts
+++ b/src/main/services/__tests__/update-install-script.test.ts
@@ -1,0 +1,106 @@
+/**
+ * 更新安装脚本生成（#72 P2/B6）：钉死三平台 loose 原位更新的关键操作与回退分支、引号转义。
+ * 执行是真机项；本测只验生成的脚本字符串结构正确。
+ */
+import {
+  buildWindowsUpdateVbs,
+  buildLinuxAppImageScript,
+  buildMacUpdateScript,
+  macAppBundleFromExe,
+} from '../update-install-script';
+
+describe('buildWindowsUpdateVbs', () => {
+  const tmp = 'C:\\Users\\u\\AppData\\Local\\Temp\\FlowZ-portable.exe';
+
+  it('便携态：覆盖回原 exe 原位 + 启动原位 + 删临时；含覆盖失败回退', () => {
+    const target = 'D:\\Apps\\FlowZ.exe';
+    const s = buildWindowsUpdateVbs({ installerPath: tmp, portableTarget: target });
+    // 覆盖回原 exe（双反斜杠转义）
+    expect(s).toContain(
+      'fso.CopyFile "C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-portable.exe", "D:\\\\Apps\\\\FlowZ.exe", True'
+    );
+    // 成功 → 跑原位 + 删临时
+    expect(s).toContain('WshShell.Run """D:\\\\Apps\\\\FlowZ.exe"""');
+    expect(s).toContain('If Err.Number = 0 Then');
+    expect(s).toContain('Else'); // 覆盖失败回退跑临时
+    expect(s).toMatch(/\r\n/); // VBS 用 CRLF
+  });
+
+  it('NSIS 态：跑下载的 setup、无 CopyFile（原行为）', () => {
+    const s = buildWindowsUpdateVbs({ installerPath: tmp, portableTarget: null });
+    expect(s).toContain(
+      'WshShell.Run """C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-portable.exe"""'
+    );
+    expect(s).not.toContain('fso.CopyFile');
+  });
+});
+
+describe('buildLinuxAppImageScript', () => {
+  it('覆盖回原 AppImage + chmod + 重启；覆盖失败回退跑临时', () => {
+    const s = buildLinuxAppImageScript({
+      installerPath: '/tmp/FlowZ-new.AppImage',
+      appImageTarget: '/home/u/Apps/FlowZ.AppImage',
+    });
+    expect(s).toContain("NEW='/tmp/FlowZ-new.AppImage'");
+    expect(s).toContain("DEST='/home/u/Apps/FlowZ.AppImage'");
+    expect(s).toContain('cp -f "$NEW" "$DEST"');
+    expect(s).toContain('chmod +x "$DEST"');
+    expect(s).toContain('nohup "$DEST"');
+    expect(s).toContain('nohup "$NEW"'); // 回退
+    expect(s.startsWith('#!/bin/bash')).toBe(true);
+  });
+
+  it('单引号路径安全转义', () => {
+    const s = buildLinuxAppImageScript({
+      installerPath: "/tmp/it's.AppImage",
+      appImageTarget: '/a/b.AppImage',
+    });
+    expect(s).toContain("NEW='/tmp/it'\\''s.AppImage'");
+  });
+});
+
+describe('buildMacUpdateScript', () => {
+  it('有 .app 路径：mv 原子替换 + osascript 落盘脚本提权 + 删 DMG + 重启（brick 安全 H1/H2/M2）', () => {
+    const s = buildMacUpdateScript({
+      dmgPath: '/tmp/FlowZ.dmg',
+      appBundlePath: '/Applications/FlowZ.app',
+    });
+    expect(s).toContain('hdiutil attach');
+    expect(s).toContain('ditto "$SRC" "$STAGE"');
+    // mv-swap 原子替换 + 回滚（绝不先毁后建）
+    expect(s).toContain('mv "$DEST" "$BAK"');
+    expect(s).toContain('mv "$STAGE" "$DEST"');
+    expect(s).toContain('mv "$BAK" "$DEST"'); // 回滚
+    // H1：绝无「先 rm 目标再建」的不可恢复 brick 路径
+    expect(s).not.toContain("rm -rf '$DEST'");
+    // H2：提权命令落盘脚本 + osascript 单层引号跑 bash，路径 printf %q 转义（免三层引号脆弱性）
+    expect(s).toContain('with administrator privileges');
+    expect(s).toContain("/bin/bash '$ELEV'");
+    expect(s).toContain('printf %q');
+    // M2：清历史中断遗留的暂存
+    expect(s).toContain('.flowz-update-*.app');
+    expect(s).toContain('xattr -dr com.apple.quarantine');
+    expect(s).toContain('rm -f "$DMG"'); // 删 DMG 避免累积
+    expect(s).toContain('open "$DEST"');
+  });
+
+  it('无 .app 路径：回退原行为仅 open DMG', () => {
+    const s = buildMacUpdateScript({ dmgPath: '/tmp/FlowZ.dmg', appBundlePath: null });
+    expect(s).toContain("open '/tmp/FlowZ.dmg'");
+    expect(s).not.toContain('hdiutil');
+    expect(s).not.toContain('ditto');
+  });
+});
+
+describe('macAppBundleFromExe', () => {
+  it('标准路径 → .app 包', () => {
+    expect(macAppBundleFromExe('/Applications/FlowZ.app/Contents/MacOS/FlowZ')).toBe(
+      '/Applications/FlowZ.app'
+    );
+  });
+
+  it('非 .app 布局 → null', () => {
+    expect(macAppBundleFromExe('/usr/local/bin/flowz')).toBeNull();
+    expect(macAppBundleFromExe('C:\\Apps\\FlowZ.exe')).toBeNull();
+  });
+});

--- a/src/main/services/update-asset.ts
+++ b/src/main/services/update-asset.ts
@@ -1,0 +1,46 @@
+/**
+ * App 更新安装包的资产选择（纯逻辑，process 平台/架构/便携态由调用方注入，便于单测）。
+ *
+ * 与 singbox-asset.findSuitableSingboxAsset 同模式：UpdateService.findSuitableAsset 仅注入 process.*。
+ *
+ * #72 根因：Windows 同时发布 setup(NSIS) 与 portable 两种 .exe（electron-builder.json win.target），
+ * 旧逻辑 `assets.find(.exe && includes('win'))` 取首个匹配、**不区分 setup/portable** → 便携版可能命中
+ * setup 包 → 跑 NSIS 装出一份全新 FlowZ（落 %LOCALAPPDATA%\Programs\FlowZ，与便携 exe 非同处）→
+ * 用户「每次更新完多一个 flowz、不知在哪」。这里按运行形态（PORTABLE_EXECUTABLE_DIR）选对应包。
+ */
+export function findSuitableUpdateAsset(
+  assets: any[],
+  platform: NodeJS.Platform,
+  arch: string,
+  portable: boolean
+): any | null {
+  if (platform === 'win32') {
+    // 保持旧筛选口径（.exe 且名含 'win'），仅在其中按运行形态消歧 setup/portable。
+    const winExe = assets.filter((a: any) => a.name.endsWith('.exe') && a.name.includes('win'));
+    if (winExe.length === 0) return null;
+    // 名字同含 setup 与 portable 的畸形包未定义（electron-builder 不产出），按 find 短路=数组首个命中，
+    // 不为它牺牲正常包的「顺序无关」（见 update-asset.test.ts 钉死现状）。
+    const isPortable = (a: any) => a.name.toLowerCase().includes('portable');
+    const isSetup = (a: any) => a.name.toLowerCase().includes('setup');
+    if (portable) {
+      // 便携版：取 portable 包；无则退取非 setup；再不行取首个（单包 release 兜底）。
+      return winExe.find(isPortable) ?? winExe.find((a: any) => !isSetup(a)) ?? winExe[0];
+    }
+    // 安装版(NSIS)：取 setup 包；无则退取非 portable；再不行取首个。
+    return winExe.find(isSetup) ?? winExe.find((a: any) => !isPortable(a)) ?? winExe[0];
+  } else if (platform === 'darwin') {
+    const archPattern = arch === 'arm64' ? 'mac-arm64' : 'mac-x64';
+    let asset = assets.find((a: any) => a.name.includes(archPattern) && a.name.endsWith('.dmg'));
+    if (!asset) {
+      asset = assets.find((a: any) => a.name.endsWith('.dmg'));
+    }
+    return asset || null;
+  } else if (platform === 'linux') {
+    let asset = assets.find((a: any) => a.name.endsWith('.AppImage'));
+    if (!asset) {
+      asset = assets.find((a: any) => a.name.endsWith('.deb'));
+    }
+    return asset || null;
+  }
+  return null;
+}

--- a/src/main/services/update-asset.ts
+++ b/src/main/services/update-asset.ts
@@ -1,18 +1,20 @@
 /**
- * App 更新安装包的资产选择（纯逻辑，process 平台/架构/便携态由调用方注入，便于单测）。
+ * App 更新安装包的资产选择（纯逻辑，process 平台/架构/运行形态由调用方注入，便于单测）。
  *
  * 与 singbox-asset.findSuitableSingboxAsset 同模式：UpdateService.findSuitableAsset 仅注入 process.*。
  *
- * #72 根因：Windows 同时发布 setup(NSIS) 与 portable 两种 .exe（electron-builder.json win.target），
- * 旧逻辑 `assets.find(.exe && includes('win'))` 取首个匹配、**不区分 setup/portable** → 便携版可能命中
- * setup 包 → 跑 NSIS 装出一份全新 FlowZ（落 %LOCALAPPDATA%\Programs\FlowZ，与便携 exe 非同处）→
- * 用户「每次更新完多一个 flowz、不知在哪」。这里按运行形态（PORTABLE_EXECUTABLE_DIR）选对应包。
+ * #72：每平台都有「loose（无安装器，单文件原位跑）」与「installed（经安装器/包管理器）」两形态，
+ * 必须按**当前运行形态**选对应包，否则错配（如便携被发 NSIS setup → 装出多余副本「凭空多一个 flowz」）。
+ *   - Windows：portable.exe(loose) / nsis setup.exe(installed)
+ *   - Linux：  AppImage(loose) / .deb(installed)
+ *   - macOS：  只有 DMG（.app 始终 loose），不分形态。
+ * `looseForm` = 当前是否以 loose 形态运行（win: PORTABLE_EXECUTABLE_DIR / linux: APPIMAGE；mac 不用）。
  */
 export function findSuitableUpdateAsset(
   assets: any[],
   platform: NodeJS.Platform,
   arch: string,
-  portable: boolean
+  looseForm: boolean
 ): any | null {
   if (platform === 'win32') {
     // 保持旧筛选口径（.exe 且名含 'win'），仅在其中按运行形态消歧 setup/portable。
@@ -22,11 +24,11 @@ export function findSuitableUpdateAsset(
     // 不为它牺牲正常包的「顺序无关」（见 update-asset.test.ts 钉死现状）。
     const isPortable = (a: any) => a.name.toLowerCase().includes('portable');
     const isSetup = (a: any) => a.name.toLowerCase().includes('setup');
-    if (portable) {
-      // 便携版：取 portable 包；无则退取非 setup；再不行取首个（单包 release 兜底）。
+    if (looseForm) {
+      // 便携(loose)：取 portable 包；无则退取非 setup；再不行取首个（单包 release 兜底）。
       return winExe.find(isPortable) ?? winExe.find((a: any) => !isSetup(a)) ?? winExe[0];
     }
-    // 安装版(NSIS)：取 setup 包；无则退取非 portable；再不行取首个。
+    // 安装(NSIS)：取 setup 包；无则退取非 portable；再不行取首个。
     return winExe.find(isSetup) ?? winExe.find((a: any) => !isPortable(a)) ?? winExe[0];
   } else if (platform === 'darwin') {
     const archPattern = arch === 'arm64' ? 'mac-arm64' : 'mac-x64';
@@ -36,11 +38,15 @@ export function findSuitableUpdateAsset(
     }
     return asset || null;
   } else if (platform === 'linux') {
-    let asset = assets.find((a: any) => a.name.endsWith('.AppImage'));
-    if (!asset) {
-      asset = assets.find((a: any) => a.name.endsWith('.deb'));
+    // 形态感知（修旧逻辑「恒先 AppImage」致 deb 用户被发 AppImage、无法经 dpkg 更新）：
+    const appImage = assets.filter((a: any) => a.name.endsWith('.AppImage'));
+    const deb = assets.filter((a: any) => a.name.endsWith('.deb'));
+    if (looseForm) {
+      // AppImage(loose) 运行：取 AppImage；无则退 .deb。
+      return appImage[0] ?? deb[0] ?? null;
     }
-    return asset || null;
+    // deb 安装：取 .deb（dpkg 原位升级）；无则退 AppImage。
+    return deb[0] ?? appImage[0] ?? null;
   }
   return null;
 }

--- a/src/main/services/update-install-script.ts
+++ b/src/main/services/update-install-script.ts
@@ -1,0 +1,168 @@
+/**
+ * 更新安装脚本生成（纯字符串，便于 Linux 单测钉死 Windows/macOS/Linux 引号与回退分支；执行是真机项）。
+ *
+ * #72 loose 形态原位更新（无安装器，需显式覆盖单文件）：
+ * - Windows 便携：覆盖回原便携 exe（`PORTABLE_EXECUTABLE_FILE`）再从原位启动。
+ * - Linux AppImage：覆盖回原 `$APPIMAGE` 文件 + chmod+x 再启动。
+ * - macOS .app：自动挂载 DMG → 暂存 → 原子替换 `/Applications/FlowZ.app`（带备份回滚）→ 重启。
+ * 失败一律回退原行为（跑临时副本 / open DMG），绝不留破损件。
+ *
+ * 「只换单个产物文件、不碰用户数据」不变量（loose 形态原位更新安全的根据）：
+ *   配置/已更新内核/规则都在**独立的 data 目录**，不在产物文件里——
+ *   · Windows 便携：`<exe 同级>\data\`（config + core_update + rules）
+ *   · Linux AppImage：`~/.config/FlowZ`（XDG userData）
+ *   · macOS：`~/Library/Application Support/FlowZ`
+ *   故覆盖 exe / AppImage / .app 单个产物 → data 原样保留 → 用户配置与已更新内核零丢失。
+ *   installed 形态（NSIS / dpkg）由安装器自身原位升级，亦不动各自 data 目录。
+ */
+
+/** VBS 字符串字面量里的反斜杠按既有约定双写（与旧 installUpdate 一致，Windows 容忍双反斜杠路径）。 */
+const vbsPath = (p: string): string => p.replace(/\\/g, '\\\\');
+
+/** bash 单引号安全转义。 */
+const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Windows 更新 VBS。portableTarget 非空=便携态（覆盖回原 exe 再启动）；否则=NSIS（运行下载的 setup，原行为逐字保留）。
+ * 便携只覆盖 exe 一个文件，exe 同级 `data\`（config/core_update/rules）原样保留。
+ */
+export function buildWindowsUpdateVbs(opts: {
+  installerPath: string;
+  portableTarget?: string | null;
+}): string {
+  const src = vbsPath(opts.installerPath);
+  if (opts.portableTarget) {
+    const dst = vbsPath(opts.portableTarget);
+    return [
+      'WScript.Sleep 2000',
+      'Set WshShell = CreateObject("WScript.Shell")',
+      'Set fso = CreateObject("Scripting.FileSystemObject")',
+      'On Error Resume Next',
+      // 只覆盖便携 exe 这一个文件（运行进程实跑在 %TEMP% 解压副本，原 exe 未被锁，可覆盖）；
+      // exe 同级 data\ 不动 → 用户配置 + 已更新内核(core_update) 零丢失。
+      `fso.CopyFile "${src}", "${dst}", True`,
+      'If Err.Number = 0 Then',
+      '  Err.Clear',
+      // 覆盖成功 → 从原位置启动新版（持久更新），并清掉临时下载包
+      `  WshShell.Run """${dst}""", 1, False`,
+      `  fso.DeleteFile "${src}", True`,
+      'Else',
+      '  Err.Clear',
+      // 覆盖失败（原位只读/占用）→ 退回跑临时副本，至少本次拿到新版（不删临时包）
+      `  WshShell.Run """${src}""", 1, False`,
+      'End If',
+      'On Error Goto 0',
+      'fso.DeleteFile WScript.ScriptFullName, True',
+    ].join('\r\n');
+  }
+  // NSIS 安装态：与旧 installUpdate 逐字等价（运行 setup + 删自身）。NSIS 据注册表记住的目录原位升级、不动 %APPDATA% data。
+  return [
+    'WScript.Sleep 2000',
+    'Set WshShell = CreateObject("WScript.Shell")',
+    `WshShell.Run """${src}""", 1, False`,
+    'Set fso = CreateObject("Scripting.FileSystemObject")',
+    'fso.DeleteFile WScript.ScriptFullName, True',
+  ].join('\r\n');
+}
+
+/**
+ * Linux AppImage 原位更新脚本：覆盖回原 `$APPIMAGE` 文件 + chmod+x + 重启；失败退回跑临时新版。
+ * 只换 AppImage 一个文件，`~/.config/FlowZ`（config/core_update/rules）不动 → 用户数据零丢失。
+ * deb 安装态不走此函数（installUpdate 仍 openPath(.deb) 交 dpkg 原位升级）。
+ */
+export function buildLinuxAppImageScript(opts: {
+  installerPath: string;
+  appImageTarget: string;
+}): string {
+  const src = shq(opts.installerPath);
+  const dst = shq(opts.appImageTarget);
+  return [
+    '#!/bin/bash',
+    'sleep 2',
+    `NEW=${src}`,
+    `DEST=${dst}`,
+    // 只覆盖 AppImage 这一个文件；~/.config/FlowZ 不动 → 配置 + 已更新内核零丢失。
+    'if cp -f "$NEW" "$DEST" 2>/dev/null; then',
+    '  chmod +x "$DEST" 2>/dev/null',
+    '  rm -f "$NEW" 2>/dev/null',
+    '  nohup "$DEST" >/dev/null 2>&1 &',
+    'else',
+    // 覆盖失败（原 AppImage 只读/无权限）→ 跑临时新版，至少本次拿到新版（不删临时）
+    '  chmod +x "$NEW" 2>/dev/null',
+    '  nohup "$NEW" >/dev/null 2>&1 &',
+    'fi',
+    '',
+  ].join('\n');
+}
+
+/**
+ * macOS 更新脚本（原子替换，避免 DMG 累积）。appBundlePath 非空=自动替换 .app；为空（定位不到 .app）=回退 open DMG。
+ * 提权策略：先**无提权** mv 原子替换（/Applications 对 admin 用户组可写，绝大多数免密码）；失败才 osascript 一次性
+ * 管理员授权（系统原生密码框，**不依赖常驻 helper**）。
+ * brick 安全（review H1/H2）：替换一律「mv 暂存↔目标」，**绝不先 rm 目标再建**；任一步失败回滚旧版、**保留 $BAK 不删**；
+ * 提权步骤把替换命令落盘成脚本、osascript 只跑 `bash '<脚本>'`（单层引号，复用 runRootScript 套路；路径经 printf %q
+ * 转义，免三层引号脆弱性）；仅当 $DEST 确为新版到位才善后（删 BAK/STAGE/DMG），否则保留可恢复 + 回退手动。
+ */
+export function buildMacUpdateScript(opts: {
+  dmgPath: string;
+  appBundlePath?: string | null;
+}): string {
+  const dmg = shq(opts.dmgPath);
+  if (!opts.appBundlePath) {
+    return ['#!/bin/bash', 'sleep 2', `open ${dmg}`, ''].join('\n');
+  }
+  const dest = shq(opts.appBundlePath);
+  return [
+    '#!/bin/bash',
+    'sleep 2',
+    `DMG=${dmg}`,
+    `DEST=${dest}`,
+    'BAK="$DEST.bak-$$"',
+    'STAGE="$(dirname "$DEST")/.flowz-update-$$.app"',
+    // 清历史中断遗留的暂存（M2，防 /Applications 下 .flowz-update-*.app 垃圾堆积）
+    'rm -rf "$(dirname "$DEST")"/.flowz-update-*.app 2>/dev/null',
+    // 挂载 DMG（失败=极罕见→回退手动 open，唯一保留 DMG 的分支）
+    'MNT=$(hdiutil attach "$DMG" -nobrowse -noautoopen -mountrandom /tmp 2>/dev/null | grep -o "/tmp/[^[:space:]]*" | tail -1)',
+    '[ -z "$MNT" ] && { open "$DMG"; exit 0; }',
+    'SRC=$(/usr/bin/find "$MNT" -maxdepth 1 -name "*.app" | head -1)',
+    '[ -z "$SRC" ] && { hdiutil detach "$MNT" >/dev/null 2>&1; rm -f "$DMG"; exit 0; }',
+    // 整包暂存到目标同卷（mv 原子），失败即清理退出
+    'rm -rf "$STAGE"',
+    'if ! ditto "$SRC" "$STAGE"; then hdiutil detach "$MNT" >/dev/null 2>&1; rm -rf "$STAGE"; rm -f "$DMG"; exit 0; fi',
+    'hdiutil detach "$MNT" >/dev/null 2>&1',
+    // 原子替换（mv-swap，绝不先毁后建；失败回滚旧版、保留 $BAK 可恢复）。先尝试无提权。
+    'replace() {',
+    '  mv "$DEST" "$BAK" 2>/dev/null || return 1',
+    '  if mv "$STAGE" "$DEST" 2>/dev/null; then rm -rf "$BAK"; return 0; fi',
+    '  mv "$BAK" "$DEST" 2>/dev/null; return 1',
+    '}',
+    'if ! replace; then',
+    // 无提权失败 → 把同一 mv-swap 落盘成脚本（路径 printf %q 转义），osascript 一次性 root 跑 `bash '<脚本>'`（单层引号）
+    '  ELEV="$(dirname "$DEST")/.flowz-elev-$$.sh"',
+    '  cat > "$ELEV" <<EOF',
+    '#!/bin/bash',
+    'mv $(printf %q "$DEST") $(printf %q "$BAK") || exit 1',
+    'mv $(printf %q "$STAGE") $(printf %q "$DEST") || { mv $(printf %q "$BAK") $(printf %q "$DEST"); exit 1; }',
+    'rm -rf $(printf %q "$BAK")',
+    'EOF',
+    '  osascript -e "do shell script \\"/bin/bash \'$ELEV\'\\" with administrator privileges" 2>/dev/null',
+    '  rm -f "$ELEV"',
+    'fi',
+    // 仅当新版确到位（$DEST 存在且无残留 $BAK=替换成功）才善后；失败则 $BAK/$STAGE 保留可人工恢复、不删 DMG 便于重试
+    'if [ -d "$DEST" ] && [ ! -d "$BAK" ]; then',
+    '  xattr -dr com.apple.quarantine "$DEST" 2>/dev/null',
+    '  rm -rf "$STAGE" 2>/dev/null',
+    '  rm -f "$DMG"',
+    '  open "$DEST"',
+    'else',
+    '  open "$DMG"',
+    'fi',
+    '',
+  ].join('\n');
+}
+
+/** 从可执行路径推导 .app 包路径（/Applications/FlowZ.app/Contents/MacOS/FlowZ → /Applications/FlowZ.app）；不匹配返回 null。 */
+export function macAppBundleFromExe(exePath: string): string | null {
+  const m = exePath.match(/^(.*\.app)\/Contents\/MacOS\/[^/]+$/);
+  return m ? m[1] : null;
+}


### PR DESCRIPTION
Closes #72

## 问题
更新器按「首个 .exe」选包、不区分 setup/portable（Linux 同理 AppImage/deb 恒先 AppImage）。便携用户被错装成 NSIS 全新副本（落 `%LOCALAPPDATA%\Programs\FlowZ`，与便携 exe 非同处）→「每次更新完多一个 flowz、找不到」。

## 修复（按 installed vs loose 形态）
- 形态感知选包 `findSuitableUpdateAsset`：loose（win 便携 `PORTABLE_EXECUTABLE_DIR` / linux `APPIMAGE`）取 portable/AppImage；installed 取 setup/deb。
- loose 原位更新：win 覆盖回 `PORTABLE_EXECUTABLE_FILE`、linux 覆盖 `$APPIMAGE`+chmod、mac 挂载 DMG → `mv` 原子替换 `/Applications/FlowZ.app`（无提权优先，失败 osascript 一次性提权跑落盘脚本；**brick 安全：绝不先毁后建、失败保留备份回滚**）+ 删 temp DMG。
- 只换单产物、不碰 data 目录（win exe 旁 / linux `~/.config` / mac `~/Library`）→ 配置 + 已更新内核零丢失。installed 形态由安装器自身原位升级。

## 验证
脚本生成纯函数化 + Linux 单测钉死引号/提权/回退分支；mac mv-swap brick 安全经 Linux 沙箱实测（成功→新版、失败→旧版恢复绝不丢）。tsc + 全量单测 + build 全绿。
**真机待验**：当前已是最新版本、无可更新触发原子替换（依赖自动化测试 + review 定稿）。