### PR TITLE
fix(ui): 深色 outline 按钮糊背景——bg-muted/40→bg-secondary 提辨识

### DIFF
--- a/src/renderer/components/ui/button.tsx
+++ b/src/renderer/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-input bg-muted/40 hover:border-primary/40 hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-secondary hover:border-primary/40 hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',


### PR DESCRIPTION
## 问题

深色模式下 outline 按钮（如路由规则页右上角「编辑顺序」、设置页「重置」等）几乎糊进卡片背景，辨识度过低，旁边的「添加规则」(default/青实心) 反差却很大。

## 根因

`src/renderer/components/ui/button.tsx` 的 outline variant 用 `bg-muted/40` 填充：

- 深色：`--card` ≈ L11%，`--muted/40` 叠加后 ≈ L13%，仅差约 2% 近乎隐形；
- 边框 `border-input` ≈ L20% 对卡片只有 +9%，弱边框撑不起辨识度；
- 结果 outline 按钮糊进卡片，而同排 default（`bg-primary` 青实心）醒目，对比割裂。

## 改动

单 token，最小改动 —— outline variant 的填充 `bg-muted/40` → `bg-secondary`：

```diff
 outline:
-  'border border-input bg-muted/40 hover:border-primary/40 hover:bg-accent hover:text-accent-foreground',
+  'border border-input bg-secondary hover:border-primary/40 hover:bg-accent hover:text-accent-foreground',
```

- 深色 `--secondary` L18% 实心对卡片 L11% = +7%，清晰可辨 chip；
- 浅色 `--secondary` L92% 对卡片 L100% = +8%，同样提升；
- 纯 token、双主题、无裸 hex（符合 eslint `no-restricted-syntax` 护栏）；
- hover 态（`hover:border-primary/40 hover:bg-accent`）保持不变。

## 影响面

影响全 app ~90 处 `variant="outline"` 按钮，属预期的一致性提升；outline 与 default 仍清晰可区分，outline 不过重。

## 验证

- `npx eslint src --ext .ts,.tsx`：0 errors（护栏通过）。
- `npx tsc -p tsconfig.renderer.json --noEmit`：通过。
- `npx jest`：1296/1296 测试通过，27/27 快照通过（纯样式改动零影响）。
- 双主题 headless 渲染核对（google-chrome --headless，用 `index.css` 真实 token + 真实 outline 类）：
  - 深色：「编辑顺序」从「几乎隐形」变为清晰浮出卡片的浅色 chip，仍明显从属于青色 default；
  - 浅色：outline 从极淡近白变为清晰浅灰 chip，提升且不过重；
  - 两态下 outline 与 default 始终可区分。