### PR TITLE
feat(home): 导流脊端点跟随连接态——中性提亮 + 降级琥珀断点

### DIFF
--- a/src/renderer/components/home/__tests__/spine-state.test.ts
+++ b/src/renderer/components/home/__tests__/spine-state.test.ts
@@ -1,0 +1,39 @@
+import { deriveSpineVisual } from '../spine-state';
+
+describe('deriveSpineVisual — 导流脊三态矩阵', () => {
+  it('离线：整条灰睡，端点不提亮', () => {
+    expect(deriveSpineVisual(false, false)).toEqual({
+      youDotLit: false,
+      leg1: 'idle',
+      leg2: 'idle',
+      internet: 'muted',
+    });
+  });
+
+  it('离线时忽略 degraded（离线的 error 与代理路径无关）', () => {
+    expect(deriveSpineVisual(false, true)).toEqual({
+      youDotLit: false,
+      leg1: 'idle',
+      leg2: 'idle',
+      internet: 'muted',
+    });
+  });
+
+  it('已连健康：两段 flow，Internet 端点中性提亮（foreground，非染绿）', () => {
+    expect(deriveSpineVisual(true, false)).toEqual({
+      youDotLit: true,
+      leg1: 'flow',
+      leg2: 'flow',
+      internet: 'foreground',
+    });
+  });
+
+  it('降级：leg1 仍 flow（核在）、leg2 fault、Internet 端点 warning', () => {
+    expect(deriveSpineVisual(true, true)).toEqual({
+      youDotLit: true,
+      leg1: 'flow',
+      leg2: 'fault',
+      internet: 'warning',
+    });
+  });
+});

--- a/src/renderer/components/home/network-info-card.tsx
+++ b/src/renderer/components/home/network-info-card.tsx
@@ -7,6 +7,7 @@ import { formatBytes } from '@/lib/format';
 import { Eye, EyeOff, RotateCw, Globe, ArrowUp, ArrowDown, Activity } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { IpInfo } from '@/bridge/types';
+import { deriveSpineVisual, type SpineState } from './spine-state';
 
 const MASK_KEY = 'flowz:maskIp';
 const MASKED_IP = '••• ••• ••• •••';
@@ -37,13 +38,26 @@ function countryNameOf(cc: string | undefined, lang: string): string | undefined
 }
 
 /** 导流连接线：连上=live 绿 + 流动光点（motion-safe，reduced-motion 下静止）；未连=暗线。 */
-function ConduitLink({ running }: { running: boolean }) {
+function ConduitLink({ state }: { state: SpineState }) {
+  if (state === 'fault') {
+    // 断点段:琥珀虚线、无流光——与上游绿色活路对比,读作「流到这里断了」。
+    return (
+      <div className="relative h-px flex-1">
+        <div className="h-0 w-full border-t border-dashed border-warning/70" />
+      </div>
+    );
+  }
+  if (state === 'flow') {
+    return (
+      <div className="relative h-px flex-1">
+        <div className="h-px w-full bg-success/40" />
+        <span className="absolute top-1/2 h-1 w-1 -translate-y-1/2 rounded-full bg-success shadow-[0_0_6px] shadow-success motion-safe:animate-conduit-flow" />
+      </div>
+    );
+  }
   return (
     <div className="relative h-px flex-1">
-      <div className={running ? 'h-px w-full bg-success/40' : 'h-px w-full bg-border'} />
-      {running && (
-        <span className="absolute top-1/2 h-1 w-1 -translate-y-1/2 rounded-full bg-success shadow-[0_0_6px] shadow-success motion-safe:animate-conduit-flow" />
-      )}
+      <div className="h-px w-full bg-border" />
     </div>
   );
 }
@@ -88,6 +102,20 @@ export function NetworkInfoCard() {
 
   const running = connectionStatus?.proxyCore?.running ?? false;
   const loading = ipInfo?.loading ?? false;
+
+  // 导流脊三态。降级=连上但出口 IP 探测异常(error==='fetch_failed'),复用 IP 卡标题黄点的同源信号——
+  // 仅 running 时对脊有意义(未连时 error 是直连探测失败,与代理路径无关)。loading 中暂不判降级,等探测落定。
+  // error 是「本地+代理出口」探测的并集(IpInfoService.doRefresh),故末段琥珀是「出口探测降级」的保守提示,
+  // 非「外网确定不可达」;proxy 探测失败会保留旧 IP 值,故只能靠 error 判降级,不能靠 proxy 是否为空。
+  const degraded = running && !!ipInfo?.error && !loading;
+  const spine = deriveSpineVisual(running, degraded);
+  // 端点色档→class。中性提亮(muted→foreground,不染绿,绿留给流光+出口);降级转 warning。
+  const internetColor =
+    spine.internet === 'warning'
+      ? 'text-warning'
+      : spine.internet === 'foreground'
+        ? 'text-foreground'
+        : 'text-muted-foreground';
 
   const [masked, setMasked] = useState<boolean>(() => localStorage.getItem(MASK_KEY) === '1');
 
@@ -183,11 +211,14 @@ export function NetworkInfoCard() {
         </div>
       </CardHeader>
       <CardContent>
-        {/* 导流脊:你 ● ── 出口 ◉(连上 live 绿锁定) ── Internet。签名,数据见下方 IP 详情 */}
+        {/* 导流脊:你 ● ── 出口 ◉(连上 live 绿锁定) ── Internet。签名,数据见下方 IP 详情。
+            端点中性提亮(非染绿)、降级末段转琥珀虚线;绿色专留给流光+出口节点,保视觉主次。 */}
         <div className="mb-5 flex items-center gap-2.5 px-1">
           <span className="shrink-0 text-xs font-medium">{t('home.myDevice')}</span>
-          <span className="h-2.5 w-2.5 shrink-0 rounded-full border border-muted-foreground/50" />
-          <ConduitLink running={running} />
+          <span
+            className={`h-2.5 w-2.5 shrink-0 rounded-full border ${spine.youDotLit ? 'border-foreground/60' : 'border-muted-foreground/50'}`}
+          />
+          <ConduitLink state={spine.leg1} />
           <span
             className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 ${running ? 'border-success shadow-[0_0_8px] shadow-success/40' : 'border-muted-foreground/40'}`}
             title={t('home.proxyExit')}
@@ -196,9 +227,14 @@ export function NetworkInfoCard() {
               className={`h-1.5 w-1.5 rounded-full ${running ? 'bg-success motion-safe:animate-pulse' : 'bg-muted-foreground/40'}`}
             />
           </span>
-          <ConduitLink running={running} />
-          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="shrink-0 text-xs text-muted-foreground">Internet</span>
+          <ConduitLink state={spine.leg2} />
+          <Globe className={`h-4 w-4 shrink-0 ${internetColor}`} />
+          <span
+            className={`shrink-0 text-xs ${internetColor}`}
+            title={degraded ? t('home.ipStale', '部分出口 IP 获取失败，显示为上次结果') : undefined}
+          >
+            Internet
+          </span>
         </div>
 
         {/* IP 详情:本地出口 / 代理出口（含国旗 + IP + 地区，保留全部信息） */}

--- a/src/renderer/components/home/spine-state.ts
+++ b/src/renderer/components/home/spine-state.ts
@@ -1,0 +1,44 @@
+/**
+ * 导流脊（NetworkInfoCard 顶部「你 ── 出口 ── Internet」）的视觉态推导 —— 纯函数，从组件抽出便于
+ * 单测覆盖状态矩阵（同 connection-status.ts 模式）。无 react/store 依赖，输入两个布尔、输出视觉档。
+ */
+
+/** 脊一段的连通态：idle=灰睡 / flow=绿色活路+流光 / fault=琥珀虚线断点（流光停）。 */
+export type SpineState = 'idle' | 'flow' | 'fault';
+
+/** Internet 端点（Globe+文字）的语义色档：muted=睡 / foreground=醒（中性提亮，非染绿）/ warning=降级。 */
+export type EndpointTone = 'muted' | 'foreground' | 'warning';
+
+export interface SpineVisual {
+  /** 「你的设备」端口圆点：连上中性提亮（muted→foreground），睡时灰。 */
+  youDotLit: boolean;
+  /** 你 → 出口 段。 */
+  leg1: SpineState;
+  /** 出口 → Internet 段。 */
+  leg2: SpineState;
+  /** Internet 端点色档。 */
+  internet: EndpointTone;
+}
+
+/**
+ * 三态视觉：离线（整条灰睡）/ 已连健康（绿活路 + 端点中性提亮）/ 降级（你→出口 green、出口→Internet 琥珀断、
+ * Internet 端点琥珀）。配色纪律：绿色专留给流光+出口节点（载流量的主体），端点只做中性提亮不染绿，避免「糊成一片绿」。
+ *
+ * @param running 代理核心是否在跑（connectionStatus.proxyCore.running）。
+ * @param degraded 连上但出口 IP 探测异常（调用方算 running && ipInfo.error && !loading）。未连时无意义——
+ *   本函数在 !running 时一律返回 idle，忽略 degraded（离线的 error 是直连探测失败，与代理路径无关）。
+ *   注意 ipInfo.error 是「本地出口 ∪ 代理出口」探测的并集（IpInfoService.doRefresh），故 degraded 触发面
+ *   ⊇「仅代理出口失败」——这是有意的保守近似：单一 error 标记不分通道，宁可偏保守显降级。
+ *
+ * 降级时 leg1（你→出口）仍为 flow、仅 leg2 转 fault：核心在跑即隧道已建；末段琥珀（warning，非 destructive）
+ * 是「出口可达性存疑/连接质量降级」的保守提示，不强断言外网确定不可达。
+ */
+export function deriveSpineVisual(running: boolean, degraded: boolean): SpineVisual {
+  if (!running) {
+    return { youDotLit: false, leg1: 'idle', leg2: 'idle', internet: 'muted' };
+  }
+  if (degraded) {
+    return { youDotLit: true, leg1: 'flow', leg2: 'fault', internet: 'warning' };
+  }
+  return { youDotLit: true, leg1: 'flow', leg2: 'flow', internet: 'foreground' };
+}


### PR DESCRIPTION
## 问题

首页「网络信息」卡顶部的导流脊「你 ── 出口 ── Internet」两端语义不对称：「你」恒为前景色、Internet 端点（Globe + 文字）**恒灰**、仅中段出口节点随连接态变绿。连上时整条脊不「点亮」，读起来是「中间有块绿」而非「一条从我到外网的活路」，不直观。

## 改动

导流脊改为三态，配色遵循三色纪律（灰 = 未连 / 绿 = 活路 / 琥珀 = 降级），单元素不同时挂两色：

- **离线**：整条灰睡。
- **已连（健康）**：你→出口、出口→Internet 两段绿色流光，出口节点绿环脉冲；端点（「你」端口圆点 + Globe/Internet）从 muted **中性提亮到 foreground**——刻意**不染绿**，把绿色留给真正载流量的流光与出口节点，避免「糊成一片绿」、保视觉主次。
- **降级**（连上但出口 IP 探测失败）：你→出口保持绿（核心在跑即隧道已建），出口→Internet 转**琥珀（warning）虚线**、Internet 端点转琥珀，把故障精确定位在「出口之后」。

降级信号复用卡片标题已有黄点的同源信号 `ipInfo.error`（`running && error && !loading`，loading 门避免连上瞬间误闪）。脊三态（idle/flow/fault）视觉推导抽成纯函数 `spine-state.ts` + 单测覆盖状态矩阵（对齐既有 `connection-status.ts` 模式）。

## 已知近似

`ipInfo.error` 是「本地出口 ∪ 代理出口」探测的并集，故降级触发面 ⊇「仅代理出口失败」：仅本地直连出口探测失败（代理实际可达）时末段也会显琥珀。属有意保守近似——琥珀（warning）语义本就是「出口探测降级 / 存疑」而非「外网确定不可达」。精确化需主进程拆分通道 error，本 PR 不含。

## 验证

- eslint（含 renderer 禁裸 hex 护栏）/ renderer tsc / jest 全绿；新增 4 用例覆盖三态矩阵。
- 新增 token 类（`border-foreground/60`、`border-warning/70`、`text-warning` / `text-foreground`）在明暗双主题均已定义。
- headless 渲染三态 × 双主题截图核对配色。
