### PR TITLE
issue 模板改用旧版单文件，彻底去除选择器卡片

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,6 @@ name: Bug 反馈
 about: 报告一个可复现的问题（连接失败 / DNS / 崩溃 / 更新安装等）
 title: "[Bug] "
 labels: bug
-assignees: ''
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,0 @@
-blank_issues_enabled: false


### PR DESCRIPTION
## 目的

让点击 New Issue 对所有人（含维护者）直接预填正文、零选择器。

目录式模板（`.github/ISSUE_TEMPLATE/`）对**维护者始终保留 Blank issue 入口**，`blank_issues_enabled: false` 只对普通用户生效，无法对维护者关闭 → 维护者永远看到「模板 + Blank」两张卡，必然弹选择器。

改用**旧版单文件** `.github/ISSUE_TEMPLATE.md`（选择器出现之前的机制）：点 New Issue 直接把正文填入编辑框，不弹任何卡片。

- 删 `.github/ISSUE_TEMPLATE/`（bug_report.md + config.yml）
- 新增 `.github/ISSUE_TEMPLATE.md`，正文沿用原 Bug 模板分段（问题描述/复现步骤/原始日志/环境/旁证）
