### PR TITLE
主题选项「跟随系统」置于首位

### DIFF
--- a/src/renderer/components/settings/appearance-settings.tsx
+++ b/src/renderer/components/settings/appearance-settings.tsx
@@ -49,9 +49,10 @@ export function AppearanceSettings() {
             value={theme}
             onChange={handleThemeChange}
             options={[
+              // 跟随系统排首位：它是默认值（uiTheme 默认 'system'），默认项置首更符合预期。
+              { value: 'system', label: t('settings.appearance.system') },
               { value: 'light', label: t('settings.appearance.light') },
               { value: 'dark', label: t('settings.appearance.dark') },
-              { value: 'system', label: t('settings.appearance.system') },
             ]}
           />
         </SettingsRow>


### PR DESCRIPTION
外观设置的主题分段控件，把「跟随系统」从末位移到首位。

## 理由
主题默认值本就是 `system`（`ConfigManager.createDefaultConfig` 的 `uiTheme: 'system'`）；默认/推荐项置于选项首位更符合用户预期（对齐 macOS/主流应用 System→Light→Dark 的排序）。纯顺序调整，不改默认值、不改主题逻辑。

## 验证
gate 绿（eslint + tsc renderer）。