### PR TITLE
fix(logs): 启动期瞬态噪音——更新检查网络切换重试 + 版本行解析降级

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1369,7 +1369,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       this.coreVersionLine = await this.spawnCoreVersionFirstLine();
       return this.coreVersionLine;
     } catch (error) {
-      this.logToManager('warn', `获取核心版本行失败: ${(error as any).message}`);
+      // 仅影响 classifyCoreBuild（fork 判定）的最佳努力细节；主版本检测（getCoreVersion）有独立错误日志。
+      // 命令偶发失败常自恢复（下次 start force 重取），降 debug 避免误导（曾在真机日志刷 warn 但版本已正常检测）。
+      this.logToManager('debug', `获取核心版本行失败: ${(error as any).message}`);
       this.coreVersionLine = null;
       return '';
     }

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -58,10 +58,17 @@ export class UpdateService {
     this.mainWindow = window;
   }
 
+  /** 网络切换/断连瞬态错误（TUN 起来、断网重连，启动期常见）：不报刺眼 error，延迟重试一次再定论。 */
+  private isTransientNetworkError(msg: string): boolean {
+    return /ERR_NETWORK_CHANGED|ERR_INTERNET_DISCONNECTED|ERR_NETWORK_IO_SUSPENDED|ERR_NAME_NOT_RESOLVED|ECONNRESET|ETIMEDOUT|socket hang up/i.test(
+      msg
+    );
+  }
+
   /**
-   * 检查更新
+   * 检查更新（retried：内部一次性重试标记，瞬态网络错误延迟后自重试用）
    */
-  async checkForUpdate(includePrerelease = false): Promise<UpdateCheckResult> {
+  async checkForUpdate(includePrerelease = false, retried = false): Promise<UpdateCheckResult> {
     try {
       this.logManager.addLog('info', '开始检查更新...', 'UpdateService');
       this.updateProgress({ status: 'checking', percentage: 0, message: '正在检查更新...' });
@@ -134,9 +141,25 @@ export class UpdateService {
       return { hasUpdate: true, updateInfo };
     } catch (error: any) {
       const errorMessage = error?.message || '检查更新失败';
-      this.logManager.addLog('error', `检查更新失败: ${errorMessage}`, 'UpdateService');
+      const transient = this.isTransientNetworkError(errorMessage);
+      // 网络切换/瞬态（TUN 起来、断网重连，启动期常见）：不报刺眼 error；首次延迟 5s 自重试一次（等网络稳定）。
+      if (transient && !retried) {
+        this.logManager.addLog(
+          'info',
+          `网络切换中，5s 后重试检查更新: ${errorMessage}`,
+          'UpdateService'
+        );
+        await new Promise((r) => setTimeout(r, 5000));
+        return this.checkForUpdate(includePrerelease, true);
+      }
+      // 重试后仍失败的瞬态 → warn + 静默（no-update），不弹 error UI；其它 → error。
+      this.logManager.addLog(
+        transient ? 'warn' : 'error',
+        `检查更新失败: ${errorMessage}`,
+        'UpdateService'
+      );
       this.updateProgress({
-        status: 'error',
+        status: transient ? 'no-update' : 'error',
         percentage: 0,
         message: '检查更新失败',
         error: errorMessage,


### PR DESCRIPTION
实测真机启动日志两处误导性噪音（功能正常却报 error/warn）：

- **更新检查 net::ERR_NETWORK_CHANGED**：TUN 起来瞬间网络重配，启动期自动检查更新撞 `ERR_NETWORK_CHANGED` → 原 ERROR「检查更新失败」。改：`isTransientNetworkError` 识别网络切换瞬态，**首次延迟 5s 自重试一次**（等网络稳定，多半即成）；重试仍失败 → warn + 静默 no-update（不弹 error UI）；非瞬态才 error。
- **getCoreVersionLine 失败 → debug**：`sing-box version` 行解析偶发失败仅影响 fork 判定的最佳努力细节，主版本检测（getCoreVersion）正常且有独立错误日志，故 warn 降 debug（曾在真机刷 warn 但版本已正常检测）。