### PR TITLE
feat(warp): Cloudflare WARP 设备注销（删除入队 + 机会式 drain 重试）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1270,7 +1270,7 @@ if (gotTheLock) {
     // 注册 IPC 处理器（需要在 ProxyManager 创建后）
     registerConfigHandlers(configManager);
     registerPrivacyHandlers();
-    registerServerHandlers(protocolParser, configManager);
+    registerServerHandlers(protocolParser, configManager, logManager);
     registerLogHandlers(logManager, proxyManager);
     registerProxyHandlers(proxyManager, statsService);
     registerIpInfoHandlers(ipInfoService);

--- a/src/main/ipc/handlers/server-handlers.ts
+++ b/src/main/ipc/handlers/server-handlers.ts
@@ -11,7 +11,7 @@ import { registerIpcHandler } from '../ipc-handler';
 import { ProtocolParser } from '../../services/ProtocolParser';
 import { ConfigManager } from '../../services/ConfigManager';
 import { WarpService, type WarpWireGuardDraft } from '../../services/WarpService';
-import { WarpDeregisterQueue } from '../../services/WarpDeregisterQueue';
+import { getWarpDeregisterQueue } from '../../services/WarpDeregisterQueue';
 import { tailscaleStateDir, tailscaleStateExists } from '../../services/tailscale-state';
 import type { LogManager } from '../../services/LogManager';
 
@@ -25,11 +25,8 @@ export function registerServerHandlers(
   logManager?: LogManager
 ): void {
   // WARP 待注销队列（删除带 warpDevice 凭据的节点 → 入队；成功注册后机会式 drain）。
-  // unregister 注入 WarpService，文件 IO 默认 <userData>/warp/pending-deregister.json；无常驻定时器。
-  const warpDeregisterQueue = new WarpDeregisterQueue({
-    unregister: (deviceId, token) => new WarpService(logManager).unregister(deviceId, token),
-    logManager,
-  });
+  // 进程内单例：与 startup-tasks 启动 drain 共用同一实例，使串行链（opChain）覆盖全部触发点、杜绝跨实例并发写。
+  const warpDeregisterQueue = getWarpDeregisterQueue(logManager);
   // 解析协议 URL
   registerIpcHandler<{ url: string }, ServerConfig>(
     IPC_CHANNELS.SERVER_PARSE_URL,

--- a/src/main/ipc/handlers/server-handlers.ts
+++ b/src/main/ipc/handlers/server-handlers.ts
@@ -11,15 +11,25 @@ import { registerIpcHandler } from '../ipc-handler';
 import { ProtocolParser } from '../../services/ProtocolParser';
 import { ConfigManager } from '../../services/ConfigManager';
 import { WarpService, type WarpWireGuardDraft } from '../../services/WarpService';
+import { WarpDeregisterQueue } from '../../services/WarpDeregisterQueue';
 import { tailscaleStateDir, tailscaleStateExists } from '../../services/tailscale-state';
+import type { LogManager } from '../../services/LogManager';
 
 /**
  * 注册服务器管理相关的 IPC 处理器
+ * @param logManager 可选，供 WARP 设备注销队列记录日志（只打 deviceId 前缀，绝不打 token）
  */
 export function registerServerHandlers(
   protocolParser: ProtocolParser,
-  configManager: ConfigManager
+  configManager: ConfigManager,
+  logManager?: LogManager
 ): void {
+  // WARP 待注销队列（删除带 warpDevice 凭据的节点 → 入队；成功注册后机会式 drain）。
+  // unregister 注入 WarpService，文件 IO 默认 <userData>/warp/pending-deregister.json；无常驻定时器。
+  const warpDeregisterQueue = new WarpDeregisterQueue({
+    unregister: (deviceId, token) => new WarpService(logManager).unregister(deviceId, token),
+    logManager,
+  });
   // 解析协议 URL
   registerIpcHandler<{ url: string }, ServerConfig>(
     IPC_CHANNELS.SERVER_PARSE_URL,
@@ -119,6 +129,20 @@ export function registerServerHandlers(
           .rm(tailscaleStateDir(args.serverId), { recursive: true, force: true })
           .catch(() => {});
       }
+
+      // WARP 节点删除 → 若带自删凭据（warpDevice.token 存在）则把 {deviceId, token, enqueuedAt} 入待注销队列，
+      // 后台机会式 drain 远端注销（删除恒瞬时、不内联调网络，不阻断）。判据=token 存在与否（零误判，不靠端点启发式）：
+      // 本特性前的旧 WARP 节点无 warpDevice → 跳过入队、仅删本地、不报错（注定孤儿、无凭可注销，已接受的历史债）。
+      const warpDevice = removed?.wireguardSettings?.warpDevice;
+      if (warpDevice?.token && warpDevice?.deviceId) {
+        await warpDeregisterQueue
+          .enqueue({
+            deviceId: warpDevice.deviceId,
+            token: warpDevice.token,
+            enqueuedAt: Date.now(),
+          })
+          .catch(() => {}); // 入队失败不阻断删除（本地已删，凭据丢失=退化为旧节点孤儿，可接受）
+      }
     }
   );
 
@@ -168,7 +192,10 @@ export function registerServerHandlers(
   registerIpcHandler<{ licenseKey?: string }, WarpWireGuardDraft>(
     IPC_CHANNELS.WARP_REGISTER,
     async (_event: IpcMainInvokeEvent, args: { licenseKey?: string }) => {
-      return new WarpService().register({ licenseKey: args?.licenseKey });
+      const draft = await new WarpService(logManager).register({ licenseKey: args?.licenseKey });
+      // 成功注册后机会式 drain 待注销队列（fire-and-forget，不阻塞返回；网络已通的好时机）。
+      warpDeregisterQueue.drainInBackground();
+      return draft;
     }
   );
 }

--- a/src/main/services/WarpDeregisterQueue.ts
+++ b/src/main/services/WarpDeregisterQueue.ts
@@ -1,0 +1,185 @@
+/**
+ * WARP 待注销队列（机会式后台 drain）。
+ *
+ * 删除带 warpDevice 凭据的 WARP 节点时，凭据 {deviceId, token, enqueuedAt} 入 <userData>/warp/pending-deregister.json
+ * （删除恒瞬时、不阻断；见 server-handlers SERVER_DELETE）。本服务在 **app 启动 + 每次成功注册 WARP 后** 机会式
+ * drain：逐条按年龄/失败分类决定 done/drop/retry——done/drop/超龄出队，retry 留队等下个触发点。**无常驻定时器**
+ * （从不重开 app 者既不 drain 也不产生新孤儿，副作用自洽）。
+ *
+ * 纯逻辑（入队护栏 / 年龄判定 / MAX_PER_DRAIN 截断 / 失败分类）在 shared/warp.ts 且有单测；本服务只做 IO +
+ * 注入式编排。网络（unregister）与文件读写经构造注入，便于单测不触网/不碰真实 FS。
+ *
+ * 日志红线：只打 deviceId 前缀，绝不打 token。
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import type { LogManager } from './LogManager';
+import { getUserDataPath } from '../utils/paths';
+import {
+  planDeregisterDrain,
+  enqueuePendingDeregister,
+  WARP_DEREGISTER_MAX_PER_DRAIN,
+  type PendingDeregisterEntry,
+  type DeregisterResult,
+} from '../../shared/warp';
+
+/** 注入依赖：注销实现 + 文件读写 + 时钟（单测全可替换，不触网/不碰真实 FS）。 */
+export interface WarpDeregisterQueueDeps {
+  /** 调远端注销（默认 WarpService.unregister）。返回 done/drop/retry。 */
+  unregister: (deviceId: string, token: string) => Promise<DeregisterResult>;
+  logManager?: LogManager;
+  /** 队列文件路径（默认 <userData>/warp/pending-deregister.json）。 */
+  queueFilePath?: string;
+  /** 当前时间（默认 Date.now，单测注入固定值判年龄）。 */
+  now?: () => number;
+  /** 读队列文件（默认 fs.readFile，缺失→[]）。注入便于单测。 */
+  readQueue?: () => Promise<PendingDeregisterEntry[]>;
+  /** 写队列文件（默认原子写 <userData>/warp/pending-deregister.json）。 */
+  writeQueue?: (queue: PendingDeregisterEntry[]) => Promise<void>;
+}
+
+/** 默认队列文件：<userData>/warp/pending-deregister.json。 */
+export function defaultQueueFilePath(): string {
+  return path.join(getUserDataPath(), 'warp', 'pending-deregister.json');
+}
+
+export class WarpDeregisterQueue {
+  private readonly unregister: WarpDeregisterQueueDeps['unregister'];
+  private readonly logManager?: LogManager;
+  // filePath 惰性解析：默认值经 getUserDataPath()（依赖 electron app）——注入 readQueue/writeQueue 的单测无需它，
+  // 故不在构造期 eager 求值（否则 jest 无 app 即崩）。仅磁盘 IO 路径访问 filePath 时才解析默认。
+  private readonly filePathOverride?: string;
+  private readonly now: () => number;
+  private readonly readQueueImpl: () => Promise<PendingDeregisterEntry[]>;
+  private readonly writeQueueImpl: (queue: PendingDeregisterEntry[]) => Promise<void>;
+  /** 防并发重入（启动 drain 与注册后 drain 可能并发）：同一时刻只跑一次 drain。 */
+  private draining = false;
+
+  constructor(deps: WarpDeregisterQueueDeps) {
+    this.unregister = deps.unregister;
+    this.logManager = deps.logManager;
+    this.filePathOverride = deps.queueFilePath;
+    this.now = deps.now ?? (() => Date.now());
+    this.readQueueImpl = deps.readQueue ?? (() => this.readQueueFromDisk());
+    this.writeQueueImpl = deps.writeQueue ?? ((q) => this.writeQueueToDisk(q));
+  }
+
+  /** 队列文件路径（惰性：仅磁盘 IO 时解析默认 <userData>/warp/pending-deregister.json）。 */
+  private get filePath(): string {
+    return this.filePathOverride ?? defaultQueueFilePath();
+  }
+
+  private log(level: 'info' | 'warn' | 'error', message: string): void {
+    this.logManager?.addLog(level, message, 'WarpDeregisterQueue');
+  }
+
+  /** 从磁盘读队列；文件缺失/损坏 → []（失败安全，不阻断）。 */
+  private async readQueueFromDisk(): Promise<PendingDeregisterEntry[]> {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(
+        (e): e is PendingDeregisterEntry =>
+          e &&
+          typeof e.deviceId === 'string' &&
+          typeof e.token === 'string' &&
+          typeof e.enqueuedAt === 'number'
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  /** 原子写队列（先写 .tmp 再 rename），确保目录存在。 */
+  private async writeQueueToDisk(queue: PendingDeregisterEntry[]): Promise<void> {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    const tmp = `${this.filePath}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(queue, null, 2), 'utf8');
+    await fs.rename(tmp, this.filePath);
+  }
+
+  /**
+   * 机会式 drain：读队列 → 按年龄/MAX_PER_DRAIN 计划 → 逐 eligible 调 unregister →
+   * done/drop/超龄出队、retry 留队 → 写回。fire-and-forget 调用方不 await 也安全（自吞异常）。
+   */
+  async drain(): Promise<{ done: number; dropped: number; retried: number; expired: number }> {
+    const stats = { done: 0, dropped: 0, retried: 0, expired: 0 };
+    if (this.draining) return stats; // 并发重入保护
+    this.draining = true;
+    try {
+      const queue = await this.readQueueImpl();
+      if (queue.length === 0) return stats;
+
+      const { plan, deferred } = planDeregisterDrain(queue, this.now());
+      // 留队集合：deferred（本次未轮到的在龄条目）+ 处理后判定 retry 的条目。
+      const keep: PendingDeregisterEntry[] = [...deferred];
+
+      for (const item of plan) {
+        const idPrefix = item.entry.deviceId.slice(0, 8);
+        if (item.action === 'expire') {
+          // 超龄放弃：本地节点早已删、孤儿零计费，warn 后出队（不再消耗预算）。
+          const ageDays = Math.floor((this.now() - item.entry.enqueuedAt) / 86_400_000);
+          this.log(
+            'warn',
+            `WARP 设备 ${idPrefix}… 入队 ${ageDays} 天仍未注销，超阈值放弃（本地节点早已删、可忽略）`
+          );
+          stats.expired += 1;
+          continue;
+        }
+        // eligible：调远端注销。unregister 内部已不抛（按返回值分类）；仍兜底 catch 防注入实现抛出。
+        let result: DeregisterResult;
+        try {
+          result = await this.unregister(item.entry.deviceId, item.entry.token);
+        } catch {
+          result = 'retry';
+        }
+        if (result === 'done') {
+          this.log('info', `WARP 设备 ${idPrefix}… 已注销，出队`);
+          stats.done += 1;
+        } else if (result === 'drop') {
+          this.log('info', `WARP 设备 ${idPrefix}… 凭据失效，放弃出队`);
+          stats.dropped += 1;
+        } else {
+          // retry：留队等下个触发点（启动间隔即天然退避）。
+          keep.push(item.entry);
+          stats.retried += 1;
+        }
+      }
+
+      // 只在队列实际变化时写回（全 retry 且无 expire/done/drop 时跳过写，省一次 IO）。
+      if (keep.length !== queue.length) {
+        await this.writeQueueImpl(keep);
+      }
+      if (stats.done + stats.dropped + stats.expired > 0) {
+        this.log(
+          'info',
+          `WARP 待注销 drain：done=${stats.done} drop=${stats.dropped} expire=${stats.expired} retry=${stats.retried}（剩 ${keep.length}，本次至多 ${WARP_DEREGISTER_MAX_PER_DRAIN}）`
+        );
+      }
+      return stats;
+    } catch (e: any) {
+      this.log('warn', `WARP 待注销 drain 异常（忽略，下次重试）: ${e?.message ?? e}`);
+      return stats;
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  /** fire-and-forget drain：启动/注册后触发，绝不阻塞主流程、绝不抛。 */
+  drainInBackground(): void {
+    void this.drain().catch(() => {});
+  }
+
+  /** 入队一条待注销凭据（删除节点时调）；受 MAX_QUEUE 护栏，超则丢最旧 + 日志。 */
+  async enqueue(entry: PendingDeregisterEntry): Promise<void> {
+    const queue = await this.readQueueImpl();
+    const { queue: next, dropped } = enqueuePendingDeregister(queue, entry);
+    for (const d of dropped) {
+      this.log('warn', `WARP 待注销队列已满，丢弃最旧条目 ${d.deviceId.slice(0, 8)}…`);
+    }
+    await this.writeQueueImpl(next);
+    this.log('info', `WARP 设备 ${entry.deviceId.slice(0, 8)}… 入待注销队列（剩 ${next.length}）`);
+  }
+}

--- a/src/main/services/WarpDeregisterQueue.ts
+++ b/src/main/services/WarpDeregisterQueue.ts
@@ -14,7 +14,9 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import * as crypto from 'crypto';
 import type { LogManager } from './LogManager';
+import { WarpService } from './WarpService';
 import { getUserDataPath } from '../utils/paths';
 import {
   planDeregisterDrain,
@@ -55,6 +57,13 @@ export class WarpDeregisterQueue {
   private readonly writeQueueImpl: (queue: PendingDeregisterEntry[]) => Promise<void>;
   /** 防并发重入（启动 drain 与注册后 drain 可能并发）：同一时刻只跑一次 drain。 */
   private draining = false;
+  /**
+   * 队列「读改写」串行化链（critical section mutex）。drain 的写回阶段与 enqueue 全程都排进此链 →
+   * 杜绝二者 read-modify-write 交错导致的 lost-update：drain 进行中（await unregister 网络往返数秒）用户删
+   * 新节点触发 enqueue，若无串行化，drain 用旧快照 keep 全量覆盖会抹掉 enqueue 刚追加的新凭据 → 永久孤儿。
+   * 注意：drain 的网络往返**不**占此链（否则 enqueue 被阻塞数秒），只有最终写回的「重读-合并-写」临界区进链。
+   */
+  private opChain: Promise<unknown> = Promise.resolve();
 
   constructor(deps: WarpDeregisterQueueDeps) {
     this.unregister = deps.unregister;
@@ -74,10 +83,29 @@ export class WarpDeregisterQueue {
     this.logManager?.addLog(level, message, 'WarpDeregisterQueue');
   }
 
-  /** 从磁盘读队列；文件缺失/损坏 → []（失败安全，不阻断）。 */
+  /**
+   * 把一段「读改写」临界区排进串行链，保证与其它入链操作（drain 写回 / enqueue）互不交错。
+   * 返回该段的结果。链上前序失败不污染后续（catch 续接），但本段异常照常向调用方抛出。
+   */
+  private runSerial<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.opChain.then(op, op);
+    // 链尾吞掉结果与异常，避免一段失败阻断后续；本段真实结果/异常经 run 单独传给调用方。
+    this.opChain = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  /** 从磁盘读队列；文件缺失 → []（失败安全）；损坏 JSON → warn 后 []（纵深兜底，唯一 .tmp 后缀已根除并发损坏来源）。 */
   private async readQueueFromDisk(): Promise<PendingDeregisterEntry[]> {
+    let raw: string;
     try {
-      const raw = await fs.readFile(this.filePath, 'utf8');
+      raw = await fs.readFile(this.filePath, 'utf8');
+    } catch {
+      return []; // 文件缺失（ENOENT）或不可读 → 空队列，正常路径。
+    }
+    try {
       const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) return [];
       return parsed.filter(
@@ -88,16 +116,27 @@ export class WarpDeregisterQueue {
           typeof e.enqueuedAt === 'number'
       );
     } catch {
+      // 文件存在但 JSON 损坏：极罕见（唯一 .tmp 后缀 + 原子 rename 已杜绝并发写坏正本）。warn 帮人工发现；
+      // 返 [] 维持失败安全（不阻断删除/启动），坏文件将被下次原子写正常覆盖。
+      this.log('warn', 'WARP 待注销队列文件损坏（JSON 解析失败），按空队列处理');
       return [];
     }
   }
 
-  /** 原子写队列（先写 .tmp 再 rename），确保目录存在。 */
+  /**
+   * 原子写队列：写**唯一后缀** .tmp（pid+随机）再 rename。唯一后缀杜绝多 writer（跨实例/未来多 writer）
+   * 并发写同一 .tmp 致字节交错损坏正本——各 writer 写各自临时文件，rename 各自原子落地（同分区 POSIX 原子）。
+   */
   private async writeQueueToDisk(queue: PendingDeregisterEntry[]): Promise<void> {
     await fs.mkdir(path.dirname(this.filePath), { recursive: true });
-    const tmp = `${this.filePath}.tmp`;
-    await fs.writeFile(tmp, JSON.stringify(queue, null, 2), 'utf8');
-    await fs.rename(tmp, this.filePath);
+    const tmp = `${this.filePath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+    try {
+      await fs.writeFile(tmp, JSON.stringify(queue, null, 2), 'utf8');
+      await fs.rename(tmp, this.filePath);
+    } catch (e) {
+      await fs.rm(tmp, { force: true }).catch(() => {}); // 失败清理临时文件，不留孤儿
+      throw e;
+    }
   }
 
   /**
@@ -112,9 +151,10 @@ export class WarpDeregisterQueue {
       const queue = await this.readQueueImpl();
       if (queue.length === 0) return stats;
 
-      const { plan, deferred } = planDeregisterDrain(queue, this.now());
-      // 留队集合：deferred（本次未轮到的在龄条目）+ 处理后判定 retry 的条目。
-      const keep: PendingDeregisterEntry[] = [...deferred];
+      const { plan } = planDeregisterDrain(queue, this.now());
+      // 本次「处理后出队」的 deviceId 集合（done/drop/expire）。retry 与 deferred 不入此集（留队）。
+      // 网络往返（unregister）期间用户可能 enqueue 新条目；故写回**不**用旧快照覆盖，而是按此集从最新磁盘队列剔除。
+      const removeIds = new Set<string>();
 
       for (const item of plan) {
         const idPrefix = item.entry.deviceId.slice(0, 8);
@@ -125,10 +165,11 @@ export class WarpDeregisterQueue {
             'warn',
             `WARP 设备 ${idPrefix}… 入队 ${ageDays} 天仍未注销，超阈值放弃（本地节点早已删、可忽略）`
           );
+          removeIds.add(item.entry.deviceId);
           stats.expired += 1;
           continue;
         }
-        // eligible：调远端注销。unregister 内部已不抛（按返回值分类）；仍兜底 catch 防注入实现抛出。
+        // eligible：调远端注销（网络往返，不占串行链）。unregister 内部已不抛（按返回值分类）；仍兜底 catch 防注入实现抛出。
         let result: DeregisterResult;
         try {
           result = await this.unregister(item.entry.deviceId, item.entry.token);
@@ -137,25 +178,35 @@ export class WarpDeregisterQueue {
         }
         if (result === 'done') {
           this.log('info', `WARP 设备 ${idPrefix}… 已注销，出队`);
+          removeIds.add(item.entry.deviceId);
           stats.done += 1;
         } else if (result === 'drop') {
           this.log('info', `WARP 设备 ${idPrefix}… 凭据失效，放弃出队`);
+          removeIds.add(item.entry.deviceId);
           stats.dropped += 1;
         } else {
-          // retry：留队等下个触发点（启动间隔即天然退避）。
-          keep.push(item.entry);
+          // retry：留队等下个触发点（启动间隔即天然退避）。不入 removeIds。
           stats.retried += 1;
         }
       }
 
-      // 只在队列实际变化时写回（全 retry 且无 expire/done/drop 时跳过写，省一次 IO）。
-      if (keep.length !== queue.length) {
-        await this.writeQueueImpl(keep);
+      // 写回临界区（进串行链，与 enqueue 互斥）：重读最新磁盘队列，仅剔除本次处理掉的 deviceId →
+      // 保留 retry 条目 + 网络往返期间 enqueue 新增的条目（杜绝旧快照覆盖致 lost-update）。无变化则跳过写（省 IO）。
+      let keepLen = queue.length;
+      if (removeIds.size > 0) {
+        keepLen = await this.runSerial(async () => {
+          const latest = await this.readQueueImpl();
+          const keep = latest.filter((e) => !removeIds.has(e.deviceId));
+          if (keep.length !== latest.length) {
+            await this.writeQueueImpl(keep);
+          }
+          return keep.length;
+        });
       }
       if (stats.done + stats.dropped + stats.expired > 0) {
         this.log(
           'info',
-          `WARP 待注销 drain：done=${stats.done} drop=${stats.dropped} expire=${stats.expired} retry=${stats.retried}（剩 ${keep.length}，本次至多 ${WARP_DEREGISTER_MAX_PER_DRAIN}）`
+          `WARP 待注销 drain：done=${stats.done} drop=${stats.dropped} expire=${stats.expired} retry=${stats.retried}（剩 ${keepLen}，本次至多 ${WARP_DEREGISTER_MAX_PER_DRAIN}）`
         );
       }
       return stats;
@@ -172,14 +223,48 @@ export class WarpDeregisterQueue {
     void this.drain().catch(() => {});
   }
 
-  /** 入队一条待注销凭据（删除节点时调）；受 MAX_QUEUE 护栏，超则丢最旧 + 日志。 */
+  /**
+   * 入队一条待注销凭据（删除节点时调）；受 MAX_QUEUE 护栏，超则丢最旧 + 日志。
+   * 整个「读改写」进串行链，与并发 drain 的写回互斥——杜绝 drain 用旧快照覆盖抹掉本次入队（lost-update）。
+   */
   async enqueue(entry: PendingDeregisterEntry): Promise<void> {
-    const queue = await this.readQueueImpl();
-    const { queue: next, dropped } = enqueuePendingDeregister(queue, entry);
-    for (const d of dropped) {
-      this.log('warn', `WARP 待注销队列已满，丢弃最旧条目 ${d.deviceId.slice(0, 8)}…`);
-    }
-    await this.writeQueueImpl(next);
-    this.log('info', `WARP 设备 ${entry.deviceId.slice(0, 8)}… 入待注销队列（剩 ${next.length}）`);
+    await this.runSerial(async () => {
+      const queue = await this.readQueueImpl();
+      const { queue: next, dropped } = enqueuePendingDeregister(queue, entry);
+      for (const d of dropped) {
+        this.log('warn', `WARP 待注销队列已满，丢弃最旧条目 ${d.deviceId.slice(0, 8)}…`);
+      }
+      await this.writeQueueImpl(next);
+      this.log(
+        'info',
+        `WARP 设备 ${entry.deviceId.slice(0, 8)}… 入待注销队列（剩 ${next.length}）`
+      );
+    });
   }
+}
+
+// ── 进程内单例 ──────────────────────────────────────────────────────────
+// 删除入队（server-handlers）、成功注册后 drain（server-handlers）、启动 8s drain（startup-tasks）三处必须**共用同一
+// 实例**：实例级串行链（opChain）是 lost-update / 并发写防护的载体；若各处 new 独立实例，跨实例并发读改写同一磁盘队列
+// 文件仍会交错（旧快照覆盖 / 写竞争）。故收敛为单例，所有触发点经此获取。
+let singleton: WarpDeregisterQueue | null = null;
+
+/**
+ * 获取进程内唯一的 WARP 待注销队列实例（首次惰性创建，注入 WarpService.unregister + logManager）。
+ * unregister 每次 new 一个无状态 WarpService（仅持 logManager），等价纯函数封装。
+ */
+export function getWarpDeregisterQueue(logManager?: LogManager): WarpDeregisterQueue {
+  if (!singleton) {
+    singleton = new WarpDeregisterQueue({
+      unregister: (deviceId: string, token: string) =>
+        new WarpService(logManager).unregister(deviceId, token),
+      logManager,
+    });
+  }
+  return singleton;
+}
+
+/** 仅供测试：重置单例（隔离用例间状态）。 */
+export function __resetWarpDeregisterQueueSingleton(): void {
+  singleton = null;
 }

--- a/src/main/services/WarpService.ts
+++ b/src/main/services/WarpService.ts
@@ -18,7 +18,10 @@ import {
   WARP_ALLOWED_IPS,
   buildRegisterBody,
   parseRegisterResponse,
+  buildUnregisterRequest,
+  classifyDeregisterResult,
   type WarpWireGuardDraft,
+  type DeregisterResult,
 } from '../../shared/warp';
 
 export type { WarpWireGuardDraft };
@@ -150,6 +153,72 @@ export class WarpService {
         license: result.license,
         warpPlus: result.warpPlus,
       },
+      // 破当前「token 用后即弃」：保留 deviceId+token 随节点落 wireguardSettings.warpDevice，作远端设备自删凭据
+      // （与 privateKey 同信任类、同脱敏）。无 token 时存空串——register 应返 token，缺则后续删除按「无凭据」跳过入队。
+      warpDevice: { deviceId: result.deviceId, token: token || '' },
     };
+  }
+
+  /**
+   * 注销一台已注册的 WARP 设备（删除节点时调）。裸 DELETE /{version}/reg/{deviceId} + Bearer token + 同
+   * register 的 TLS1.2/okhttp 指纹（否则 1020）。**捕获 HTTP 状态码**（不像 register 非 2xx 即抛丢失状态）→
+   * 经 classifyDeregisterResult 返 done/drop/retry；网络异常 → classify(null, err)=retry。
+   * 不抛异常（队列重试语义靠返回值，不靠 try/catch）。日志只打 deviceId 前缀，绝不打 token。
+   */
+  async unregister(deviceId: string, token: string): Promise<DeregisterResult> {
+    if (!deviceId || !token) return 'drop'; // 无凭据无从注销（旧节点 / 缺 token），视作放弃出队。
+    const { url, headers } = buildUnregisterRequest(WARP_API_VERSION, deviceId, token);
+    const idPrefix = deviceId.slice(0, 8);
+    try {
+      const status = await this.requestStatus('DELETE', url, headers);
+      const result = classifyDeregisterResult(status, undefined);
+      this.log('info', `WARP 设备注销 ${idPrefix}… → HTTP ${status}（${result}）`);
+      return result;
+    } catch (e: any) {
+      // 网络失败 / 超时：无 HTTP 状态 → retry（等网络恢复）。
+      const result = classifyDeregisterResult(null, e);
+      this.log('info', `WARP 设备注销 ${idPrefix}… 网络异常（${result}）: ${e?.message ?? e}`);
+      return result;
+    }
+  }
+
+  /**
+   * 同 request 的 TLS1.2-only + HTTP/1.1，但**返回 HTTP 状态码而非按 2xx 抛错**（注销需据 4xx/5xx 分类，
+   * 不能像 register 那样非 2xx 即抛丢失状态）。响应体被读尽丢弃（注销只关心状态码）。仅网络层错误才 reject。
+   */
+  private requestStatus(
+    method: string,
+    url: string,
+    headers: Record<string, string>
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const u = new URL(url);
+      const req = https.request(
+        {
+          method,
+          hostname: u.hostname,
+          path: u.pathname + u.search,
+          port: 443,
+          headers,
+          timeout: REQ_TIMEOUT_MS,
+          minVersion: 'TLSv1.2',
+          maxVersion: 'TLSv1.2',
+        },
+        (res) => {
+          res.setEncoding('utf8');
+          // 响应流错误（对端收 header 后 RST/提前关闭）发在 res 上而非 req → 必须显式 reject，否则永挂。
+          res.on('error', (e) => reject(e instanceof Error ? e : new Error(String(e))));
+          let len = 0;
+          res.on('data', (c) => {
+            len += c.length;
+            if (len > 1_000_000) req.destroy(new Error('WARP 响应过大'));
+          });
+          res.on('end', () => resolve(res.statusCode || 0));
+        }
+      );
+      req.on('error', reject);
+      req.on('timeout', () => req.destroy(new Error('WARP API 超时')));
+      req.end();
+    });
   }
 }

--- a/src/main/services/WarpService.ts
+++ b/src/main/services/WarpService.ts
@@ -170,8 +170,11 @@ export class WarpService {
     const { url, headers } = buildUnregisterRequest(WARP_API_VERSION, deviceId, token);
     const idPrefix = deviceId.slice(0, 8);
     try {
-      const status = await this.requestStatus('DELETE', url, headers);
-      const result = classifyDeregisterResult(status, undefined);
+      const { status, body } = await this.requestStatus('DELETE', url, headers);
+      // 关键：把响应体一并传给分类——Cloudflare WAF 1020（版本串失效）常以 **403 携带 body code 1020** 返回，
+      // 须优先于 401/403 的 drop 判定走 retry。若只传 status，403+1020 会被误当「token 死」放弃 → 版本过期时
+      // 全部设备注销被永久误放弃。body 作 err 文本喂 classifyDeregisterResult，使 1020 检测在注销路径真正生效。
+      const result = classifyDeregisterResult(status, body || undefined);
       this.log('info', `WARP 设备注销 ${idPrefix}… → HTTP ${status}（${result}）`);
       return result;
     } catch (e: any) {
@@ -183,14 +186,15 @@ export class WarpService {
   }
 
   /**
-   * 同 request 的 TLS1.2-only + HTTP/1.1，但**返回 HTTP 状态码而非按 2xx 抛错**（注销需据 4xx/5xx 分类，
-   * 不能像 register 那样非 2xx 即抛丢失状态）。响应体被读尽丢弃（注销只关心状态码）。仅网络层错误才 reject。
+   * 同 request 的 TLS1.2-only + HTTP/1.1，但**返回 HTTP 状态码 + 截断响应体**（注销需据 4xx/5xx 分类，不能像
+   * register 那样非 2xx 即抛丢失状态）。保留响应体前段（≤512B）供调用方判 body-code-1020（WAF/版本失效）——
+   * 若丢弃 body，403+1020 与「token 死的 403」无法区分。仅网络层错误才 reject。
    */
   private requestStatus(
     method: string,
     url: string,
     headers: Record<string, string>
-  ): Promise<number> {
+  ): Promise<{ status: number; body: string }> {
     return new Promise((resolve, reject) => {
       const u = new URL(url);
       const req = https.request(
@@ -208,12 +212,16 @@ export class WarpService {
           res.setEncoding('utf8');
           // 响应流错误（对端收 header 后 RST/提前关闭）发在 res 上而非 req → 必须显式 reject，否则永挂。
           res.on('error', (e) => reject(e instanceof Error ? e : new Error(String(e))));
-          let len = 0;
+          let body = '';
+          let total = 0; // 累计字节（独立于 body——body 前 512B 后早停拼接，不能复用其长度判超大）。
           res.on('data', (c) => {
-            len += c.length;
-            if (len > 1_000_000) req.destroy(new Error('WARP 响应过大'));
+            total += c.length;
+            // 只保留前 512 字节（足够含 CF body code 如 1020），但与 request 一致对超大响应主动 destroy，
+            // 防异常/恶意对端持续涌数据（timeout 是空闲超时、连续数据不触发）。
+            if (body.length < 512) body += c;
+            if (total > 1_000_000) req.destroy(new Error('WARP 响应过大'));
           });
-          res.on('end', () => resolve(res.statusCode || 0));
+          res.on('end', () => resolve({ status: res.statusCode || 0, body: body.slice(0, 512) }));
         }
       );
       req.on('error', reject);

--- a/src/main/services/__tests__/WarpDeregisterQueue.test.ts
+++ b/src/main/services/__tests__/WarpDeregisterQueue.test.ts
@@ -139,6 +139,32 @@ describe('WarpDeregisterQueue.drain', () => {
     await p1;
     expect(store).toEqual([]); // 第一次正常完成出队
   });
+
+  it('lost-update 回归：drain 网络往返期间 enqueue 新条目，写回不抹掉新条目（重读-剔除-合并）', async () => {
+    // 修复前：drain 读旧快照 [a] → await unregister 期间 enqueue(b) → drain 用旧 keep 覆盖 → b 丢失（永久孤儿）。
+    // 修复后：drain 写回前重读最新磁盘队列，仅剔除本次处理掉的 deviceId（a），保留 enqueue 新增的 b。
+    let resolveUnreg: (r: DeregisterResult) => void = () => {};
+    let store = [mk('a')];
+    const q = new WarpDeregisterQueue({
+      unregister: () =>
+        new Promise<DeregisterResult>((res) => {
+          resolveUnreg = res;
+        }),
+      now: () => NOW,
+      readQueue: async () => [...store],
+      writeQueue: async (next) => {
+        store = [...next];
+      },
+    });
+    const p1 = q.drain(); // 读快照 [a]，卡在 unregister('a')
+    await Promise.resolve(); // 让 drain 推进到 await unregister
+    await q.enqueue(mk('b')); // 网络往返期间删新节点入队 → store=[a,b]
+    expect(store.map((e) => e.deviceId)).toEqual(['a', 'b']);
+    resolveUnreg('done'); // a 注销成功
+    await p1;
+    // a 出队（done），b 保留（未被旧快照覆盖）。这是核心断言：新凭据没丢。
+    expect(store.map((e) => e.deviceId)).toEqual(['b']);
+  });
 });
 
 describe('WarpDeregisterQueue.enqueue', () => {

--- a/src/main/services/__tests__/WarpDeregisterQueue.test.ts
+++ b/src/main/services/__tests__/WarpDeregisterQueue.test.ts
@@ -1,0 +1,150 @@
+/**
+ * WarpDeregisterQueue 单测（注入式，不触网/不碰真实 FS）。
+ * unregister / readQueue / writeQueue / now 全注入；验 drain 的 done/drop/retry 出入队、超龄 expire、
+ * MAX_PER_DRAIN 截断、并发重入保护、enqueue 护栏，及「队列无变化跳过写」。
+ * 纯阈值/分流逻辑在 shared/warp.test.ts，此处只验服务编排。
+ */
+import { WarpDeregisterQueue } from '../WarpDeregisterQueue';
+import {
+  WARP_DEREGISTER_MAX_AGE_MS,
+  WARP_DEREGISTER_MAX_PER_DRAIN,
+  type PendingDeregisterEntry,
+  type DeregisterResult,
+} from '../../../shared/warp';
+
+const NOW = 2_000_000_000_000;
+const mk = (id: string, ageMs = 1000): PendingDeregisterEntry => ({
+  deviceId: id,
+  token: `t-${id}`,
+  enqueuedAt: NOW - ageMs,
+});
+
+/** 构造一个注入式队列：内存队列 + 可编排的 unregister 结果。 */
+function makeQueue(
+  initial: PendingDeregisterEntry[],
+  results: Record<string, DeregisterResult> | ((id: string) => DeregisterResult)
+) {
+  let store = [...initial];
+  const writes: PendingDeregisterEntry[][] = [];
+  const unregistered: string[] = [];
+  const q = new WarpDeregisterQueue({
+    unregister: async (deviceId: string) => {
+      unregistered.push(deviceId);
+      return typeof results === 'function' ? results(deviceId) : (results[deviceId] ?? 'retry');
+    },
+    now: () => NOW,
+    readQueue: async () => [...store],
+    writeQueue: async (queue) => {
+      store = [...queue];
+      writes.push([...queue]);
+    },
+  });
+  return { q, getStore: () => store, writes, unregistered };
+}
+
+describe('WarpDeregisterQueue.drain', () => {
+  it('done → 出队；retry → 留队', async () => {
+    const { q, getStore, unregistered } = makeQueue([mk('a'), mk('b')], { a: 'done', b: 'retry' });
+    const stats = await q.drain();
+    expect(stats).toMatchObject({ done: 1, retried: 1 });
+    expect(unregistered.sort()).toEqual(['a', 'b']);
+    expect(getStore().map((e) => e.deviceId)).toEqual(['b']); // a 出队，b 留队
+  });
+
+  it('drop → 出队（凭据死，不再重试）', async () => {
+    const { q, getStore } = makeQueue([mk('a')], { a: 'drop' });
+    const stats = await q.drain();
+    expect(stats).toMatchObject({ dropped: 1 });
+    expect(getStore()).toEqual([]);
+  });
+
+  it('超 7 天 → expire 出队，且不调 unregister（不调网络）', async () => {
+    const { q, getStore, unregistered } = makeQueue(
+      [mk('old', WARP_DEREGISTER_MAX_AGE_MS + 5000), mk('fresh', 1000)],
+      { fresh: 'done' }
+    );
+    const stats = await q.drain();
+    expect(stats).toMatchObject({ expired: 1, done: 1 });
+    expect(unregistered).toEqual(['fresh']); // old 未调网络
+    expect(getStore()).toEqual([]); // 都出队
+  });
+
+  it('单次至多 MAX_PER_DRAIN 条，余下留队等下次', async () => {
+    const entries = Array.from({ length: WARP_DEREGISTER_MAX_PER_DRAIN + 4 }, (_, i) =>
+      mk(`e${i}`, 1000)
+    );
+    const { q, getStore, unregistered } = makeQueue(entries, () => 'retry');
+    await q.drain();
+    expect(unregistered.length).toBe(WARP_DEREGISTER_MAX_PER_DRAIN); // 只处理前 N 条
+    expect(getStore().length).toBe(entries.length); // 全 retry → 全留队（无变化）
+  });
+
+  it('空队列 → no-op，不写回', async () => {
+    const { q, writes, unregistered } = makeQueue([], {});
+    const stats = await q.drain();
+    expect(stats).toEqual({ done: 0, dropped: 0, retried: 0, expired: 0 });
+    expect(writes).toEqual([]);
+    expect(unregistered).toEqual([]);
+  });
+
+  it('全 retry 且无 expire/done/drop → 跳过写回（省 IO）', async () => {
+    const { q, writes } = makeQueue([mk('a'), mk('b')], { a: 'retry', b: 'retry' });
+    await q.drain();
+    expect(writes).toEqual([]); // 队列内容未变，不写
+  });
+
+  it('有出队（done）→ 写回新队列', async () => {
+    const { q, writes } = makeQueue([mk('a'), mk('b')], { a: 'done', b: 'retry' });
+    await q.drain();
+    expect(writes.length).toBe(1);
+    expect(writes[0].map((e) => e.deviceId)).toEqual(['b']);
+  });
+
+  it('unregister 抛异常 → 当 retry 兜底（留队，不崩 drain）', async () => {
+    let store = [mk('a')];
+    const q = new WarpDeregisterQueue({
+      unregister: async () => {
+        throw new Error('boom');
+      },
+      now: () => NOW,
+      readQueue: async () => [...store],
+      writeQueue: async (next) => {
+        store = [...next];
+      },
+    });
+    const stats = await q.drain();
+    expect(stats).toMatchObject({ retried: 1 });
+    expect(store.map((e) => e.deviceId)).toEqual(['a']); // 留队
+  });
+
+  it('并发重入保护：第二次 drain 在第一次进行中直接返回零', async () => {
+    let resolveUnreg: (r: DeregisterResult) => void = () => {};
+    let store = [mk('a')];
+    const q = new WarpDeregisterQueue({
+      unregister: () =>
+        new Promise<DeregisterResult>((res) => {
+          resolveUnreg = res;
+        }),
+      now: () => NOW,
+      readQueue: async () => [...store],
+      writeQueue: async (next) => {
+        store = [...next];
+      },
+    });
+    const p1 = q.drain();
+    // p1 卡在 unregister；此时第二次 drain 应被重入保护直接返回零。
+    const stats2 = await q.drain();
+    expect(stats2).toEqual({ done: 0, dropped: 0, retried: 0, expired: 0 });
+    resolveUnreg('done');
+    await p1;
+    expect(store).toEqual([]); // 第一次正常完成出队
+  });
+});
+
+describe('WarpDeregisterQueue.enqueue', () => {
+  it('追加新条目并写回', async () => {
+    const { q, getStore } = makeQueue([mk('a')], {});
+    await q.enqueue(mk('new'));
+    expect(getStore().map((e) => e.deviceId)).toEqual(['a', 'new']);
+  });
+});

--- a/src/main/services/__tests__/WarpService.test.ts
+++ b/src/main/services/__tests__/WarpService.test.ts
@@ -1,0 +1,146 @@
+/**
+ * WarpService 单测（设备移除特性）。覆盖：
+ * - register 产出含 warpDevice = { deviceId, token }（破「token 用后即弃」——token 随 draft 回渲染）。
+ * - unregister 据 HTTP 状态码经 classifyDeregisterResult 返 done/drop/retry，且**捕获 4xx/5xx 不抛**。
+ *
+ * mock node `https`（参考 ClashApiClient.test 的 fake req/res 驱动）：仅 mock request，crypto 用真实
+ * （register 内 generateKeyPairSync('x25519') 需真实 keypair）。日志红线由「unregister 不打 token」靠代码保证，
+ * 此处验返回值语义即可。
+ */
+import { EventEmitter } from 'events';
+
+const mockRequest = jest.fn();
+jest.mock('https', () => ({
+  ...jest.requireActual('https'),
+  request: (...args: any[]) => mockRequest(...args),
+}));
+
+import { WarpService } from '../WarpService';
+import { WARP_API_BASE } from '../../../shared/warp';
+
+class FakeRes extends EventEmitter {
+  statusCode = 200;
+  setEncoding = jest.fn();
+}
+class FakeReq extends EventEmitter {
+  written: unknown[] = [];
+  write = jest.fn((p?: unknown) => {
+    this.written.push(p);
+  });
+  end = jest.fn();
+  destroy = jest.fn((err?: Error) => {
+    this.emit('error', err ?? new Error('socket hang up'));
+  });
+}
+
+interface Call {
+  options: any;
+  req: FakeReq;
+  res: FakeRes;
+}
+
+/** 安装 https.request mock：每次调用按 responders 队列取一个驱动（statusCode + body）。 */
+function installHttps(
+  responders: Array<{ statusCode: number; body?: string; networkError?: Error }>
+): Call[] {
+  const calls: Call[] = [];
+  mockRequest.mockReset();
+  const queue = [...responders];
+  mockRequest.mockImplementation((options: any, cb?: (res: FakeRes) => void): FakeReq => {
+    const req = new FakeReq();
+    const res = new FakeRes();
+    calls.push({ options, req, res });
+    const r = queue.shift();
+    if (r) res.statusCode = r.statusCode;
+    process.nextTick(() => {
+      if (r?.networkError) {
+        req.emit('error', r.networkError);
+        return;
+      }
+      if (cb) cb(res);
+      if (r?.body) res.emit('data', r.body);
+      res.emit('end');
+    });
+    return req;
+  });
+  return calls;
+}
+
+const REG_OK = JSON.stringify({
+  id: 'device-abc-123',
+  token: 'secret-token-xyz',
+  account: { id: 'acct1', license: 'lic1', warp_plus: false },
+  config: {
+    client_id: Buffer.from([1, 2, 3]).toString('base64'),
+    interface: { addresses: { v4: '172.16.0.2', v6: '2606:4700:110::1' } },
+    peers: [{ public_key: 'PEERPUB', endpoint: { host: 'engage.cloudflareclient.com:2408' } }],
+  },
+});
+
+describe('WarpService.register → draft.warpDevice', () => {
+  it('产出 draft.warpDevice = { deviceId, token }（不再丢弃凭据）', async () => {
+    installHttps([{ statusCode: 200, body: REG_OK }]);
+    const draft = await new WarpService().register();
+    expect(draft.warpDevice).toEqual({ deviceId: 'device-abc-123', token: 'secret-token-xyz' });
+    // 其余字段照旧
+    expect(draft.peerPublicKey).toBe('PEERPUB');
+    expect(draft.meta.deviceId).toBe('device-abc-123');
+    expect(draft.reserved).toEqual([1, 2, 3]);
+  });
+
+  it('响应缺 token → warpDevice.token 退化为空串（后续删除按「无凭据」跳过入队）', async () => {
+    const noToken = JSON.parse(REG_OK);
+    delete noToken.token;
+    installHttps([{ statusCode: 200, body: JSON.stringify(noToken) }]);
+    const draft = await new WarpService().register();
+    expect(draft.warpDevice).toEqual({ deviceId: 'device-abc-123', token: '' });
+  });
+});
+
+describe('WarpService.unregister', () => {
+  it('204 → done，且发 DELETE /{version}/reg/{deviceId} + Bearer', async () => {
+    const calls = installHttps([{ statusCode: 204 }]);
+    const r = await new WarpService().unregister('device-abc-123', 'tok');
+    expect(r).toBe('done');
+    expect(calls[0].options.method).toBe('DELETE');
+    expect(calls[0].options.path).toBe('/v0a2158/reg/device-abc-123');
+    expect(calls[0].options.headers.Authorization).toBe('Bearer tok');
+    // TLS1.2 指纹钉死
+    expect(calls[0].options.minVersion).toBe('TLSv1.2');
+    expect(calls[0].options.maxVersion).toBe('TLSv1.2');
+  });
+
+  it('404 → done（别处已销）', async () => {
+    installHttps([{ statusCode: 404 }]);
+    expect(await new WarpService().unregister('d', 't')).toBe('done');
+  });
+
+  it('401 → drop（token 死）——4xx 不抛、捕获状态码分类', async () => {
+    installHttps([{ statusCode: 401, body: 'Not authorized' }]);
+    await expect(new WarpService().unregister('d', 't')).resolves.toBe('drop');
+  });
+
+  it('500 → retry', async () => {
+    installHttps([{ statusCode: 500 }]);
+    expect(await new WarpService().unregister('d', 't')).toBe('retry');
+  });
+
+  it('网络异常 → retry（无 HTTP 状态）', async () => {
+    installHttps([{ statusCode: 0, networkError: new Error('ECONNRESET') }]);
+    expect(await new WarpService().unregister('d', 't')).toBe('retry');
+  });
+
+  it('缺 deviceId / token → drop（无凭可注销，不发网络）', async () => {
+    const calls = installHttps([]);
+    expect(await new WarpService().unregister('', 't')).toBe('drop');
+    expect(await new WarpService().unregister('d', '')).toBe('drop');
+    expect(calls.length).toBe(0); // 未发任何请求
+  });
+});
+
+// 别名占用，避免 import 未用告警（断言常量稳定）。
+describe('常量', () => {
+  it('WARP_API_BASE 固定 CF 域名', () => {
+    expect(WARP_API_BASE).toBe('https://api.cloudflareclient.com');
+  });
+});

--- a/src/main/services/__tests__/WarpService.test.ts
+++ b/src/main/services/__tests__/WarpService.test.ts
@@ -120,6 +120,18 @@ describe('WarpService.unregister', () => {
     await expect(new WarpService().unregister('d', 't')).resolves.toBe('drop');
   });
 
+  it('403 + body code 1020（WAF/版本串失效）→ retry（集成回归：body 须传入分类，否则误判 drop）', async () => {
+    // 真实场景：CF 版本串过期时注销返 403 携带 body {"code":1020}。若 unregister 丢弃 body 只传 status，
+    // 会命中 403→drop 永久误放弃所有设备注销。修复后 requestStatus 保留截断 body 喂 classifyDeregisterResult → retry。
+    installHttps([{ statusCode: 403, body: '{"success":false,"errors":[{"code":1020}]}' }]);
+    expect(await new WarpService().unregister('d', 't')).toBe('retry');
+  });
+
+  it('403 无 1020 body（纯 token 死）→ drop（与上条区分：仅 1020 才豁免 drop）', async () => {
+    installHttps([{ statusCode: 403, body: '{"errors":[{"code":1012}]}' }]);
+    expect(await new WarpService().unregister('d', 't')).toBe('drop');
+  });
+
   it('500 → retry', async () => {
     installHttps([{ statusCode: 500 }]);
     expect(await new WarpService().unregister('d', 't')).toBe('retry');

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -12,8 +12,7 @@ import type { ConfigManager } from './services/ConfigManager';
 import type { ProxyManager } from './services/ProxyManager';
 import type { UpdateService } from './services/UpdateService';
 import type { CoreUpdateService } from './services/CoreUpdateService';
-import { WarpService } from './services/WarpService';
-import { WarpDeregisterQueue } from './services/WarpDeregisterQueue';
+import { getWarpDeregisterQueue } from './services/WarpDeregisterQueue';
 
 /** 注入依赖：服务单例 + proxyManager getter（call-time 取值）+ 托盘状态刷新。 */
 export interface StartupTaskDeps {
@@ -113,11 +112,8 @@ export function scheduleStartupTasks(deps: StartupTaskDeps): void {
 
   // 启动后机会式 drain WARP 待注销队列（延迟 8 秒，让网络/服务先就绪；fire-and-forget 不阻塞、绝不抛）。
   // 与「成功注册 WARP 后」并为两个触发点；无常驻定时器——不重开 app 者既不 drain 也不产生新孤儿（副作用自洽）。
+  // 复用进程内单例（与 server-handlers 同实例）：串行链覆盖启动 drain 与删除入队，杜绝跨实例并发写同一队列文件。
   setTimeout(() => {
-    const queue = new WarpDeregisterQueue({
-      unregister: (deviceId, token) => new WarpService(logManager).unregister(deviceId, token),
-      logManager,
-    });
-    queue.drainInBackground();
+    getWarpDeregisterQueue(logManager).drainInBackground();
   }, 8000);
 }

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -12,6 +12,8 @@ import type { ConfigManager } from './services/ConfigManager';
 import type { ProxyManager } from './services/ProxyManager';
 import type { UpdateService } from './services/UpdateService';
 import type { CoreUpdateService } from './services/CoreUpdateService';
+import { WarpService } from './services/WarpService';
+import { WarpDeregisterQueue } from './services/WarpDeregisterQueue';
 
 /** 注入依赖：服务单例 + proxyManager getter（call-time 取值）+ 托盘状态刷新。 */
 export interface StartupTaskDeps {
@@ -108,4 +110,14 @@ export function scheduleStartupTasks(deps: StartupTaskDeps): void {
       logManager.addLog('error', `自动检查更新异常: ${error}`, 'Main');
     }
   }, 5000);
+
+  // 启动后机会式 drain WARP 待注销队列（延迟 8 秒，让网络/服务先就绪；fire-and-forget 不阻塞、绝不抛）。
+  // 与「成功注册 WARP 后」并为两个触发点；无常驻定时器——不重开 app 者既不 drain 也不产生新孤儿（副作用自洽）。
+  setTimeout(() => {
+    const queue = new WarpDeregisterQueue({
+      unregister: (deviceId, token) => new WarpService(logManager).unregister(deviceId, token),
+      logManager,
+    });
+    queue.drainInBackground();
+  }, 8000);
 }

--- a/src/renderer/components/settings/warp-panel.tsx
+++ b/src/renderer/components/settings/warp-panel.tsx
@@ -43,6 +43,9 @@ export function WarpPanel({ onSubmit, nameMissing }: WarpPanelProps) {
           persistentKeepalive: 25,
           mtu: draft.mtu,
           reserved: draft.reserved,
+          // 不再丢弃注册产出的自删凭据：随节点落 wireguardSettings.warpDevice（与 privateKey 同脱敏），
+          // 删除此节点时据它注销远端匿名设备（见 WARP 设计 §设备移除 / 方案 F）。保存路径不变，仍走 dialog handleSave。
+          warpDevice: draft.warpDevice,
         },
       });
     } catch (e: any) {

--- a/src/renderer/components/settings/wireguard-form.tsx
+++ b/src/renderer/components/settings/wireguard-form.tsx
@@ -158,6 +158,8 @@ export function WireGuardForm({ serverConfig, onSubmit }: WireGuardFormProps) {
         persistentKeepalive: values.persistentKeepalive,
         mtu: values.mtu || undefined,
         reserved: parseReserved(values.reserved),
+        // WARP 自删凭据非表单字段：编辑保存时原样透传既有值，否则编辑过 WARP 节点后凭据丢失 → 删除时无从注销。
+        warpDevice: serverConfig?.wireguardSettings?.warpDevice,
       },
     };
     await onSubmit(config);

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -69,6 +69,33 @@ describe('redactDeep — 密钥脱敏（红线：零明文密钥）', () => {
     expect(out.secret).toBe(REDACTED); // 对象整体打码
   });
 
+  it('WARP 节点 wireguardSettings.warpDevice.token 被脱敏，deviceId 保留（非密钥）', () => {
+    // 设备移除特性：token 随节点落 wireguardSettings.warpDevice + 入 pending-deregister.json。
+    // SECRET_KEYS 已含 token（归一化键名）→ 递归脱敏天然覆盖；deviceId 非密钥、保留以判形态/可追溯。
+    const out = redactDeep({
+      protocol: 'wireguard',
+      wireguardSettings: {
+        privateKey: 'PRIV',
+        peerPublicKey: 'PEERPUB',
+        warpDevice: { deviceId: 'device-abc-123', token: 'SECRET_TOKEN' },
+      },
+    }) as any;
+    expect(out.wireguardSettings.privateKey).toBe(REDACTED);
+    expect(out.wireguardSettings.peerPublicKey).toBe('PEERPUB'); // 公钥公开，保留
+    expect(out.wireguardSettings.warpDevice.token).toBe(REDACTED); // 红线：token 脱敏
+    expect(out.wireguardSettings.warpDevice.deviceId).toBe('device-abc-123'); // 非密钥，保留
+  });
+
+  it('pending-deregister.json 条目数组：每条 token 被脱敏（队列文件若进诊断也安全）', () => {
+    const out = redactDeep([
+      { deviceId: 'd1', token: 'TOK1', enqueuedAt: 1 },
+      { deviceId: 'd2', token: 'TOK2', enqueuedAt: 2 },
+    ]) as any[];
+    expect(out[0].token).toBe(REDACTED);
+    expect(out[1].token).toBe(REDACTED);
+    expect(out[0].deviceId).toBe('d1'); // deviceId 保留
+  });
+
   it('custom 协议：按节点 secretKeys 额外打码 outbound 内的密钥键', () => {
     const out = redactDeep({
       protocol: 'custom',

--- a/src/shared/__tests__/warp.test.ts
+++ b/src/shared/__tests__/warp.test.ts
@@ -3,8 +3,19 @@ import {
   splitEndpoint,
   buildRegisterBody,
   parseRegisterResponse,
+  buildUnregisterRequest,
+  classifyDeregisterResult,
+  enqueuePendingDeregister,
+  planDeregisterDrain,
+  WARP_API_BASE,
+  WARP_USER_AGENT,
+  WARP_CLIENT_VERSION,
+  WARP_DEREGISTER_MAX_AGE_MS,
+  WARP_DEREGISTER_MAX_QUEUE,
+  WARP_DEREGISTER_MAX_PER_DRAIN,
   WARP_DEFAULT_ENDPOINT_HOST,
   WARP_DEFAULT_ENDPOINT_PORT,
+  type PendingDeregisterEntry,
 } from '../warp';
 
 describe('reservedFromClientId', () => {
@@ -100,5 +111,120 @@ describe('parseRegisterResponse', () => {
         config: { peers: [{ public_key: 'P', endpoint: { host: 'h:1' } }], interface: {} },
       })
     ).toThrow();
+  });
+});
+
+// ── 设备注销 / 待注销队列 ──────────────────────────────────────────────
+
+describe('buildUnregisterRequest', () => {
+  it('裸 DELETE /{version}/reg/{deviceId} + Bearer + UA/CF-Client-Version', () => {
+    const { url, headers } = buildUnregisterRequest('v0a2158', 'dev-123', 'tok-abc');
+    expect(url).toBe(`${WARP_API_BASE}/v0a2158/reg/dev-123`);
+    expect(headers.Authorization).toBe('Bearer tok-abc');
+    expect(headers['User-Agent']).toBe(WARP_USER_AGENT);
+    expect(headers['CF-Client-Version']).toBe(WARP_CLIENT_VERSION);
+  });
+  it('版本段随入参（应对 CF 版本滚动）', () => {
+    expect(buildUnregisterRequest('v9x9', 'd', 't').url).toBe(`${WARP_API_BASE}/v9x9/reg/d`);
+  });
+});
+
+describe('classifyDeregisterResult（全矩阵）', () => {
+  it('204 / 404 → done（已注销 / 别处已销）', () => {
+    expect(classifyDeregisterResult(204)).toBe('done');
+    expect(classifyDeregisterResult(404)).toBe('done');
+  });
+  it('401 / 403 → drop（token 死，重试浪费）', () => {
+    expect(classifyDeregisterResult(401)).toBe('drop');
+    expect(classifyDeregisterResult(403)).toBe('drop');
+  });
+  it('网络失败/超时(null) → retry', () => {
+    expect(classifyDeregisterResult(null)).toBe('retry');
+    expect(classifyDeregisterResult(null, new Error('ETIMEDOUT'))).toBe('retry');
+  });
+  it('5xx / 400 → retry（暂时不可达 / 待版本升级）', () => {
+    expect(classifyDeregisterResult(500)).toBe('retry');
+    expect(classifyDeregisterResult(502)).toBe('retry');
+    expect(classifyDeregisterResult(503)).toBe('retry');
+    expect(classifyDeregisterResult(400)).toBe('retry');
+  });
+  it('含 1020（WAF/版本失效）→ retry', () => {
+    expect(classifyDeregisterResult(403, new Error('WARP API 403: error 1020'))).toBe('retry');
+    // err 文本里带 1020，即便状态码非典型也 retry
+    expect(classifyDeregisterResult(429, { message: 'code 1020' })).toBe('retry');
+  });
+  it('其它未知 4xx（非 1020）→ drop（非暂时性，不无限占预算）', () => {
+    expect(classifyDeregisterResult(429)).toBe('drop');
+    expect(classifyDeregisterResult(410)).toBe('drop');
+  });
+});
+
+describe('enqueuePendingDeregister（MAX_QUEUE 丢最旧）', () => {
+  const mk = (id: string, at = 0): PendingDeregisterEntry => ({
+    deviceId: id,
+    token: `t-${id}`,
+    enqueuedAt: at,
+  });
+
+  it('未满 → 追加，无丢弃', () => {
+    const { queue, dropped } = enqueuePendingDeregister([mk('a'), mk('b')], mk('c'));
+    expect(queue.map((e) => e.deviceId)).toEqual(['a', 'b', 'c']);
+    expect(dropped).toEqual([]);
+  });
+  it('超 MAX_QUEUE → 丢最旧（FIFO），长度封顶', () => {
+    const full = Array.from({ length: WARP_DEREGISTER_MAX_QUEUE }, (_, i) => mk(`d${i}`));
+    const { queue, dropped } = enqueuePendingDeregister(full, mk('new'));
+    expect(queue.length).toBe(WARP_DEREGISTER_MAX_QUEUE);
+    expect(dropped.map((e) => e.deviceId)).toEqual(['d0']); // 最旧被挤掉
+    expect(queue[queue.length - 1].deviceId).toBe('new'); // 新条目在队尾
+    expect(queue[0].deviceId).toBe('d1');
+  });
+});
+
+describe('planDeregisterDrain（年龄 + MAX_PER_DRAIN 截断）', () => {
+  const NOW = 10_000_000_000;
+  const mk = (id: string, ageMs: number): PendingDeregisterEntry => ({
+    deviceId: id,
+    token: `t-${id}`,
+    enqueuedAt: NOW - ageMs,
+  });
+
+  it('超 7 天 → expire（不调网络）；在龄 → eligible', () => {
+    const queue = [
+      mk('old', WARP_DEREGISTER_MAX_AGE_MS + 1),
+      mk('fresh', WARP_DEREGISTER_MAX_AGE_MS - 1),
+    ];
+    const { plan, deferred } = planDeregisterDrain(queue, NOW);
+    expect(plan.find((p) => p.entry.deviceId === 'old')?.action).toBe('expire');
+    expect(plan.find((p) => p.entry.deviceId === 'fresh')?.action).toBe('eligible');
+    expect(deferred).toEqual([]);
+  });
+
+  it('恰好 7 天（边界）不算超龄 → eligible（> 才超）', () => {
+    const { plan } = planDeregisterDrain([mk('edge', WARP_DEREGISTER_MAX_AGE_MS)], NOW);
+    expect(plan[0].action).toBe('eligible');
+  });
+
+  it('eligible 至多 MAX_PER_DRAIN 条，余下 deferred（留队，不动）', () => {
+    const queue = Array.from({ length: WARP_DEREGISTER_MAX_PER_DRAIN + 3 }, (_, i) =>
+      mk(`e${i}`, 1000)
+    );
+    const { plan, deferred } = planDeregisterDrain(queue, NOW);
+    expect(plan.filter((p) => p.action === 'eligible').length).toBe(WARP_DEREGISTER_MAX_PER_DRAIN);
+    expect(deferred.length).toBe(3);
+  });
+
+  it('expire 不占 MAX_PER_DRAIN 预算（超龄直接计划 expire，不挤掉在龄的处理名额）', () => {
+    // 前置一批超龄 + 后置 MAX_PER_DRAIN 条在龄 → 在龄全应 eligible，超龄全 expire，无 deferred。
+    const expired = Array.from({ length: 5 }, (_, i) =>
+      mk(`x${i}`, WARP_DEREGISTER_MAX_AGE_MS + 1000)
+    );
+    const fresh = Array.from({ length: WARP_DEREGISTER_MAX_PER_DRAIN }, (_, i) =>
+      mk(`f${i}`, 1000)
+    );
+    const { plan, deferred } = planDeregisterDrain([...expired, ...fresh], NOW);
+    expect(plan.filter((p) => p.action === 'expire').length).toBe(5);
+    expect(plan.filter((p) => p.action === 'eligible').length).toBe(WARP_DEREGISTER_MAX_PER_DRAIN);
+    expect(deferred.length).toBe(0);
   });
 });

--- a/src/shared/types/protocol-settings.ts
+++ b/src/shared/types/protocol-settings.ts
@@ -136,6 +136,10 @@ export interface WireGuardSettings {
   // Phase 2：反向 mesh（system=真内核 WG 接口，提供「被组网访问/作 subnet router」反向可达）；默认 false=userspace
   // gVisor 栈。true 时 peer.allowed_ips 恒 specific-only（去 0/0，结论A：内核接口永不当全局出口），需 helper/提权。
   reverseMesh?: boolean;
+  // Cloudflare WARP 设备凭据（仅 WARP 注册产出的节点填；普通 WG 节点无）。deviceId+token 是注册时一次性返回、
+  // 事后无法再取的「自删凭据」——删除此节点时据它发 DELETE /reg/{deviceId} 注销远端匿名设备（见 WARP 设计 §设备移除）。
+  // token 与 privateKey 同信任类（device-scoped、客户端所有），随 config 落盘 + 经诊断脱敏（SECRET_KEYS 含 token）。
+  warpDevice?: { deviceId: string; token: string };
 }
 
 // Tailscale（sing-box endpoint，账号制 mesh，无 server address/port——连控制面）。Phase 1 userspace。

--- a/src/shared/warp.ts
+++ b/src/shared/warp.ts
@@ -63,7 +63,11 @@ export function splitEndpoint(endpoint: string | undefined): { host: string; por
   return { host: e, port: WARP_DEFAULT_ENDPOINT_PORT };
 }
 
-/** WARP 注册产出的 WireGuard 草稿（无 id，供渲染端填表）。token 不在内（不持久化）。 */
+/**
+ * WARP 注册产出的 WireGuard 草稿（无 id，供渲染端填表）。
+ * warpDevice = 自删凭据（deviceId+token），随节点落 wireguardSettings.warpDevice、与 privateKey 同脱敏
+ * （历史上「token 不持久化」红线已被用户拍板放宽，见 WARP 设计 §设备移除 / 不变量）。
+ */
 export interface WarpWireGuardDraft {
   address: string;
   port: number;
@@ -74,6 +78,8 @@ export interface WarpWireGuardDraft {
   reserved?: number[];
   mtu: number;
   meta: { deviceId: string; accountId: string; license: string; warpPlus: boolean };
+  /** 远端设备自删凭据（deviceId+token）。删除此节点时据它发 DELETE /reg/{deviceId} 注销匿名设备。 */
+  warpDevice: { deviceId: string; token: string };
 }
 
 /** WARP 注册响应里 FlowZ 关心的子集。 */
@@ -125,4 +131,117 @@ export function parseRegisterResponse(json: any): WarpRegisterResult {
     license: json?.account?.license || '',
     warpPlus: !!json?.account?.warp_plus,
   };
+}
+
+// ── 设备注销 / 待注销队列（纯逻辑，网络/文件 IO 在 WarpService / WarpDeregisterQueue） ──────────────
+
+/**
+ * 注销重试阈值（常量化便于调）。
+ * 主阈值按「入队年龄」而非次数——重试等的是网络恢复（wall-clock 量纲），次数随开 app 频率漂移不可比。
+ */
+export const WARP_DEREGISTER_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 天未成功 → 放弃（孤儿零计费）
+export const WARP_DEREGISTER_MAX_QUEUE = 100; // 队列条数上限，超则丢最旧 + 日志（防 register-loop 撑爆）
+export const WARP_DEREGISTER_MAX_PER_DRAIN = 10; // 单次 drain 至多处理条数（避免启动 hammer CF / 触 1020）
+
+/** 待注销队列条目（落 <userData>/warp/pending-deregister.json）。token=自删凭据，与 privateKey 同脱敏。 */
+export interface PendingDeregisterEntry {
+  deviceId: string;
+  token: string;
+  enqueuedAt: number; // Date.now()，按年龄判超时
+}
+
+/**
+ * 构造注销请求（纯函数，无网络）。裸 DELETE /{version}/reg/{deviceId} + Bearer token + 同 register 的
+ * UA/CF-Client-Version（TLS1.2/okhttp 指纹在 WarpService，否则 1020）。
+ * 实测：自删走裸 /reg/{id}（非 .../account/reg/{id}——那是登录账户删绑定设备、自删返 401）→ 204；再删 404。
+ */
+export function buildUnregisterRequest(
+  version: string,
+  deviceId: string,
+  token: string
+): { url: string; headers: Record<string, string> } {
+  return {
+    url: `${WARP_API_BASE}/${version}/reg/${deviceId}`,
+    headers: {
+      'User-Agent': WARP_USER_AGENT,
+      'CF-Client-Version': WARP_CLIENT_VERSION,
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  };
+}
+
+/** 注销结果分类：done=出队（已注销/别处已销）；drop=出队（凭据死，重试纯浪费）；retry=留队消耗重试预算。 */
+export type DeregisterResult = 'done' | 'drop' | 'retry';
+
+/**
+ * 注销失败分类（纯函数）。status=null 表网络失败/超时（无 HTTP 状态）。
+ *  - 204 / 404 → done（404=别处已销，视作成功）
+ *  - 401 / 403 → drop（token 失效/被拒，重试死 token 纯浪费）
+ *  - 网络失败/超时(null) / 5xx / 400 / 含 1020 → retry（暂时不可达 / 待 app 升级版本串）
+ *  - 其它未知 4xx → drop（非暂时性，重试无收益；保守不无限占预算）
+ */
+export function classifyDeregisterResult(status: number | null, err?: unknown): DeregisterResult {
+  // 网络失败 / 超时：无 HTTP 状态 → 暂时不可达，重试。
+  if (status == null) return 'retry';
+  if (status === 204 || status === 404) return 'done'; // definitive success，优先于一切
+  // Cloudflare WAF 1020（版本串失效）常以 403 携带 body code 1020 返回——这是「待 app 升级版本串」信号，
+  // 须**优先于** 401/403 的 drop 判定（否则被误当 token 死而放弃）。err 文本含 1020 一律 retry（升级后恢复）。
+  if (err != null && String((err as { message?: unknown })?.message ?? err).includes('1020')) {
+    return 'retry';
+  }
+  if (status === 401 || status === 403) return 'drop'; // token 失效/被拒，重试死 token 纯浪费
+  if (status >= 500) return 'retry';
+  if (status === 400) return 'retry';
+  // 其它未知 4xx：非暂时性，drop（不无限占重试预算）。
+  return 'drop';
+}
+
+/**
+ * 入队（纯函数）：追加新条目，受 WARP_DEREGISTER_MAX_QUEUE 护栏——超上限丢最旧（FIFO）。
+ * 返回 { queue, dropped }：dropped=被挤掉的最旧条目（供调用方日志，只打 deviceId 前缀）。
+ */
+export function enqueuePendingDeregister(
+  queue: PendingDeregisterEntry[],
+  entry: PendingDeregisterEntry
+): { queue: PendingDeregisterEntry[]; dropped: PendingDeregisterEntry[] } {
+  const next = [...queue, entry];
+  const dropped: PendingDeregisterEntry[] = [];
+  while (next.length > WARP_DEREGISTER_MAX_QUEUE) {
+    const old = next.shift();
+    if (old) dropped.push(old);
+  }
+  return { queue: next, dropped };
+}
+
+/** 单条 drain 计划：超龄 expire（不调网络直接 drop）/ 在龄 eligible（调 unregister）。 */
+export interface DrainPlanItem {
+  entry: PendingDeregisterEntry;
+  action: 'expire' | 'eligible';
+}
+
+/**
+ * drain 计划（纯函数，无 IO）：按年龄分流 + 截断到 MAX_PER_DRAIN。
+ *  - 年龄 > MAX_AGE_MS → expire（放弃，warn 后出队，不调网络）
+ *  - 否则 → eligible（本次调 unregister）；eligible 至多取前 MAX_PER_DRAIN 条，余下顺延下个触发点
+ * expired 不占 MAX_PER_DRAIN 预算（不调网络）。返回 plan（本次处理）+ deferred（本次不动、留队）。
+ */
+export function planDeregisterDrain(
+  queue: PendingDeregisterEntry[],
+  now: number
+): { plan: DrainPlanItem[]; deferred: PendingDeregisterEntry[] } {
+  const plan: DrainPlanItem[] = [];
+  const deferred: PendingDeregisterEntry[] = [];
+  let eligibleCount = 0;
+  for (const entry of queue) {
+    if (now - entry.enqueuedAt > WARP_DEREGISTER_MAX_AGE_MS) {
+      plan.push({ entry, action: 'expire' });
+    } else if (eligibleCount < WARP_DEREGISTER_MAX_PER_DRAIN) {
+      plan.push({ entry, action: 'eligible' });
+      eligibleCount += 1;
+    } else {
+      deferred.push(entry);
+    }
+  }
+  return { plan, deferred };
 }


### PR DESCRIPTION
## 背景
WARP「一键生成」会在 Cloudflare 侧注册一台匿名设备，但删本地节点时**远端设备无从注销**：当前 `register()` 拿到的 token 用后即弃、`draft.meta` 也被丢弃，FlowZ 没有凭据可调注销 API → 设备永久残留（匿名、零计费，但长期积累不优雅）。

## 设计
- **持久化凭据**：`register()` 不再丢 token，把 `{deviceId, token}` 随节点存进 `wireguardSettings.warpDevice`（与 `privateKey` 同处、同脱敏）。判据「是否需注销」= `warpDevice.token` 存在与否（零误判，不靠端点启发式）。
- **删除恒瞬时**：删节点时凭据移入 `<userData>/warp/pending-deregister.json`（**不内联调网络**，删本地是纯本地操作、不依赖 Cloudflare 可达）。
- **机会式 drain**：后台在 **app 启动后** + **每次成功注册 WARP 后** 触发，按失败分类重试 `DELETE /{version}/reg/{deviceId}`（Bearer + TLS1.2/okhttp 指纹）。**无常驻定时器**。
  - 失败分类：`204/404`→done、`401/403`→drop、网络/超时/`5xx`/`400`/`1020`→retry。
  - 阈值：入队年龄 > 7d 放弃（孤儿零计费）；队列上限 100（丢最旧）；单次 drain ≤10。
- **兼容**：本特性前的 WARP 节点无 `warpDevice` → 删除时跳过入队、仅删本地、不报错（注定孤儿、历史债）。
- **安全红线**：token 绝不入日志/诊断——`SECRET_KEYS` 含 `token`、`redactDeep` 递归打码 `warpDevice.token` 与队列文件每条 token；日志只打 `deviceId` 前缀；诊断采集不读队列文件。

## 验证
- 单测：注销请求构造、失败分类全矩阵（含 1020 优先 retry）、队列年龄/上限/截断/done·drop·retry、并发重入与 lost-update 防护、token 脱敏断言。
- gate：eslint 0 / 双 tsc 0 / jest **94 套 · 1423 测试 · 34 快照 全绿**。
- API 已真机实测（register→`DELETE /reg/{id}`+Bearer→204；再删→404 `Registration not found`）。
- 真机待验（Mac/Win）：生成节点 warpDevice 落盘+token 诊断脱敏、删除入队、drain 实发 204 出队、断网删除恢复、旧节点不入队。