### PR TITLE
fix(tray): 托盘图标状态刷新日志降级 info→debug

### DIFF
--- a/src/main/services/TrayManager.ts
+++ b/src/main/services/TrayManager.ts
@@ -231,7 +231,8 @@ export class TrayManager implements ITrayManager {
 
       this.updateTrayTooltip();
 
-      this.logManager.addLog('info', `Tray icon updated to state: ${state}`, 'TrayManager');
+      // 托盘图标状态刷新较频繁（状态轮询/重启/切节点都会触发），降到 debug 避免刷屏 info 日志。
+      this.logManager.addLog('debug', `Tray icon updated to state: ${state}`, 'TrayManager');
     } catch (error) {
       this.logManager.addLog(
         'error',


### PR DESCRIPTION
`updateTrayIcon` 在状态轮询 / 重启 / 切节点时高频触发，info 级「Tray icon updated to state: …」刷屏常规日志。降到 debug（需要排查时开 debug 仍可见），常规日志更干净。
