### PR TITLE
refactor(shared): dedupe 工具 + DoH 上游 IP 单一真值

### DIFF
--- a/src/main/services/singbox-dns-builder.ts
+++ b/src/main/services/singbox-dns-builder.ts
@@ -8,6 +8,7 @@
 import * as path from 'path';
 import type { UserConfig } from '../../shared/types';
 import { parseDnsServerSpec, type ParsedDnsServer } from '../../shared/dns';
+import { dedupe } from '../../shared/collections';
 import { ruleConditions } from '../../shared/rules';
 import { normalizeNeighborDomain, isSourceDeviceMatchSupported } from '../../shared/neighbor';
 import { effectiveRegionRouting, REGION_LOCAL_GEO } from '../../shared/region-routing';
@@ -293,7 +294,7 @@ export function buildDnsConfig(
   if (domestic.isDomain) bootstrapDomains.push(domestic.server);
   if (foreign.isDomain) bootstrapDomains.push(foreign.server);
   dnsRules.push({
-    domain: Array.from(new Set(bootstrapDomains)),
+    domain: dedupe(bootstrapDomains),
     server: 'dns-bootstrap-udp',
   } as SingBoxDnsRule);
 

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -10,7 +10,7 @@
 
 import * as path from 'path';
 import type { UserConfig } from '../../shared/types';
-import { BOOTSTRAP_DIRECT_DNS_IPS } from '../../shared/dns';
+import { BOOTSTRAP_DIRECT_DNS_IPS, DOH_UPSTREAM_IPS } from '../../shared/dns';
 import {
   endpointForcedRouteCidrs,
   meshForcedRouteCidrs,
@@ -20,6 +20,7 @@ import {
   meshForceRoutedServers,
 } from '../../shared/endpoint-routes';
 import { cidrOverlapsAny, partitionCidrsByOverlap } from '../../shared/ip';
+import { dedupe } from '../../shared/collections';
 import { FAKEIP_INET4_RANGE, FAKEIP_INET6_RANGE } from '../../shared/fakeip-filter';
 import {
   effectiveRegionRouting,
@@ -225,7 +226,7 @@ export function buildRouteConfig(
         ? [hostToExcludeCidr(deps.lanResolverForDns)].filter((c): c is string => c !== null)
         : []),
     ],
-    port: Array.from(new Set([53, 443, ...(customDomesticDns ? [customDomesticDns.port] : [])])),
+    port: dedupe([53, 443, ...(customDomesticDns ? [customDomesticDns.port] : [])]),
     action: 'route',
     outbound: 'direct',
   });
@@ -627,8 +628,8 @@ export function buildRouteConfig(
   });
 
   rules.push({
-    // #57：1.12.12.12（DNSPod IP-DoH，节点域名解析器 DNSPod 档）与 223.5.5.5 同列直连放行
-    ip_cidr: ['223.5.5.5/32', '1.12.12.12/32'],
+    // DoH 上游 IP（223.5.5.5 AliDNS + 1.12.12.12 DNSPod #57）直连放行，派生自单一真值 DOH_UPSTREAM_IPS。
+    ip_cidr: DOH_UPSTREAM_IPS.map((ip) => `${ip}/32`),
     port: [53, 443],
     action: 'route',
     outbound: 'direct',

--- a/src/renderer/components/settings/mesh-info-popover.tsx
+++ b/src/renderer/components/settings/mesh-info-popover.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { Info } from 'lucide-react';
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import { isAccountBasedProtocol, isEndpointProtocol } from '../../../shared/endpoint-routes';
+import { dedupe } from '../../../shared/collections';
 import { useAppStore } from '../../store/app-store';
 import type { ServerConfigWithId } from './server-list-helpers';
 
@@ -32,7 +33,7 @@ function meshRoutes(server: ServerConfigWithId): string[] {
   if (isAccountBasedProtocol(server.protocol)) {
     const ts = server.tailscaleSettings;
     // accept routes（routes）+ advertise routes（本机对外广告）并集去重；纯展示，与 force-route 计算解耦。
-    return Array.from(new Set([...(ts?.routes || []), ...(ts?.advertiseRoutes || [])]));
+    return dedupe([...(ts?.routes || []), ...(ts?.advertiseRoutes || [])]);
   }
   return server.wireguardSettings?.allowedIPs || [];
 }

--- a/src/shared/__tests__/collections.test.ts
+++ b/src/shared/__tests__/collections.test.ts
@@ -1,0 +1,24 @@
+import { dedupe, dedupeTrim } from '../collections';
+
+describe('dedupe — 去重保序', () => {
+  it('保留首次出现顺序、剔重复', () => {
+    expect(dedupe([3, 1, 3, 2, 1])).toEqual([3, 1, 2]);
+    expect(dedupe(['a', 'b', 'a', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+  it('空 / 无重复原样', () => {
+    expect(dedupe([])).toEqual([]);
+    expect(dedupe([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+  it('接受任意 Iterable（如 Set）', () => {
+    expect(dedupe(new Set([1, 2, 2, 3]))).toEqual([1, 2, 3]);
+  });
+});
+
+describe('dedupeTrim — 去重 + trim + 去空', () => {
+  it('修剪空白后去重、丢空串、保序', () => {
+    expect(dedupeTrim([' a ', 'a', 'b', '', '  ', 'b'])).toEqual(['a', 'b']);
+  });
+  it('全空 → []', () => {
+    expect(dedupeTrim(['', '   ', '\t'])).toEqual([]);
+  });
+});

--- a/src/shared/__tests__/system-dns.test.ts
+++ b/src/shared/__tests__/system-dns.test.ts
@@ -1,4 +1,11 @@
-import { BOOTSTRAP_DIRECT_DNS_IPS, CONTROLLED_TUN_DNS_IP, isBootstrapDirectDnsIp } from '../dns';
+import {
+  BOOTSTRAP_DIRECT_DNS_IPS,
+  CONTROLLED_TUN_DNS_IP,
+  DOH_UPSTREAM_IPS,
+  DOH_ALIDNS_IP,
+  DOH_DNSPOD_IP,
+  isBootstrapDirectDnsIp,
+} from '../dns';
 import {
   controlledTunDnsIp,
   isControlledDnsIpValid,
@@ -46,6 +53,15 @@ describe('受控 DNS IP 选择守卫（核心不变量）', () => {
   it('isBootstrapDirectDnsIp trim 空白后比较', () => {
     expect(isBootstrapDirectDnsIp(' 223.5.5.5 ')).toBe(true);
     expect(isBootstrapDirectDnsIp('8.8.8.8')).toBe(false);
+  });
+
+  // 单一真值不变量（#9）：DoH 上游 IP 必须 ∈ bootstrap-direct 列表，否则其 :443 DoH 不被直连放行 / 不进 TUN
+  // exclude → 命中 TUN CIDR 回流死循环。锁死「新增或更换 DoH 上游 IP 时必须同步进 BOOTSTRAP_DIRECT_DNS_IPS」。
+  it('DOH_UPSTREAM_IPS ⊆ BOOTSTRAP_DIRECT_DNS_IPS（换上游 IP 不漏 exclude/直连放行）', () => {
+    expect(DOH_UPSTREAM_IPS).toEqual([DOH_ALIDNS_IP, DOH_DNSPOD_IP]);
+    for (const ip of DOH_UPSTREAM_IPS) {
+      expect(isBootstrapDirectDnsIp(ip)).toBe(true);
+    }
   });
 });
 

--- a/src/shared/collections.ts
+++ b/src/shared/collections.ts
@@ -1,0 +1,16 @@
+/**
+ * 通用集合工具 —— 纯函数、无 I/O、可单测。
+ *
+ * 把散落各处的 `Array.from(new Set(...))` 去重惯用法收敛为单一真值（主进程 + 渲染端共用），
+ * 杜绝同款去重逻辑多份重复实现。
+ */
+
+/** 去重保序：按首次出现顺序返回去重后的数组（= Array.from(new Set(items))）。 */
+export function dedupe<T>(items: Iterable<T>): T[] {
+  return Array.from(new Set(items));
+}
+
+/** 字符串去重 + 修剪空白 + 丢弃空串（dedupe 的「trim + filter(Boolean)」变体），保序。 */
+export function dedupeTrim(list: Iterable<string>): string[] {
+  return dedupe(Array.from(list, (s) => s.trim()).filter(Boolean));
+}

--- a/src/shared/dns.ts
+++ b/src/shared/dns.ts
@@ -1,16 +1,27 @@
 import { isIpv4 } from './ip';
 
 /**
+ * 节点域名解析器（#57 resolve-ahead）实际启用的 IP-DoH 上游 IP：AliDNS 223.5.5.5 + DNSPod 1.12.12.12。
+ * 单一真值——node-domain-resolver 的 DoH URL、route 直连放行、Windows TUN route_exclude 全派生自此，
+ * 杜绝「新增/更换 DoH 上游 IP，却漏同步到 exclude → 该上游连接命中 TUN CIDR 回流死循环」（#57 类回环）。
+ * 不变量：这两个 IP【必须】∈ BOOTSTRAP_DIRECT_DNS_IPS（单测护栏断言），否则其 :443 DoH 不被直连放行。
+ */
+export const DOH_ALIDNS_IP = '223.5.5.5';
+export const DOH_DNSPOD_IP = '1.12.12.12';
+export const DOH_UPSTREAM_IPS: readonly string[] = [DOH_ALIDNS_IP, DOH_DNSPOD_IP];
+
+/**
  * sing-box route 在 hijack-dns 之前「直连放行」的国内 bootstrap DNS IP（:53/:443）。单一真值：
  *   - generateRouteConfig 的引导直连规则（C 段）引用，保证核心 DNS 自举不被 hijack 成 FakeIP；
  *   - SystemDnsManager 受控 DNS IP 的选择守卫引用——受控 IP 绝不能落在此列表，否则其 :53 查询被该
- *     直连规则放行、逃逸 hijack-dns，DNS 接管失效（见 docs/design/dns-ipv6-takeover.md）。
- * 含 1.12.12.12（#57 DNSPod IP-DoH 档，与 223.5.5.5 同列直连）。
+ *     直连规则放行、逃逸 hijack-dns，DNS 接管失效（见 docs/design/dns-ipv6-takeover.md）；
+ *   - singbox-inbounds-builder 的 Windows TUN route_exclude 引用（防 WFP 进程匹配失效时回流死循环）。
+ * 含 DoH 上游 IP（DOH_UPSTREAM_IPS：223.5.5.5 + 1.12.12.12）+ AliDNS 备 + DNSPod/114 公共 DNS。
  */
 export const BOOTSTRAP_DIRECT_DNS_IPS: readonly string[] = [
-  '223.5.5.5',
+  DOH_ALIDNS_IP, // 223.5.5.5（AliDNS IP-DoH 上游）
   '223.6.6.6',
-  '1.12.12.12',
+  DOH_DNSPOD_IP, // 1.12.12.12（DNSPod IP-DoH 上游，#57）
   '119.29.29.29',
   '119.28.28.28',
   '114.114.114.114',

--- a/src/shared/endpoint-routes.ts
+++ b/src/shared/endpoint-routes.ts
@@ -1,4 +1,5 @@
 import type { ServerConfig, Protocol, UserConfig } from './types';
+import { dedupe, dedupeTrim } from './collections';
 
 /** sing-box endpoint 协议（顶层 endpoints[]、非 outbound）：WireGuard / Tailscale。单一真值，杜绝多处枚举漂移。 */
 export const ENDPOINT_PROTOCOLS: readonly Protocol[] = ['wireguard', 'tailscale'];
@@ -57,7 +58,7 @@ export function endpointForcedRouteCidrs(server: ServerConfig): string[] {
   } else {
     return [];
   }
-  return Array.from(new Set(raw.map((c) => c.trim()).filter(Boolean)));
+  return dedupeTrim(raw);
 }
 
 /**
@@ -189,7 +190,7 @@ export function wireguardPeerAllowedIps(server: ServerConfig): string[] | null {
     return specific.length > 0 ? specific : null;
   }
   if (meshAllowsInternet(server)) {
-    return Array.from(new Set([...specific, ...FULL_TUNNEL_CIDRS]));
+    return dedupe([...specific, ...FULL_TUNNEL_CIDRS]);
   }
   return specific.length > 0 ? specific : null;
 }
@@ -232,7 +233,7 @@ export function meshSelectedExitFallsBackToDirect(config: UserConfig): boolean {
  * main 的 config-gen warn + renderer 的内联 hint/列表角标。用全量 servers（非仅 emitted）以覆盖潜在重叠。
  */
 export function meshForcedRouteCidrs(servers: ServerConfig[]): string[] {
-  return Array.from(new Set(servers.flatMap((s) => endpointForcedRouteCidrs(s))));
+  return dedupe(servers.flatMap((s) => endpointForcedRouteCidrs(s)));
 }
 
 /**

--- a/src/shared/system-dns.ts
+++ b/src/shared/system-dns.ts
@@ -5,6 +5,7 @@
  */
 
 import { CONTROLLED_TUN_DNS_IP, isBootstrapDirectDnsIp } from './dns';
+import { dedupe } from './collections';
 
 /**
  * 系统 DNS marker：记录「DNS 由 FlowZ 接管」+ 接管前每个网络服务/接口的原始 DNS（[] = DHCP/自动）。
@@ -77,7 +78,7 @@ export function winSetDnsCommands(netshExe: string, iface: string, ips: string[]
 export function parseWinShowDnsServers(stdout: string): string[] {
   if (!/Statically Configured DNS Servers|静态配置的 DNS 服务器/i.test(stdout)) return [];
   const ips = stdout.match(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g) || [];
-  return Array.from(new Set(ips));
+  return dedupe(ips);
 }
 
 /**

--- a/src/shared/system-proxy-bypass.ts
+++ b/src/shared/system-proxy-bypass.ts
@@ -4,6 +4,8 @@
  * 机制（保存原列表→开启写入→关闭还原）由 SystemProxyManager 负责，对齐 Clash 系。可单测、无 electron 依赖。
  */
 
+import { dedupe, dedupeTrim } from './collections';
+
 /**
  * 默认 bypass 清单（业内聚合清单，含私网/保留段 + Apple 连通性 + 国内会被代理打断的 App/网银）。
  * 用户可在设置里编辑（逗号分隔）；缺省取此。注：非 ClashX 出厂 9 条原版，是社区聚合的「业内」广覆盖清单。
@@ -109,11 +111,6 @@ export function ipv4CidrToWindowsPatterns(cidr: string): string[] {
   return [];
 }
 
-/** 对条目数组做 trim + 去重，纯函数（mac/linux 共用）。 */
-function dedupeTrim(list: string[]): string[] {
-  return Array.from(new Set(list.map((s) => s.trim()).filter(Boolean)));
-}
-
 /**
  * macOS networksetup -setproxybypassdomains 参数（接受 CIDR(v4/v6) + 域名 + *.通配，原样下发）。
  */
@@ -139,7 +136,7 @@ export function formatBypassForWindows(list: string[]): string {
     }
   }
   if (!out.includes('<local>')) out.push('<local>');
-  return Array.from(new Set(out)).join(';');
+  return dedupe(out).join(';');
 }
 
 /** Linux gsettings ignore-hosts 数组（接受 CIDR + 域名，原样去重）。 */


### PR DESCRIPTION
collections.ts 新增 dedupe/dedupeTrim 收敛 Array.from(new Set())；dns.ts DOH_UPSTREAM_IPS(223.5.5.5/1.12.12.12)单一真值，route 直连放行/route_exclude 派生自此，消除多处硬编码漂移；endpoint-routes 及消费点改用。纯收敛、无功能变更、含单测。