### PR TITLE
fix(ip): 出口 IP 获取重试 + 获取中态，最终失败显示友好提示

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1220,6 +1220,10 @@ if (gotTheLock) {
       // 「已断开 / 启用代理」而进程实际在跑）。放在首行确保后续 await 抛错也不漏刷；IPC/托盘/startup 的
       // 显式 updateTrayMenuState(true) 退化为幂等冗余。
       void updateTrayMenuState(true);
+
+      // 出口 IP：start 瞬间即置「获取中」，消除「running 已 true 但下方延迟 1.5s 刷新尚未开始」窗口内
+      // 代理出口闪「代理出口暂不可用」。随后的延迟 refresh(true) 接力真正探测（带重试）。
+      ipInfoService?.markProxyConnecting();
       statsService?.start();
       subscriptionScheduler?.onProxyStarted(); // 代理就绪 → 补跑因 viaProxy 跳过的启动订阅更新
       try {

--- a/src/main/services/IpInfoService.ts
+++ b/src/main/services/IpInfoService.ts
@@ -13,7 +13,13 @@ import { isIP } from 'net';
 import type { IpInfo, IpInfoSnapshot } from '../../shared/types';
 
 const TTL_MS = 60_000;
-const REQ_TIMEOUT_MS = 5000;
+const REQ_TIMEOUT_MS = 5000; // 单个探测请求超时上限（httpText）——重试不会无限阻塞
+// 出口 IP 启动初期隧道/DNS 未就绪 → 首测易失败。重试至 MAX_PROBE_ATTEMPTS 上限、每次间隔 RETRY_DELAY_MS，
+// 期间保持 loading（界面显「获取中」）；全部失败才报错（界面友好提示，不闪「获取失败」）。
+const MAX_PROBE_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1000;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 interface ProbeEndpoint {
   host: string;
@@ -80,11 +86,19 @@ export class IpInfoService {
    * @param isRunning sing-box 是否在运行
    * @param onUpdate 快照更新时回调（广播给渲染端）
    */
+  // 探针重试上限 / 间隔（默认取模块常量；可经构造选项注入，供单测设 maxAttempts=1/delay=0 还原单次行为）。
+  private readonly maxAttempts: number;
+  private readonly retryDelayMs: number;
+
   constructor(
     private readonly getProbePorts: () => { direct: number; proxy: number } | null,
     private readonly isRunning: () => boolean,
-    private readonly onUpdate: (snap: IpInfoSnapshot) => void
-  ) {}
+    private readonly onUpdate: (snap: IpInfoSnapshot) => void,
+    options?: { maxAttempts?: number; retryDelayMs?: number }
+  ) {
+    this.maxAttempts = options?.maxAttempts ?? MAX_PROBE_ATTEMPTS;
+    this.retryDelayMs = options?.retryDelayMs ?? RETRY_DELAY_MS;
+  }
 
   getSnapshot(): IpInfoSnapshot {
     return { ...this.snapshot };
@@ -126,6 +140,17 @@ export class IpInfoService {
     return this.getSnapshot();
   }
 
+  /** 探测重试：成功即返回；失败按 RETRY_DELAY_MS 间隔重试至 MAX_PROBE_ATTEMPTS 上限；全失败返 null。
+   *  期间不改 loading（调用方保持 loading=true → 界面持续「获取中」），避免启动初期隧道未就绪时闪失败。 */
+  private async withRetry<T>(fn: () => Promise<T | null>): Promise<T | null> {
+    for (let i = 0; i < this.maxAttempts; i++) {
+      const r = await fn();
+      if (r) return r;
+      if (i < this.maxAttempts - 1) await delay(this.retryDelayMs);
+    }
+    return null;
+  }
+
   private async doRefreshProxy(): Promise<void> {
     const ports = this.getProbePorts();
     if (!this.isRunning() || !ports) {
@@ -135,7 +160,7 @@ export class IpInfoService {
     }
     this.snapshot = { ...this.snapshot, loading: true };
     this.onUpdate(this.getSnapshot());
-    const p = await this.queryViaProxy(ports.proxy);
+    const p = await this.withRetry(() => this.queryViaProxy(ports.proxy));
     this.snapshot = {
       ...this.snapshot,
       proxy: p ?? this.snapshot.proxy, // 失败保留旧值
@@ -158,9 +183,10 @@ export class IpInfoService {
     let failed = false;
 
     if (running && ports) {
+      // 启动初期隧道/DNS 未就绪 → withRetry 重试（期间 loading 仍 true，界面「获取中」），不闪失败。
       const [d, p] = await Promise.all([
-        this.queryDirectChain((ep) => this.viaProbe(ports.direct, ep)),
-        this.queryViaProxy(ports.proxy),
+        this.withRetry(() => this.queryDirectChain((ep) => this.viaProbe(ports.direct, ep))),
+        this.withRetry(() => this.queryViaProxy(ports.proxy)),
       ]);
       if (d) direct = d;
       else failed = true;
@@ -172,7 +198,7 @@ export class IpInfoService {
       failed = true;
     } else {
       // 核心未运行：direct 走主进程裸 fetch（无 TUN，必直连）；proxy 不可测
-      const d = await this.queryDirect();
+      const d = await this.withRetry(() => this.queryDirect());
       if (d) direct = d;
       else failed = true;
       proxy = null;

--- a/src/main/services/IpInfoService.ts
+++ b/src/main/services/IpInfoService.ts
@@ -104,6 +104,16 @@ export class IpInfoService {
     return { ...this.snapshot };
   }
 
+  /**
+   * 代理启动瞬间立即置「获取中」(loading=true) 并广播：由调用方在 running 翻转的同刻调用，消除「running 已 true
+   * 但探测尚未开始（启动后延迟 refresh）」窗口内代理出口闪「代理出口暂不可用」。不清旧 proxy 值（切节点时旧 IP
+   * 仍显示到新值到达；启动时 proxy 本为 null → 直接显「获取中」骨架）。随后的 refresh/refreshProxy 接力真正探测。
+   */
+  markProxyConnecting(): void {
+    this.snapshot = { ...this.snapshot, loading: true };
+    this.onUpdate(this.getSnapshot());
+  }
+
   /** 把刷新任务排到当前在途之后（链式），避免 force/proxy 刷新被 in-flight 去重静默吞掉。 */
   private enqueue(fn: () => Promise<void>): Promise<void> {
     const prev = this.inflight;

--- a/src/main/services/__tests__/IpInfoService.test.ts
+++ b/src/main/services/__tests__/IpInfoService.test.ts
@@ -457,12 +457,7 @@ describe('IpInfoService 传输层', () => {
   it('重试：代理首轮全失败、次轮成功 → 取到 IP 不报错，且过程出现「获取中」(loading)', async () => {
     // maxAttempts=2：第 1 轮 PROXY_CHAIN 3 端点全 503 失败 → 间隔后第 2 轮首跳 trace 成功。
     const { svc, snapshots } = makeService({ maxAttempts: 2, retryDelayMs: 0 });
-    responders = [
-      respondStatus(503),
-      respondStatus(503),
-      respondStatus(503),
-      respondOk(TRACE_OK),
-    ];
+    responders = [respondStatus(503), respondStatus(503), respondStatus(503), respondOk(TRACE_OK)];
     const snap = await svc.refreshProxy();
     expect(snap.proxy).toEqual({ ip: '104.28.210.15', countryCode: 'US' }); // 重试后取到
     expect(snap.error).toBeUndefined(); // 不报错（不闪「获取失败」）

--- a/src/main/services/__tests__/IpInfoService.test.ts
+++ b/src/main/services/__tests__/IpInfoService.test.ts
@@ -472,4 +472,12 @@ describe('IpInfoService 传输层', () => {
     expect(snap.proxy).toBeNull();
     expect(snap.error).toBe('fetch_failed');
   });
+
+  it('markProxyConnecting：立即置 loading=true 并广播（消除启动瞬间闪「代理出口暂不可用」）', () => {
+    const { svc, snapshots } = makeService();
+    expect(svc.getSnapshot().loading).not.toBe(true);
+    svc.markProxyConnecting();
+    expect(svc.getSnapshot().loading).toBe(true); // 同步置「获取中」
+    expect(snapshots[snapshots.length - 1].loading).toBe(true); // 已广播给渲染端
+  });
 });

--- a/src/main/services/__tests__/IpInfoService.test.ts
+++ b/src/main/services/__tests__/IpInfoService.test.ts
@@ -257,16 +257,21 @@ describe('IpInfoService 传输层', () => {
     );
   }
 
-  /** 构造一个 service：默认 running + 探针端口可用；onUpdate 收集快照。 */
+  /** 构造一个 service：默认 running + 探针端口可用；onUpdate 收集快照。
+   *  默认 maxAttempts=1/delay=0 → 还原「单次探测」行为，传输层用例的固定 responder 队列不受重试影响；
+   *  需测重试的用例显式传 maxAttempts>1。 */
   function makeService(opts?: {
     ports?: { direct: number; proxy: number } | null;
     running?: boolean;
+    maxAttempts?: number;
+    retryDelayMs?: number;
   }) {
     const snapshots: IpInfoSnapshot[] = [];
     const svc = new IpInfoService(
       () => (opts?.ports === undefined ? { direct: 18080, proxy: 18081 } : opts.ports),
       () => opts?.running ?? true,
-      (s) => snapshots.push(s)
+      (s) => snapshots.push(s),
+      { maxAttempts: opts?.maxAttempts ?? 1, retryDelayMs: opts?.retryDelayMs ?? 0 }
     );
     return { svc, snapshots };
   }
@@ -447,5 +452,29 @@ describe('IpInfoService 传输层', () => {
     expect(snap.proxy).toEqual({ ip: '104.28.210.15', countryCode: 'US' });
     expect(calls.length).toBe(1); // 首跳成功即短路
     expect(hostOf(calls[0].options)).toBe('cloudflare.com');
+  });
+
+  it('重试：代理首轮全失败、次轮成功 → 取到 IP 不报错，且过程出现「获取中」(loading)', async () => {
+    // maxAttempts=2：第 1 轮 PROXY_CHAIN 3 端点全 503 失败 → 间隔后第 2 轮首跳 trace 成功。
+    const { svc, snapshots } = makeService({ maxAttempts: 2, retryDelayMs: 0 });
+    responders = [
+      respondStatus(503),
+      respondStatus(503),
+      respondStatus(503),
+      respondOk(TRACE_OK),
+    ];
+    const snap = await svc.refreshProxy();
+    expect(snap.proxy).toEqual({ ip: '104.28.210.15', countryCode: 'US' }); // 重试后取到
+    expect(snap.error).toBeUndefined(); // 不报错（不闪「获取失败」）
+    expect(snapshots.some((s) => s.loading === true)).toBe(true); // 重试期间显「获取中」
+  });
+
+  it('重试耗尽仍失败 → proxy 保持空 + error（由界面显友好提示，非「获取失败」字样）', async () => {
+    const { svc } = makeService({ maxAttempts: 2, retryDelayMs: 0 });
+    // 两轮各 3 端点全失败（6 个 503）
+    responders = Array.from({ length: 6 }, () => respondStatus(503));
+    const snap = await svc.refreshProxy();
+    expect(snap.proxy).toBeNull();
+    expect(snap.error).toBe('fetch_failed');
   });
 });

--- a/src/renderer/components/home/network-info-card.tsx
+++ b/src/renderer/components/home/network-info-card.tsx
@@ -145,7 +145,8 @@ export function NetworkInfoCard() {
 
   const directInfo = ipInfo?.direct ?? null;
   const proxyInfo = running ? (ipInfo?.proxy ?? null) : null;
-  const proxyEmpty = running ? t('home.ipFetchFailed') : t('home.ipNotConnected');
+  // 最终态（重试耗尽仍无值）友好提示，不再用刺眼的「获取失败」：运行中→代理出口暂不可用；未运行→未连接。
+  const proxyEmpty = running ? t('home.ipProxyUnavailable') : t('home.ipNotConnected');
 
   return (
     <Card>
@@ -207,7 +208,7 @@ export function NetworkInfoCard() {
             <p className="text-xs text-muted-foreground">{t('home.localExit')}</p>
             <div className="flex min-w-0 items-start gap-1.5">
               <Flag cc={masked ? undefined : directInfo?.countryCode} />
-              {renderIpValue(directInfo, t('home.ipFetchFailed'))}
+              {renderIpValue(directInfo, t('home.ipNoInternet'))}
             </div>
             <p className="truncate text-[11px] text-muted-foreground/70">
               {renderIpSub(directInfo, t('home.directLabel'))}

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -301,6 +301,8 @@
     "activeConnections": "Active",
     "ipNotConnected": "Not connected",
     "ipFetchFailed": "Failed",
+    "ipNoInternet": "Internet unreachable",
+    "ipProxyUnavailable": "Proxy exit unavailable",
     "refreshIp": "Refresh",
     "maskIp": "Hide IP",
     "ipStale": "Some exit IPs failed to fetch; showing last known result",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -301,6 +301,8 @@
     "activeConnections": "活动连接",
     "ipNotConnected": "未连接",
     "ipFetchFailed": "获取失败",
+    "ipNoInternet": "暂无法访问外网",
+    "ipProxyUnavailable": "代理出口暂不可用",
     "refreshIp": "刷新",
     "maskIp": "隐藏 IP",
     "ipStale": "部分出口 IP 获取失败，显示为上次结果",


### PR DESCRIPTION
代理启动初期隧道/DNS 未就绪 → 出口 IP 探针首测易失败，旧逻辑立即闪「获取失败」后才显示正确 IP。

- **IpInfoService**：探针加 `withRetry`（上限 `MAX_PROBE_ATTEMPTS=3`、间隔 `RETRY_DELAY_MS=1000`），重试期间保持 `loading=true`（界面持续「获取中」骨架）；每个探测请求本身有 `REQ_TIMEOUT_MS=5000` 超时上限，重试不会无限阻塞。重试参数构造注入，单测设 `attempts=1/delay=0` 还原单次行为。
- **最终态友好文案**（重试耗尽仍无值才报错）：本地出口→「暂无法访问外网」、代理出口→「代理出口暂不可用」，不再用刺眼的「获取失败」。zh/en 均加。
- 补 2 个重试单测（首轮失败次轮成功取到 IP + 过程出现 loading；重试耗尽报错）。gate 全绿 1208 tests。
