### PR TITLE
服务器列表 UX：订阅节点隐藏删除按钮 + 测速结果全局同步

### DIFF
--- a/src/renderer/components/settings/server-actions.tsx
+++ b/src/renderer/components/settings/server-actions.tsx
@@ -115,43 +115,48 @@ export function ServerActions({
       >
         <Edit className="h-3.5 w-3.5" />
       </Button>
-      <AlertDialog>
-        <AlertDialogTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            disabled={!!server.subscriptionId}
-            onClick={(e) => {
-              if (stopPropagation) e.stopPropagation();
-            }}
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </Button>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('servers.deleteServerTitle')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('servers.deleteServerDesc', { name: server.name })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
-              {t('common.cancel')}
-            </AlertDialogCancel>
-            <AlertDialogAction
+      {/* 订阅节点不可单独删除（随订阅更新/「删除订阅」统一管理）→ 直接隐藏删除按钮，而非置灰：
+          置灰按钮浅/深色对比都低易被误认为可点，且 disabled 的 pointer-events-none 还 hover 不出提示。
+          与「无分享链接隐藏复制按钮」同范式。 */}
+      {!server.subscriptionId && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              title={t('common.delete')}
+              className="h-7 w-7 p-0"
               onClick={(e) => {
-                e.stopPropagation();
-                onDelete(server.id);
+                if (stopPropagation) e.stopPropagation();
               }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              {t('common.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t('servers.deleteServerTitle')}</AlertDialogTitle>
+              <AlertDialogDescription>
+                {t('servers.deleteServerDesc', { name: server.name })}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
+                {t('common.cancel')}
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(server.id);
+                }}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {t('common.delete')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </div>
   );
 }

--- a/src/renderer/components/settings/use-speed-test.ts
+++ b/src/renderer/components/settings/use-speed-test.ts
@@ -32,10 +32,8 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
       return;
     }
     setIsTestingSpeed(true);
-    // 订阅声明在 try 外，确保 catch/finally 路径都能 unsubscribe（防 listener 泄漏：测速失败时曾漏清）。
-    const unsubscribeResult = api.server.onSpeedTestResult(({ serverId, latency }) => {
-      setLatencyMap((prev) => ({ ...prev, [serverId]: latency }));
-    });
+    // per-node 结果监听已上移到 use-native-events 顶层持久 hook（托盘/UI 两入口共用，写全局 latencyMap，跨页不丢）；
+    // 此处仅订阅进度（页面局部进度条）+ 末尾兜底同步。订阅声明在 try 外，确保 catch/finally 都能 unsubscribe。
     const unsubscribeProgress = api.server.onSpeedTestProgress(({ tested, ok, total }) => {
       setSpeedProgress({ tested, ok, total });
     });
@@ -51,7 +49,6 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
         description: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      unsubscribeResult();
       unsubscribeProgress();
       setIsTestingSpeed(false);
       setSpeedProgress(null);

--- a/src/renderer/hooks/use-native-events.ts
+++ b/src/renderer/hooks/use-native-events.ts
@@ -41,6 +41,7 @@ interface NativeEventData {
   tailscaleAuth: { nodeName: string; url: string; transient?: boolean; serverId?: string };
   tailscaleAuthOk: { serverId: string; nodeName: string };
   systemProxyResidual: { proxy: string };
+  speedTestResult: { serverId: string; latency: number };
 }
 
 type NativeEventListener<K extends keyof NativeEventData> = (data: NativeEventData[K]) => void;
@@ -86,6 +87,9 @@ export function useNativeEvent<K extends keyof NativeEventData>(
         break;
       case 'systemProxyResidual':
         unsubscribe = api.proxy.onSystemProxyResidual(callback as any);
+        break;
+      case 'speedTestResult':
+        unsubscribe = api.server.onSpeedTestResult(callback as any);
         break;
       default:
         console.warn(`Unknown event: ${eventName}`);
@@ -260,6 +264,13 @@ function handleSystemProxyResidual(data: NativeEventData['systemProxyResidual'])
   });
 }
 
+function handleSpeedTestResult(data: NativeEventData['speedTestResult']) {
+  // 全局持久监听 per-node 测速结果 → 全局 latencyMap：托盘/UI 两入口测速都经此写入，服务器列表延迟徽标恒同步。
+  // 修：原 per-node 监听写在 use-speed-test 的 handler 作用域内（仅 UI 测速期间临时订阅），托盘测速结果无人接、
+  // 切走服务器页期间的流式结果也丢失。提到此顶层持久 hook 后两入口统一捕获、跨页不丢。
+  useAppStore.getState().setLatencyMap((prev) => ({ ...prev, [data.serverId]: data.latency }));
+}
+
 /**
  * Hook to listen to all native events and update store
  */
@@ -275,4 +286,5 @@ export function useNativeEventListeners() {
   useNativeEvent('tailscaleAuth', handleTailscaleAuth);
   useNativeEvent('tailscaleAuthOk', handleTailscaleAuthOk);
   useNativeEvent('systemProxyResidual', handleSystemProxyResidual);
+  useNativeEvent('speedTestResult', handleSpeedTestResult);
 }


### PR DESCRIPTION
两个服务器列表/测速的体验问题。

## 1. 订阅节点隐藏删除按钮
订阅节点本不可单独删除（随订阅更新/「删除订阅」统一管理），原为 `disabled` 置灰——但置灰按钮在**浅色/深色下对比都低**、易被误认为可点，且 `disabled` 的 `pointer-events-none` 还 hover 不出提示。改为**直接隐藏**（与「无分享链接隐藏复制按钮」同范式），无误导 affordance。

## 2. 测速结果全局同步（托盘/UI 两入口）
per-node 测速结果监听（`EVENT_SPEED_TEST_RESULT → setLatencyMap`）原写在 `use-speed-test` 的 handler 作用域内（**仅 UI 测速期间临时订阅**，finally 退订）→ **托盘测速结果无人接**（服务器列表延迟徽标不更新），切走服务器页期间的流式结果也丢失。
上移到 `use-native-events` 顶层**持久 hook**（与其它 IPC 事件监听同处），托盘/UI 两入口统一捕获、写全局 `latencyMap`（本就 persisted across views）→ 服务器列表延迟徽标恒同步、跨页不丢。use-speed-test 保留进度订阅 + 末尾兜底同步。

## 验证
gate 绿（eslint + tsc renderer + jest 35 snapshots）。真机：① 订阅节点无删除按钮、自建节点有；② 托盘点测速 → 服务器列表延迟徽标同步更新；③ 测速中切页再回来结果不丢。