### PR TITLE
feat(servers): 节点表单支持 gRPC 传输 + 修复 HTTP/2(http) 静默降级裸 TCP

### DIFF
--- a/src/main/services/__tests__/singbox-outbound-builder.test.ts
+++ b/src/main/services/__tests__/singbox-outbound-builder.test.ts
@@ -221,3 +221,79 @@ describe('buildProxyOutbound — resolve-ahead（resolvedHosts → outbound.serv
     );
   });
 });
+
+// H2(http)/gRPC 传输：generateTransportConfig 之前漏 http 分支 → network=http 静默降级裸 TCP（表单 + 导入两路皆坏）。
+// 此处锁 http 分支生成真 http 传输、grpc 照常、tcp 无 transport。
+describe('buildProxyOutbound — http(H2)/gRPC 传输生成', () => {
+  const tags = new Map<string, string>();
+  const node = (over: Partial<ServerConfig>): ServerConfig =>
+    ({
+      id: 'n',
+      name: 'N',
+      address: 'node.example.com',
+      port: 443,
+      ...over,
+    }) as unknown as ServerConfig;
+
+  it('http(H2)：httpSettings → transport {type:http, host[], path}', () => {
+    const ob = buildProxyOutbound(
+      node({
+        protocol: 'vless',
+        uuid: 'u',
+        security: 'tls',
+        network: 'http',
+        httpSettings: { path: '/h2', host: ['a.com', 'b.com'] },
+      }),
+      tags
+    );
+    expect(ob.transport).toEqual({ type: 'http', host: ['a.com', 'b.com'], path: '/h2' });
+  });
+
+  it('http 无 httpSettings：仍生成 http 传输（path 默认 /），不回退裸 TCP', () => {
+    const ob = buildProxyOutbound(
+      node({ protocol: 'vless', uuid: 'u', security: 'tls', network: 'http' }),
+      tags
+    );
+    expect(ob.transport?.type).toBe('http');
+    expect(ob.transport?.path).toBe('/');
+  });
+
+  it('grpc：grpcSettings → transport {type:grpc, service_name}', () => {
+    const ob = buildProxyOutbound(
+      node({
+        protocol: 'trojan',
+        password: 'p',
+        security: 'tls',
+        network: 'grpc',
+        grpcSettings: { serviceName: 'GunSvc' },
+      }),
+      tags
+    );
+    expect(ob.transport).toEqual({ type: 'grpc', service_name: 'GunSvc' });
+  });
+
+  it('network=tcp：无 transport', () => {
+    const ob = buildProxyOutbound(
+      node({ protocol: 'vless', uuid: 'u', security: 'tls', network: 'tcp' }),
+      tags
+    );
+    expect(ob.transport).toBeUndefined();
+  });
+
+  it("legacy 'h2'（旧表单遗留 network 值）→ 兼容生成 http 传输（非裸 TCP）", () => {
+    const ob = buildProxyOutbound(
+      {
+        id: 'n',
+        name: 'N',
+        address: 'node.example.com',
+        port: 443,
+        protocol: 'vless',
+        uuid: 'u',
+        security: 'tls',
+        network: 'h2',
+      } as unknown as ServerConfig,
+      tags
+    );
+    expect(ob.transport?.type).toBe('http');
+  });
+});

--- a/src/main/services/singbox-config-types.ts
+++ b/src/main/services/singbox-config-types.ts
@@ -141,7 +141,8 @@ export interface SingBoxOutbound {
   transport?: {
     type: string;
     path?: string;
-    host?: string;
+    host?: string | string[];
+    method?: string;
     headers?: Record<string, string | string[]>;
     service_name?: string;
     max_early_data?: number;

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -414,6 +414,19 @@ function generateTransportConfig(server: ServerConfig): SingBoxOutbound['transpo
     };
   }
 
+  // HTTP/2 传输（v2ray http transport，需 TLS）：host 为 string[]、path 默认 '/'。
+  // 不严格门控 httpSettings——任何 network=http 都生成 http 传输，避免回退裸 TCP（导入/表单两路统一）。
+  // 'h2' 为旧表单遗留的 network 值（现已统一为 'http'）；兼容旧配置：不必重新编辑即生效。
+  if (server.network === 'http' || (server.network as string) === 'h2') {
+    return {
+      type: 'http',
+      host: server.httpSettings?.host,
+      path: server.httpSettings?.path || '/',
+      method: server.httpSettings?.method,
+      headers: server.httpSettings?.headers,
+    };
+  }
+
   // httpupgrade：较 ws 更隐蔽的 HTTP Upgrade 传输（复用 ws 的 path / Host）
   if (server.network === 'httpupgrade') {
     return {

--- a/src/renderer/components/settings/shared/field-schemas.ts
+++ b/src/renderer/components/settings/shared/field-schemas.ts
@@ -93,3 +93,48 @@ export function buildMultiplexSettings(
       }
     : undefined;
 }
+
+/**
+ * 传输层（ws / httpupgrade / http(H2) / grpc）字段的共享 path/Host/serviceName 读写。
+ * 三表单（vless/vmess/trojan）此前各自重复构造 wsSettings/httpSettings/grpcSettings 与读取默认值。
+ * 渲染层组件在 transport-fields.tsx（WsPathField/WsHostField/GrpcServiceNameField）。
+ */
+interface TransportValues {
+  wsPath?: string;
+  wsHost?: string;
+  grpcServiceName?: string;
+}
+
+/** 从既有 serverConfig 读取传输字段默认值（ws/http 共用 wsPath/wsHost 输入框；undefined=新建分支）。 */
+export function readTransportDefaults(serverConfig?: ServerConfig) {
+  return {
+    wsPath: serverConfig?.wsSettings?.path || serverConfig?.httpSettings?.path || '',
+    wsHost:
+      serverConfig?.wsSettings?.headers?.['Host'] || serverConfig?.httpSettings?.host?.[0] || '',
+    grpcServiceName: serverConfig?.grpcSettings?.serviceName || '',
+  };
+}
+
+/**
+ * 按规范化后的 network（小写真值：tcp/ws/grpc/http/httpupgrade）构造对应传输 settings；
+ * 其余置 null（与各表单既有 wsSettings 三元同构）。ws 与 httpupgrade 共用 wsSettings。
+ */
+export function buildTransportSettings(network: string, values: TransportValues) {
+  return {
+    wsSettings:
+      network === 'ws' || network === 'httpupgrade'
+        ? {
+            path: values.wsPath || '/',
+            headers: values.wsHost ? { Host: values.wsHost } : undefined,
+          }
+        : null,
+    httpSettings:
+      network === 'http'
+        ? {
+            path: values.wsPath || '/',
+            host: values.wsHost ? [values.wsHost] : undefined,
+          }
+        : null,
+    grpcSettings: network === 'grpc' ? { serviceName: values.grpcServiceName?.trim() || '' } : null,
+  };
+}

--- a/src/renderer/components/settings/shared/transport-fields.tsx
+++ b/src/renderer/components/settings/shared/transport-fields.tsx
@@ -58,3 +58,23 @@ export function WsHostField({ control, t }: { control: AnyControl; t: TFn }) {
     />
   );
 }
+
+/** gRPC service name。约定字段名：grpcServiceName?: string。 */
+export function GrpcServiceNameField({ control, t }: { control: AnyControl; t: TFn }) {
+  return (
+    <FormField
+      control={control}
+      name="grpcServiceName"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{t('servers.grpcServiceName')}</FormLabel>
+          <FormControl>
+            <Input placeholder="GunService" {...field} />
+          </FormControl>
+          <FormDescription>{t('servers.grpcServiceNameDesc')}</FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/renderer/components/settings/trojan-form.tsx
+++ b/src/renderer/components/settings/trojan-form.tsx
@@ -27,7 +27,7 @@ import {
   AllowInsecureField,
   AlpnField,
 } from './shared/tls-fields';
-import { WsPathField, WsHostField } from './shared/transport-fields';
+import { WsPathField, WsHostField, GrpcServiceNameField } from './shared/transport-fields';
 import { FormSection, FieldGrid, FieldSpan } from './shared/form-layout';
 import { FormButtons } from './shared/form-buttons';
 import {
@@ -38,6 +38,8 @@ import {
   readEchDefault,
   readMultiplexDefaults,
   buildMultiplexSettings,
+  readTransportDefaults,
+  buildTransportSettings,
 } from './shared/field-schemas';
 import type { ServerConfig } from '@/bridge/types';
 import { useTranslation } from 'react-i18next';
@@ -47,7 +49,7 @@ const createTrojanSchema = (t: any) =>
     address: z.string().min(1, t('servers.addressRequired')),
     port: z.number().min(1).max(65535),
     password: z.string().min(1, t('servers.passwordRequired')),
-    network: z.enum(['tcp', 'ws', 'h2', 'httpupgrade']),
+    network: z.enum(['tcp', 'ws', 'grpc', 'http', 'httpupgrade']),
     security: z.enum(['none', 'tls']),
     tlsServerName: z.string().optional(),
     tlsAllowInsecure: z.boolean(),
@@ -55,6 +57,7 @@ const createTrojanSchema = (t: any) =>
     alpn: z.string().optional(),
     wsPath: z.string().optional(),
     wsHost: z.string().optional(),
+    grpcServiceName: z.string().optional(),
     ...echSchemaShape,
     ...multiplexSchemaShape,
   });
@@ -82,8 +85,7 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
       tlsAllowInsecure: false,
       tlsFingerprint: 'none',
       alpn: '',
-      wsPath: '',
-      wsHost: '',
+      ...readTransportDefaults(),
       ...echDefaults,
       ...multiplexDefaults,
     },
@@ -92,11 +94,14 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
   useEffect(() => {
     if (serverConfig && serverConfig.protocol?.toLowerCase() === 'trojan') {
       // 标准化 network 和 security 值（转为全小写以匹配 schema）
-      const normalizeNetwork = (n: string | undefined): 'tcp' | 'ws' | 'h2' | 'httpupgrade' => {
+      const normalizeNetwork = (
+        n: string | undefined
+      ): 'tcp' | 'ws' | 'grpc' | 'http' | 'httpupgrade' => {
         const lower = (n || 'tcp').toLowerCase();
         if (lower === 'ws' || lower === 'websocket') return 'ws';
         if (lower === 'httpupgrade') return 'httpupgrade';
-        if (lower === 'h2' || lower === 'http2') return 'h2';
+        if (lower === 'grpc') return 'grpc';
+        if (lower === 'h2' || lower === 'http' || lower === 'http2') return 'http';
         return 'tcp';
       };
       const normalizeSecurity = (s: string | undefined): 'none' | 'tls' => {
@@ -114,8 +119,7 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
         tlsAllowInsecure: serverConfig.tlsSettings?.allowInsecure || false,
         tlsFingerprint: serverConfig.tlsSettings?.fingerprint || 'none',
         alpn: serverConfig.tlsSettings?.alpn?.join(',') || '',
-        wsPath: serverConfig.wsSettings?.path || '',
-        wsHost: serverConfig.wsSettings?.headers?.['Host'] || '',
+        ...readTransportDefaults(serverConfig),
         ...readEchDefault(serverConfig),
         ...readMultiplexDefaults(serverConfig),
       };
@@ -124,12 +128,13 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
   }, [serverConfig, form]);
 
   const handleSubmit = async (values: TrojanFormValues) => {
+    const network = values.network;
     const config = {
       protocol: 'trojan',
       address: values.address,
       port: values.port,
       password: values.password,
-      network: values.network,
+      network,
       security: values.security,
       tlsSettings:
         values.security === 'tls'
@@ -142,13 +147,7 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
               echConfig: values.echConfig?.trim() || undefined,
             }
           : null,
-      wsSettings:
-        values.network === 'ws' || values.network === 'httpupgrade'
-          ? {
-              path: values.wsPath || '/',
-              headers: values.wsHost ? { Host: values.wsHost } : undefined,
-            }
-          : null,
+      ...buildTransportSettings(network, values),
       multiplexSettings: buildMultiplexSettings(values),
     };
 
@@ -156,8 +155,10 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
   };
 
   const isTlsEnabled = form.watch('security') === 'tls';
-  const isWebSocketEnabled =
-    form.watch('network') === 'ws' || form.watch('network') === 'httpupgrade';
+  const watchedNetwork = form.watch('network');
+  const showPathHostFields =
+    watchedNetwork === 'ws' || watchedNetwork === 'httpupgrade' || watchedNetwork === 'http';
+  const isGrpcEnabled = watchedNetwork === 'grpc';
 
   return (
     <Form {...form}>
@@ -201,8 +202,9 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
                     <SelectContent>
                       <SelectItem value="tcp">TCP</SelectItem>
                       <SelectItem value="ws">WebSocket</SelectItem>
+                      <SelectItem value="grpc">gRPC</SelectItem>
                       <SelectItem value="httpupgrade">HTTPUpgrade</SelectItem>
-                      <SelectItem value="h2">HTTP/2</SelectItem>
+                      <SelectItem value="http">HTTP/2</SelectItem>
                     </SelectContent>
                   </Select>
                   <FormDescription>{t('servers.transportDesc')}</FormDescription>
@@ -250,10 +252,16 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
             </FieldGrid>
           )}
 
-          {isWebSocketEnabled && (
+          {showPathHostFields && (
             <FieldGrid cols={2}>
               <WsPathField control={form.control} t={t} />
               <WsHostField control={form.control} t={t} />
+            </FieldGrid>
+          )}
+
+          {isGrpcEnabled && (
+            <FieldGrid cols={2}>
+              <GrpcServiceNameField control={form.control} t={t} />
             </FieldGrid>
           )}
 

--- a/src/renderer/components/settings/vless-form.tsx
+++ b/src/renderer/components/settings/vless-form.tsx
@@ -22,7 +22,7 @@ import { FormButtons } from './shared/form-buttons';
 import { EchField, MultiplexFields } from './shared/anti-censor-fields';
 import { AddressField, PortField } from './shared/basic-fields';
 import { TlsServerNameField, FingerprintField, AllowInsecureField } from './shared/tls-fields';
-import { WsPathField, WsHostField } from './shared/transport-fields';
+import { WsPathField, WsHostField, GrpcServiceNameField } from './shared/transport-fields';
 import { RealityPublicKeyField, RealityShortIdField } from './shared/reality-fields';
 import { FormSection, FieldGrid, FieldSpan } from './shared/form-layout';
 import {
@@ -33,6 +33,8 @@ import {
   readEchDefault,
   readMultiplexDefaults,
   buildMultiplexSettings,
+  readTransportDefaults,
+  buildTransportSettings,
 } from './shared/field-schemas';
 import type { ServerConfig } from '@/bridge/types';
 import { useTranslation } from 'react-i18next';
@@ -50,7 +52,7 @@ const createVlessSchema = (t: any) =>
       ),
     encryption: z.string().optional(),
     flow: z.string().optional(),
-    network: z.enum(['Tcp', 'Ws', 'H2', 'HttpUpgrade']),
+    network: z.enum(['Tcp', 'Ws', 'Grpc', 'Http', 'HttpUpgrade']),
     security: z.enum(['None', 'Tls', 'Reality']),
     tlsServerName: z.string().optional(),
     tlsAllowInsecure: z.boolean(),
@@ -59,6 +61,7 @@ const createVlessSchema = (t: any) =>
     realityShortId: z.string().optional(),
     wsPath: z.string().optional(),
     wsHost: z.string().optional(),
+    grpcServiceName: z.string().optional(),
     ...echSchemaShape,
     ...multiplexSchemaShape,
   });
@@ -74,11 +77,14 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
   const { t } = useTranslation();
   const vlessFormSchema = createVlessSchema(t);
 
-  const normalizeNetwork = (n: string | undefined): 'Tcp' | 'Ws' | 'H2' | 'HttpUpgrade' => {
+  const normalizeNetwork = (
+    n: string | undefined
+  ): 'Tcp' | 'Ws' | 'Grpc' | 'Http' | 'HttpUpgrade' => {
     const lower = (n || 'tcp').toLowerCase();
     if (lower === 'ws' || lower === 'websocket') return 'Ws';
     if (lower === 'httpupgrade') return 'HttpUpgrade';
-    if (lower === 'h2' || lower === 'http2') return 'H2';
+    if (lower === 'grpc') return 'Grpc';
+    if (lower === 'h2' || lower === 'http' || lower === 'http2') return 'Http';
     return 'Tcp';
   };
 
@@ -104,8 +110,7 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
         tlsFingerprint: serverConfig.tlsSettings?.fingerprint || 'chrome',
         realityPublicKey: serverConfig.realitySettings?.publicKey || '',
         realityShortId: serverConfig.realitySettings?.shortId || '',
-        wsPath: serverConfig.wsSettings?.path || '',
-        wsHost: serverConfig.wsSettings?.headers?.['Host'] || '',
+        ...readTransportDefaults(serverConfig),
         ...readEchDefault(serverConfig),
         ...readMultiplexDefaults(serverConfig),
       };
@@ -123,8 +128,7 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
       tlsFingerprint: 'chrome',
       realityPublicKey: '',
       realityShortId: '',
-      wsPath: '',
-      wsHost: '',
+      ...readTransportDefaults(),
       ...echDefaults,
       ...multiplexDefaults,
     };
@@ -136,7 +140,7 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
   });
 
   const handleSubmit = async (values: VlessFormValues) => {
-    const network = values.network.toLowerCase() as 'tcp' | 'ws' | 'h2' | 'httpupgrade';
+    const network = values.network.toLowerCase();
     const security = values.security.toLowerCase() as 'none' | 'tls' | 'reality';
 
     const serverConfig = {
@@ -165,13 +169,7 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
               shortId: values.realityShortId?.trim() || undefined,
             }
           : null,
-      wsSettings:
-        network === 'ws' || network === 'httpupgrade'
-          ? {
-              path: values.wsPath || '/',
-              headers: values.wsHost ? { Host: values.wsHost } : undefined,
-            }
-          : null,
+      ...buildTransportSettings(network, values),
       multiplexSettings: buildMultiplexSettings(values, { skipVisionFlow: true }),
     };
 
@@ -180,8 +178,10 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
 
   const isTlsEnabled = form.watch('security') === 'Tls';
   const isRealityEnabled = form.watch('security') === 'Reality';
-  const isWebSocketEnabled =
-    form.watch('network') === 'Ws' || form.watch('network') === 'HttpUpgrade';
+  const watchedNetwork = form.watch('network');
+  const showPathHostFields =
+    watchedNetwork === 'Ws' || watchedNetwork === 'HttpUpgrade' || watchedNetwork === 'Http';
+  const isGrpcEnabled = watchedNetwork === 'Grpc';
 
   return (
     <Form {...form}>
@@ -242,8 +242,9 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
                     <SelectContent>
                       <SelectItem value="Tcp">TCP</SelectItem>
                       <SelectItem value="Ws">WebSocket</SelectItem>
+                      <SelectItem value="Grpc">gRPC</SelectItem>
                       <SelectItem value="HttpUpgrade">HTTPUpgrade</SelectItem>
-                      <SelectItem value="H2">HTTP/2</SelectItem>
+                      <SelectItem value="Http">HTTP/2</SelectItem>
                     </SelectContent>
                   </Select>
                   <FormDescription>{t('servers.transportDesc')}</FormDescription>
@@ -338,10 +339,16 @@ export function VlessForm({ serverConfig, onSubmit }: VlessFormProps) {
             </FieldGrid>
           )}
 
-          {isWebSocketEnabled && (
+          {showPathHostFields && (
             <FieldGrid cols={2}>
               <WsPathField control={form.control} t={t} />
               <WsHostField control={form.control} t={t} />
+            </FieldGrid>
+          )}
+
+          {isGrpcEnabled && (
+            <FieldGrid cols={2}>
+              <GrpcServiceNameField control={form.control} t={t} />
             </FieldGrid>
           )}
 

--- a/src/renderer/components/settings/vmess-form.tsx
+++ b/src/renderer/components/settings/vmess-form.tsx
@@ -22,7 +22,7 @@ import { FormButtons } from './shared/form-buttons';
 import { EchField, MultiplexFields } from './shared/anti-censor-fields';
 import { AddressField, PortField } from './shared/basic-fields';
 import { TlsServerNameField, FingerprintField, AllowInsecureField } from './shared/tls-fields';
-import { WsPathField, WsHostField } from './shared/transport-fields';
+import { WsPathField, WsHostField, GrpcServiceNameField } from './shared/transport-fields';
 import { FormSection, FieldGrid, FieldSpan } from './shared/form-layout';
 import {
   echSchemaShape,
@@ -32,6 +32,8 @@ import {
   readEchDefault,
   readMultiplexDefaults,
   buildMultiplexSettings,
+  readTransportDefaults,
+  buildTransportSettings,
 } from './shared/field-schemas';
 import type { ServerConfig } from '@/bridge/types';
 import { useTranslation } from 'react-i18next';
@@ -49,13 +51,14 @@ const createVmessSchema = (t: any) =>
       ),
     alterId: z.number().default(0),
     vmessSecurity: z.string().default('auto'),
-    network: z.enum(['Tcp', 'Ws', 'H2', 'HttpUpgrade']),
+    network: z.enum(['Tcp', 'Ws', 'Grpc', 'Http', 'HttpUpgrade']),
     security: z.enum(['None', 'Tls']),
     tlsServerName: z.string().optional().or(z.literal('')),
     tlsAllowInsecure: z.boolean(),
     tlsFingerprint: z.string().optional().or(z.literal('')),
     wsPath: z.string().optional().or(z.literal('')),
     wsHost: z.string().optional().or(z.literal('')),
+    grpcServiceName: z.string().optional().or(z.literal('')),
     ...echSchemaShape,
     ...multiplexSchemaShape,
   });
@@ -71,11 +74,14 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
   const { t } = useTranslation();
   const vmessFormSchema = createVmessSchema(t);
 
-  const normalizeNetwork = (n: string | undefined): 'Tcp' | 'Ws' | 'H2' | 'HttpUpgrade' => {
+  const normalizeNetwork = (
+    n: string | undefined
+  ): 'Tcp' | 'Ws' | 'Grpc' | 'Http' | 'HttpUpgrade' => {
     const lower = (n || 'tcp').toLowerCase();
     if (lower === 'ws' || lower === 'websocket') return 'Ws';
     if (lower === 'httpupgrade') return 'HttpUpgrade';
-    if (lower === 'h2' || lower === 'http2') return 'H2';
+    if (lower === 'grpc') return 'Grpc';
+    if (lower === 'h2' || lower === 'http' || lower === 'http2') return 'Http';
     return 'Tcp';
   };
 
@@ -98,8 +104,7 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
         tlsServerName: serverConfig.tlsSettings?.serverName || '',
         tlsAllowInsecure: serverConfig.tlsSettings?.allowInsecure || false,
         tlsFingerprint: serverConfig.tlsSettings?.fingerprint || 'chrome',
-        wsPath: serverConfig.wsSettings?.path || '',
-        wsHost: serverConfig.wsSettings?.headers?.['Host'] || '',
+        ...readTransportDefaults(serverConfig),
         ...readEchDefault(serverConfig),
         ...readMultiplexDefaults(serverConfig),
       };
@@ -115,8 +120,7 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
       tlsServerName: '',
       tlsAllowInsecure: false,
       tlsFingerprint: 'chrome',
-      wsPath: '',
-      wsHost: '',
+      ...readTransportDefaults(),
       ...echDefaults,
       ...multiplexDefaults,
     };
@@ -128,7 +132,7 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
   });
 
   const handleSubmit = async (values: VmessFormValues) => {
-    const network = values.network.toLowerCase() as 'tcp' | 'ws' | 'h2' | 'httpupgrade';
+    const network = values.network.toLowerCase();
     const security = values.security.toLowerCase() as 'none' | 'tls';
 
     const serverConfig = {
@@ -150,13 +154,7 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
               echConfig: values.echConfig?.trim() || undefined,
             }
           : null,
-      wsSettings:
-        network === 'ws' || network === 'httpupgrade'
-          ? {
-              path: values.wsPath || '/',
-              headers: values.wsHost ? { Host: values.wsHost } : undefined,
-            }
-          : null,
+      ...buildTransportSettings(network, values),
       multiplexSettings: buildMultiplexSettings(values),
     };
 
@@ -164,8 +162,10 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
   };
 
   const isTlsEnabled = form.watch('security') === 'Tls';
-  const isWebSocketEnabled =
-    form.watch('network') === 'Ws' || form.watch('network') === 'HttpUpgrade';
+  const watchedNetwork = form.watch('network');
+  const showPathHostFields =
+    watchedNetwork === 'Ws' || watchedNetwork === 'HttpUpgrade' || watchedNetwork === 'Http';
+  const isGrpcEnabled = watchedNetwork === 'Grpc';
 
   return (
     <Form {...form}>
@@ -260,8 +260,9 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
                     <SelectContent>
                       <SelectItem value="Tcp">TCP</SelectItem>
                       <SelectItem value="Ws">WebSocket</SelectItem>
+                      <SelectItem value="Grpc">gRPC</SelectItem>
                       <SelectItem value="HttpUpgrade">HTTPUpgrade</SelectItem>
-                      <SelectItem value="H2">HTTP/2</SelectItem>
+                      <SelectItem value="Http">HTTP/2</SelectItem>
                     </SelectContent>
                   </Select>
                   <FormDescription>{t('servers.transportDesc')}</FormDescription>
@@ -306,10 +307,16 @@ export function VmessForm({ serverConfig, onSubmit }: VmessFormProps) {
             </FieldGrid>
           )}
 
-          {isWebSocketEnabled && (
+          {showPathHostFields && (
             <FieldGrid cols={2}>
               <WsPathField control={form.control} t={t} />
               <WsHostField control={form.control} t={t} />
+            </FieldGrid>
+          )}
+
+          {isGrpcEnabled && (
+            <FieldGrid cols={2}>
+              <GrpcServiceNameField control={form.control} t={t} />
             </FieldGrid>
           )}
 

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -776,6 +776,8 @@
     "wsPathDesc": "WebSocket connection path",
     "wsHost": "WebSocket Host",
     "wsHostDesc": "WebSocket Host header",
+    "grpcServiceName": "gRPC Service Name",
+    "grpcServiceNameDesc": "gRPC service_name; must match the server.",
     "none": "None",
     "optional": "Optional",
     "random": "Random",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -776,6 +776,8 @@
     "wsPathDesc": "WebSocket 连接路径",
     "wsHost": "WebSocket 主机头",
     "wsHostDesc": "WebSocket Host 请求头",
+    "grpcServiceName": "gRPC 服务名",
+    "grpcServiceNameDesc": "gRPC service_name，需与服务端一致",
     "none": "无",
     "optional": "可选",
     "random": "随机",


### PR DESCRIPTION
## 背景
`generateTransportConfig` 缺 `http` 分支 → `network=http` 的节点（表单选 H2 / 订阅导入 `type=http`）静默回退裸 TCP（`transport` 为 undefined），H2 传输端到端不可用。

## 改动
- **builder**：补 `http` 传输分支（`{type:'http', host, path}`），`network=http` 即生成真 v2ray http 传输，不门控 httpSettings（避免裸 TCP 回退）；兼容旧表单遗留的 `network='h2'` 值。
- **表单（vless/vmess/trojan）**：network 选择器新增 **gRPC**（+ `service_name` 输入）；H2 表单值统一为规范 `'http'`，删除跨层 `'h2'` 方言（parser/builder/类型早已用 `'http'`，表单是最后滞留点）。
- **复用**：共享 `GrpcServiceNameField`；`field-schemas` 抽 `buildTransportSettings`/`readTransportDefaults`，消除 3 表单传输 settings 构造/默认读取重复。
- **类型**：`transport.host` 放宽 `string | string[]` + 补 `method`，对齐 sing-box http 传输 wire 格式。
- **i18n**：双 locale `servers.grpcServiceName`。

## 验证
tsc（main+renderer）/eslint/jest 全绿（1218 tests / 27 snapshots）；`buildProxyOutbound` 单测覆盖 http / grpc / h2-legacy / tcp 四路。

## 已知限制（后续，非本 PR 引入）
- http 传输需 TLS，表单允许 `Http + security=none`（旧 H2 同此）；可后续加 `network=http ⇒ security≠none` 校验。
- SubscriptionService JSON 订阅导入丢 `http.host`（既有，未触及）。