### PR TITLE
fix(mesh): smart 模式选中关外网组网节点为主时海外流量黑洞回退 direct (D7)

### DIFF
--- a/src/main/services/__tests__/proxy-manager-global-mode.test.ts
+++ b/src/main/services/__tests__/proxy-manager-global-mode.test.ts
@@ -193,6 +193,82 @@ describe('优先级重排 + mesh 重叠提醒', () => {
   });
 });
 
+describe('D7：选中 off-mesh 主节点 → 外网出口回退 direct（global+smart）', () => {
+  const offWg = (allowedIPs: string[], allowInternet: boolean) => ({
+    id: 'wg1',
+    name: 'WG',
+    protocol: 'wireguard',
+    address: 'wg.example.com',
+    port: 51820,
+    wireguardSettings: {
+      privateKey: 'a',
+      peerPublicKey: 'b',
+      localAddress: ['10.0.0.2/32'],
+      allowedIPs,
+      allowInternet,
+    },
+  });
+  const cfg = (
+    proxyMode: 'smart' | 'global',
+    allowInternet: boolean,
+    blockQuic = false
+  ): UserConfig =>
+    ({
+      proxyMode,
+      servers: [offWg(['10.8.0.0/24'], allowInternet)],
+      selectedServerId: 'wg1',
+      blockQuic,
+    }) as unknown as UserConfig;
+  const idMap = new Map([['wg1', 'proxy-wg1']]);
+  // 用 domain_keyword(google) + final 断言「→代理」出口：geosite-!cn 是 rule_set，本测试环境无 .srs →
+  // 该 rule_set 规则会被悬空引用剪枝移除（与现有 smart 测试同），故不依赖它；google 关键词规则恒在。
+  const googleRule = (route: any) =>
+    (route.rules || []).find(
+      (r: any) =>
+        Array.isArray(r.domain_keyword) &&
+        r.domain_keyword.includes('google') &&
+        r.action === 'route'
+    );
+
+  it('smart + off WG 主节点 → final/google 均 direct（消除海外黑洞）', () => {
+    const route = buildRouteConfig(cfg('smart', false), idMap, routeDeps());
+    expect(route.final).toBe('direct');
+    expect(googleRule(route)?.outbound).toBe('direct');
+  });
+
+  it('global + off WG 主节点 → final direct（D4 原有，保持）', () => {
+    expect(buildRouteConfig(cfg('global', false), idMap, routeDeps()).final).toBe('direct');
+  });
+
+  it('对照：smart + on WG 主节点 → final/google = proxy-selector（不回退）', () => {
+    const route = buildRouteConfig(cfg('smart', true), idMap, routeDeps());
+    expect(route.final).toBe('proxy-selector');
+    expect(googleRule(route)?.outbound).toBe('proxy-selector');
+  });
+
+  it('smart + off WG + blockQuic → google/foreign 走 direct 且其前不配对 UDP443 reject', () => {
+    const route = buildRouteConfig(cfg('smart', false, true), idMap, routeDeps());
+    const rules = (route.rules || []) as any[];
+    const gIdx = rules.findIndex(
+      (r) =>
+        Array.isArray(r.domain_keyword) &&
+        r.domain_keyword.includes('google') &&
+        r.action === 'route'
+    );
+    expect(gIdx).toBeGreaterThanOrEqual(0);
+    expect(rules[gIdx].outbound).toBe('direct');
+    const prev = rules[gIdx - 1];
+    const prevIsGoogleUdpReject =
+      !!prev &&
+      prev.action === 'reject' &&
+      Array.isArray(prev.port) &&
+      prev.port.includes(443) &&
+      Array.isArray(prev.domain_keyword) &&
+      prev.domain_keyword.includes('google');
+    expect(prevIsGoogleUdpReject).toBe(false);
+  });
+});
+
 describe('configGenerationNorm：global 下用户路由变更不翻转 norm（免无谓重启）', () => {
   const svc = makeSvc();
   const addRule = (cfg: UserConfig): UserConfig =>

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -15,7 +15,7 @@ import { BOOTSTRAP_DIRECT_DNS_IPS } from '../../shared/dns';
 import {
   endpointForcedRouteCidrs,
   meshForcedRouteCidrs,
-  meshGlobalFinalFallsBackToDirect,
+  meshSelectedExitFallsBackToDirect,
 } from '../../shared/endpoint-routes';
 import { cidrOverlapsAny } from '../../shared/ip';
 import { ruleIpCidrs } from '../../shared/rules';
@@ -110,6 +110,18 @@ export function buildRouteConfig(
   // 主代理出站统一走 selector(proxy-selector)：clash_api 热切换即改 selector 指向、路由无需重生成。
   // 具体 targetServerId 的 app/custom 分流在各自逻辑里直指节点 tag，不经此变量。
   const selectedServerTag = 'proxy-selector';
+
+  // D4/D7：主节点是「关外网组网节点」时，「→代理」的用户出口（smart 的 geosite-!cn/google + 两模式的 final）
+  // 整体回退 direct（proxy-selector.default=该 off-mesh 节点，海外/非具体段流量进其用户态栈被丢弃→黑洞）。
+  // 具体段仍由 force-route 经组网（排在这些规则之前）。global+smart 同此兜底；probe/rule-sel 仍用 selector。
+  const exitFallback = meshSelectedExitFallsBackToDirect(config);
+  const userExitTag = exitFallback ? 'direct' : selectedServerTag;
+  if (exitFallback) {
+    deps.log(
+      'warn',
+      '选中的组网节点已关闭外网访问：外网流量已回退直连（具体网段仍经组网节点），如需经此节点全隧道请开启该节点「允许访问外网」'
+    );
+  }
 
   // blockQuic（节点无关）：开启时对"将走代理"的 QUIC(UDP443) 执行 reject，逼浏览器回退 TCP。
   // 「禁 QUIC」即禁 QUIC，与选中节点的协议/中继能力无关，对所有节点一视同仁。两点实测保证安全：
@@ -224,23 +236,14 @@ export function buildRouteConfig(
     outbound: 'direct',
   });
 
-  // D4：global 模式选中「关闭外网的组网节点」(WG/Tailscale, allowInternet=off) → final 兜底 'direct'。否则非具体段
-  // 流量进该节点用户态栈被 cryptokey routing 丢弃 → 黑洞断网；兜底直连后用户仍能上网，具体段仍由 force-route 经组网。
-  const meshFinalFallback = meshGlobalFinalFallsBackToDirect(config);
-  if (meshFinalFallback) {
-    deps.log(
-      'warn',
-      '全局模式选中的组网节点已关闭外网访问：默认出口已回退直连（具体网段仍经组网节点），如需全隧道请开启该节点「允许访问外网」'
-    );
-  }
   const routeConfig: SingBoxRouteConfig = {
     rules,
     // 核心修复：default_domain_resolver 使用 IP-based DoH 引导解析器 (dns-bootstrap)，
     // 既避免解析 doh.pub 域名时的死循环，又免疫 UDP 53 限速/劫持（dns-bootstrap 同为 IP-based）。
     default_domain_resolver: 'dns-bootstrap',
     auto_detect_interface: true,
-    // 如果模式是全局代理 (global/proxy)，则最终出口是所选节点（经 proxy-selector）；direct 模式或 D4 兜底→direct。
-    final: proxyMode === 'direct' || meshFinalFallback ? 'direct' : selectedServerTag,
+    // 如果模式是全局代理 (global/proxy)，则最终出口是所选节点（经 proxy-selector）；direct 模式或 D4/D7 兜底→direct。
+    final: proxyMode === 'direct' ? 'direct' : userExitTag,
   };
 
   // 【DNS 引导与辅助直连】：
@@ -617,21 +620,26 @@ export function buildRouteConfig(
     // 代理向 UDP（smart）：在每条"→代理"规则之前配对一条 reject，使该走代理的 UDP 在被路由到代理
     // 前就 reject——不能中继的节点拦全部 UDP，能中继+blockQuic 仅拦 QUIC(UDP443)。下方 CN 直连规则
     // 不配对，故 CN/直连 UDP 不受影响（兜底见 generateRouteConfig 末尾）。
-    const googleUdpReject = proxyUdpRejectFor({ domain_keyword: googleKeywords });
+    // exitFallback 时这两条走 direct（非代理），不能在其前配对「代理向 UDP reject」（否则误拒直连 UDP/QUIC）。
+    const googleUdpReject = exitFallback
+      ? null
+      : proxyUdpRejectFor({ domain_keyword: googleKeywords });
     if (googleUdpReject) rules.push(googleUdpReject);
     rules.push({
       domain_keyword: googleKeywords,
       action: 'route',
-      outbound: selectedServerTag,
+      outbound: userExitTag, // D7：off-mesh 主节点时回退 direct，避免海外黑洞
     });
 
     // 国外域名走代理
-    const foreignUdpReject = proxyUdpRejectFor({ rule_set: 'geosite-geolocation-!cn' });
+    const foreignUdpReject = exitFallback
+      ? null
+      : proxyUdpRejectFor({ rule_set: 'geosite-geolocation-!cn' });
     if (foreignUdpReject) rules.push(foreignUdpReject);
     rules.push({
       rule_set: 'geosite-geolocation-!cn',
       action: 'route',
-      outbound: selectedServerTag,
+      outbound: userExitTag, // D7：off-mesh 主节点时回退 direct，避免海外黑洞
     });
     // 中国域名直连
     rules.push({
@@ -709,6 +717,8 @@ export function buildRouteConfig(
   // 【代理向 QUIC 兜底】：放在所有直连/分流规则之后，拦截"会落到 final(代理)"的剩余 QUIC(udp443)。
   // global 模式拦全部代理向 QUIC；smart 模式拦未被上方 →代理 配对 reject 命中的（CN 已直连豁免）。
   // 只拦 QUIC——非 QUIC 的代理向 UDP 若节点不能中继，由 sing-box 出站层自动拒绝（见上方 blockProxyQuic）。
+  // D7 注：exitFallback 时 final/外网规则已回退 direct，此兜底仍 RST 漏网 QUIC → 浏览器 TCP 回退后走 direct，
+  // 即「强制 TCP」语义、不黑洞（blockProxyQuic 仅看 blockQuic/mode/节点数，与 exitFallback 正交，行为正确）。
   if (blockProxyQuic) {
     rules.push(udp443RejectRule());
   }

--- a/src/renderer/components/home/proxy-control-card.tsx
+++ b/src/renderer/components/home/proxy-control-card.tsx
@@ -18,7 +18,11 @@ import type { ProxyMode, ProxyModeType } from '@/bridge/types';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { isServerComplete } from '../../../shared/server-completeness';
-import { isMeshNodeUnroutable } from '../../../shared/endpoint-routes';
+import {
+  isMeshNodeUnroutable,
+  isEndpointProtocol,
+  meshAllowsInternet,
+} from '../../../shared/endpoint-routes';
 
 /**
  * 首页代理控制卡：两行 OpenClash 风格分段切换（接管方式 / 分流策略）+ 启停按钮。
@@ -61,6 +65,13 @@ export function ProxyControlCard() {
       ? t('home.meshNoInternetGate')
       : t('home.plsConfigServer')
     : hasError || '';
+  // D7：选中「关外网+有具体段」的组网节点为主节点（可连接，非置灰）→ 外网回退直连、仅其网段经此节点。非阻断提示。
+  const meshExitDirect =
+    !!selectedServer &&
+    isEndpointProtocol(selectedServer.protocol) &&
+    !meshAllowsInternet(selectedServer) &&
+    !meshNoInternet &&
+    (config?.proxyMode || 'smart').toLowerCase() !== 'direct';
 
   // ── 接管方式（proxyModeType）────────────────────────────────────────────
   const applyTakeover = async (modeType: ProxyModeType) => {
@@ -197,6 +208,14 @@ export function ProxyControlCard() {
               </>
             )}
           </Button>
+          {meshExitDirect && (
+            <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
+              {t(
+                'home.meshExitDirectHint',
+                '所选组网节点未开启外网访问：外网流量走直连，仅其网段经此节点。'
+              )}
+            </p>
+          )}
         </div>
       </CardContent>
 

--- a/src/renderer/components/settings/server-list.tsx
+++ b/src/renderer/components/settings/server-list.tsx
@@ -58,6 +58,7 @@ import {
   isAccountBasedProtocol,
   isEndpointProtocol,
   meshAllowsInternet,
+  meshShadowedCidrs,
 } from '../../../shared/endpoint-routes';
 
 type ServerConfigWithId = ServerConfig;
@@ -161,6 +162,9 @@ export function ServerList({
   } | null>(null);
   const [testingServerIds, setTestingServerIds] = useState<Set<string>>(new Set());
   const { t, i18n } = useTranslation();
+
+  // 组网同网段「被覆盖」检测（首声明者占有，与 route-builder 同一不变量）：列表角标提醒用，零布局破坏。
+  const shadowedCidrs = useMemo(() => meshShadowedCidrs(servers), [servers]);
 
   // 记住用户的视图偏好
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -890,6 +894,19 @@ export function ServerList({
                         {t('servers.noInternetBadge', 'LAN only')}
                       </Badge>
                     )}
+                    {shadowedCidrs.has(server.id) && (
+                      <Badge
+                        variant="outline"
+                        title={t(
+                          'servers.meshShadowedTip',
+                          '以下网段已被列表中靠前的组网节点占有、不会经此节点：{{cidrs}}。可去重 / 调整节点顺序 / 用自定义规则覆盖。',
+                          { cidrs: shadowedCidrs.get(server.id)!.join(', ') }
+                        )}
+                        className="text-xs h-4 px-1 bg-badge-amber/15 text-badge-amber border-badge-amber/30"
+                      >
+                        {t('servers.meshShadowedBadge', '网段被覆盖')}
+                      </Badge>
+                    )}
                     {selectedServerId === server.id && (
                       <Badge variant="outline" className="text-xs h-4 px-1">
                         {t('servers.current')}
@@ -1026,6 +1043,19 @@ export function ServerList({
                         className="text-[10px] h-4 px-1 flex-shrink-0 bg-badge-amber/15 text-badge-amber border-badge-amber/30"
                       >
                         {t('servers.noInternetBadge', 'LAN only')}
+                      </Badge>
+                    )}
+                    {shadowedCidrs.has(server.id) && (
+                      <Badge
+                        variant="outline"
+                        title={t(
+                          'servers.meshShadowedTip',
+                          '以下网段已被列表中靠前的组网节点占有、不会经此节点：{{cidrs}}。可去重 / 调整节点顺序 / 用自定义规则覆盖。',
+                          { cidrs: shadowedCidrs.get(server.id)!.join(', ') }
+                        )}
+                        className="text-[10px] h-4 px-1 flex-shrink-0 bg-badge-amber/15 text-badge-amber border-badge-amber/30"
+                      >
+                        {t('servers.meshShadowedBadge', '网段被覆盖')}
                       </Badge>
                     )}
                     {server.shadowTlsSettings && (

--- a/src/renderer/components/settings/wireguard-form.tsx
+++ b/src/renderer/components/settings/wireguard-form.tsx
@@ -159,6 +159,13 @@ export function WireGuardForm({ serverConfig, onSubmit }: WireGuardFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        {/* 组网概要：降低 WG/组网概念门槛（与 Tailscale tsIntro 对齐） */}
+        <p className="text-xs text-muted-foreground">
+          {t(
+            'servers.wgIntro',
+            'WireGuard node: reach a peer LAN, or act as an internet exit. "Allow internet access" controls whether it carries default outbound traffic (off = only routes the subnets below). When several mesh nodes list the same subnet, the first in the list wins; override with a custom rule.'
+          )}
+        </p>
         {/* 粘贴 wg-quick .conf 自动填充（可选；手写为主） */}
         <div className="space-y-2 rounded-md border border-dashed p-3">
           <FormLabel>

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -315,6 +315,7 @@
     "domainAlreadyInRule": "{{domain}} already exists in a rule",
     "plsConfigServer": "Please configure a server first",
     "meshNoInternetGate": "No internet access: enable \"Allow internet access\" for this node, or add routed subnets",
+    "meshExitDirectHint": "Selected mesh node has internet access off: outbound traffic goes direct; only its subnets route through it.",
     "stopProxyFailed": "Failed to stop proxy"
   },
   "settings": {
@@ -825,6 +826,7 @@
     "saveFailed": "Failed to save",
     "echConfig": "ECH Config (optional)",
     "echConfigDesc": "Leave empty to auto-load from DNS (HTTPS record); paste ECHConfigList (PEM) to set explicitly",
+    "wgIntro": "WireGuard node: reach a peer LAN, or act as an internet exit. \"Allow internet access\" controls whether it carries default outbound traffic (off = only routes the subnets below). When several mesh nodes list the same subnet, the first in the list wins; override with a custom rule.",
     "wgImportConf": "Import from wg-quick .conf (optional)",
     "wgParseAndFill": "Parse & fill",
     "wgConfParseFailed": "Could not parse the .conf — please fill the fields manually",
@@ -862,6 +864,8 @@
     "tsAllowInternetDesc": "When off, this node never acts as a full-tunnel exit (the exit node below is ignored); it only reaches the tailnet and routed subnets.",
     "tsAllowInternetOffHint": "Internet access off: exit node ignored; this node only reaches the tailnet / routed subnets.",
     "noInternetBadge": "LAN only",
+    "meshShadowedBadge": "Overlapped",
+    "meshShadowedTip": "These subnets are already claimed by an earlier mesh node and won't route via this one: {{cidrs}}. Dedupe / reorder nodes / override with a custom rule.",
     "wgAllowedIPs": "Routed subnets (Allowed IPs)",
     "wgAllowedIPsDesc": "Subnets (CIDR) to route through this node, comma/newline-separated. Empty = full tunnel (all traffic). For peer LAN only, list specific CIDRs like 10.8.0.0/24.",
     "wgAllowedIPsPlaceholder": "Empty = full tunnel; or 10.8.0.0/24",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -315,6 +315,7 @@
     "domainAlreadyInRule": "{{domain}} 已在现有规则中",
     "plsConfigServer": "请先配置服务器",
     "meshNoInternetGate": "无外网访问权限：请开启该节点的「允许访问外网」或添加路由网段",
+    "meshExitDirectHint": "所选组网节点未开启外网访问：外网流量走直连，仅其网段经此节点。",
     "stopProxyFailed": "停止代理失败"
   },
   "settings": {
@@ -825,6 +826,7 @@
     "saveFailed": "保存失败",
     "echConfig": "ECH 配置（可选）",
     "echConfigDesc": "留空则自动从 DNS(HTTPS 记录) 获取；粘贴 ECHConfigList(PEM) 可显式指定",
+    "wgIntro": "WireGuard 组网节点：可访问对端内网、或作为外网出口。「允许访问外网」控制是否承载默认出网流量（关 = 仅路由下方网段）；多个组网节点同网段时按列表顺序首个生效，可用自定义规则覆盖。",
     "wgImportConf": "从 wg-quick .conf 导入（可选）",
     "wgParseAndFill": "解析并填充",
     "wgConfParseFailed": "无法解析该 .conf，请手动填写字段",
@@ -862,6 +864,8 @@
     "tsAllowInternetDesc": "关闭后此节点不作全隧道出口（忽略下方出口节点），仅访问 tailnet 与已路由的子网。",
     "tsAllowInternetOffHint": "已关闭外网访问：忽略出口节点，此节点仅访问 tailnet / 子网路由。",
     "noInternetBadge": "仅内网",
+    "meshShadowedBadge": "网段被覆盖",
+    "meshShadowedTip": "以下网段已被列表中靠前的组网节点占有、不会经此节点：{{cidrs}}。可去重 / 调整节点顺序 / 用自定义规则覆盖。",
     "wgAllowedIPs": "路由网段 (AllowedIPs)",
     "wgAllowedIPsDesc": "填写需经此节点路由的网段（CIDR），多个用逗号或换行分隔。留空 = 全部流量经此节点（全隧道）。仅访问对端内网则填具体段，如 10.8.0.0/24。",
     "wgAllowedIPsPlaceholder": "留空=全隧道；或 10.8.0.0/24",

--- a/src/shared/__tests__/endpoint-routes.test.ts
+++ b/src/shared/__tests__/endpoint-routes.test.ts
@@ -4,7 +4,8 @@ import {
   meshAllowsInternet,
   wireguardPeerAllowedIps,
   isMeshNodeUnroutable,
-  meshGlobalFinalFallsBackToDirect,
+  meshSelectedExitFallsBackToDirect,
+  meshShadowedCidrs,
 } from '../endpoint-routes';
 import type { ServerConfig, UserConfig } from '../types';
 
@@ -115,23 +116,78 @@ describe('isMeshNodeUnroutable', () => {
   });
 });
 
-describe('meshGlobalFinalFallsBackToDirect（D4）', () => {
+describe('meshSelectedExitFallsBackToDirect（D4/D7：global+smart 同兜底）', () => {
   const cfg = (server: ServerConfig, proxyMode: string): UserConfig =>
     ({ proxyMode, servers: [server], selectedServerId: server.id }) as any;
   it('global + 选中 off WG → true', () => {
-    expect(meshGlobalFinalFallsBackToDirect(cfg(wg([], false), 'global'))).toBe(true);
+    expect(meshSelectedExitFallsBackToDirect(cfg(wg([], false), 'global'))).toBe(true);
   });
   it('global + 选中 off TS → true', () => {
-    expect(meshGlobalFinalFallsBackToDirect(cfg(ts([], false), 'global'))).toBe(true);
+    expect(meshSelectedExitFallsBackToDirect(cfg(ts([], false), 'global'))).toBe(true);
   });
   it('global + 选中 on WG → false', () => {
-    expect(meshGlobalFinalFallsBackToDirect(cfg(wg([], true), 'global'))).toBe(false);
+    expect(meshSelectedExitFallsBackToDirect(cfg(wg([], true), 'global'))).toBe(false);
   });
-  it('smart + 选中 off WG → false（仅 global 兜底）', () => {
-    expect(meshGlobalFinalFallsBackToDirect(cfg(wg([], false), 'smart'))).toBe(false);
+  // D7 修复：smart 现也兜底（原 false 留下海外黑洞）
+  it('smart + 选中 off WG → true（D7：smart 同兜底）', () => {
+    expect(meshSelectedExitFallsBackToDirect(cfg(wg([], false), 'smart'))).toBe(true);
   });
-  it('global + 选中非组网节点 → false', () => {
+  it('smart + 选中 off+具体段 WG → true（off 即兜底，与有无 specific 无关）', () => {
+    expect(meshSelectedExitFallsBackToDirect(cfg(wg(['10.8.0.0/24'], false), 'smart'))).toBe(true);
+  });
+  it('smart + 选中 on WG → false', () => {
+    expect(meshSelectedExitFallsBackToDirect(cfg(wg([], true), 'smart'))).toBe(false);
+  });
+  it('direct + 选中 off WG → false（direct 本就 final=direct，不适用）', () => {
+    expect(meshSelectedExitFallsBackToDirect(cfg(wg([], false), 'direct'))).toBe(false);
+  });
+  it('选中非组网节点 → false', () => {
     const v = { id: 'v', protocol: 'vless' } as any;
-    expect(meshGlobalFinalFallsBackToDirect(cfg(v, 'global'))).toBe(false);
+    expect(meshSelectedExitFallsBackToDirect(cfg(v, 'global'))).toBe(false);
+    expect(meshSelectedExitFallsBackToDirect(cfg(v, 'smart'))).toBe(false);
+  });
+});
+
+describe('meshShadowedCidrs（同网段首声明者占有）', () => {
+  const wgNode = (id: string, allowedIPs: string[]): ServerConfig =>
+    ({
+      id,
+      name: id,
+      protocol: 'wireguard',
+      address: '1.2.3.4',
+      port: 51820,
+      wireguardSettings: {
+        privateKey: 'k',
+        peerPublicKey: 'p',
+        localAddress: ['10.0.0.2/32'],
+        allowedIPs,
+      },
+    }) as any;
+
+  it('两节点同段 → 后者该段被覆盖', () => {
+    const a = wgNode('a', ['10.8.0.0/24']);
+    const b = wgNode('b', ['10.8.0.0/24', '192.168.9.0/24']);
+    const m = meshShadowedCidrs([a, b]);
+    expect(m.has('a')).toBe(false); // 首声明者不被覆盖
+    expect(m.get('b')).toEqual(['10.8.0.0/24']); // 仅重复段被覆盖，独有段不计
+  });
+
+  it('无重叠 → 空 map', () => {
+    const a = wgNode('a', ['10.8.0.0/24']);
+    const b = wgNode('b', ['192.168.9.0/24']);
+    expect(meshShadowedCidrs([a, b]).size).toBe(0);
+  });
+
+  it('catch-all 不参与（force-route 已剔）', () => {
+    const a = wgNode('a', ['0.0.0.0/0', '::/0']);
+    const b = wgNode('b', ['0.0.0.0/0', '::/0']);
+    expect(meshShadowedCidrs([a, b]).size).toBe(0);
+  });
+
+  it('顺序决定归属：调换则被覆盖方互换', () => {
+    const a = wgNode('a', ['10.8.0.0/24']);
+    const b = wgNode('b', ['10.8.0.0/24']);
+    expect(meshShadowedCidrs([a, b]).get('b')).toEqual(['10.8.0.0/24']);
+    expect(meshShadowedCidrs([b, a]).get('a')).toEqual(['10.8.0.0/24']);
   });
 });

--- a/src/shared/endpoint-routes.ts
+++ b/src/shared/endpoint-routes.ts
@@ -89,12 +89,19 @@ export function isMeshNodeUnroutable(server: ServerConfig): boolean {
 }
 
 /**
- * D4：global 模式选中「关闭外网的组网节点」时 route.final 应兜底回 'direct'（而非 proxy-selector）。
- * 否则非具体段流量会被送进该节点的用户态 WG 栈、因 allowed_ips 不含 0/0 被 cryptokey routing 丢弃 → 黑洞断网。
- * 具体段仍由 force-route（排在 final 之前）经组网节点；用户其余流量直连保上网。仅 global 命中（smart/direct 不适用）。
+ * D4/D7：选中「关闭外网的组网节点」(WG/Tailscale, allowInternet=off) 为**主节点**时，「→代理」的用户出口
+ * （global 的 route.final；smart 的 geosite-!cn / google 关键词 / final）应整体兜底回 'direct'，而非
+ * proxy-selector——proxy-selector.default = 该 off-mesh 节点，非具体段/海外流量进其用户态栈被 cryptokey
+ * routing 丢弃（allowed_ips 不含 0/0）→ 黑洞断网。具体段仍由 force-route（排在这些规则之前）经组网节点；
+ * 用户其余流量直连保上网。**global 与 smart 同此兜底**（D7 修复：原仅 global 留下 smart 海外黑洞）；direct 模式
+ * 本就 final=direct、无「→代理」规则，不适用。
+ *
+ * 残留（已知较窄，非本兜底覆盖）：用户显式创建的「应用分流·代理·无固定目标」规则仍 default=proxy-selector→
+ * off-mesh 节点；该 app 的流量仍会被丢弃。属用户对 off-mesh 主节点显式指定代理的自相矛盾配置，由角标/警告提示，
+ * 不在本运行期兜底内（彻底消除需「禁止 off-mesh 作主节点」更大改动，列为后续）。
  */
-export function meshGlobalFinalFallsBackToDirect(config: UserConfig): boolean {
-  if ((config.proxyMode || 'smart').toLowerCase() !== 'global') return false;
+export function meshSelectedExitFallsBackToDirect(config: UserConfig): boolean {
+  if ((config.proxyMode || 'smart').toLowerCase() === 'direct') return false;
   const selected = config.servers?.find((s) => s.id === config.selectedServerId);
   return !!selected && isEndpointProtocol(selected.protocol) && !meshAllowsInternet(selected);
 }
@@ -105,4 +112,25 @@ export function meshGlobalFinalFallsBackToDirect(config: UserConfig): boolean {
  */
 export function meshForcedRouteCidrs(servers: ServerConfig[]): string[] {
   return Array.from(new Set(servers.flatMap((s) => endpointForcedRouteCidrs(s))));
+}
+
+/**
+ * 跨组网节点同网段「被覆盖（shadowed）」检测：按 `servers` 顺序「首声明者占有」（与 route-builder
+ * `claimedCidrs` 同一不变量——一条 ip_cidr 只能指向一个 outbound，首条命中即生效）。返回 serverId →
+ * 该节点中被更早节点抢占、因而**不会**实际生效的具体段列表（仅含有冲突的节点）。供列表「网段被覆盖」角标
+ * 提醒用：用户据此去重/调序/用自定义规则覆盖。route-builder 仅对 emitted 端点应用此规则并 warn；本函数用
+ * 全量 servers 给 UI 概览（更早暴露潜在重叠）。
+ */
+export function meshShadowedCidrs(servers: ServerConfig[]): Map<string, string[]> {
+  const claimed = new Set<string>();
+  const result = new Map<string, string[]>();
+  for (const s of servers) {
+    const shadowed: string[] = [];
+    for (const c of endpointForcedRouteCidrs(s)) {
+      if (claimed.has(c)) shadowed.push(c);
+      else claimed.add(c);
+    }
+    if (shadowed.length > 0) result.set(s.id, shadowed);
+  }
+  return result;
 }


### PR DESCRIPTION
> 实验性：本 PR 修改组网节点的路由出口兜底逻辑，已过本机 gate + 独立复审，**真机抓包验证尚未完成**（见末尾「验证状态」）。涉及实际路由行为，合入前建议在 Mac/Win 真机确认。

## 背景

组网（WireGuard / Tailscale / WARP）「允许访问外网」开关（Phase 1）+ 连接闸门已随 #82 合并进 `main`。本 PR 是其上的**单点修复**，只动出口兜底逻辑，不重复 Phase 1。

## 问题（根因）

当用户把一个**关闭「允许访问外网」**的组网节点选作当前主出口时，该节点的 `peer.allowed_ips` 只承载对端内网具体段、不含 `0.0.0.0/0`。此时被导向该节点 tag 的**海外流量无出口 → 黑洞**。

此前的兜底（D4，`meshGlobalFinalFallsBackToDirect`）**只覆盖 global 模式的 final 出口**，smart 模式的 `geosite-!cn` / `google` / `final` 三条海外路径仍然黑洞。

## 改动（D7）

- `meshGlobalFinalFallsBackToDirect` → **`meshSelectedExitFallsBackToDirect`**：global 与 smart **同兜底**——选中节点为「关外网组网节点」时，用户出口（global 的 `final`、smart 的 `geosite-!cn`/`google`/`final`）整体回退 `direct`，海外流量直连而非黑洞。
- `userExitTag = exitFallback ? 'direct' : 'proxy-selector'`；`exitFallback` 时跳过其前的 `blockQuic` UDP reject，避免误拒直连 UDP。
- **不采用「置灰 connect / 禁止 off-mesh 作主」**：那会阻断启动 sing-box，连组网本身都用不了。
- 新增 **`meshShadowedCidrs`**：多个组网节点声明重叠网段时，按首声明者占有，被覆盖的节点在概览中显示「网段被覆盖」角标。

单一真值仍在 `shared/endpoint-routes.ts`；路由生成接线 `singbox-route-builder.ts`，UI 接线 `server-list.tsx` / `proxy-control-card.tsx`。

## 影响面 / 正交性

- 与上游近期合入的 **#82**（Phase 1）、**#78**（节点「直连」项，哨兵 `__direct__` 不在 `config.servers`，与回退逻辑天然正交）、**#79**（Conduit UI）、**#83**（DoH 预解析）均无符号/语义冲突。
- 回退仅作用于「选中关外网组网节点为主」这一情形；其余模式行为不变（global on/off、smart on/off、direct 四象限旧版语义等价，唯 smart-off 由黑洞→直连，即本次修复目标）。

## 验证状态

- [x] typecheck（tsc）0 error
- [x] eslint 0 error
- [x] jest 全量 1217 通过（含 D7 global/smart/direct on-off + shadowedCidrs 顺序/去重/catch-all 11 例、出口回退 + blockQuic 配对剔除 4 例）
- [x] 独立代码复审 SOUND（集成无回归）
- [ ] **真机抓包**（Mac/Win）：WG on/off 出网 + 对端内网可达 / global·smart+off 海外走直连不黑洞 / TUN 无系统路由污染 / WARP 等价 — 待补
