### PR TITLE
feat(rules): 资源库搜索结果高亮匹配关键词

### DIFF
--- a/src/renderer/components/rules/resource-catalog-dialog.tsx
+++ b/src/renderer/components/rules/resource-catalog-dialog.tsx
@@ -13,6 +13,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { SegmentedControl } from '@/components/ui/segmented-control';
+import { HighlightText } from '@/components/ui/highlight-text';
 import {
   CheckCircle2,
   CircleAlert,
@@ -195,8 +196,12 @@ export function ResourceCatalogDialog({
   const renderItem = (d: DisplayItem) => {
     const meta = (
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium">{d.name}</div>
-        <div className="truncate font-mono text-xs text-muted-foreground">{d.path}</div>
+        <div className="truncate text-sm font-medium">
+          <HighlightText text={d.name} query={search} />
+        </div>
+        <div className="truncate font-mono text-xs text-muted-foreground">
+          <HighlightText text={d.path} query={search} />
+        </div>
       </div>
     );
     const badges = (

--- a/src/renderer/components/ui/__tests__/highlight-text-utils.test.ts
+++ b/src/renderer/components/ui/__tests__/highlight-text-utils.test.ts
@@ -1,0 +1,78 @@
+import { escapeRegExp, splitByQuery } from '../highlight-text-utils';
+
+describe('escapeRegExp', () => {
+  it('转义正则元字符', () => {
+    expect(escapeRegExp('a.b*c+d?')).toBe('a\\.b\\*c\\+d\\?');
+    expect(escapeRegExp('(g)[e]{o}|^$')).toBe('\\(g\\)\\[e\\]\\{o\\}\\|\\^\\$');
+    expect(escapeRegExp('a\\b')).toBe('a\\\\b');
+  });
+
+  it('普通字符不变', () => {
+    expect(escapeRegExp('youtube')).toBe('youtube');
+  });
+});
+
+describe('splitByQuery', () => {
+  it('空 query / 纯空白 query → 单个非命中段（原样）', () => {
+    expect(splitByQuery('youtube', '')).toEqual([{ text: 'youtube', match: false }]);
+    expect(splitByQuery('youtube', '   ')).toEqual([{ text: 'youtube', match: false }]);
+  });
+
+  it('无命中 → 单个非命中段', () => {
+    expect(splitByQuery('youtube', 'zzz')).toEqual([{ text: 'youtube', match: false }]);
+  });
+
+  it('单处命中切成三段', () => {
+    expect(splitByQuery('category-ads-all', 'ads')).toEqual([
+      { text: 'category-', match: false },
+      { text: 'ads', match: true },
+      { text: '-all', match: false },
+    ]);
+  });
+
+  it('大小写不敏感，且保留原文大小写', () => {
+    expect(splitByQuery('YouTube', 'tube')).toEqual([
+      { text: 'You', match: false },
+      { text: 'Tube', match: true },
+    ]);
+  });
+
+  it('多处命中全部标记', () => {
+    expect(splitByQuery('cncn', 'cn')).toEqual([
+      { text: 'cn', match: true },
+      { text: 'cn', match: true },
+    ]);
+  });
+
+  it('命中位于开头/结尾', () => {
+    expect(splitByQuery('cn-list', 'cn')).toEqual([
+      { text: 'cn', match: true },
+      { text: '-list', match: false },
+    ]);
+    expect(splitByQuery('list-cn', 'cn')).toEqual([
+      { text: 'list-', match: false },
+      { text: 'cn', match: true },
+    ]);
+  });
+
+  it('query 含正则元字符按字面量匹配（不当模式解释）', () => {
+    // '.' 字面量：只命中真正的点，不命中任意字符
+    expect(splitByQuery('geo.srs', '.')).toEqual([
+      { text: 'geo', match: false },
+      { text: '.', match: true },
+      { text: 'srs', match: false },
+    ]);
+    // 含元字符的 query 无字面量命中 → 不报错、原样返回
+    expect(splitByQuery('abc', 'a.c')).toEqual([{ text: 'abc', match: false }]);
+    // 路径形态字面量命中
+    expect(splitByQuery('geo/geosite/youtube.srs', 'geosite/you')).toEqual([
+      { text: 'geo/', match: false },
+      { text: 'geosite/you', match: true },
+      { text: 'tube.srs', match: false },
+    ]);
+  });
+
+  it('整串即命中', () => {
+    expect(splitByQuery('cn', 'cn')).toEqual([{ text: 'cn', match: true }]);
+  });
+});

--- a/src/renderer/components/ui/highlight-text-utils.ts
+++ b/src/renderer/components/ui/highlight-text-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * highlight-text 的纯逻辑（与 React 无关，便于在 node/.ts jest 下单测）。
+ * 把文本按 query（大小写不敏感、字面量）切分为命中/非命中片段，渲染层据此包 <mark>。
+ */
+
+/** 正则元字符转义：query 原样作字面量匹配，避免用户输入的 . * ( ) 等被当模式解释。 */
+export function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** 切分后的单个片段：text=原文子串，match=是否命中关键词（命中者高亮）。 */
+export interface HighlightSegment {
+  text: string;
+  match: boolean;
+}
+
+/**
+ * 按 query（trim 后，大小写不敏感）把 text 切成交替片段。
+ * 空 query 或无命中 → 单个 { text, match:false }，渲染层原样输出不引入额外节点。
+ * 保留原文大小写：命中片段用 text 中的实际子串，不替换为 query。
+ */
+export function splitByQuery(text: string, query: string): HighlightSegment[] {
+  const q = query.trim();
+  if (!q) return [{ text, match: false }];
+
+  // 捕获组 → split 结果交替为 [非命中, 命中, 非命中, 命中, ...]
+  const parts = text.split(new RegExp(`(${escapeRegExp(q)})`, 'gi'));
+  if (parts.length === 1) return [{ text, match: false }]; // 无命中
+
+  const lowerQ = q.toLowerCase();
+  return parts
+    .filter((p) => p !== '') // split 在相邻命中处会插入空串，过滤避免空节点
+    .map((p) => ({ text: p, match: p.toLowerCase() === lowerQ }));
+}

--- a/src/renderer/components/ui/highlight-text.tsx
+++ b/src/renderer/components/ui/highlight-text.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import { splitByQuery } from './highlight-text-utils';
+
+interface HighlightTextProps {
+  /** 待渲染文本。 */
+  text: string;
+  /** 高亮关键词（大小写不敏感）。空/无命中时 text 原样返回。 */
+  query: string;
+  /** 透传给 <mark> 的额外类名（覆盖/补充默认品牌淡底样式）。 */
+  className?: string;
+}
+
+/**
+ * 把 text 中所有命中 query 的子串（大小写不敏感）包进 <mark> 高亮，其余文本原样。
+ * 切分逻辑见 splitByQuery（query 先正则转义按字面量匹配）；空 query 或无命中时
+ * 直接返回 text，不引入额外节点。样式用品牌 accent 淡底（bg-primary/15），
+ * 双主题自适应，禁黄色/裸 hex。
+ */
+export function HighlightText({ text, query, className }: HighlightTextProps) {
+  const segments = splitByQuery(text, query);
+
+  // 无命中（单段且未命中）→ 原样返回，不包额外节点。
+  if (segments.length === 1 && !segments[0].match) return <>{text}</>;
+
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.match ? (
+          <mark
+            key={i}
+            className={cn('rounded-sm bg-primary/15 px-0.5 text-foreground', className)}
+          >
+            {seg.text}
+          </mark>
+        ) : (
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        )
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## 背景

「规则资源」页的资源选择对话框（`resource-catalog-dialog`）输入关键词过滤结果列表后，匹配的子串没有任何视觉反馈，用户难以一眼看出每项因何命中。

## 改动

新增可复用 `HighlightText` 组件，把结果项**名称**与**路径**中命中关键词的子串包进 `<mark>` 高亮：

- **`src/renderer/components/ui/highlight-text.tsx`** — 入参 `text` + `query`：
  - query 先做正则元字符转义，按**字面量、大小写不敏感**切分；
  - 命中片段用品牌 accent 淡底 `bg-primary/15 text-foreground rounded-sm px-0.5`（token 驱动，双主题自适应，无黄色 / 无裸 hex）；
  - 空 query 或无命中时原样返回 `text`，不引入额外节点。
- **`src/renderer/components/ui/highlight-text-utils.ts`** — 纯切分逻辑 `splitByQuery` / `escapeRegExp` 抽出，便于在现有 node/`.ts` jest 下单测。
- **`src/renderer/components/ui/__tests__/highlight-text-utils.test.ts`** — 覆盖转义、大小写不敏感、多处命中、首尾命中、元字符字面量匹配、边界等。
- **`resource-catalog-dialog.tsx`** — 行渲染的名称与路径改用 `HighlightText`（`query={search}`），多处命中均标；**不改过滤逻辑**。

## 验证

- `npx eslint src --ext .ts,.tsx`：0 error（仅 2 个 untouched 文件的既有 prettier 警告）
- `npx tsc -p tsconfig.renderer.json --noEmit`：通过
- `npm test`：88/88 套件、1323 测试全绿（含新增 10 条）
- 双主题 headless 渲染核对：light（query「you」）与 dark（query「cn」）下名称 + 路径命中片段均以品牌 teal 淡底高亮，非命中行不变，多命中全标。