### PR TITLE
fix(routing): ICMP 跟随 final 出口（WG/TS 全隧道经隧道，其余直连）

### DIFF
--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -439,10 +439,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -568,6 +564,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -1083,10 +1086,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -1197,6 +1196,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -1703,10 +1709,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -1817,6 +1819,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -2351,10 +2360,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -2465,6 +2470,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -2954,10 +2966,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -3068,6 +3076,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -3540,10 +3555,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -3654,6 +3665,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -4114,10 +4132,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -4228,6 +4242,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -4671,10 +4692,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -4785,6 +4802,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -5304,10 +5328,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -5418,6 +5438,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -5929,10 +5956,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -6043,6 +6066,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -6584,10 +6614,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -6698,6 +6724,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -7202,10 +7235,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -7316,6 +7345,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "proxy-selector",
         },
         {
           "action": "reject",
@@ -7815,10 +7851,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -7948,6 +7980,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -8478,10 +8517,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -8566,6 +8601,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             ".1234567.com.cn",
             ".gw.com.cn",
             ".tdx.com.cn",
+          ],
+          "outbound": "direct",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
           ],
           "outbound": "direct",
         },
@@ -9059,10 +9101,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "port": [
             53,
           ],
-        },
-        {
-          "action": "reject",
-          "protocol": "icmp",
         },
         {
           "action": "route",
@@ -9663,10 +9701,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -9777,6 +9811,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -10244,10 +10285,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -10358,6 +10395,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -10855,10 +10899,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -10971,6 +11011,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -11486,10 +11533,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -11600,6 +11643,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -12089,10 +12139,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -12203,6 +12249,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -12702,10 +12755,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -12830,6 +12879,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -13333,10 +13389,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -13447,6 +13499,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -13936,10 +13995,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -14050,6 +14105,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -14564,10 +14626,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -14678,6 +14736,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -15212,10 +15277,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -15328,6 +15389,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -15843,10 +15911,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -15961,6 +16025,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -16475,10 +16546,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -16594,6 +16661,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -17083,10 +17157,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -17197,6 +17267,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -17698,10 +17775,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -17812,6 +17885,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -18308,10 +18388,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -18422,6 +18498,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -18906,10 +18989,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -19020,6 +19099,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -19565,10 +19651,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -19679,6 +19761,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -20183,10 +20272,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -20297,6 +20382,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",
@@ -20814,10 +20906,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           ],
         },
         {
-          "action": "reject",
-          "protocol": "icmp",
-        },
-        {
           "action": "route",
           "outbound": "direct",
           "process_name": [
@@ -20928,6 +21016,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "action": "route",
           "outbound": "direct",
           "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
         },
         {
           "action": "reject",

--- a/src/main/services/__tests__/dns-resolver-baseline.json
+++ b/src/main/services/__tests__/dns-resolver-baseline.json
@@ -146,10 +146,6 @@
         "action": "hijack-dns"
       },
       {
-        "protocol": "icmp",
-        "action": "reject"
-      },
-      {
         "process_name": [
           "Surge",
           "Surge 4",
@@ -263,6 +259,13 @@
           "240.0.0.0/4",
           "fd00::/8",
           "fe80::/10"
+        ],
+        "action": "route",
+        "outbound": "direct"
+      },
+      {
+        "network": [
+          "icmp"
         ],
         "action": "route",
         "outbound": "direct"
@@ -533,10 +536,6 @@
         "action": "hijack-dns"
       },
       {
-        "protocol": "icmp",
-        "action": "reject"
-      },
-      {
         "process_name": [
           "Surge",
           "Surge 4",
@@ -650,6 +649,13 @@
           "240.0.0.0/4",
           "fd00::/8",
           "fe80::/10"
+        ],
+        "action": "route",
+        "outbound": "direct"
+      },
+      {
+        "network": [
+          "icmp"
         ],
         "action": "route",
         "outbound": "direct"
@@ -888,10 +894,6 @@
         "action": "hijack-dns"
       },
       {
-        "protocol": "icmp",
-        "action": "reject"
-      },
-      {
         "process_name": [
           "Surge",
           "Surge 4",
@@ -1005,6 +1007,13 @@
           "240.0.0.0/4",
           "fd00::/8",
           "fe80::/10"
+        ],
+        "action": "route",
+        "outbound": "direct"
+      },
+      {
+        "network": [
+          "icmp"
         ],
         "action": "route",
         "outbound": "direct"

--- a/src/main/services/__tests__/singbox-route-builder.test.ts
+++ b/src/main/services/__tests__/singbox-route-builder.test.ts
@@ -12,6 +12,7 @@ import type { ServerConfig, UserConfig } from '../../../shared/types';
 import type { SingBoxEndpoint } from '../singbox-config-types';
 
 const wgEp = (tag: string, system = false): SingBoxEndpoint => ({ type: 'wireguard', tag, system });
+const tsEp = (tag: string, system = false): SingBoxEndpoint => ({ type: 'tailscale', tag, system });
 
 const deps = (
   pendingEndpoints: SingBoxEndpoint[],
@@ -39,6 +40,17 @@ const wgNode = (id: string, name: string, allowedIPs: string[], over: any = {}):
       peerPublicKey: 'pub',
       localAddress: ['10.0.0.2/32'],
       allowedIPs,
+      ...over,
+    },
+  }) as unknown as ServerConfig;
+
+const tsNode = (id: string, name: string, over: any = {}): ServerConfig =>
+  ({
+    id,
+    name,
+    protocol: 'tailscale',
+    tailscaleSettings: {
+      routes: [],
       ...over,
     },
   }) as unknown as ServerConfig;
@@ -234,5 +246,93 @@ describe('buildRouteConfig — WebRTC 防泄露（webrtcLeakProtection）', () =
         r.protocol === undefined
     );
     expect(udp443).toBeDefined();
+  });
+});
+
+// 找到 ICMP 兜底规则（network:['icmp'] + action:'route'）与已删的死规则（protocol:'icmp'）。
+const icmpRule = (rc: any): any =>
+  (rc.rules || []).find((r: any) => Array.isArray(r.network) && r.network.includes('icmp'));
+const hasProtocolIcmp = (rc: any): boolean =>
+  (rc.rules || []).some((r: any) => r.protocol === 'icmp');
+
+describe('buildRouteConfig — ICMP 路由（跟随 final 出口）', () => {
+  it('① 无任何 protocol:icmp 规则（死规则已删）', () => {
+    const n = proxyNode();
+    const rc = buildRouteConfig(cfg([n], { proxyMode: 'smart' }), idMap([n]), deps([]));
+    expect(hasProtocolIcmp(rc)).toBe(false);
+  });
+
+  it('② <1.13 核 → 无 network:icmp 规则（维持核默认）', () => {
+    const n = proxyNode();
+    const rc = buildRouteConfig(
+      cfg([n], { proxyMode: 'smart' }),
+      idMap([n]),
+      deps([], { coreVersion: '1.12.8' })
+    );
+    expect(icmpRule(rc)).toBeUndefined();
+    expect(hasProtocolIcmp(rc)).toBe(false);
+  });
+
+  it('③a 选中普通代理 → network:icmp → direct（普通代理转不了 ICMP）', () => {
+    const n = proxyNode();
+    const rc = buildRouteConfig(cfg([n], { proxyMode: 'smart' }), idMap([n]), deps([]));
+    const r = icmpRule(rc);
+    expect(r).toBeDefined();
+    expect(r.action).toBe('route');
+    expect(r.outbound).toBe('direct');
+  });
+
+  it('③b direct 模式 → network:icmp → direct', () => {
+    const wg = wgNode('w1', 'WG', ['10.8.0.0/24']); // 即便选中 endpoint，direct 模式恒直连
+    const rc = buildRouteConfig(
+      cfg([wg], { proxyMode: 'direct' }),
+      idMap([wg]),
+      deps([wgEp('WG')])
+    );
+    const r = icmpRule(rc);
+    expect(r).toBeDefined();
+    expect(r.outbound).toBe('direct');
+  });
+
+  it('③c specific-only mesh（关外网组网节点选中为主）→ network:icmp → direct（userExitTag 已= direct）', () => {
+    const wg = wgNode('w1', 'WG', ['10.8.0.0/24'], { allowInternet: false });
+    const rc = buildRouteConfig(cfg([wg], { proxyMode: 'smart' }), idMap([wg]), deps([wgEp('WG')]));
+    const r = icmpRule(rc);
+    expect(r).toBeDefined();
+    expect(r.outbound).toBe('direct');
+  });
+
+  it('③d 选中 WG 全隧道节点 → network:icmp → userExitTag(proxy-selector)', () => {
+    const wg = wgNode('w1', 'WG', ['10.8.0.0/24']); // allowInternet 缺省=on，非 system → 承载 0/0
+    const rc = buildRouteConfig(cfg([wg], { proxyMode: 'smart' }), idMap([wg]), deps([wgEp('WG')]));
+    const r = icmpRule(rc);
+    expect(r).toBeDefined();
+    expect(r.action).toBe('route');
+    expect(r.outbound).toBe('proxy-selector');
+  });
+
+  it('③e 选中 Tailscale 全隧道节点 → network:icmp → userExitTag(proxy-selector)', () => {
+    const ts = tsNode('t1', 'TS'); // allowInternet 缺省=on，非 system → 承载 0/0
+    const rc = buildRouteConfig(cfg([ts], { proxyMode: 'smart' }), idMap([ts]), deps([tsEp('TS')]));
+    const r = icmpRule(rc);
+    expect(r).toBeDefined();
+    expect(r.outbound).toBe('proxy-selector');
+  });
+
+  it('④ mesh force-route 仍在、且排在 network:icmp 兜底之前', () => {
+    const wg = wgNode('w1', 'WG', ['10.8.0.0/24']);
+    const rc = buildRouteConfig(cfg([wg], { proxyMode: 'smart' }), idMap([wg]), deps([wgEp('WG')]));
+    const forceRoute = meshRule(rc, 'WG');
+    expect(forceRoute).toBeDefined();
+    expect(forceRoute.ip_cidr).toContain('10.8.0.0/24');
+    const forceIdx = (rc.rules || []).findIndex(
+      (r: any) => r.outbound === 'WG' && r.action === 'route' && Array.isArray(r.ip_cidr)
+    );
+    const icmpIdx = (rc.rules || []).findIndex(
+      (r: any) => Array.isArray(r.network) && r.network.includes('icmp')
+    );
+    expect(forceIdx).toBeGreaterThan(-1);
+    expect(icmpIdx).toBeGreaterThan(-1);
+    expect(forceIdx).toBeLessThan(icmpIdx);
   });
 });

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -19,6 +19,7 @@ import {
   shouldForceRouteSubnets,
   collectRuleTargetedServerIds,
   meshForceRoutedServers,
+  isEndpointProtocol,
 } from '../../shared/endpoint-routes';
 import { cidrOverlapsAny, partitionCidrsByOverlap } from '../../shared/ip';
 import { FAKEIP_INET4_RANGE, FAKEIP_INET6_RANGE } from '../../shared/fakeip-filter';
@@ -235,13 +236,6 @@ export function buildRouteConfig(
   rules.push({
     port: [53],
     action: 'hijack-dns',
-  });
-
-  // F. 静默屏蔽 ICMP 流量（FakeIP 下常见，但代理节点通常不支持）
-  // 放置在靠前位置，防止 ICMP 流量误入不支持的代理出站引发报错
-  rules.push({
-    protocol: 'icmp',
-    action: 'reject',
   });
 
   rules.push({
@@ -621,6 +615,21 @@ export function buildRouteConfig(
     if (isValidSrsFile(path.join(getRuntimeRulesDir(), 'geosite-private.srs'))) {
       rules.push({ rule_set: 'geosite-private', action: 'route', outbound: 'direct' });
     }
+  }
+
+  // ICMP 兜底（仅 sing-box ≥1.13 支持 network:icmp 匹配）：放在 mesh force-route(块 0c) + bypass-LAN 之后，
+  // 故组网具体段经其 endpoint、局域网私网段直连先匹配，本条只兜底其余（外网）ICMP。
+  //   · final 出口为 WG/Tailscale 全隧道节点（isEndpoint 且非 direct 模式）→ 经其出口 userExitTag：
+  //     endpoint 出站能转 ICMP，与 0/0 全隧道一致、防 ping 泄露真实 IP。
+  //   · 普通代理（转不了 ICMP）/ specific-only mesh(userExitTag 已= 'direct' 经 D4/D7 兜底)/ direct 模式 → 直连。
+  // 版本门 <1.13 → 不发射，维持核默认（gVisor 栈本地伪应答 ICMP echo）。
+  if (coreVersionAtLeast(deps.coreVersion, 1, 13)) {
+    const selectedServer = config.servers.find((s) => s.id === config.selectedServerId);
+    const icmpOutbound =
+      proxyMode !== 'direct' && isEndpointProtocol(selectedServer?.protocol)
+        ? userExitTag
+        : 'direct';
+    rules.push({ network: ['icmp'], action: 'route', outbound: icmpOutbound });
   }
 
   // 【QUIC 阻断】：放在自定义规则和应用分流之后，确保用户的 direct/proxy 规则优先级更高

--- a/src/shared/__tests__/endpoint-routes.test.ts
+++ b/src/shared/__tests__/endpoint-routes.test.ts
@@ -65,6 +65,15 @@ describe('endpointForcedRouteCidrs', () => {
   it('TS: 无 routes → 仅 tailnet 段（达 tailnet peer 的必需路由）', () => {
     expect(endpointForcedRouteCidrs(ts())).toEqual([TAILNET_CGNAT]);
   });
+  it('TS: routes 含 catch-all(0/0) → 被剥、tailnet 保留（与 WG 对齐）', () => {
+    expect(endpointForcedRouteCidrs(ts(['0.0.0.0/0', '::/0', '192.168.50.0/24']))).toEqual([
+      TAILNET_CGNAT,
+      '192.168.50.0/24',
+    ]);
+  });
+  it('TS: routes 仅 catch-all → 仅 tailnet 段（0/0 全剥）', () => {
+    expect(endpointForcedRouteCidrs(ts(['0.0.0.0/0', '::/0']))).toEqual([TAILNET_CGNAT]);
+  });
   it('trim/去空/去重', () => {
     expect(endpointForcedRouteCidrs(wg([' 10.10.10.0/24 ', '10.10.10.0/24', '', '  ']))).toEqual([
       '10.10.10.0/24',

--- a/src/shared/endpoint-routes.ts
+++ b/src/shared/endpoint-routes.ts
@@ -42,7 +42,8 @@ export function endpointForcedRouteCidrs(server: ServerConfig): string[] {
   if (p === 'wireguard') {
     raw = stripCatchAll(server.wireguardSettings?.allowedIPs);
   } else if (p === 'tailscale') {
-    raw = [TAILNET_CGNAT, ...(server.tailscaleSettings?.routes || [])];
+    // 与 WireGuard 分支对齐：剥 catch-all（0/0），TS 全隧道走 exitNode，routes 不该承载 0.0.0.0/0。
+    raw = [TAILNET_CGNAT, ...stripCatchAll(server.tailscaleSettings?.routes)];
   } else {
     return [];
   }


### PR DESCRIPTION
## 问题
路由配置里 `{protocol:'icmp', action:'reject'}` 字段写错——sing-box 的 `protocol` 匹配的是嗅探出的应用层协议（不含 icmp），该规则**匹配不到任何 ICMP 流量、是 no-op**。结果：ICMP（如 ping）不受路由策略控制，由内核 gVisor 栈本地伪应答，ping「通」≠ 真到达；全隧道（WG/WARP/Tailscale）出口下 ping 外网仍可能泄露真实 IP。

## 改动（全自动，无开关）
- **删死规则** `{protocol:'icmp',action:'reject'}`（≥1.13 核已自处理 ICMP，不会误入普通代理，原顾虑过时）。
- **ICMP 跟随 final 出口**：在 mesh force-route + bypass-LAN 之后插入 `{network:['icmp'], action:'route', outbound: ...}`——普通代理/direct 模式/specific-only mesh → `direct`；选中 WG/Tailscale 全隧道节点 → 用户出口（ICMP 加入 0/0 全隧道，出口 IP=节点，防 ping 泄露真实 IP）。`network:'icmp'` 仅 sing-box ≥1.13 发射（版本门）。
- mesh 具体段 ICMP 由现有 force-route（`ip_cidr` 不限 network）自动覆盖，零新代码。
- **TS routes 补 `stripCatchAll`**：Tailscale 分支与 WireGuard 对齐，避免 routes 含 0/0 时强占全流量。

## 验证
- 单测：route-builder 矩阵 8 例（死规则删除 / <1.13 版本门 / 五档 outbound / force-route 优先级断言）+ endpoint-routes TS catch-all 剥离 2 例。
- gate：eslint 0 / 双 tsc 0 / jest 88 套 · 1342 测试 · 34 快照 全绿。
- config-snapshot：仅 ICMP 规则迁移（34 删 protocol:icmp / 33 加 network:icmp，含 1.12.x 版本门正确不发射），零其它路由漂移。
- 真机待验（TUN）：WG/WARP 全隧道出口 ping 外网回包源=节点出口 IP。