### PR TITLE
fix(protocol): TUIC 0-RTT / AnyTLS idle / SSH client-version 字段收敛回填 + duration 单一真值

### DIFF
--- a/src/main/services/ClashSubscriptionParser.ts
+++ b/src/main/services/ClashSubscriptionParser.ts
@@ -13,6 +13,7 @@
 import { randomUUID } from 'crypto';
 import { load as yamlLoad } from 'js-yaml';
 import type { ServerConfig, Protocol } from '../../shared/types';
+import { normalizeDuration } from '../../shared/duration';
 
 // ── 探测正则 / 校验 ──────────────────────────────────────────────────────────
 /** 内联 proxies: 或 proxy-providers: 任一命中即「确为 Clash 意图」。 */
@@ -70,25 +71,6 @@ function bool(v: unknown): boolean | undefined {
   if (typeof v === 'boolean') return v;
   if (v === 'true' || v === 1 || v === '1') return true;
   if (v === 'false' || v === 0 || v === '0') return false;
-  return undefined;
-}
-
-/**
- * 时长字段规整成 sing-box 接受的 Go duration（`time.ParseDuration`）。
- * mihomo 常把 heartbeat-interval 写成毫秒整数（如 10000），裸传给 sing-box 会报 "missing unit"
- * 启动失败。规则：纯数字（含数字字符串）→ 视为毫秒补 `ms`；已带单位字符串透传。
- */
-export function normalizeDuration(v: unknown): string | undefined {
-  if (v === undefined || v === null) return undefined;
-  if (typeof v === 'number') {
-    return Number.isFinite(v) ? `${v}ms` : undefined;
-  }
-  if (typeof v === 'string') {
-    const t = v.trim();
-    if (t === '') return undefined;
-    // 纯数字（可含小数）→ 毫秒补单位；否则视为已带单位（10s/500ms/1m 等）透传。
-    return /^[0-9]+(\.[0-9]+)?$/.test(t) ? `${t}ms` : t;
-  }
   return undefined;
 }
 
@@ -497,6 +479,17 @@ function mapNode(rawProxy: unknown, subscriptionId: string, now: string): NodeOu
       const password = str(p['password']);
       if (!password) return { kind: 'fail', reason: `anytls 节点 "${name}" 缺 password` };
       config.password = password;
+      // anytls 会话保活三件套：与 parseAnyTls/AnyTlsForm 收敛面对齐（mihomo 连字符 key，兼容下划线）
+      const at: NonNullable<ServerConfig['anyTlsSettings']> = {};
+      const idleCheck = normalizeDuration(
+        p['idle-session-check-interval'] ?? p['idle_session_check_interval']
+      );
+      if (idleCheck) at.idleSessionCheckInterval = idleCheck;
+      const idleTimeout = normalizeDuration(p['idle-session-timeout'] ?? p['idle_session_timeout']);
+      if (idleTimeout) at.idleSessionTimeout = idleTimeout;
+      const minIdle = num(p['min-idle-session'] ?? p['min_idle_session']);
+      if (minIdle !== undefined) at.minIdleSession = minIdle;
+      if (Object.keys(at).length > 0) config.anyTlsSettings = at;
       applyTransportAndTls(config, p, true); // anytls 默认 TLS
     } else if (protocol === 'socks') {
       // socks5：可选用户名/密码；指纹凭据取 username。
@@ -536,6 +529,8 @@ function mapNode(rawProxy: unknown, subscriptionId: string, now: string): NodeOu
         const a = hka.map((x) => str(x)).filter((x): x is string => !!x);
         if (a.length > 0) ssh.hostKeyAlgorithms = a;
       }
+      const cv = str(p['client-version']);
+      if (cv) ssh.clientVersion = cv;
       config.network = 'tcp';
       config.security = 'none';
       if (Object.keys(ssh).length > 0) config.sshSettings = ssh;

--- a/src/main/services/ProtocolParser.ts
+++ b/src/main/services/ProtocolParser.ts
@@ -19,6 +19,7 @@ import type {
   AnyTlsSettings,
   LogLevel,
 } from '../../shared/types';
+import { normalizeDuration } from '../../shared/duration';
 import type { LogManager } from './LogManager';
 
 export interface IProtocolParser {
@@ -428,6 +429,10 @@ export class ProtocolParser implements IProtocolParser {
     if (heartbeat) {
       config.tuicSettings!.heartbeat = heartbeat;
     }
+    const zrtt = params.get('zero_rtt_handshake');
+    if (zrtt) {
+      config.tuicSettings!.zeroRttHandshake = zrtt === '1' || zrtt === 'true';
+    }
 
     return config;
   }
@@ -455,8 +460,8 @@ export class ProtocolParser implements IProtocolParser {
 
     // AnyTLS 会话参数
     const anyTlsSettings: AnyTlsSettings = {};
-    const idleCheckInterval = params.get('idle_session_check_interval');
-    const idleTimeout = params.get('idle_session_timeout');
+    const idleCheckInterval = normalizeDuration(params.get('idle_session_check_interval'));
+    const idleTimeout = normalizeDuration(params.get('idle_session_timeout'));
     const minIdle = params.get('min_idle_session');
     if (idleCheckInterval) anyTlsSettings.idleSessionCheckInterval = idleCheckInterval;
     if (idleTimeout) anyTlsSettings.idleSessionTimeout = idleTimeout;
@@ -1200,6 +1205,9 @@ export class ProtocolParser implements IProtocolParser {
       }
       if (config.tuicSettings.heartbeat) {
         params.set('heartbeat', config.tuicSettings.heartbeat);
+      }
+      if (config.tuicSettings.zeroRttHandshake) {
+        params.set('zero_rtt_handshake', '1');
       }
     }
 

--- a/src/main/services/SubscriptionService.ts
+++ b/src/main/services/SubscriptionService.ts
@@ -10,9 +10,9 @@ import {
   tryLoadClashDoc,
   parseClashProxies,
   resolveProxyProviders,
-  normalizeDuration,
   type ClashDoc,
 } from './ClashSubscriptionParser';
+import { normalizeDuration } from '../../shared/duration';
 
 /** 默认订阅 UA：纯中性 `FlowZ/<版本>`（去除 clash.meta/mihomo 标识，陈先生 2026-06-12 决策）。 */
 export function defaultSubscriptionUserAgent(): string {

--- a/src/main/services/__tests__/ClashSubscriptionParser.test.ts
+++ b/src/main/services/__tests__/ClashSubscriptionParser.test.ts
@@ -12,13 +12,13 @@ import {
   compileProviderFilter,
   applyProviderFilters,
   applyOverride,
-  normalizeDuration,
   MAX_FILTER_PATTERN_LEN,
   MAX_FILTER_NAME_LEN,
   type ProviderDeps,
   type ClashParseResult,
 } from '../ClashSubscriptionParser';
 import { ProtocolParser } from '../ProtocolParser';
+import { normalizeDuration } from '../../../shared/duration';
 import type { ServerConfig } from '../../../shared/types';
 
 const SUB_ID = 'sub-test';
@@ -346,6 +346,59 @@ describe('parseClashProxies — 协议映射', () => {
     const ssh = byName(servers, 'ssh');
     expect(ssh.sshSettings?.password).toBe('sshpw');
     expect(ssh.sshSettings?.user).toBe('root');
+  });
+
+  // 收敛面回填：anytls idle 三件套 + ssh client-version 此前 mapNode 不读 → 订阅导入丢字段。
+  it('anytls 读 idle 三件套（连字符 key + 毫秒整数规整 ms）', () => {
+    const { servers } = parseClashProxies(
+      [
+        {
+          name: 'anytls',
+          type: 'anytls',
+          server: '9.9.9.9',
+          port: 443,
+          password: 'ap',
+          sni: 'a.com',
+          'idle-session-check-interval': 30000,
+          'idle-session-timeout': '60s',
+          'min-idle-session': 5,
+        },
+      ],
+      SUB_ID,
+      NOW
+    );
+    const at = byName(servers, 'anytls').anyTlsSettings;
+    expect(at?.idleSessionCheckInterval).toBe('30000ms'); // 裸毫秒整数补单位
+    expect(at?.idleSessionTimeout).toBe('60s'); // 已带单位透传
+    expect(at?.minIdleSession).toBe(5);
+  });
+
+  it('anytls 无 idle 字段 → anyTlsSettings 不被臆造', () => {
+    const { servers } = parseClashProxies(
+      [{ name: 'anytls', type: 'anytls', server: '9.9.9.9', port: 443, password: 'ap' }],
+      SUB_ID,
+      NOW
+    );
+    expect(byName(servers, 'anytls').anyTlsSettings).toBeUndefined();
+  });
+
+  it('ssh 读 client-version（有值才写，守卫式）', () => {
+    const { servers } = parseClashProxies(
+      [
+        {
+          name: 'ssh',
+          type: 'ssh',
+          server: '10.0.0.3',
+          port: 22,
+          username: 'root',
+          password: 'sshpw',
+          'client-version': 'SSH-2.0-OpenSSH_9.0',
+        },
+      ],
+      SUB_ID,
+      NOW
+    );
+    expect(byName(servers, 'ssh').sshSettings?.clientVersion).toBe('SSH-2.0-OpenSSH_9.0');
   });
 
   it('不支持类型聚合告警（ssr/wireguard），不整批失败', () => {

--- a/src/main/services/__tests__/protocol-parser.test.ts
+++ b/src/main/services/__tests__/protocol-parser.test.ts
@@ -225,6 +225,19 @@ describe('AnyTLS', () => {
     expect(c.security).toBe('tls');
   });
 
+  // 收敛面对齐：URL 导入路径的 idle duration 与 Clash 路径同款经 normalizeDuration
+  // 规整裸毫秒（防外部手写 anytls:// 带无单位 idle → sing-box "missing unit"）。
+  it('idle duration 裸毫秒补 ms（与 Clash 路径一致）', () => {
+    const c = parser.parseUrl(
+      'anytls://pw@f.example.com:443?security=tls&idle_session_check_interval=30000&idle_session_timeout=5000&min_idle_session=3#n'
+    );
+    expect(c.anyTlsSettings).toEqual({
+      idleSessionCheckInterval: '30000ms',
+      idleSessionTimeout: '5000ms',
+      minIdleSession: 3,
+    });
+  });
+
   it('往返不动点', () =>
     void expectRoundTripStable(
       'anytls://atlspass@f.example.com:443?security=tls&sni=at.example.com&fp=chrome&idle_session_timeout=30s&idle_session_check_interval=5s&min_idle_session=2#anytls-1'
@@ -259,6 +272,30 @@ describe('TUIC', () => {
     void expectRoundTripStable(
       'tuic://uuid-tuic:tuicpass@g.example.com:443?congestion_control=bbr&udp_relay_mode=native&alpn=h3&sni=tu.example.com&allow_insecure=1#tuic-1'
     ));
+
+  // zero_rtt_handshake parse↔generate 往返守恒：加字段漏扫 generate 端会在此断言失守。
+  it('zero_rtt_handshake=1 解析为 true', () => {
+    const c = parser.parseUrl(
+      'tuic://uuid-tuic:tuicpass@g.example.com:443?congestion_control=bbr&zero_rtt_handshake=1&sni=tu.example.com#zrtt'
+    );
+    expect(c.tuicSettings?.zeroRttHandshake).toBe(true);
+    // generate 端必须回写，否则往返丢字段
+    expect(parser.generateUrl(c)).toContain('zero_rtt_handshake=1');
+  });
+
+  it('往返不动点（zeroRttHandshake=true）', () =>
+    void expectRoundTripStable(
+      'tuic://uuid-tuic:tuicpass@g.example.com:443?congestion_control=bbr&udp_relay_mode=native&zero_rtt_handshake=1&alpn=h3&sni=tu.example.com#zrtt-on'
+    ));
+
+  it('往返不动点（zeroRttHandshake 缺省，不被臆造）', () => {
+    const url =
+      'tuic://uuid-tuic:tuicpass@g.example.com:443?congestion_control=bbr&sni=tu.example.com#zrtt-off';
+    const c = parser.parseUrl(url);
+    expect(c.tuicSettings?.zeroRttHandshake).toBeUndefined();
+    expect(parser.generateUrl(c)).not.toContain('zero_rtt_handshake');
+    void expectRoundTripStable(url);
+  });
 });
 
 describe('Naive', () => {

--- a/src/shared/duration.ts
+++ b/src/shared/duration.ts
@@ -1,0 +1,21 @@
+/**
+ * 时长字段规整成 sing-box 接受的 Go duration（`time.ParseDuration`）。
+ * mihomo / 分享链常把时长字段写成毫秒整数（如 10000），裸传给 sing-box 会报 "missing unit"
+ * 启动失败。规则：纯数字（含数字字符串）→ 视为毫秒补 `ms`；已带单位字符串透传。
+ *
+ * 单一真值：Clash 订阅解析（heartbeat / anytls idle）与 ProtocolParser 的 anytls idle URL 导入
+ * 共用本函数，避免两条导入路径产出不一致的 duration 串（收敛面对齐）。
+ */
+export function normalizeDuration(v: unknown): string | undefined {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v === 'number') {
+    return Number.isFinite(v) ? `${v}ms` : undefined;
+  }
+  if (typeof v === 'string') {
+    const t = v.trim();
+    if (t === '') return undefined;
+    // 纯数字（可含小数）→ 毫秒补单位；否则视为已带单位（10s/500ms/1m 等）透传。
+    return /^[0-9]+(\.[0-9]+)?$/.test(t) ? `${t}ms` : t;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## 背景
节点表单可选设置(#101)等新增字段只补了部分落点，导致协议字段在 parse / generate / Clash mapNode 间漂移（导入/导出丢字段）。

## 改动
- **TUIC zeroRttHandshake**：parseTuic 补读 + generateTuicUrl 补写，分享链往返守恒
- **AnyTLS idle 三件套 / SSH client-version**：ClashSubscriptionParser mapNode 补读（订阅导入不再丢配）
- **normalizeDuration 抽 `src/shared/duration.ts`**：ProtocolParser / ClashSubscriptionParser / SubscriptionService 三处共用单一真值（顺带修 anytls URL 导入 idle 未规整、与 Clash 路径不一致）
- 补 protocol-parser / ClashSubscriptionParser 单测锁字段往返与读取

## 验证
main tsc + jest（protocol-parser / ClashSubscriptionParser 154 测）全绿。
