### PR TITLE
fix(i18n): 语言切换提示按新选语言显示（off-by-one）

### DIFF
--- a/src/renderer/components/settings/appearance-settings.tsx
+++ b/src/renderer/components/settings/appearance-settings.tsx
@@ -37,7 +37,7 @@ export function AppearanceSettings() {
     i18n.changeLanguage(value);
     localStorage.setItem('app-language', value);
     api.config.setLanguage(value).catch(console.error);
-    toast.success(t('settings.appearance.languageUpdated'));
+    toast.success(t('settings.appearance.languageUpdated', { lng: value }));
   };
 
   return (


### PR DESCRIPTION
## 问题
切换界面语言时，成功提示显示的是**切换前**的语言（off-by-one）：英→中显示 "Switched to English"，中→他显示 "已切换为简体中文"。

## 根因
`appearance-settings.tsx` 的 `handleLanguageChange` 里 `toast.success(t('settings.appearance.languageUpdated'))` 用的 `t` 是点击 handler 闭包捕获的**旧渲染快照实例**（绑定切换前语言）。`changeLanguage` 虽同步切了 i18next store，但该 `t` 实例的语言上下文不变，仍按旧语言查表；而 `languageUpdated` 在每个 locale 是写死的母语自名 → 永远显示切换前那句。

## 修复（1 行）
`t('settings.appearance.languageUpdated', { lng: value })`——i18next `{ lng }` 第三参强制按指定语言查表，`value` 为刚选的新语言（bundle 已同步在内存），两种现象同时修好。零波及：不动 t 实例/i18n 配置/resources；dir(RTL) 切换、首次加载、其它 toast 均不受影响。

## 验证
gate：eslint 0 / tsc 0 / jest 92 套 · 1385 测试全绿。