### PR TITLE
feat(dns): #57 节点域名解析前置(resolve-ahead) — 主进程并发多上游 DoH 预解析节点域名为 IP

### DIFF
--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -142,7 +142,9 @@ export class DiagnosticService {
       redactedSingboxConfig: redactedSingbox,
       appLogTail,
       singboxLogTail,
-      nodeIdentifiers: collectNodeIdentifiers(config),
+      // #57 resolve-ahead：把预解析得到的节点 IP 一并纳入身份脱敏（它们已写进 redactedSingboxConfig 的
+      // outbound.server，但不在 config.servers 里 → 不补会以明文漏进报告）。
+      nodeIdentifiers: collectNodeIdentifiers(config, this.proxyManager.getResolvedNodeIps()),
       hint: wantDeeper
         ? `当前日志级别为 ${effLevel}，未含 DNS 解析等连接详情，但日志中已出现连接/DNS 类错误。建议到 设置 → 高级 → 诊断 开启「诊断采集」，复现问题后再次导出可获得更完整的根因数据。`
         : undefined,

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -51,6 +51,7 @@ import {
   buildOutbounds,
   type PendingRuleSelector,
 } from './singbox-outbound-builder';
+import { resolveNodeDomains, upstreamsForResolverMode } from './node-domain-resolver';
 import { retry } from '../utils/retry';
 import { coreVersionAtLeast } from '../../shared/version';
 import { parseTailscaleAuthLine } from '../../shared/tailscale';
@@ -116,6 +117,7 @@ export interface IProxyManager {
   getStatus(): ProxyStatus;
   isStartedViaHelper(): boolean;
   generateSingBoxConfig(config: UserConfig, resolvedIps?: Record<string, string>): SingBoxConfig;
+  getResolvedNodeIps(): string[];
   on(
     event: 'started' | 'stopped' | 'error' | 'node-hot-switched',
     listener: (...args: any[]) => void
@@ -151,6 +153,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // 供 generateDnsConfig 把内网/captive 域名重定向到它（takeover 后 dns-local=公网解不了内网）+ rule C 直连放行防环。
   // null=无可用 LAN 解析器（非 TUN/关/DHCP 读不到/仅公网）→ 退回 dns-local。每次 start 入口重置重读。
   private lanResolverForDns: string | null = null;
+  // #57 resolve-ahead：节点服务器域名→IP 预解析表（域名作 key）。仅 start 路径（开关开时）在 generateSingBoxConfig
+  // 前用并发多上游 DoH 填充，由 generateSingBoxConfig 透传 buildOutbounds → buildProxyOutbound 写 outbound.server。
+  // 空 Map=现状（域名）：snapshot/preflight/speedtest/未启动路径恒空 → 生成物逐字节回现状。模块级 TTL 缓存使重启廉价。
+  private lastResolvedHosts: Map<string, string> = new Map();
   // 杀核前「静默 clash_api 客户端」回调（停 StatsService 轮询 + 关其到 9090 的 keep-alive 连接）：让 client 主动关
   // → 9090 不进 TIME_WAIT → 下次用户态 sing-box 免撞 root TIME_WAIT 等 30s（P0-2 治本 TIME_WAIT）。
   private quiesceClashClients: (() => void) | null = null;
@@ -450,6 +456,44 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           'info',
           `DNS 接管：内网/captive 域名将经原 LAN 解析器 ${this.lanResolverForDns} 解析`
         );
+      }
+    }
+
+    // 3.9 #57 resolve-ahead：start 前把代理节点【服务器域名】并发多上游(DoH)预解析为 IP → this.lastResolvedHosts，
+    //     供 generateSingBoxConfig→buildProxyOutbound 写 outbound.server（SNI/Host 仍原域名），使拨号不依赖运行时
+    //     单点 DNS（#57 L1 根治）。开关 resolveNodeDomainsAhead 默认开；解析失败的域名不进表→回退原域名（既有
+    //     dns-bootstrap 兜底，零回归）。整批受预算硬约束，绝不无限阻塞 start。与上方 resolvedServerIps（Windows
+    //     TUN route_exclude，serverId→IP）正交：键/用途不同、互不影响。
+    this.lastResolvedHosts = new Map();
+    if (config.dnsConfig?.resolveNodeDomainsAhead !== false) {
+      // 仅普通拨号出站参与（buildProxyOutbound 路径）；custom 透传 / wireguard·tailscale endpoint 走各自构造、
+      // 不读 resolvedHosts，故不预解析（与 doc：v1 不纳入 WG peer / 账号制 mesh）。IP 字面量由 resolveNodeDomains 跳过。
+      const skipProtocols = new Set(['custom', 'wireguard', 'tailscale']);
+      const nodeDomains = new Set<string>();
+      for (const s of config.servers) {
+        if (skipProtocols.has((s.protocol || '').toLowerCase())) continue;
+        const addr = s.address?.trim();
+        if (addr) nodeDomains.add(addr); // resolveNodeDomains 内部再去重 + 跳过 IP 字面量
+      }
+      if (nodeDomains.size > 0) {
+        const t0 = Date.now();
+        try {
+          // 解析档位（nodeDomainResolver）决定预解析上游：auto=AliDNS+DNSPod DoH / dnspod=DNSPod / system=纯系统 DNS。
+          this.lastResolvedHosts = await resolveNodeDomains([...nodeDomains], {
+            upstreams: upstreamsForResolverMode(config.dnsConfig?.nodeDomainResolver),
+          });
+          this.logToManager(
+            'info',
+            `节点域名解析前置：已将 ${this.lastResolvedHosts.size} 个节点域名预解析为 IP，耗时 ${Date.now() - t0}ms`
+          );
+        } catch (e) {
+          // 预解析整体异常绝不阻断启动：清空表 → 全部回退原域名（现状行为）。
+          this.lastResolvedHosts = new Map();
+          this.logToManager(
+            'warn',
+            `节点域名解析前置失败，回退域名: ${(e as Error)?.message ?? e}`
+          );
+        }
       }
     }
 
@@ -1654,6 +1698,14 @@ done
   }
 
   /**
+   * #57 resolve-ahead：本次预解析得到的节点 IP（写进了 outbound.server）。供 DiagnosticService 把这些
+   * config.servers 之外的真实节点 IP 一并按节点身份脱敏（<ip-N>），杜绝漏进诊断报告（红线：零节点身份明文）。
+   */
+  getResolvedNodeIps(): string[] {
+    return [...this.lastResolvedHosts.values()];
+  }
+
+  /**
    * 生成 sing-box 配置（sing-box 1.12.x / 1.13.x 兼容格式）
    */
   generateSingBoxConfig(config: UserConfig, resolvedIps?: Record<string, string>): SingBoxConfig {
@@ -1708,6 +1760,8 @@ done
       coreVersion: this.coreVersion,
       gateInvalidNodes: this.gateInvalidNodes,
       log: (level, message) => this.logToManager(level, message),
+      // #57 resolve-ahead：透传预解析表（startInternal 前置填充）。空 Map → buildProxyOutbound 回退原域名（现状）。
+      resolvedHosts: this.lastResolvedHosts,
     });
     this.pendingEndpoints = outboundsResult.pendingEndpoints;
     this.pendingRuleSelectors = outboundsResult.pendingRuleSelectors;

--- a/src/main/services/__tests__/node-domain-resolver.test.ts
+++ b/src/main/services/__tests__/node-domain-resolver.test.ts
@@ -1,0 +1,230 @@
+/**
+ * #57 resolve-ahead 解析器单测 —— 全 mock，零真实网络（本项目铁律：本机禁触宿主网络）。
+ * 注入 doh / systemResolve4 / now / cache，验证分层 race / 去重 / IP 跳过 / TTL / 预算 / Tier 优先级。
+ */
+import {
+  resolveNodeDomains,
+  upstreamsForResolverMode,
+  DOH_UPSTREAMS,
+  DOH_DNSPOD,
+  type NodeResolveOptions,
+} from '../node-domain-resolver';
+
+const SINGLE = ['https://u1/dns-query'];
+
+/** doh 返回固定 IP（不论上游/域名）。 */
+const dohConst = (ip: string) => jest.fn(async (_u: string, _d: string, _s: AbortSignal) => [ip]);
+
+describe('resolveNodeDomains — Tier1 DoH', () => {
+  it('单上游返回 A → 写入 map', async () => {
+    const doh = dohConst('1.2.3.4');
+    const map = await resolveNodeDomains(['node.example.com'], {
+      doh,
+      upstreams: SINGLE,
+      cache: new Map(),
+    });
+    expect(map.get('node.example.com')).toBe('1.2.3.4');
+  });
+
+  it('多上游 first-valid：快上游胜出', async () => {
+    const doh = jest.fn(async (u: string, _d: string, _s: AbortSignal) => {
+      if (u.includes('slow')) {
+        await new Promise((r) => setTimeout(r, 60));
+        return ['9.9.9.9'];
+      }
+      return ['2.2.2.2']; // 快上游立即返回
+    });
+    const map = await resolveNodeDomains(['n.example.com'], {
+      doh,
+      upstreams: ['https://slow/dns-query', 'https://fast/dns-query'],
+      cache: new Map(),
+    });
+    expect(map.get('n.example.com')).toBe('2.2.2.2');
+  });
+
+  it('上游返回空/无 A → 不取空，转 Tier2', async () => {
+    const doh = jest.fn(async () => [] as string[]);
+    const systemResolve4 = jest.fn(async () => ['8.8.4.4']);
+    const map = await resolveNodeDomains(['n.example.com'], {
+      doh,
+      systemResolve4,
+      upstreams: SINGLE,
+      cache: new Map(),
+    });
+    expect(map.get('n.example.com')).toBe('8.8.4.4');
+    expect(systemResolve4).toHaveBeenCalledTimes(1);
+  });
+
+  it('DoH 成功时不调用系统 DNS（系统不抢跑）', async () => {
+    const doh = dohConst('1.1.1.1');
+    const systemResolve4 = jest.fn(async () => ['8.8.8.8']);
+    const map = await resolveNodeDomains(['n.example.com'], {
+      doh,
+      systemResolve4,
+      upstreams: SINGLE,
+      cache: new Map(),
+    });
+    expect(map.get('n.example.com')).toBe('1.1.1.1');
+    expect(systemResolve4).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveNodeDomains — 兜底与降级', () => {
+  it('Tier1 抛错 + Tier2 抛错 → 不进 map（回退域名）', async () => {
+    const doh = jest.fn(async () => {
+      throw new Error('doh down');
+    });
+    const systemResolve4 = jest.fn(async () => {
+      throw new Error('servfail');
+    });
+    const map = await resolveNodeDomains(['n.example.com'], {
+      doh,
+      systemResolve4,
+      upstreams: SINGLE,
+      cache: new Map(),
+    });
+    expect(map.has('n.example.com')).toBe(false);
+  });
+
+  it('整批预算超时：挂死上游不阻塞，返回空 map', async () => {
+    // doh 永不 resolve，仅在 signal abort 时 reject；预算 50ms 应令整批快速结束。
+    const doh = jest.fn(
+      (_u: string, _d: string, signal: AbortSignal) =>
+        new Promise<string[]>((_res, rej) => {
+          signal.addEventListener('abort', () => rej(new Error('aborted')), { once: true });
+        })
+    );
+    const systemResolve4 = jest.fn(async () => ['1.1.1.1']); // 预算耗尽后不应被调用
+    const start = Date.now();
+    const map = await resolveNodeDomains(['n.example.com'], {
+      doh,
+      systemResolve4,
+      upstreams: SINGLE,
+      perUpstreamTimeoutMs: 1000,
+      totalBudgetMs: 50,
+      cache: new Map(),
+    });
+    expect(map.size).toBe(0);
+    expect(systemResolve4).not.toHaveBeenCalled(); // budget aborted → 跳过 Tier2
+    expect(Date.now() - start).toBeLessThan(900); // 远早于 per-upstream 1000ms
+  });
+});
+
+describe('resolveNodeDomains — 去重 / IP 字面量', () => {
+  it('重复域名只解析一次', async () => {
+    const seen: string[] = [];
+    const doh = jest.fn(async (_u: string, d: string) => {
+      seen.push(d);
+      return ['5.5.5.5'];
+    });
+    await resolveNodeDomains(['a.com', 'a.com', 'b.com', ' a.com '], {
+      doh,
+      upstreams: SINGLE,
+      cache: new Map(),
+    });
+    expect(seen.sort()).toEqual(['a.com', 'b.com']); // a.com 去重（含 trim）
+  });
+
+  it('IP 字面量（v4/v6）跳过，不调用 doh', async () => {
+    const doh = jest.fn(async () => ['7.7.7.7']);
+    const map = await resolveNodeDomains(['1.2.3.4', '2001:db8::1', 'real.example.com'], {
+      doh,
+      upstreams: SINGLE,
+      cache: new Map(),
+    });
+    expect(map.has('1.2.3.4')).toBe(false);
+    expect(map.has('2001:db8::1')).toBe(false);
+    expect(map.get('real.example.com')).toBe('7.7.7.7');
+    expect(doh).toHaveBeenCalledTimes(1); // 仅 real.example.com
+  });
+
+  it('空入参 / 全 IP 入参 → 空 map，零 doh', async () => {
+    const doh = jest.fn(async () => ['7.7.7.7']);
+    expect((await resolveNodeDomains([], { doh, cache: new Map() })).size).toBe(0);
+    expect((await resolveNodeDomains(['1.2.3.4'], { doh, cache: new Map() })).size).toBe(0);
+    expect(doh).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveNodeDomains — TTL 缓存', () => {
+  it('未过期命中缓存，不重复 doh；过期后重解析', async () => {
+    const cache = new Map();
+    let clock = 1000;
+    const doh = jest.fn(async () => ['3.3.3.3']);
+    const common: NodeResolveOptions = {
+      doh,
+      upstreams: SINGLE,
+      cache,
+      ttlMs: 5000,
+      now: () => clock,
+    };
+
+    // t=1000：解析，写缓存 expireAt=6000
+    await resolveNodeDomains(['x.com'], common);
+    expect(doh).toHaveBeenCalledTimes(1);
+
+    // t=2000 < 6000：命中缓存，doh 不再调用
+    clock = 2000;
+    const hit = await resolveNodeDomains(['x.com'], common);
+    expect(hit.get('x.com')).toBe('3.3.3.3');
+    expect(doh).toHaveBeenCalledTimes(1);
+
+    // t=7000 > 6000：过期，重解析
+    clock = 7000;
+    await resolveNodeDomains(['x.com'], common);
+    expect(doh).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('默认上游池', () => {
+  it('含 AliDNS + DNSPod IP-DoH', () => {
+    expect(DOH_UPSTREAMS).toContain('https://223.5.5.5/dns-query');
+    expect(DOH_UPSTREAMS).toContain('https://1.12.12.12/dns-query');
+  });
+});
+
+describe('upstreamsForResolverMode — 档位 → 预解析上游', () => {
+  it('auto/缺省 → AliDNS+DNSPod 池；dnspod → 仅 DNSPod；system → 空池（纯系统 DNS）', () => {
+    expect(upstreamsForResolverMode('auto')).toEqual(DOH_UPSTREAMS);
+    expect(upstreamsForResolverMode(undefined)).toEqual(DOH_UPSTREAMS);
+    expect(upstreamsForResolverMode('dnspod')).toEqual([DOH_DNSPOD]);
+    expect(upstreamsForResolverMode('system')).toEqual([]);
+  });
+
+  it('system（空上游池）→ 跳过 DoH，直接用系统 DNS', async () => {
+    const doh = jest.fn(async () => ['9.9.9.9']);
+    const systemResolve4 = jest.fn(async () => ['10.0.0.5']);
+    const map = await resolveNodeDomains(['n.example.com'], {
+      doh,
+      systemResolve4,
+      upstreams: upstreamsForResolverMode('system'),
+      cache: new Map(),
+    });
+    expect(map.get('n.example.com')).toBe('10.0.0.5');
+    expect(doh).not.toHaveBeenCalled(); // 空池 → 不发 DoH
+    expect(systemResolve4).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('并发池', () => {
+  it('maxConcurrency 限流下全部域名仍解析，且同时在飞数不超上限', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const doh = jest.fn(async (_u: string, d: string) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return [`1.1.1.${d.length}`];
+    });
+    const domains = Array.from({ length: 10 }, (_v, i) => `n${i}.example.com`);
+    const map = await resolveNodeDomains(domains, {
+      doh,
+      upstreams: SINGLE,
+      maxConcurrency: 3,
+      cache: new Map(),
+    });
+    expect(map.size).toBe(10);
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+});

--- a/src/main/services/__tests__/node-resolve-ahead-integration.test.ts
+++ b/src/main/services/__tests__/node-resolve-ahead-integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #57 resolve-ahead 集成：generateSingBoxConfig 把 this.lastResolvedHosts 透传到节点 outbound.server。
+ * 本项目铁律：DNS runtime 改动须以生成物验证。这里验证「线」——预解析表填充时 server=IP 且 SNI=原域名；
+ * 空表（默认/未启动/snapshot 路径）时 server 仍=域名（逐字节回现状由 config-snapshot.test 另行守护）。
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-resolve-ahead-'));
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => TMP,
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => TMP,
+  },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import { buildFixtures, NODE_A, NODE_B, NODE_IP } from './dns-resolver-fixtures';
+
+type AnyCfg = any;
+
+const IP_A = '203.0.113.10';
+const IP_B = '203.0.113.11';
+
+function tunSmartConfig() {
+  return buildFixtures().find((f) => f.name === 'tun-smart__auto')!.config;
+}
+function outboundByTag(cfg: AnyCfg, tag: string): AnyCfg {
+  return (cfg.outbounds as AnyCfg[]).find((o) => o.tag === tag);
+}
+
+describe('#57 resolve-ahead：lastResolvedHosts → outbound.server（SNI 不变）', () => {
+  it('填充预解析表 → 节点 server=IP，tls.server_name 仍=原域名/SNI', () => {
+    const pm = new ProxyManager();
+    // 私有字段：模拟 startInternal 预解析后的状态（仅解析 server.address，不含 SNI）。
+    (pm as unknown as { lastResolvedHosts: Map<string, string> }).lastResolvedHosts = new Map([
+      [NODE_A.address, IP_A],
+      [NODE_B.address, IP_B],
+    ]);
+    const cfg = pm.generateSingBoxConfig(tunSmartConfig()) as AnyCfg;
+
+    const a = outboundByTag(cfg, NODE_A.name); // 香港 A（vless + 显式 SNI）
+    expect(a.server).toBe(IP_A);
+    expect(a.tls.server_name).toBe('sni-a.example.net'); // SNI 未被 IP 覆盖
+
+    const b = outboundByTag(cfg, NODE_B.name); // 美国 B（trojan，SNI=域名）
+    expect(b.server).toBe(IP_B);
+    expect(b.tls.server_name).toBe('b.trycloudflare.com');
+
+    const ipNode = outboundByTag(cfg, NODE_IP.name); // IP 字面量节点不在表 → 原样
+    expect(ipNode.server).toBe('203.0.113.7');
+  });
+
+  it('空预解析表（默认）→ 节点 server 仍=原域名（现状）', () => {
+    const pm = new ProxyManager(); // lastResolvedHosts 默认空 Map
+    const cfg = pm.generateSingBoxConfig(tunSmartConfig()) as AnyCfg;
+    expect(outboundByTag(cfg, NODE_A.name).server).toBe(NODE_A.address);
+    expect(outboundByTag(cfg, NODE_B.name).server).toBe(NODE_B.address);
+  });
+
+  it('部分命中：未解析的节点回退域名，已解析的写 IP', () => {
+    const pm = new ProxyManager();
+    (pm as unknown as { lastResolvedHosts: Map<string, string> }).lastResolvedHosts = new Map([
+      [NODE_A.address, IP_A], // 仅 A 解析成功
+    ]);
+    const cfg = pm.generateSingBoxConfig(tunSmartConfig()) as AnyCfg;
+    expect(outboundByTag(cfg, NODE_A.name).server).toBe(IP_A);
+    expect(outboundByTag(cfg, NODE_B.name).server).toBe(NODE_B.address); // B 回退域名
+  });
+
+  it('Shadow-TLS：外层 shadowtls 出站 server 也写解析 IP，SNI 仍=原 sni（拨号目标全覆盖）', () => {
+    const cfg = JSON.parse(JSON.stringify(tunSmartConfig()));
+    const STLS_ADDR = 'stls.example.com';
+    cfg.servers.push({
+      id: 'node-stls',
+      name: 'STLS 节点',
+      protocol: 'shadowsocks',
+      address: STLS_ADDR,
+      port: 443,
+      shadowsocksSettings: { method: 'aes-128-gcm', password: 'pw' },
+      shadowTlsSettings: { password: 'stlspw', sni: 'sni-stls.example.net', port: 8443 },
+    });
+    const pm = new ProxyManager();
+    (pm as unknown as { lastResolvedHosts: Map<string, string> }).lastResolvedHosts = new Map([
+      [STLS_ADDR, '203.0.113.20'],
+    ]);
+    const sb = pm.generateSingBoxConfig(cfg) as AnyCfg;
+    const stls = (sb.outbounds as AnyCfg[]).find((o) => o.type === 'shadowtls');
+    expect(stls.server).toBe('203.0.113.20'); // 外层拨号目标 = IP
+    expect(stls.tls.server_name).toBe('sni-stls.example.net'); // 身份 SNI 不被 IP 覆盖
+  });
+});

--- a/src/main/services/__tests__/singbox-outbound-builder.test.ts
+++ b/src/main/services/__tests__/singbox-outbound-builder.test.ts
@@ -5,6 +5,7 @@
  */
 import {
   buildWireGuardEndpoint,
+  buildProxyOutbound,
   isNodeUsable,
   prunedSelectorDefault,
 } from '../singbox-outbound-builder';
@@ -101,5 +102,88 @@ describe('prunedSelectorDefault', () => {
     expect(prunedSelectorDefault('proxy-selector', [])).toBeUndefined();
     // rule-sel 恒嵌套回 proxy-selector，与成员是否剔空无关。
     expect(prunedSelectorDefault('rule-sel-y', [])).toBe('proxy-selector');
+  });
+});
+
+// #57 resolve-ahead：buildProxyOutbound 的 resolvedHosts 仅改 outbound.server，绝不动 SNI/server_name。
+describe('buildProxyOutbound — resolve-ahead（resolvedHosts → outbound.server）', () => {
+  const DOMAIN = 'node.example.com';
+  const IP = '203.0.113.7';
+  const idMap = new Map<string, string>();
+  const RESOLVED: ReadonlyMap<string, string> = new Map([[DOMAIN, IP]]);
+  const srv = (over: Partial<ServerConfig>): ServerConfig =>
+    ({ id: 'x', name: 'X', address: DOMAIN, port: 443, ...over }) as unknown as ServerConfig;
+
+  it('命中：server=IP，但 tls.server_name 仍= 显式 SNI（不被 IP 覆盖）', () => {
+    const ob = buildProxyOutbound(
+      srv({
+        protocol: 'vless',
+        uuid: 'u',
+        security: 'tls',
+        tlsSettings: { serverName: 'sni.example.net' },
+      }),
+      idMap,
+      'dns-bootstrap',
+      RESOLVED
+    );
+    expect(ob.server).toBe(IP);
+    expect(ob.tls?.server_name).toBe('sni.example.net');
+    expect(ob.domain_resolver).toBe('dns-bootstrap'); // 档位 tag 保留（回退路径仍用）
+  });
+
+  it('命中且无显式 SNI：server=IP，但 tls.server_name 回退【原域名】而非 IP（核心断言）', () => {
+    const ob = buildProxyOutbound(
+      srv({ protocol: 'trojan', password: 'pw', security: 'tls' }),
+      idMap,
+      'dns-bootstrap',
+      RESOLVED
+    );
+    expect(ob.server).toBe(IP);
+    expect(ob.tls?.server_name).toBe(DOMAIN);
+  });
+
+  it('reality 无 SNI：server=IP，server_name 仍 undefined（不被 IP 顶替）', () => {
+    const ob = buildProxyOutbound(
+      srv({
+        protocol: 'vless',
+        uuid: 'u',
+        security: 'reality',
+        realitySettings: { publicKey: 'pk', shortId: 'sid' },
+      }),
+      idMap,
+      'dns-bootstrap',
+      RESOLVED
+    );
+    expect(ob.server).toBe(IP);
+    expect(ob.tls?.server_name).toBeUndefined();
+  });
+
+  it('naive：server=IP，tls.server_name 回退原域名', () => {
+    const ob = buildProxyOutbound(
+      srv({ protocol: 'naive', username: 'u', password: 'p' }),
+      idMap,
+      'dns-bootstrap',
+      RESOLVED
+    );
+    expect(ob.server).toBe(IP);
+    expect(ob.tls?.server_name).toBe(DOMAIN);
+  });
+
+  it('未命中（map 无此域名）/ 不传 resolvedHosts → server 保持原域名（现状）', () => {
+    const base = srv({ protocol: 'trojan', password: 'pw', security: 'tls' });
+    expect(buildProxyOutbound(base, idMap, 'dns-bootstrap', new Map()).server).toBe(DOMAIN);
+    expect(buildProxyOutbound(base, idMap, 'dns-bootstrap').server).toBe(DOMAIN);
+  });
+
+  it('IP 字面量节点不在 map → server 原样（前置层不会把 IP 当 key）', () => {
+    const ipNode = srv({
+      address: '198.51.100.9',
+      protocol: 'trojan',
+      password: 'pw',
+      security: 'tls',
+    });
+    expect(buildProxyOutbound(ipNode, idMap, 'dns-bootstrap', RESOLVED).server).toBe(
+      '198.51.100.9'
+    );
   });
 });

--- a/src/main/services/node-domain-resolver.ts
+++ b/src/main/services/node-domain-resolver.ts
@@ -1,0 +1,251 @@
+/**
+ * #57 resolve-ahead：配置生成前，把代理节点服务器域名并发多上游预解析为 IP。
+ *
+ * 根因：节点域名解析绑死单点（dial→dns-bootstrap、rule1→dns-domestic），任一被限速/劫持/不可达 → 整条代理挂。
+ * sing-box 无原生 DNS fallback/racing，故在 FlowZ 主进程侧把节点域名解析成 IP 字面量、写进 outbound.server
+ * （SNI/Host 仍保留原域名，见 buildProxyOutbound）。本质 = 自动化「优选 IP」，拨号不再依赖运行时 DNS。
+ *
+ * 分层 race（抗污染）：
+ *  - Tier 1：IP-DoH 池（AliDNS 223.5.5.5 + DNSPod 1.12.12.12）并发，Promise.any 取首个返回合法 A 的；单上游超时。
+ *  - Tier 2：系统 DNS resolve4，仅在 Tier1 全失败后兜底（系统 DNS 可能被污染 → 不与 DoH 抢跑）。
+ *  - 全失败 → 该域名不进结果（调用方回退原域名，走既有 dns-bootstrap，优雅降级）。
+ *
+ * 边界：去重入参、跳过 IP 字面量、TTL 缓存（重启仅重解析过期项）、整批时间预算（绝不无限阻塞 start）。
+ * 仅解析 A（IPv4）——与关 IPv6 时 ipv4_only 一致；节点仅 v6 的极少数情形回退域名。
+ *
+ * 全部网络出入口（doh / systemResolve4 / now / cache）可注入 → 单测零真实网络（见 node-domain-resolver.test.ts）。
+ */
+import { isIpv4 } from '../../shared/ip';
+import { isIpLiteral } from '../../shared/dns';
+import { encodeDnsQuery, decodeDnsAnswers } from '../../shared/dns-wire';
+
+/** IP-DoH 端点（IP 字面量，证书含 IP SAN；与 dns-bootstrap/dns-node 同源，主进程直连可达）。 */
+export const DOH_ALIDNS = 'https://223.5.5.5/dns-query';
+export const DOH_DNSPOD = 'https://1.12.12.12/dns-query';
+/** Tier1 IP-DoH 上游池（auto 档）：AliDNS + DNSPod 并发抗污染。 */
+export const DOH_UPSTREAMS: readonly string[] = [DOH_ALIDNS, DOH_DNSPOD];
+
+export const DEFAULT_TTL_MS = 5 * 60_000; // 5min：start/restart 仅重解析过期项
+export const DEFAULT_PER_UPSTREAM_TIMEOUT_MS = 1500;
+export const DEFAULT_TOTAL_BUDGET_MS = 3000; // 整批硬上限，超时未完者按未解析处理
+export const DEFAULT_MAX_CONCURRENCY = 16; // 域名级并发上限，防大订阅一次性数百 fetch 触发上游限流/FD 压力
+
+/**
+ * 节点解析「档位」(dnsConfig.nodeDomainResolver) → 预解析上游池，使「前置开关」与「解析档位」正交：
+ * 档位选【用哪个解析器】、开关选【是否前置】，不再相互架空（修 review 重复冗余）。
+ *  - auto（缺省）→ AliDNS + DNSPod DoH 池（并发抗污染）；
+ *  - dnspod      → 仅 DNSPod DoH；
+ *  - system      → 空池（跳过 DoH，纯系统 DNS resolve4）——尊重用户显式选 system 的意图，前置仍生效。
+ */
+export function upstreamsForResolverMode(
+  mode: 'auto' | 'dnspod' | 'system' | undefined
+): readonly string[] {
+  if (mode === 'system') return [];
+  if (mode === 'dnspod') return [DOH_DNSPOD];
+  return DOH_UPSTREAMS;
+}
+
+interface CacheEntry {
+  ip: string;
+  expireAt: number;
+}
+
+export interface NodeResolveOptions {
+  /** 注入 DoH 查询（默认 fetch + dns-wire）。返回该域名的 IPv4 列表（空=无 A）。signal 触发即中断。 */
+  doh?: (upstream: string, domain: string, signal: AbortSignal) => Promise<string[]>;
+  /** 注入系统 DNS resolve4（默认 dns.promises.resolve4）。 */
+  systemResolve4?: (domain: string) => Promise<string[]>;
+  /** 注入时钟（默认 Date.now），供 TTL 单测。 */
+  now?: () => number;
+  /** 注入/复用 TTL 缓存（默认模块级单例，跨 start 持久）。 */
+  cache?: Map<string, CacheEntry>;
+  ttlMs?: number;
+  perUpstreamTimeoutMs?: number;
+  totalBudgetMs?: number;
+  upstreams?: readonly string[];
+  /** 域名级并发上限（默认 16）。整批仍受 totalBudgetMs 硬约束，池只平滑并发、不改预算上限。 */
+  maxConcurrency?: number;
+}
+
+/** 模块级 TTL 缓存单例：跨 start/restart 持久，重启廉价（仅重解析过期项）。 */
+const sharedCache = new Map<string, CacheEntry>();
+
+/** 默认 DoH：POST application/dns-message，解出 A 记录。非 2xx / 解码失败 → []。 */
+async function defaultDoh(
+  upstream: string,
+  domain: string,
+  signal: AbortSignal
+): Promise<string[]> {
+  const resp = await fetch(upstream, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/dns-message',
+      accept: 'application/dns-message',
+    },
+    body: encodeDnsQuery(domain).buffer as ArrayBuffer,
+    signal,
+  });
+  if (!resp.ok) return [];
+  return decodeDnsAnswers(new Uint8Array(await resp.arrayBuffer()));
+}
+
+/**
+ * Promise.any 等价物（避免要求 ES2021 lib）：首个 fulfilled 即 resolve；全部 reject → reject。
+ * 用于 DoH 池 first-valid——任一上游先返回合法 A 即胜出，全失败才回退 Tier2。
+ */
+function firstResolved<T>(promises: Promise<T>[]): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let pending = promises.length;
+    if (pending === 0) {
+      reject(new Error('no upstreams'));
+      return;
+    }
+    for (const p of promises) {
+      p.then(resolve, () => {
+        if (--pending === 0) reject(new Error('all upstreams failed'));
+      });
+    }
+  });
+}
+
+/** 默认系统解析：dns.promises.resolve4（与 ProxyManager 现有用法同源）。 */
+async function defaultSystemResolve4(domain: string): Promise<string[]> {
+  const dns = require('dns').promises;
+  return dns.resolve4(domain);
+}
+
+/** 把不可取消的 promise 包成「预算 signal abort 即提前 reject」（底层任务在后台自然结束，调用方不再 await）。 */
+function abortable<T>(p: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error('aborted'));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error('aborted'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    p.then(
+      (v) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(e);
+      }
+    );
+  });
+}
+
+/** 单上游 DoH：单上游超时 + 跟随整批预算中断；返回首个合法 IPv4，否则 reject（供 Promise.any 跳过）。 */
+async function attemptDoh(
+  upstream: string,
+  domain: string,
+  doh: NonNullable<NodeResolveOptions['doh']>,
+  perTimeoutMs: number,
+  budgetSignal: AbortSignal
+): Promise<string> {
+  const ctrl = new AbortController();
+  const onBudget = () => ctrl.abort();
+  budgetSignal.addEventListener('abort', onBudget, { once: true });
+  const timer = setTimeout(() => ctrl.abort(), perTimeoutMs);
+  try {
+    const ips = await doh(upstream, domain, ctrl.signal);
+    const ip = ips.find((x) => isIpv4(x));
+    if (!ip) throw new Error('no A record'); // reject → Promise.any 转向其它上游
+    return ip;
+  } finally {
+    clearTimeout(timer);
+    budgetSignal.removeEventListener('abort', onBudget);
+  }
+}
+
+/** Tier1：DoH 池并发 first-valid。全失败/空 → null。 */
+async function raceDoh(
+  domain: string,
+  opts: NodeResolveOptions,
+  budgetSignal: AbortSignal
+): Promise<string | null> {
+  const upstreams = opts.upstreams ?? DOH_UPSTREAMS;
+  const doh = opts.doh ?? defaultDoh;
+  const perTimeoutMs = opts.perUpstreamTimeoutMs ?? DEFAULT_PER_UPSTREAM_TIMEOUT_MS;
+  try {
+    return await firstResolved(
+      upstreams.map((u) => attemptDoh(u, domain, doh, perTimeoutMs, budgetSignal))
+    );
+  } catch {
+    return null; // 所有上游失败/无 A
+  }
+}
+
+/** 单域名：Tier1 DoH race → 失败兜 Tier2 系统 DNS（不抢跑）→ 全失败 null。 */
+async function resolveOne(
+  domain: string,
+  opts: NodeResolveOptions,
+  budgetSignal: AbortSignal
+): Promise<string | null> {
+  const fromDoh = await raceDoh(domain, opts, budgetSignal);
+  if (fromDoh) return fromDoh;
+  if (budgetSignal.aborted) return null; // 预算耗尽：不再发起系统解析
+  const systemResolve4 = opts.systemResolve4 ?? defaultSystemResolve4;
+  try {
+    const ips = await abortable(systemResolve4(domain), budgetSignal);
+    return ips.find((x) => isIpv4(x)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 把一组节点域名并发解析为 IP。返回 Map<域名, IP>；解析不到的域名**不进 map**（调用方回退原域名）。
+ * 入参自动去重 + 跳过 IP 字面量；命中未过期缓存直接复用；整批受 totalBudgetMs 硬约束。
+ */
+export async function resolveNodeDomains(
+  domains: string[],
+  opts: NodeResolveOptions = {}
+): Promise<Map<string, string>> {
+  const now = opts.now ?? Date.now;
+  const cache = opts.cache ?? sharedCache;
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  const totalBudgetMs = opts.totalBudgetMs ?? DEFAULT_TOTAL_BUDGET_MS;
+
+  const unique = Array.from(new Set(domains.map((d) => d.trim()).filter(Boolean))).filter(
+    (d) => !isIpLiteral(d)
+  );
+
+  const maxConcurrency = opts.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+
+  const results = new Map<string, string>();
+  const toResolve: string[] = [];
+  const tNow = now();
+  for (const d of unique) {
+    const cached = cache.get(d);
+    if (cached && cached.expireAt > tNow) {
+      results.set(d, cached.ip);
+    } else {
+      if (cached) cache.delete(d); // 顺手淘汰过期项，防模块级缓存随会话无界增长
+      toResolve.push(d);
+    }
+  }
+  if (toResolve.length === 0) return results;
+
+  const budgetCtrl = new AbortController();
+  const budgetTimer = setTimeout(() => budgetCtrl.abort(), totalBudgetMs);
+  const resolveInto = async (d: string) => {
+    const ip = await resolveOne(d, opts, budgetCtrl.signal);
+    if (ip) {
+      results.set(d, ip);
+      cache.set(d, { ip, expireAt: now() + ttlMs });
+    }
+  };
+  try {
+    // 域名级并发池（≤maxConcurrency）：大订阅去重后仍可能数百域名，无界并发会一次性打出数百 fetch →
+    // 触发上游 DoH 限流 / FD 压力。共享游标拉取，整批受 budgetCtrl 硬约束（预算到点剩余项 resolveOne 立即返 null）。
+    let cursor = 0;
+    const workers = Array.from({ length: Math.min(maxConcurrency, toResolve.length) }, async () => {
+      while (cursor < toResolve.length) {
+        await resolveInto(toResolve[cursor++]);
+      }
+    });
+    await Promise.all(workers);
+  } finally {
+    clearTimeout(budgetTimer);
+  }
+  return results;
+}

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -77,7 +77,11 @@ export function buildProxyOutbound(
   idToTagMap: Map<string, string>,
   // #57：节点域名 dial 解析器 tag，由调用方传 getNodeResolverTag(config,'dial')。
   // 缺省 dns-bootstrap（AliDNS IP-DoH）= 现状，兼容无 config 上下文的兜底调用。
-  nodeResolverTag: string = 'dns-bootstrap'
+  nodeResolverTag: string = 'dns-bootstrap',
+  // #57 resolve-ahead：域名→IP 预解析表（域名作 key）。命中则 outbound.server 写 IP、拨号不依赖运行时 DNS；
+  // 未命中（解析失败/IP 字面量/开关关）→ 回退原 server.address。SNI/Host/ws-path 一律仍用原域名（见下）。
+  // 缺省 undefined = 现状（不预解析）。
+  resolvedHosts?: ReadonlyMap<string, string>
 ): SingBoxOutbound {
   // sing-box 要求协议类型必须是小写
   const protocol = server.protocol.toLowerCase();
@@ -102,7 +106,9 @@ export function buildProxyOutbound(
   const outbound: SingBoxOutbound = {
     type: protocol,
     tag: idToTagMap.get(server.id) || `proxy-${server.id}`,
-    server: server.address,
+    // #57 resolve-ahead：命中预解析表 → 写 IP（拨号免运行时 DNS）；否则回退原域名。绝不 mutate server.address——
+    // 下方 SNI（tls/reality/naive server_name）与 ws Host 仍读 server.address（原域名），覆盖会致无显式 SNI 节点握手失败。
+    server: resolvedHosts?.get(server.address) ?? server.address,
     server_port: server.port,
     // 代理节点域名经引导解析（默认 dns-bootstrap=AliDNS IP-DoH），免疫 UDP 53 限速/劫持，
     // 避免节点解析失败导致全断流；同时防止 dns-local 死循环导致的连接挂起。
@@ -486,6 +492,9 @@ export interface OutboundsDeps {
   coreVersion: string;
   gateInvalidNodes: Map<string, InvalidNodeInfo>;
   log: (level: 'debug' | 'info' | 'warn' | 'error' | 'fatal', message: string) => void;
+  // #57 resolve-ahead：域名→IP 预解析表（this.lastResolvedHosts），透传 buildProxyOutbound 写 outbound.server。
+  // 缺省 undefined（preflight/speedtest/snapshot/未启动路径）= 现状（域名）。
+  resolvedHosts?: ReadonlyMap<string, string>;
 }
 
 /** Tailscale state 目录：`<userData>/tailscale/<serverId>`，跨重启免重认证、删节点时清理。 */
@@ -683,7 +692,12 @@ export function buildOutbounds(
         continue;
       }
       try {
-        const ob = buildProxyOutbound(server, idToTagMap, getNodeResolverTag(config, 'dial'));
+        const ob = buildProxyOutbound(
+          server,
+          idToTagMap,
+          getNodeResolverTag(config, 'dial'),
+          deps.resolvedHosts
+        );
         ob.tag = tag;
         if (server.detour && config.servers.some((s) => s.id === server.detour)) {
           // 环检测：沿 detour 链行进，若回到本节点即成环 → 不设 detour，避免 sing-box 报循环引用启动失败
@@ -804,7 +818,9 @@ export function buildOutbounds(
       const stlsOutbound: SingBoxOutbound = {
         type: 'shadowtls',
         tag: stlsTag,
-        server: srv.address,
+        // #57 resolve-ahead：外层 shadowtls 才是真正的 TCP 拨号目标（内层 SS 经 detour 指向它），同样命中预解析表
+        // 写 IP；server_name（下方 :827）仍用 shadowTlsSettings.sni（身份），不被 IP 覆盖。与 buildProxyOutbound 同语义。
+        server: deps.resolvedHosts?.get(srv.address) ?? srv.address,
         server_port: srv.shadowTlsSettings.port || srv.port,
         version: 3,
         password: srv.shadowTlsSettings.password,

--- a/src/renderer/components/settings/network-settings.tsx
+++ b/src/renderer/components/settings/network-settings.tsx
@@ -364,6 +364,18 @@ export function NetworkSettings() {
               </Select>
             </SettingsRow>
             <SettingsRow
+              label={t('settings.advanced.resolveNodeDomainsAhead', '节点域名解析前置')}
+              description={t(
+                'settings.advanced.resolveNodeDomainsAheadDesc',
+                '连接前用并发多上游 DoH 把节点服务器域名预解析为 IP，避免单点 DNS 被限速/劫持导致整条代理连不上（解析失败自动回退域名）。建议开启。'
+              )}
+            >
+              <Switch
+                checked={config.dnsConfig?.resolveNodeDomainsAhead !== false}
+                onCheckedChange={(c) => updateDns({ resolveNodeDomainsAhead: c })}
+              />
+            </SettingsRow>
+            <SettingsRow
               label={t('settings.advanced.takeoverSystemDns', 'TUN 接管系统 DNS')}
               description={t(
                 'settings.advanced.takeoverSystemDnsDesc',

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -475,6 +475,8 @@
       "nodeResolverDnspod": "DNSPod",
       "nodeResolverSystem": "System DNS",
       "nodeResolverExperimental": "experimental",
+      "resolveNodeDomainsAhead": "Resolve node domains ahead",
+      "resolveNodeDomainsAheadDesc": "Before connecting, pre-resolve node server domains to IPs via concurrent multi-upstream DoH, so a single throttled/hijacked DNS can't take down the whole proxy (falls back to the domain on failure; SNI still uses the original domain). Recommended.",
       "takeoverSystemDns": "Take over system DNS in TUN",
       "takeoverSystemDnsDesc": "In TUN, temporarily set system DNS to 8.8.8.8 so proxied domains resolve through the tunnel (auto-restored on stop). Off is friendlier for internal domains but some proxied domains may resolve wrong. Recommended on.",
       "mainSessionViaProxy": "Update checks via proxy",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -475,6 +475,8 @@
       "nodeResolverDnspod": "DNSPod",
       "nodeResolverSystem": "系统 DNS",
       "nodeResolverExperimental": "实验性",
+      "resolveNodeDomainsAhead": "节点域名解析前置",
+      "resolveNodeDomainsAheadDesc": "连接前用并发多上游 DoH 把节点服务器域名预解析为 IP，避免单点 DNS 被限速/劫持导致整条代理连不上（解析失败自动回退域名，SNI 仍用原域名）。建议开启。",
       "takeoverSystemDns": "TUN 接管系统 DNS",
       "takeoverSystemDnsDesc": "TUN 模式临时把系统 DNS 改为 8.8.8.8，让代理域名经隧道正确解析（停止自动还原）。关闭更利于内网域名，但部分代理域名可能解析异常。建议开启。",
       "mainSessionViaProxy": "更新检查走代理",

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -278,6 +278,30 @@ describe('collectNodeIdentifiers — 节点标识符提取 + 类型化占位（P
     expect(ids).toHaveLength(1);
     expect(ids[0].placeholder).toBe('<domain-1>');
   });
+
+  it('#57 resolve-ahead：extraAddresses（预解析节点 IP）按 <ip-N> 一并收集、去重', () => {
+    const ids = collectNodeIdentifiers(
+      { servers: [{ address: 'hk.airport.com' }] }, // 域名 → <domain-1>
+      ['203.0.113.55', '203.0.113.55', '198.51.100.9'] // 预解析 IP（含重复）
+    );
+    const map = Object.fromEntries(ids.map((i) => [i.value, i.placeholder]));
+    expect(map['hk.airport.com']).toBe('<domain-1>');
+    expect(map['203.0.113.55']).toBe('<ip-1>');
+    expect(map['198.51.100.9']).toBe('<ip-2>');
+    expect(ids).toHaveLength(3); // 重复 IP 去重
+  });
+
+  it('#57：预解析 IP 经 redactIdentifiers 在配置文本里被打码（杜绝真实节点 IP 明文泄漏）', () => {
+    const ids = collectNodeIdentifiers({ servers: [{ address: 'hk.airport.com' }] }, [
+      '203.0.113.55',
+    ]);
+    // 模拟报告里 outbound.server 已是预解析 IP 的配置 JSON 片段
+    const cfgText = '"server": "203.0.113.55",\n"tls": { "server_name": "hk.airport.com" }';
+    const out = redactIdentifiers(cfgText, ids);
+    expect(out).not.toContain('203.0.113.55'); // IP 被打码
+    expect(out).toContain('<ip-1>');
+    expect(out).toContain('<domain-1>'); // SNI 域名仍按域名打码
+  });
 });
 
 describe('redactIdentifiers — 文本统一打码 + 主机边界锚定（P0.6 / H1）', () => {

--- a/src/shared/__tests__/dns-wire.test.ts
+++ b/src/shared/__tests__/dns-wire.test.ts
@@ -1,0 +1,130 @@
+import { encodeDnsQuery, decodeDnsAnswers } from '../dns-wire';
+
+/** 取查询包（含 header+question），翻成响应：flags→0x8180|rcode、ANCOUNT、追加 answer 记录。 */
+function makeResponse(
+  query: Uint8Array,
+  answerRecords: number[][],
+  opts: { rcode?: number; ancount?: number } = {}
+): Uint8Array {
+  const head = Array.from(query);
+  head[2] = 0x81;
+  head[3] = 0x80 | ((opts.rcode ?? 0) & 0x0f); // QR=1 RD=1 RA=1 + RCODE
+  const an = opts.ancount ?? answerRecords.length;
+  head[6] = (an >> 8) & 0xff;
+  head[7] = an & 0xff;
+  return new Uint8Array([...head, ...answerRecords.flat()]);
+}
+
+/** A 记录：NAME=指向 question 名的压缩指针(0xC00C) + TYPE=A + CLASS=IN + TTL + RDLENGTH=4 + IPv4。 */
+function aRecord(ip: string): number[] {
+  const octets = ip.split('.').map((n) => parseInt(n, 10));
+  return [0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2c, 0x00, 0x04, ...octets];
+}
+
+/** AAAA 记录（type 28, rdlength 16）——应被 A 抽取忽略。 */
+function aaaaRecord(): number[] {
+  return [
+    0xc0,
+    0x0c,
+    0x00,
+    0x1c,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x01,
+    0x2c,
+    0x00,
+    0x10,
+    ...new Array(16).fill(0),
+  ];
+}
+
+/** CNAME 记录（type 5）——A 抽取应跳过、继续解析后续 A。 */
+function cnameRecord(): number[] {
+  // rdata = 压缩指针(2 字节) 指回 question 名，作为别名目标（内容不影响 A 抽取）
+  return [0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2c, 0x00, 0x02, 0xc0, 0x0c];
+}
+
+describe('encodeDnsQuery — A 记录查询包', () => {
+  it('example.com 逐字节固定', () => {
+    const q = encodeDnsQuery('example.com', 0);
+    expect(Array.from(q)).toEqual([
+      // header: id=0, flags=0x0100(RD), QD=1, AN/NS/AR=0
+      0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      // QNAME: 7 "example"
+      0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+      // 3 "com"
+      0x03, 0x63, 0x6f, 0x6d,
+      // root
+      0x00,
+      // QTYPE=A, QCLASS=IN
+      0x00, 0x01, 0x00, 0x01,
+    ]);
+  });
+
+  it('id 写入 header、尾部去掉根点', () => {
+    const q = encodeDnsQuery('a.example-argo.com.', 0xbeef);
+    expect((q[0] << 8) | q[1]).toBe(0xbeef);
+    // QDCOUNT=1，最后 4 字节恒为 QTYPE=A + QCLASS=IN
+    expect(Array.from(q.slice(-4))).toEqual([0x00, 0x01, 0x00, 0x01]);
+  });
+
+  it('超长 label(>63) 抛错（不静默截断）', () => {
+    expect(() => encodeDnsQuery(`${'x'.repeat(64)}.com`)).toThrow();
+  });
+});
+
+describe('decodeDnsAnswers — 抽 IPv4 A 记录', () => {
+  it('单 A 记录', () => {
+    const q = encodeDnsQuery('example.com');
+    const resp = makeResponse(q, [aRecord('93.184.216.34')]);
+    expect(decodeDnsAnswers(resp)).toEqual(['93.184.216.34']);
+  });
+
+  it('多 A 记录按报文顺序返回', () => {
+    const q = encodeDnsQuery('cdn.example.com');
+    const resp = makeResponse(q, [aRecord('1.1.1.1'), aRecord('2.2.2.2'), aRecord('3.3.3.3')]);
+    expect(decodeDnsAnswers(resp)).toEqual(['1.1.1.1', '2.2.2.2', '3.3.3.3']);
+  });
+
+  it('CNAME + A 混合：跳过 CNAME 返回 A', () => {
+    const q = encodeDnsQuery('alias.example.com');
+    const resp = makeResponse(q, [cnameRecord(), aRecord('5.6.7.8')]);
+    expect(decodeDnsAnswers(resp)).toEqual(['5.6.7.8']);
+  });
+
+  it('AAAA-only → []（v1 不解析 v6）', () => {
+    const q = encodeDnsQuery('v6.example.com');
+    const resp = makeResponse(q, [aaaaRecord()]);
+    expect(decodeDnsAnswers(resp)).toEqual([]);
+  });
+
+  it('RCODE!=0（SERVFAIL）→ []', () => {
+    const q = encodeDnsQuery('fail.example.com');
+    const resp = makeResponse(q, [], { rcode: 2, ancount: 0 });
+    expect(decodeDnsAnswers(resp)).toEqual([]);
+  });
+
+  it('ANCOUNT=0 → []', () => {
+    const q = encodeDnsQuery('empty.example.com');
+    expect(decodeDnsAnswers(makeResponse(q, []))).toEqual([]);
+  });
+
+  it('截断响应（rdata 不全）→ []，绝不抛', () => {
+    const q = encodeDnsQuery('trunc.example.com');
+    const full = makeResponse(q, [aRecord('9.9.9.9')]);
+    const cut = full.slice(0, full.length - 2); // 砍掉最后 2 字节 IPv4
+    expect(decodeDnsAnswers(cut)).toEqual([]);
+  });
+
+  it('过短报文（< 12 字节 header）→ []', () => {
+    expect(decodeDnsAnswers(new Uint8Array([0x00, 0x01, 0x02]))).toEqual([]);
+  });
+
+  it('round-trip：encode 的 question 段可被响应复用解析', () => {
+    const q = encodeDnsQuery('b.trycloudflare.com');
+    const resp = makeResponse(q, [aRecord('104.16.0.1')]);
+    expect(decodeDnsAnswers(resp)).toEqual(['104.16.0.1']);
+  });
+});

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -180,7 +180,10 @@ function addHostHeaders(headers: unknown, add: (v: unknown) => void): void {
  * 节点名 <4 字符跳过（防误伤日志普通词）；地址类不设长度阈值（靠 redactIdentifiers 的主机边界锚定防误替）。
  */
 export function collectNodeIdentifiers(
-  config: { servers?: ReadonlyArray<ServerLike> } | null | undefined
+  config: { servers?: ReadonlyArray<ServerLike> } | null | undefined,
+  // #57 resolve-ahead：节点域名被预解析成 IP 写进生成 config 的 outbound.server，这些 IP 不在 config.servers 里、
+  // 否则会以明文漏进诊断报告 → 调用方（DiagnosticService）把它们传入，一并按节点 IP 身份打码为 <ip-N>。
+  extraAddresses?: Iterable<string>
 ): NodeIdentifier[] {
   const out: NodeIdentifier[] = [];
   const seen = new Set<string>();
@@ -223,6 +226,8 @@ export function collectNodeIdentifiers(
     collectHostsDeep(s?.customSettings?.outbound, (v) => add(v, 'addr'));
     add(s?.name, 'name');
   }
+  // resolve-ahead 预解析得到的节点 IP（在 config.servers 之外）：按 IP 身份打码，杜绝真实节点 IP 漏进报告。
+  for (const ip of extraAddresses ?? []) add(ip, 'addr');
   return out;
 }
 

--- a/src/shared/dns-wire.ts
+++ b/src/shared/dns-wire.ts
@@ -1,0 +1,105 @@
+/**
+ * 极小 DNS wire（application/dns-message, RFC 1035）编解码 —— 纯函数、无 I/O、可逐字节单测。
+ *
+ * 用途（#57 resolve-ahead）：FlowZ 主进程在生成 sing-box 配置前，用 DoH（POST application/dns-message）
+ * 把节点服务器域名并发解析为 IP。选 wire 而非各家 JSON API：universal、与现有 dns-bootstrap 同协议、
+ * 易固定包字节断言。仅需 A（IPv4）记录——v1 不解析 AAAA（与关 IPv6 时 ipv4_only 一致）。
+ *
+ * 解码绝不抛：非法 / 截断 / RCODE!=0 / 无 A → 返回 []，由调用方回退（域名 / 系统 DNS / 不进 map）。
+ */
+
+const TYPE_A = 0x0001;
+const CLASS_IN = 0x0001;
+
+/**
+ * 组装 A 记录查询包：固定 header（RD=1，QDCOUNT=1）+ QNAME + QTYPE=A + QCLASS=IN。
+ * id 默认 0（DoH 经 HTTPS 单请求单响应，无需用 id 复用匹配）；可显式传 id 便于固定字节单测。
+ */
+export function encodeDnsQuery(domain: string, id = 0): Uint8Array {
+  const labels = domain.replace(/\.$/, '').split('.');
+  const enc = new TextEncoder();
+  const labelBytes = labels.map((l) => {
+    const b = enc.encode(l);
+    if (b.length === 0 || b.length > 63) {
+      throw new Error(`invalid DNS label length: "${l}"`);
+    }
+    return b;
+  });
+
+  // header(12) + Σ(1+label) + 1(root) + QTYPE(2) + QCLASS(2)
+  const qnameLen = labelBytes.reduce((n, b) => n + 1 + b.length, 0) + 1;
+  const buf = new Uint8Array(12 + qnameLen + 4);
+  const view = new DataView(buf.buffer);
+
+  view.setUint16(0, id & 0xffff); // ID
+  view.setUint16(2, 0x0100); // flags: QR=0 Opcode=0 RD=1
+  view.setUint16(4, 1); // QDCOUNT
+  view.setUint16(6, 0); // ANCOUNT
+  view.setUint16(8, 0); // NSCOUNT
+  view.setUint16(10, 0); // ARCOUNT
+
+  let off = 12;
+  for (const b of labelBytes) {
+    buf[off++] = b.length;
+    buf.set(b, off);
+    off += b.length;
+  }
+  buf[off++] = 0; // root label
+  view.setUint16(off, TYPE_A);
+  view.setUint16(off + 2, CLASS_IN);
+  return buf;
+}
+
+/** 越界即抛（顶层 catch 兜成 []）；处理 QNAME / NAME 的标签序列与压缩指针（0xC0）。 */
+function skipName(buf: Uint8Array, offset: number): number {
+  let off = offset;
+  // 循环上限 = buf 长度，杜绝构造畸形包导致死循环（无 root、自指指针等）。
+  for (let guard = 0; guard <= buf.length; guard++) {
+    if (off >= buf.length) throw new RangeError('name out of bounds');
+    const len = buf[off];
+    if (len === 0) return off + 1; // root，名字结束
+    if ((len & 0xc0) === 0xc0) return off + 2; // 压缩指针占 2 字节，名字到此结束
+    off += 1 + len;
+  }
+  throw new RangeError('malformed name');
+}
+
+/**
+ * 从 DNS 响应抽出全部 A 记录 IPv4（点分十进制）。任何异常/截断/RCODE!=0/无 A → []。
+ * 不做去重/排序，按报文出现顺序返回（调用方取首个）。
+ */
+export function decodeDnsAnswers(resp: Uint8Array): string[] {
+  try {
+    if (resp.length < 12) return [];
+    const view = new DataView(resp.buffer, resp.byteOffset, resp.byteLength);
+    const flags = view.getUint16(2);
+    if ((flags & 0x000f) !== 0) return []; // RCODE != 0（SERVFAIL/NXDOMAIN/…）→ 无可用答案
+    const qd = view.getUint16(4);
+    const an = view.getUint16(6);
+
+    let off = 12;
+    // 跳过 question 段：每条 = QNAME + QTYPE(2) + QCLASS(2)
+    for (let i = 0; i < qd; i++) {
+      off = skipName(resp, off);
+      off += 4;
+    }
+
+    const ips: string[] = [];
+    for (let i = 0; i < an; i++) {
+      off = skipName(resp, off);
+      if (off + 10 > resp.length) throw new RangeError('answer header out of bounds');
+      const type = view.getUint16(off);
+      const klass = view.getUint16(off + 2);
+      const rdlength = view.getUint16(off + 8);
+      const rdata = off + 10;
+      if (rdata + rdlength > resp.length) throw new RangeError('rdata out of bounds');
+      if (type === TYPE_A && klass === CLASS_IN && rdlength === 4) {
+        ips.push(`${resp[rdata]}.${resp[rdata + 1]}.${resp[rdata + 2]}.${resp[rdata + 3]}`);
+      }
+      off = rdata + rdlength;
+    }
+    return ips;
+  } catch {
+    return [];
+  }
+}

--- a/src/shared/dns.ts
+++ b/src/shared/dns.ts
@@ -60,7 +60,8 @@ function isIpv6Literal(host: string): boolean {
   return /^[0-9a-fA-F:]+$/.test(h) && (h.match(/:/g)?.length ?? 0) >= 2;
 }
 
-function isIpLiteral(host: string): boolean {
+/** 主机字符串是否 IP 字面量（v4 严格 + v6 去括号≥2 冒号）。节点域名预解析跳过判定亦复用，避免多处 v6 判定漂移。 */
+export function isIpLiteral(host: string): boolean {
   return isIpv4Literal(host) || isIpv6Literal(host);
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -266,6 +266,11 @@ export interface DnsConfig {
   // auto（缺省）=AliDNS IP-DoH（dns-bootstrap，零行为变化）/ dnspod=DNSPod IP-DoH（dns-node，1.12.12.12）/
   // system=系统 DNS（dns-local；TUN 下 rule ctx 仍强制 IP-DoH 防递归）。旧配置无此字段 → 视为 auto。
   nodeDomainResolver?: 'auto' | 'dnspod' | 'system';
+  // 节点域名解析前置（#57 resolve-ahead）：缺省/true=开（默认）。开 → start 前在主进程用并发多上游 DoH
+  // 把代理节点【服务器域名】预解析为 IP 写进 outbound.server（SNI/Host 仍保留原域名），使拨号不依赖运行时
+  // 单点 DNS，规避节点域名解析失败导致全断流。解析失败的域名自动回退原域名（走既有 dns-bootstrap）。
+  // 关 → 不预解析、保持现状（域名 + domain_resolver 引导解析）。旧配置无此字段 → 视为开。
+  resolveNodeDomainsAhead?: boolean;
   // TUN 模式强制接管系统 DNS（SystemDnsManager）：缺省/true=开（默认）。on-link 的 LAN/ISP DNS 不进 TUN →
   // hijack-dns 看不到 → 需代理的域名走系统解析得到真实/错族 IP（双栈站 ERR_CONNECTION_CLOSED / 真 v6 泄漏）。
   // 开 → TUN 启动把系统 DNS 改为可路由的 8.8.8.8 使其经 TUN 被 hijack；停止/退出/崩溃还原。


### PR DESCRIPTION
## 背景 / 根因（#57）
节点提示「DNS 无法解析到 IP」连不上（CDN 优选域名/优选 IP 节点，Cloudflare，Windows）。根因：节点域名解析绑死单点——dial 走 dns-bootstrap(223.5.5.5)、rule1 走 dns-domestic(doh.pub)，任一被运营商限速/劫持/不可达即整条代理挂；sing-box 无原生 DNS fallback/racing。

## 方案：解析前置（resolve-ahead）
主进程在生成 sing-box 配置前，对 address 为域名的节点并发多上游解析得到 IP，写进 `outbound.server`；`tls.server_name`/reality/naive server_name/ws-host 一律仍用原域名。拨号不再依赖运行时 DNS，多上游并发取先到 → 无新单点。本质 = 自动化「优选 IP」。

- 分层 race：Tier1 IP-DoH 池（AliDNS 223.5.5.5 + DNSPod 1.12.12.12）first-valid + 单上游超时；Tier2 系统 DNS 仅兜底（抗污染，不与 DoH 抢跑）；全失败回退原域名。
- 开关 `设置 · 网络 · 高级 DNS · 节点域名解析前置`（默认开）；解析档位「节点域名解析器」(auto/dnspod/system) 决定预解析上游——**档位选解析器、开关选是否前置，正交**。
- 覆盖普通拨号出站 + 外层 Shadow-TLS 出站两类真实拨号目标。
- TTL 缓存（5min，重启廉价）+ 域名级并发池（≤16，防大订阅数百并发 fetch）+ 整批预算硬约束（3s），绝不阻塞 start。
- 诊断报告脱敏一并覆盖预解析得到的节点 IP（`<ip-N>`），不泄漏真实节点 IP。

## 兼容 / 影响面
- 关开关 / 解析失败 / IP 字面量节点 / custom / WireGuard·Tailscale → 不预解析，逐字节回现状（snapshot 27 项不破）。
- 旧配置无开关字段视为开（修复默认生效）。
- 不改 `buildDnsConfig`；与既有 Windows-TUN `resolvedServerIps`（route_exclude）正交。

## 测试
新增单测覆盖：dns-wire 编解码、resolver（分层 race / 去重 / IP 跳过 / TTL / 预算 / 并发池 / 档位→上游）、`buildProxyOutbound`（server=IP 且 SNI=原域名）、`generateSingBoxConfig` 集成、Shadow-TLS、诊断脱敏。本地 gate 全绿：tsc(main+renderer) + eslint + jest **80 suites / 1147 tests / 27 snapshots**。

## 待真机验证（提交者本机为 Linux，禁触宿主网络）
- Windows（#57 复现环境）：Cloudflare CDN 优选域名节点开 resolve-ahead → `outbound.server` 为 IP、连通；关 → 回退域名现状。
- DoH-over-IP 证书：Node `fetch` 对 `https://223.5.5.5/dns-query` 的 TLS 是否校验 IP-SAN 通过（预期通过；若失败则降级 Tier2 系统 DNS，仍不回归、仅失抗污染收益）。
- 单条 DoH 上游被阻断 → 仍解析连通（验证无单点）；全部阻断 → 回退系统 DNS。

Close #57
