### PR TITLE
fix(ui): 深色 --destructive 亮度 30.6%→48%（红色淡底徽标去暗）

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -62,7 +62,7 @@
     --muted-foreground: 214 12% 60%;
     --accent: 214 16% 17%;
     --accent-foreground: 184 78% 58%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 62.8% 48%;
     --destructive-foreground: 0 0% 98%;
     /* 语义色（暗）：饱和度降、亮度提，与暗 destructive 同梯度 */
     --success: 158 70% 54%;


### PR DESCRIPTION
## 背景
深色 `--destructive` 是语义色族里唯一未谐调的：30.6% L，远暗于 success(54%)/warning(60%)/primary(45%)。作实心填充+白字（关闭代理按钮）尚可，但 #104 起 action/角标徽标改用淡底+同色字（`bg-destructive/15` + `text-destructive`）后，红字在深色下太暗、读不清（阻断 / 资源缺失徽标）。

## 改动
`.dark --destructive` 30.6% → **48%**（保持饱和 62.8%，`--destructive-foreground` 仍白）。淡底徽标红字清晰可读；实心红按钮白字对比仍稳（~4:1）。浅色模式不动。

## 验证
renderer tsc + lint 全绿（纯 CSS token 值，无 tsc/jest 影响）；深色实感对照已确认 48% 为稳妥档。