### PR TITLE
fix(tray): 修复切节点/重启后菜单栏图标状态与主程序不一致

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1215,6 +1215,11 @@ if (gotTheLock) {
     };
 
     proxyManager.on('started', async () => {
+      // 托盘刷新（与 on('stopped') 对称，#75）：所有 start 路径最终都汇入此事件——含 switchMode / 节点回退 /
+      // 崩溃后 attemptAutoRestart 的内部 stop→start（stopped 腿已把托盘刷成断开态，此处不刷则卡在
+      // 「已断开 / 启用代理」而进程实际在跑）。放在首行确保后续 await 抛错也不漏刷；IPC/托盘/startup 的
+      // 显式 updateTrayMenuState(true) 退化为幂等冗余。
+      void updateTrayMenuState(true);
       statsService?.start();
       subscriptionScheduler?.onProxyStarted(); // 代理就绪 → 补跑因 viaProxy 跳过的启动订阅更新
       try {

--- a/src/main/services/__tests__/tray-manager-menu.test.ts
+++ b/src/main/services/__tests__/tray-manager-menu.test.ts
@@ -1,0 +1,126 @@
+/**
+ * TrayManager 菜单映射回归（#75）。
+ *
+ * 守护「托盘状态头 / 启停开关 / 图标」三者恒与 isProxyRunning 一致」——即同一次渲染内不可能出现
+ * 「状态头=已连接 而 开关=启用代理」这种自相矛盾（截图里的现象其实是托盘整体停在断开态、未随
+ * 代理 started 刷新；根因修复在 index.ts on('started') 补刷，本测守住菜单映射这一半）。
+ *
+ * 仅依赖 electron / ResourceManager mock；不拉主进程 bootstrap。
+ */
+
+// ── electron mock：捕获 Menu.buildFromTemplate 传入的模板以做断言 ──────────────
+let lastTemplate: any[] = [];
+const buildFromTemplate = jest.fn((tpl: any[]) => {
+  lastTemplate = tpl;
+  return { __menu: true };
+});
+const imgStub: any = { resize: () => imgStub, isEmpty: () => false };
+
+jest.mock('electron', () => ({
+  app: { getLocale: () => 'zh-CN', isPackaged: false },
+  BrowserWindow: class {},
+  Tray: class {
+    setToolTip = jest.fn();
+    setImage = jest.fn();
+    setContextMenu = jest.fn();
+    destroy = jest.fn();
+    on = jest.fn();
+  },
+  Menu: { buildFromTemplate: (tpl: any[]) => buildFromTemplate(tpl) },
+  nativeImage: {
+    createFromPath: () => imgStub,
+    createFromDataURL: () => imgStub,
+    createFromBuffer: () => imgStub,
+    createEmpty: () => imgStub,
+  },
+}));
+
+// loadTrayIcon 内 require('./ResourceManager')，给个返回固定路径的桩（真实 fs.existsSync 对该路径返回 false
+// → 走 createDefaultTrayIcon → nativeImage.createFromDataURL，全部命中上面的桩）。
+const getTrayIconPath = jest.fn((_connected?: boolean) => '/nonexistent/tray-icon.png');
+jest.mock('../ResourceManager', () => ({
+  resourceManager: { getTrayIconPath: (connected?: boolean) => getTrayIconPath(connected) },
+}));
+
+import { TrayManager, type TrayMenuData } from '../TrayManager';
+
+const makeLogger = () => ({ addLog: jest.fn() }) as any;
+
+const baseData = (isProxyRunning: boolean): TrayMenuData => ({
+  isProxyRunning,
+  servers: [],
+  subscriptions: [],
+  selectedServerId: null,
+  proxyMode: 'smart',
+  proxyModeType: 'tun',
+});
+
+/** 从最近一次模板里取「状态头」label 与「启停开关」label。 */
+function readMenu(): { status: string; toggle: string } {
+  const status = String(lastTemplate[0]?.label ?? '');
+  const toggleItem = lastTemplate.find((i) => i?.label === '启用代理' || i?.label === '禁用代理');
+  return { status, toggle: String(toggleItem?.label ?? '') };
+}
+
+function makeTray(): TrayManager {
+  const tm = new TrayManager(null, makeLogger(), {});
+  tm.createTray();
+  return tm;
+}
+
+beforeEach(() => {
+  lastTemplate = [];
+  buildFromTemplate.mockClear();
+  getTrayIconPath.mockClear();
+});
+
+describe('TrayManager 菜单状态映射 (#75)', () => {
+  it('代理运行中 → 状态头「已连接」且开关「禁用代理」', () => {
+    const tm = makeTray();
+    tm.updateFullTrayMenu(baseData(true));
+
+    const { status, toggle } = readMenu();
+    expect(status).toBe('已连接');
+    expect(toggle).toBe('禁用代理');
+    // 状态头带圆点图标（connected）
+    expect(lastTemplate[0]?.icon).toBe(imgStub);
+  });
+
+  it('代理已停止 → 状态头「已断开」且开关「启用代理」', () => {
+    const tm = makeTray();
+    tm.updateFullTrayMenu(baseData(false));
+
+    const { status, toggle } = readMenu();
+    expect(status).toBe('已断开');
+    expect(toggle).toBe('启用代理');
+  });
+
+  it('hasError → 状态头「连接异常」（开关仍按运行态）', () => {
+    const tm = makeTray();
+    tm.updateFullTrayMenu({ ...baseData(false), hasError: true });
+    expect(readMenu().status).toBe('连接异常');
+  });
+
+  it('不变量：状态头与开关恒一致，绝不出现「已连接 + 启用代理」', () => {
+    const tm = makeTray();
+    for (const running of [true, false, true, false]) {
+      tm.updateFullTrayMenu(baseData(running));
+      const { status, toggle } = readMenu();
+      if (status === '已连接') expect(toggle).toBe('禁用代理');
+      if (status === '已断开') expect(toggle).toBe('启用代理');
+    }
+  });
+
+  it('updateTrayMenu(true) 简化入口也渲染连接态', () => {
+    const tm = makeTray();
+    tm.updateTrayMenu(true);
+    expect(readMenu()).toEqual({ status: '已连接', toggle: '禁用代理' });
+  });
+
+  it('updateTrayIcon(connected) 取彩色图标并 setImage', () => {
+    const tm = makeTray();
+    tm.updateTrayIcon('connected');
+    // getTrayIconPath(connected=true)
+    expect(getTrayIconPath).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
Closes #75

## 问题
托盘 `on('stopped')` 刷新菜单而 `on('started')` 不刷 → switchMode 切节点/切接管方式、节点回退、崩溃后自动重启、PROXY_RESTART 这些「内部 stop→start」被 stopped 腿刷成「已断开」后、started 腿不补 → 托盘图标/状态/「启用代理」卡在断开态，而代理实际在跑（issue 截图：主窗已连接、菜单栏仍显已断开）。

## 修复
`on('started')` 首行补 `void updateTrayMenuState(true)`，与 `on('stopped')` 对称，使 started 事件成为托盘连接态单一真值——覆盖所有重启型 start（含散点补刷漏掉的崩溃自愈路径）。补 TrayManager 菜单映射回归单测。

## 验证
tsc + 全量单测 + build 全绿。macOS 菜单栏真机待验。