### PR TITLE
fix(i18n): 补齐 fa-IR 缺失的 9 个 Tailscale 登录键

### DIFF
--- a/src/renderer/i18n/locales/fa-IR.json
+++ b/src/renderer/i18n/locales/fa-IR.json
@@ -956,7 +956,16 @@
       "idleTimeoutDesc": "یک نشست را پس از ماندن در حالت بی‌کاری به این مدت ببند، مثلاً 30s. خالی از پیش‌فرض هسته استفاده می‌کند.",
       "minIdleSession": "حداقل نشست‌های بی‌کار",
       "minIdleSessionDesc": "حداقل تعداد نشست‌های بی‌کاری که باز نگه داشته شوند. پیش‌فرض 0."
-    }
+    },
+    "tsLoginAction": "ورود",
+    "tsLoginAlready": "گره Tailscale «{{name}}» قبلاً وارد شده است",
+    "tsLoginFailed": "شروع ورود برای «{{name}}» ناموفق بود",
+    "tsLoginInProgress": "ورود برای «{{name}}» هم‌اکنون در حال انجام است",
+    "tsLoginNow": "اکنون وارد شوید",
+    "tsLoginNowDesc": "اکنون مرورگر را برای تکمیل ورود Tailscale باز کنید (بدون نیاز به کلید احراز هویت).",
+    "tsLoginOk": "گره Tailscale «{{name}}» وارد شد",
+    "tsLoginOpening": "در حال ورود به «{{name}}»",
+    "tsLoginOpeningDesc": "در حال باز کردن مرورگر برای تکمیل ورود. آنجا مجوز دهید، سپس بازگردید."
   },
   "rules": {
     "ruleColumn": "قانون",


### PR DESCRIPTION
## 问题
#118（fa-IR + locale-parity 测试）与 #119（Tailscale 登录体验，给 en-US 新增 9 个 `servers.tsLogin*` 键）合并后，`fa-IR.json`（基于旧 en-US）缺这 9 个键 → `locale-parity` 测试红（fa-IR 精确 parity + 占位符校验失败），主线 CI 失败。

## 修复
给 `fa-IR.json` 补齐 9 个波斯语登录键（`tsLoginAction/Now/NowDesc/Opening/OpeningDesc/InProgress/Already/Failed/Ok`），`{{name}}` 占位符保留。仅 `fa-IR.json` value 改动。

## 验证
- gate：eslint 0 / 双 tsc 0 / jest **92 套 · 1385 测试 · 34 快照 全绿**（locale-parity 7/7 通过）。
- 5 locale（en/zh-CN/zh-TW/ru/fa-IR）全 parity。