### PR TITLE
feat(dns): 节点域名预解析逐域名 debug 日志

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -485,6 +485,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           // 解析档位（nodeDomainResolver）决定预解析上游：auto=AliDNS+DNSPod DoH / dnspod=DNSPod / system=纯系统 DNS。
           this.lastResolvedHosts = await resolveNodeDomains([...nodeDomains], {
             upstreams: upstreamsForResolverMode(config.dnsConfig?.nodeDomainResolver),
+            // debug 级逐域名解析路径（域名→IP/上游/失败回退/缓存命中），logLevel=debug 时可见，供 #57 真机排查。
+            log: (level, message) => this.logToManager(level, message),
           });
           this.logToManager(
             'info',

--- a/src/main/services/__tests__/node-domain-resolver.test.ts
+++ b/src/main/services/__tests__/node-domain-resolver.test.ts
@@ -228,3 +228,35 @@ describe('并发池', () => {
     expect(peak).toBeLessThanOrEqual(3);
   });
 });
+
+describe('debug 日志回调', () => {
+  it('逐域名 debug：DoH 命中带上游 / 系统兜底带「系统 DNS」 / 失败带「回退域名」', async () => {
+    const logs: string[] = [];
+    const log = (lvl: 'debug' | 'info' | 'warn', msg: string) => logs.push(`${lvl}|${msg}`);
+    const doh = jest.fn(async (_u: string, d: string) => (d === 'a.com' ? ['1.1.1.1'] : []));
+    const systemResolve4 = jest.fn(async (d: string) => (d === 'b.com' ? ['2.2.2.2'] : []));
+    await resolveNodeDomains(['a.com', 'b.com', 'c.com'], {
+      doh,
+      systemResolve4,
+      upstreams: ['https://u1/dns-query'],
+      cache: new Map(),
+      log,
+    });
+    expect(logs.some((l) => l.includes('a.com → 1.1.1.1') && l.includes('u1'))).toBe(true);
+    expect(logs.some((l) => l.includes('b.com → 2.2.2.2') && l.includes('系统 DNS'))).toBe(true);
+    expect(logs.some((l) => l.includes('回退域名') && l.includes('c.com'))).toBe(true);
+    expect(logs.every((l) => l.startsWith('debug|'))).toBe(true);
+  });
+
+  it('缓存命中也打 debug（标「缓存」）', async () => {
+    const logs: string[] = [];
+    const log = (lvl: 'debug' | 'info' | 'warn', msg: string) => logs.push(`${lvl}|${msg}`);
+    const cache = new Map();
+    const doh = jest.fn(async () => ['3.3.3.3']);
+    const common = { doh, upstreams: ['https://u1/dns-query'], cache };
+    await resolveNodeDomains(['x.com'], common); // 首解 → 写缓存
+    await resolveNodeDomains(['x.com'], { ...common, log }); // 命中缓存
+    expect(logs.some((l) => l.includes('x.com → 3.3.3.3') && l.includes('缓存'))).toBe(true);
+    expect(doh).toHaveBeenCalledTimes(1); // 第二次未再 DoH
+  });
+});

--- a/src/main/services/node-domain-resolver.ts
+++ b/src/main/services/node-domain-resolver.ts
@@ -65,6 +65,8 @@ export interface NodeResolveOptions {
   upstreams?: readonly string[];
   /** 域名级并发上限（默认 16）。整批仍受 totalBudgetMs 硬约束，池只平滑并发、不改预算上限。 */
   maxConcurrency?: number;
+  /** 日志回调：debug 级逐域名打解析路径（域名→IP/经哪个上游/失败回退/缓存命中），供 #57 真机排查。 */
+  log?: (level: 'debug' | 'info' | 'warn', message: string) => void;
 }
 
 /** 模块级 TTL 缓存单例：跨 start/restart 持久，重启廉价（仅重解析过期项）。 */
@@ -140,7 +142,7 @@ async function attemptDoh(
   doh: NonNullable<NodeResolveOptions['doh']>,
   perTimeoutMs: number,
   budgetSignal: AbortSignal
-): Promise<string> {
+): Promise<{ ip: string; upstream: string }> {
   const ctrl = new AbortController();
   const onBudget = () => ctrl.abort();
   budgetSignal.addEventListener('abort', onBudget, { once: true });
@@ -148,8 +150,8 @@ async function attemptDoh(
   try {
     const ips = await doh(upstream, domain, ctrl.signal);
     const ip = ips.find((x) => isIpv4(x));
-    if (!ip) throw new Error('no A record'); // reject → Promise.any 转向其它上游
-    return ip;
+    if (!ip) throw new Error('no A record'); // reject → firstResolved 转向其它上游
+    return { ip, upstream }; // 带上游，供调用方 debug 日志标注解析来源
   } finally {
     clearTimeout(timer);
     budgetSignal.removeEventListener('abort', onBudget);
@@ -161,7 +163,7 @@ async function raceDoh(
   domain: string,
   opts: NodeResolveOptions,
   budgetSignal: AbortSignal
-): Promise<string | null> {
+): Promise<{ ip: string; upstream: string } | null> {
   const upstreams = opts.upstreams ?? DOH_UPSTREAMS;
   const doh = opts.doh ?? defaultDoh;
   const perTimeoutMs = opts.perUpstreamTimeoutMs ?? DEFAULT_PER_UPSTREAM_TIMEOUT_MS;
@@ -174,19 +176,26 @@ async function raceDoh(
   }
 }
 
+/** 单域名解析结果：IP + 来源（DoH 上游 URL 或「系统 DNS」），供调用方 debug 日志标注。 */
+interface ResolveHit {
+  ip: string;
+  via: string;
+}
+
 /** 单域名：Tier1 DoH race → 失败兜 Tier2 系统 DNS（不抢跑）→ 全失败 null。 */
 async function resolveOne(
   domain: string,
   opts: NodeResolveOptions,
   budgetSignal: AbortSignal
-): Promise<string | null> {
+): Promise<ResolveHit | null> {
   const fromDoh = await raceDoh(domain, opts, budgetSignal);
-  if (fromDoh) return fromDoh;
+  if (fromDoh) return { ip: fromDoh.ip, via: fromDoh.upstream };
   if (budgetSignal.aborted) return null; // 预算耗尽：不再发起系统解析
   const systemResolve4 = opts.systemResolve4 ?? defaultSystemResolve4;
   try {
     const ips = await abortable(systemResolve4(domain), budgetSignal);
-    return ips.find((x) => isIpv4(x)) ?? null;
+    const ip = ips.find((x) => isIpv4(x));
+    return ip ? { ip, via: '系统 DNS' } : null;
   } catch {
     return null;
   }
@@ -218,6 +227,7 @@ export async function resolveNodeDomains(
     const cached = cache.get(d);
     if (cached && cached.expireAt > tNow) {
       results.set(d, cached.ip);
+      opts.log?.('debug', `节点域名预解析 ${d} → ${cached.ip}（缓存）`);
     } else {
       if (cached) cache.delete(d); // 顺手淘汰过期项，防模块级缓存随会话无界增长
       toResolve.push(d);
@@ -228,10 +238,13 @@ export async function resolveNodeDomains(
   const budgetCtrl = new AbortController();
   const budgetTimer = setTimeout(() => budgetCtrl.abort(), totalBudgetMs);
   const resolveInto = async (d: string) => {
-    const ip = await resolveOne(d, opts, budgetCtrl.signal);
-    if (ip) {
-      results.set(d, ip);
-      cache.set(d, { ip, expireAt: now() + ttlMs });
+    const hit = await resolveOne(d, opts, budgetCtrl.signal);
+    if (hit) {
+      results.set(d, hit.ip);
+      cache.set(d, { ip: hit.ip, expireAt: now() + ttlMs });
+      opts.log?.('debug', `节点域名预解析 ${d} → ${hit.ip}（${hit.via}）`);
+    } else {
+      opts.log?.('debug', `节点域名预解析失败，回退域名：${d}`);
     }
   };
   try {


### PR DESCRIPTION
## 背景
resolve-ahead（#83）原只一行 info 汇总（命中数 + 耗时），debug 下也看不到逐域名细节，不便排查 #57 真机（哪个域名走哪条路解析、哪些失败回退）。

## 改动
给 `resolveNodeDomains` 注入 log 回调，debug 级逐域名打：
- `节点域名 <domain> → <ip>（<DoH 上游> / 系统 DNS / 缓存）`
- `节点域名预解析失败，回退域名：<domain>`

内部 `resolveOne` 回传解析来源（上游 / 系统）；汇总 info 行保留。

## 测试
扩 `node-domain-resolver` 单测覆盖 DoH/系统/失败三路径 + 缓存命中日志。本地 gate 全绿（tsc + eslint + jest 1208 tests）。
