### PR TITLE
恢复目录式 issue 模板，找回正文/标题预填

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,7 @@ name: Bug 反馈
 about: 报告一个可复现的问题（连接失败 / DNS / 崩溃 / 更新安装等）
 title: "[Bug] "
 labels: bug
+assignees: ''
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## 目的

恢复目录式 issue 模板，找回正文/标题/label 预填。

#87 改用的旧版单文件 `.github/ISSUE_TEMPLATE.md` 在 GitHub **新版 issue 创建体验下不再预填正文**（官方已移除对旧模板的支持），导致点 New Issue 进到空编辑框——失去模板引导价值。

本 PR revert #87，回到目录式单模板：

- `.github/ISSUE_TEMPLATE/bug_report.md`（正文/标题 `[Bug] `/label `bug` 正常预填）
- `.github/ISSUE_TEMPLATE/config.yml`：`blank_issues_enabled: false`

代价（GitHub 硬限制，无法规避）：维护者点 New Issue 会先看到 Bug + Blank 选择卡；普通报告者在 blank 关闭下基本无感。想直达可用 `issues/new?template=bug_report.md`。
