### PR TITLE
fix(ui): 深色模式去眩光——徽标淡色调 + --primary 降饱和 + 导流脊末端 success

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,6 +71,16 @@ module.exports = [
           message:
             '禁裸 hex 颜色(UI 防偏移):改用 Conduit token——className 走 bg-primary/text-success/fill-primary 等,或 hsl(var(--xxx));色值定义只在 index.css token 块。确需 hex(如 Electron API/非颜色)请就地加 eslint-disable 并注明理由。',
         },
+        {
+          // UI 防偏移(护栏盲区根治):禁裸 Tailwind 灰阶 palette class(gray/zinc/slate/neutral/stone-50..950),
+          // 必须带标准颜色功能前缀(text/bg/border/fill/... -灰阶-档)才命中,避免误伤散文字符串或 scrollbar-* 插件 class。
+          // 灰阶档已有 Conduit 语义 token 等价物(text-muted-foreground / bg-muted / border-border 等),一律改走 token 随双主题。
+          // 彩色档(amber 等警示色)暂不纳入:现存成体系 warning 用法待独立批次按语义 token 迁移,避免本规则大面积误报。
+          selector:
+            'Literal[value=/(^|[\\s:!])(text|bg|border|fill|stroke|ring|ring-offset|from|via|to|divide|outline|decoration|accent|caret|placeholder|shadow)-(gray|zinc|slate|neutral|stone)-(50|100|200|300|400|500|600|700|800|900|950)\\b/]',
+          message:
+            '禁裸 Tailwind 灰阶 class(UI 防偏移):改用 Conduit 语义 token——text-muted-foreground / text-foreground / bg-muted / border-border 等,随深浅双主题。色值真值只在 index.css token 块。确需(如第三方插件 class)请就地加 eslint-disable 并注明理由。',
+        },
       ],
     },
   },

--- a/src/renderer/components/home/__tests__/spine-state.test.ts
+++ b/src/renderer/components/home/__tests__/spine-state.test.ts
@@ -19,12 +19,12 @@ describe('deriveSpineVisual — 导流脊三态矩阵', () => {
     });
   });
 
-  it('已连健康：两段 flow，Internet 端点中性提亮（foreground，非染绿）', () => {
+  it('已连健康：两段 flow，Internet 端点 success（已抵达，低强度绿）', () => {
     expect(deriveSpineVisual(true, false)).toEqual({
       youDotLit: true,
       leg1: 'flow',
       leg2: 'flow',
-      internet: 'foreground',
+      internet: 'success',
     });
   });
 

--- a/src/renderer/components/home/network-info-card.tsx
+++ b/src/renderer/components/home/network-info-card.tsx
@@ -109,12 +109,12 @@ export function NetworkInfoCard() {
   // 非「外网确定不可达」;proxy 探测失败会保留旧 IP 值,故只能靠 error 判降级,不能靠 proxy 是否为空。
   const degraded = running && !!ipInfo?.error && !loading;
   const spine = deriveSpineVisual(running, degraded);
-  // 端点色档→class。中性提亮(muted→foreground,不染绿,绿留给流光+出口);降级转 warning。
+  // 端点色档→class。健康连通末端低强度 success(读作「已抵达」;高饱和绿仍留给流光+出口节点);降级转 warning;离线 muted。
   const internetColor =
     spine.internet === 'warning'
       ? 'text-warning'
-      : spine.internet === 'foreground'
-        ? 'text-foreground'
+      : spine.internet === 'success'
+        ? 'text-success'
         : 'text-muted-foreground';
 
   const [masked, setMasked] = useState<boolean>(() => localStorage.getItem(MASK_KEY) === '1');

--- a/src/renderer/components/home/spine-state.ts
+++ b/src/renderer/components/home/spine-state.ts
@@ -6,8 +6,8 @@
 /** 脊一段的连通态：idle=灰睡 / flow=绿色活路+流光 / fault=琥珀虚线断点（流光停）。 */
 export type SpineState = 'idle' | 'flow' | 'fault';
 
-/** Internet 端点（Globe+文字）的语义色档：muted=睡 / foreground=醒（中性提亮，非染绿）/ warning=降级。 */
-export type EndpointTone = 'muted' | 'foreground' | 'warning';
+/** Internet 端点（Globe+文字）的语义色档：muted=睡 / success=醒（已抵达且健康，低强度绿）/ warning=降级。 */
+export type EndpointTone = 'muted' | 'success' | 'warning';
 
 export interface SpineVisual {
   /** 「你的设备」端口圆点：连上中性提亮（muted→foreground），睡时灰。 */
@@ -21,8 +21,9 @@ export interface SpineVisual {
 }
 
 /**
- * 三态视觉：离线（整条灰睡）/ 已连健康（绿活路 + 端点中性提亮）/ 降级（你→出口 green、出口→Internet 琥珀断、
- * Internet 端点琥珀）。配色纪律：绿色专留给流光+出口节点（载流量的主体），端点只做中性提亮不染绿，避免「糊成一片绿」。
+ * 三态视觉：离线（整条灰睡）/ 已连健康（绿活路 + Internet 端点低强度 success「已抵达」）/ 降级（你→出口 green、
+ * 出口→Internet 琥珀断、Internet 端点琥珀）。配色纪律：高饱和绿专留给流光+出口节点（载流量的主体），
+ * 末端 success 低一档、不与流光同强度，避免「糊成一片绿」。
  *
  * @param running 代理核心是否在跑（connectionStatus.proxyCore.running）。
  * @param degraded 连上但出口 IP 探测异常（调用方算 running && ipInfo.error && !loading）。未连时无意义——
@@ -40,5 +41,5 @@ export function deriveSpineVisual(running: boolean, degraded: boolean): SpineVis
   if (degraded) {
     return { youDotLit: true, leg1: 'flow', leg2: 'fault', internet: 'warning' };
   }
-  return { youDotLit: true, leg1: 'flow', leg2: 'flow', internet: 'foreground' };
+  return { youDotLit: true, leg1: 'flow', leg2: 'flow', internet: 'success' };
 }

--- a/src/renderer/components/logs/real-time-logs.tsx
+++ b/src/renderer/components/logs/real-time-logs.tsx
@@ -161,7 +161,7 @@ export function RealTimeLogs({
       case 'info':
         return 'text-info';
       case 'debug':
-        return 'text-gray-500';
+        return 'text-muted-foreground';
       default:
         return 'text-foreground';
     }

--- a/src/renderer/components/rules/sortable-rule-row.tsx
+++ b/src/renderer/components/rules/sortable-rule-row.tsx
@@ -83,7 +83,7 @@ function RuleDetailContent({
         <span className="text-xs text-muted-foreground">{t('rules.policyLabel', '策略')}</span>
         <Badge
           variant="default"
-          className={`whitespace-nowrap border-transparent text-white ${getRuleActionStyle(rule.action).badgeBg} ${getRuleActionStyle(rule.action).badgeBgHover}`}
+          className={`whitespace-nowrap border-transparent ${getRuleActionStyle(rule.action).text} ${getRuleActionStyle(rule.action).badgeBg} ${getRuleActionStyle(rule.action).badgeBgHover}`}
         >
           {ruleActionLabel(rule.action, t)}
         </Badge>
@@ -233,7 +233,7 @@ export function SortableRuleRow({
         <div className="flex flex-col items-start gap-1">
           <Badge
             variant="default"
-            className={`whitespace-nowrap border-transparent text-white ${getRuleActionStyle(rule.action).badgeBg} ${getRuleActionStyle(rule.action).badgeBgHover}`}
+            className={`whitespace-nowrap border-transparent ${getRuleActionStyle(rule.action).text} ${getRuleActionStyle(rule.action).badgeBg} ${getRuleActionStyle(rule.action).badgeBgHover}`}
           >
             {ruleActionLabel(rule.action, t)}
           </Badge>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -54,7 +54,7 @@
     --card-foreground: 210 25% 93%;
     --popover: 216 22% 9%;
     --popover-foreground: 210 25% 93%;
-    --primary: 184 78% 45%;
+    --primary: 184 70% 45%;
     --primary-foreground: 192 80% 6%;
     --secondary: 214 14% 18%;
     --secondary-foreground: 210 25% 93%;
@@ -85,7 +85,7 @@
     --badge-amber: 42.7 96.3% 56.5%;
     --border: 214 14% 18%;
     --input: 214 14% 20%;
-    --ring: 184 78% 45%;
+    --ring: 184 70% 45%;
   }
 }
 

--- a/src/renderer/lib/__tests__/rule-action-style.test.ts
+++ b/src/renderer/lib/__tests__/rule-action-style.test.ts
@@ -30,18 +30,21 @@ describe('ruleActionLabel', () => {
   });
 });
 
-describe('getRuleActionStyle 三值配色单一真值', () => {
-  it('direct → success', () => {
-    expect(getRuleActionStyle('direct').badgeBg).toBe('bg-success');
+describe('getRuleActionStyle 三值配色单一真值（badge 淡色调去眩光）', () => {
+  it('direct → success（淡色底 + 同色字）', () => {
+    expect(getRuleActionStyle('direct').badgeBg).toBe('bg-success/15');
+    expect(getRuleActionStyle('direct').text).toBe('text-success');
+    expect(getRuleActionStyle('direct').dot).toBe('bg-success'); // 拓扑点仍实色
   });
 
-  it('block 及别名 → destructive', () => {
-    expect(getRuleActionStyle('block').badgeBg).toBe('bg-destructive');
-    expect(getRuleActionStyle('reject').badgeBg).toBe('bg-destructive');
+  it('block 及别名 → destructive（淡色底）', () => {
+    expect(getRuleActionStyle('block').badgeBg).toBe('bg-destructive/15');
+    expect(getRuleActionStyle('reject').badgeBg).toBe('bg-destructive/15');
   });
 
-  it('proxy/未知 → primary', () => {
-    expect(getRuleActionStyle('proxy').badgeBg).toBe('bg-primary');
-    expect(getRuleActionStyle('node-x').badgeBg).toBe('bg-primary');
+  it('proxy/未知 → primary（淡色底 + 同色字）', () => {
+    expect(getRuleActionStyle('proxy').badgeBg).toBe('bg-primary/15');
+    expect(getRuleActionStyle('proxy').text).toBe('text-primary');
+    expect(getRuleActionStyle('node-x').badgeBg).toBe('bg-primary/15');
   });
 });

--- a/src/renderer/lib/rule-action-style.ts
+++ b/src/renderer/lib/rule-action-style.ts
@@ -12,13 +12,13 @@ import type { TFunction } from 'i18next';
 export type RuleAction = 'proxy' | 'direct' | 'block' | string;
 
 export interface RuleActionStyle {
-  /** 实心圆点颜色 class，如 "bg-primary" */
+  /** 实心圆点颜色 class（拓扑图节点点），如 "bg-primary" */
   dot: string;
-  /** 文字颜色 class，如 "text-primary" */
+  /** 文字颜色 class，如 "text-primary"（也用作淡色调 badge 的字色） */
   text: string;
-  /** badge 背景色 class（实色），如 "bg-primary" */
+  /** badge 淡色调背景 class（半透明），如 "bg-primary/15"——配合 text 同色字，深色模式去眩光，对齐资源缺失/覆盖组网角标 */
   badgeBg: string;
-  /** badge hover 背景色 class，如 "hover:bg-primary/90" */
+  /** badge hover 背景 class，如 "hover:bg-primary/25" */
   badgeBgHover: string;
 }
 
@@ -28,24 +28,24 @@ export function getRuleActionStyle(action: RuleAction): RuleActionStyle {
     return {
       dot: 'bg-success',
       text: 'text-success',
-      badgeBg: 'bg-success',
-      badgeBgHover: 'hover:bg-success/90',
+      badgeBg: 'bg-success/15',
+      badgeBgHover: 'hover:bg-success/25',
     };
   }
   if (a === 'block' || a === 'reject' || a === 'reject-drop' || a === 'drop') {
     return {
       dot: 'bg-destructive',
       text: 'text-destructive',
-      badgeBg: 'bg-destructive',
-      badgeBgHover: 'hover:bg-destructive/90',
+      badgeBg: 'bg-destructive/15',
+      badgeBgHover: 'hover:bg-destructive/25',
     };
   }
   // proxy 及具体节点名
   return {
     dot: 'bg-primary',
     text: 'text-primary',
-    badgeBg: 'bg-primary',
-    badgeBgHover: 'hover:bg-primary/90',
+    badgeBg: 'bg-primary/15',
+    badgeBgHover: 'hover:bg-primary/25',
   };
 }
 


### PR DESCRIPTION
## 背景
深色模式青色过饱和（`--primary` 184° 78%），作实心填充+白字的小徽标眩光；导流脊 Internet 端点健康态读不出「已抵达」。

## 改动
- **action 徽标**（代理/直连/阻断）实心青底白字 → 淡色调（`bg-*/15` + 同色字），与同页「资源缺失/覆盖组网」角标统一
- **深色 `--primary` / `--ring` 饱和 78% → 70%**，全局柔化（按钮/开关/链接/已连接徽标）
- **导流脊 Internet 端点**健康态中性白 → 低强度 `success`「已抵达」（高饱和绿仍留流光+出口节点）
- **eslint `no-restricted-syntax` 增灰阶 palette 护栏**（防裸 gray class 绕过 token）+ real-time-logs debug 日志 `text-gray-500` → `text-muted-foreground`
- 同步 rule-action-style / spine-state 单测

## 验证
renderer tsc + lint + jest（spine-state / rule-action-style）全绿；深色实感真机已验。
