### PR TITLE
feat(dns): macOS DNS 接管热插重灌(reconcileDns+watcher)

### DIFF
--- a/src/main/services/DnsInterfaceWatcher.ts
+++ b/src/main/services/DnsInterfaceWatcher.ts
@@ -1,0 +1,194 @@
+/**
+ * macOS DNS 接管「热插重灌」watcher（设计 §四 4.2）。
+ *
+ * 背景：setDns() 只在 TUN 启动那一刻把当时存在的网络服务接管为受控 DNS（8.8.8.8）。启动后插坞站/换 Wi-Fi/VPN 起落
+ * 会带来「新出现 / 换网后未受控」的网络服务 → 这些服务的系统 DNS 仍是 on-link LAN/ISP 地址、不进 TUN、逃逸 hijack。
+ * 本 watcher 长驻 `route -n monitor` 监听链路变化，命中后去抖调 reconcileDns() 把它们补接管为受控 DNS。
+ *
+ * 设计要点：
+ * - 机制：spawn 长驻 `route -n monitor`，stdout 按行喂 isDnsReconcileTriggerLine；命中 → 去抖（合并 burst，
+ *   插坞站连发多条 RTM_）→ 调 onTrigger（= ProxyManager 注入的「门控 + reconcileDns」入口）。
+ * - 叠加 powerMonitor 'resume'（系统唤醒，链路常已变但未必发 route 事件）→ 走同一去抖入口。
+ * - best-effort：spawn/起停/回调失败仅经注入的 onWarn 告警，绝不抛 —— watcher 故障不得阻断 TUN 生命周期/stop。
+ * - 可测性：spawn 工厂 / powerMonitor / onTrigger / schedule(setTimeout) / clearSchedule(clearTimeout) / onWarn
+ *   全部构造注入 → 单测以 jest fake timers + mock spawn/powerMonitor 完全离线覆盖去抖/门控/生命周期。
+ *
+ * 门控不在本类内（本类只管「探到变化 → 去抖 → 调 onTrigger」）；是否真 reconcile 由 ProxyManager 注入的 onTrigger
+ * 内部按 shouldReconcileDns() 判定。平台门控（仅 darwin 起）由 ProxyManager 薄接线层判定，本类不内嵌 platform 检查
+ * （保持可测、可在任意平台单测）。设计见 docs/design/dns-takeover-dynamic-interface.md §四 4.2。
+ */
+
+import type { LogLevel, UserConfig } from '../../shared/types';
+import { isDnsReconcileTriggerLine } from './dns-route-events';
+
+/** spawn 出的子进程在本类内只需 stdout 可读流 + kill + 错误事件 —— 收窄接口便于 mock，不绑死 ChildProcess 全形。 */
+export interface WatchableChildProcess {
+  stdout: { on(event: 'data', listener: (chunk: Buffer | string) => void): void } | null;
+  on(event: 'error', listener: (err: Error) => void): this;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+/** powerMonitor 子集：只用到 resume 的注册/反注册（electron 的 on/removeListener 同形）。 */
+export interface ResumeMonitor {
+  on(event: 'resume', listener: () => void): void;
+  removeListener(event: 'resume', listener: () => void): void;
+}
+
+export interface DnsInterfaceWatcherDeps {
+  /** spawn `route -n monitor` 工厂（注入便于 mock；真实实现 = () => child_process.spawn('route', ['-n','monitor'])）。 */
+  spawnRouteMonitor: () => WatchableChildProcess;
+  /** 唤醒事件源（真实 = electron powerMonitor）；null = 不订阅 resume（如平台不支持）。 */
+  powerMonitor: ResumeMonitor | null;
+  /** 命中（去抖后）调用：ProxyManager 注入的「门控 + reconcileDns」入口。可异步；其 reject 由本类 catch 成 warn。 */
+  onTrigger: () => void | Promise<void>;
+  /** 去抖窗口（ms）。设计建议 1–2s 合并 burst。 */
+  debounceMs: number;
+  /** schedule = setTimeout（注入便于 fake timers）；返回句柄交 clearSchedule。 */
+  schedule: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** clearSchedule = clearTimeout。 */
+  clearSchedule: (handle: ReturnType<typeof setTimeout>) => void;
+  /** 告警 sink（best-effort 失败仅 warn）。 */
+  onWarn: (level: LogLevel, message: string) => void;
+}
+
+/**
+ * 纯门控判定：是否应执行 DNS reconcile（镜像 setDns 的接管条件）。
+ * 仅 TUN 模式 + 未关闭接管开关 + 当前确有 marker（接管已激活）才放行 —— 系统代理/手动模式或未接管时，watcher
+ * 绝不擅自改系统 DNS。抽成纯函数便于单测，也供 ProxyManager 接线层与本判定共用同一真值。
+ *
+ * @param config 当前生效配置（ProxyManager.currentConfig）；null/非 TUN/关掉开关 → false。
+ * @param hasMarker SystemDnsManager.hasMarker() 结果（接管 marker 是否在）。
+ */
+export function shouldReconcileDns(
+  config: UserConfig | null | undefined,
+  hasMarker: boolean
+): boolean {
+  if (!config) return false;
+  if (config.proxyModeType !== 'tun') return false;
+  if (config.dnsConfig?.takeoverSystemDns === false) return false;
+  return hasMarker;
+}
+
+/**
+ * 可注入的 watcher 单元：start() spawn route monitor + 订阅 resume；命中去抖调 onTrigger；stop() 杀子进程 +
+ * 反注册 resume + 取消在飞去抖。幂等（重复 start/stop 安全）。全部 best-effort（异常仅 warn 不抛）。
+ */
+export class DnsInterfaceWatcher {
+  private child: WatchableChildProcess | null = null;
+  private debounceHandle: ReturnType<typeof setTimeout> | null = null;
+  private lineBuffer = ''; // stdout chunk 跨界拼接缓存（一条 RTM_ 行可能分片到达）。
+  private started = false;
+  private readonly resumeListener: () => void;
+
+  constructor(private readonly deps: DnsInterfaceWatcherDeps) {
+    // 绑定单一 resume 监听实例，stop() 才能精确 removeListener（匿名函数无法反注册）。
+    this.resumeListener = () => this.scheduleReconcile('系统唤醒(resume)');
+  }
+
+  /** 启动：spawn route monitor + 订阅 resume。幂等：已启动则 no-op。best-effort：spawn 抛仅 warn 不抛。 */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    try {
+      const child = this.deps.spawnRouteMonitor();
+      this.child = child;
+      child.stdout?.on('data', (chunk) => this.onStdoutData(chunk));
+      // 子进程自身错误（route 不存在/被杀）best-effort：仅 warn，不抛、不影响 TUN（watcher 失效 ≠ 接管失效，
+      // setDns 已接管的服务仍受控，只是热插补接管暂失能 —— 远好于阻断生命周期）。
+      child.on('error', (err) => {
+        this.deps.onWarn('warn', `DNS 接口 watcher 子进程错误: ${err.message}`);
+      });
+    } catch (e) {
+      // spawn 同步抛（route 二进制缺失等）→ 回退未启动态，仅 warn。
+      this.started = false;
+      this.child = null;
+      this.deps.onWarn(
+        'warn',
+        `启动 DNS 接口 watcher 失败: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+
+    // resume 订阅独立 try：spawn 失败也仍订阅唤醒（唤醒后链路常变，是另一条补接管路径）。
+    if (this.deps.powerMonitor) {
+      try {
+        this.deps.powerMonitor.on('resume', this.resumeListener);
+      } catch (e) {
+        this.deps.onWarn(
+          'warn',
+          `订阅系统唤醒事件失败: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    }
+  }
+
+  /** 停止：杀子进程 + 反注册 resume + 取消在飞去抖。幂等、best-effort（每步独立 try，单步失败不阻断其余）。 */
+  stop(): void {
+    if (this.debounceHandle !== null) {
+      this.deps.clearSchedule(this.debounceHandle);
+      this.debounceHandle = null;
+    }
+    if (this.child) {
+      try {
+        this.child.kill();
+      } catch (e) {
+        this.deps.onWarn(
+          'warn',
+          `停止 DNS 接口 watcher 子进程失败: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+      this.child = null;
+    }
+    if (this.deps.powerMonitor) {
+      try {
+        this.deps.powerMonitor.removeListener('resume', this.resumeListener);
+      } catch (e) {
+        this.deps.onWarn(
+          'warn',
+          `反注册系统唤醒事件失败: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    }
+    this.lineBuffer = '';
+    this.started = false;
+  }
+
+  /** stdout chunk → 按行切分 → 命中触发行即排去抖。chunk 可能含半行，跨 chunk 用 lineBuffer 拼接。 */
+  private onStdoutData(chunk: Buffer | string): void {
+    this.lineBuffer += chunk.toString();
+    const parts = this.lineBuffer.split('\n');
+    this.lineBuffer = parts.pop() ?? ''; // 末段可能是半行，留回缓存等下个 chunk 补全。
+    for (const line of parts) {
+      if (isDnsReconcileTriggerLine(line)) {
+        this.scheduleReconcile('链路变化(route monitor)');
+        // 一个 burst 内多条触发行只需排一次去抖（schedule 会被 scheduleReconcile 合并），继续扫完本批即可。
+      }
+    }
+  }
+
+  /** 去抖排程：合并 burst（已有在飞句柄先清再重排）→ 窗口结束调一次 onTrigger。onTrigger 异常仅 warn。 */
+  private scheduleReconcile(reason: string): void {
+    if (this.debounceHandle !== null) {
+      this.deps.clearSchedule(this.debounceHandle);
+    }
+    this.debounceHandle = this.deps.schedule(() => {
+      this.debounceHandle = null;
+      try {
+        const r = this.deps.onTrigger();
+        if (r && typeof (r as Promise<void>).catch === 'function') {
+          (r as Promise<void>).catch((e) =>
+            this.deps.onWarn(
+              'warn',
+              `DNS 重灌(${reason})失败: ${e instanceof Error ? e.message : String(e)}`
+            )
+          );
+        }
+      } catch (e) {
+        this.deps.onWarn(
+          'warn',
+          `DNS 重灌(${reason})失败: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    }, this.deps.debounceMs);
+  }
+}

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -3,7 +3,7 @@
  * 负责 sing-box 进程的生命周期管理和配置生成
  */
 
-import { BrowserWindow, Notification, shell } from 'electron';
+import { BrowserWindow, Notification, shell, powerMonitor } from 'electron';
 import { spawn, ChildProcess } from 'child_process';
 import { system32, powershellPath } from '../utils/win-system32';
 import * as fs from 'fs/promises';
@@ -25,6 +25,7 @@ import type { IPrivilegedHelper } from './IPrivilegedHelper';
 import { PlatformPrivilegeService } from './PlatformPrivilegeService';
 import { type ISystemProxyManager, SystemProxyBase } from './SystemProxyManager';
 import { type ISystemDnsManager } from './SystemDnsManager';
+import { DnsInterfaceWatcher, shouldReconcileDns } from './DnsInterfaceWatcher';
 import { localProxyPort, controlApiPort } from '../../shared/proxy-ports';
 import { effectiveBypassLan } from '../../shared/system-proxy-bypass';
 import { isDirectSelection, resolveGlobalExitTag } from '../../shared/direct-selection';
@@ -232,6 +233,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private clearingSystemProxy = false;
   // ensureSystemDnsRestored 单飞：与系统代理同终态多路并发，防重复 restore。
   private clearingSystemDns = false;
+  // macOS DNS 接管「热插重灌」watcher：setDns 成功后起、stop/终态还原时停（仅 darwin，与 setDns 真接管同口径）。
+  // 长驻 route -n monitor 探链路变化 + powerMonitor resume → 去抖调 reconcileDns 补接管新出现/换网未受控的服务。
+  private dnsInterfaceWatcher: DnsInterfaceWatcher | null = null;
   // 「主动停止/重启中」：stop() 期间置位，令 ensureSystemProxyCleared 跳过——避免重启 stop 腿清掉系统代理后
   // 又被 start() reconcile 设回的并发竞态（C1）。真·外部死亡时为 false → 信号死分支照常清理。
   private stopping = false;
@@ -817,8 +821,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     try {
       if (config.proxyModeType === 'tun' && config.dnsConfig?.takeoverSystemDns !== false) {
         await this.systemDnsManager?.setDns();
+        // 接管成功 → 起热插重灌 watcher（探链路变化/唤醒 → 去抖 reconcile 补接管换网/新服务）。仅 darwin 真起，
+        // best-effort：起失败不阻断 TUN 启动（watcher 失效 ≠ 接管失效，已接管服务仍受控）。
+        this.startDnsInterfaceWatcher();
       } else {
-        // 非 TUN / 用户关掉接管开关 → 还原可能残留的受控 DNS（覆盖 TUN→其它模式切换、开→关切换）。
+        // 非 TUN / 用户关掉接管开关 → 停 watcher（若在）+ 还原可能残留的受控 DNS（覆盖 TUN→其它模式切换、开→关切换）。
+        this.stopDnsInterfaceWatcher();
         await this.ensureSystemDnsRestored();
       }
     } catch (e) {
@@ -951,6 +959,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       clearTimeout(this.connectionFlushTimer);
       this.connectionFlushTimer = null;
     }
+    // 停 DNS 接口 watcher（停止/切模式/重启 stop 腿统一入口）：杀 route monitor 子进程 + 反注册 resume + 取消在飞去抖。
+    // 切模式重启时这里先停，紧随的 start() 会按新模式重判是否重起（TUN→重起 / 其它→保持停），零打架。best-effort 不抛。
+    this.stopDnsInterfaceWatcher();
     // 用户意图优先：取消可能在退避窗口内待发的自动重启（崩溃后进程已死、refs 均 null 会触发下面的早退，
     // 但 attemptAutoRestart 仍在退避中——退避期 isRestarting=true，故这里能拦下，M3）。
     // 条件置位（含 isRestarting）：避免 start() 启动窗口内（已过复位点、refs 尚未就绪、isRestarting=false）
@@ -4713,6 +4724,10 @@ exit 0
    */
   async ensureSystemDnsRestored(): Promise<void> {
     if (this.clearingSystemDns) return; // 单飞：多路终态并发只还原一次
+    // 还原 = DNS 接管即将/已终态 → 顺带停 watcher（覆盖崩溃/外部死亡/giveUp 这些不经 stop() 的终态点，经
+    // ensureSystemProxyCleared → 本方法收口）。幂等：watcher 不在则 no-op。放 marker 判定之前——即便已无 marker
+    // 也确保 watcher 停掉（避免接管已失效但 watcher 仍空转探链路）。
+    this.stopDnsInterfaceWatcher();
     const mgr = this.systemDnsManager;
     if (!mgr) return;
     // 仅当 DNS 确由 FlowZ 接管（marker 在）才动手 → 不误改用户自配/系统默认 DNS
@@ -4728,6 +4743,58 @@ exit 0
       );
     } finally {
       this.clearingSystemDns = false;
+    }
+  }
+
+  /**
+   * 起 macOS DNS 接管「热插重灌」watcher（薄接线）：仅 darwin 起（与 setDns 真接管同口径；Win/Linux no-op）。
+   * 长驻 route -n monitor + powerMonitor resume → 命中去抖 → 经门控（shouldReconcileDns）判定后调 reconcileDns()。
+   * 幂等（DnsInterfaceWatcher.start 内部 started 守卫）。best-effort：构造/起失败仅 warn，绝不抛、不阻断 TUN 启动。
+   */
+  private startDnsInterfaceWatcher(): void {
+    if (process.platform !== 'darwin') return; // 仅 macOS 接管系统 DNS → 仅此平台需热插重灌 watcher。
+    if (this.dnsInterfaceWatcher) return; // 幂等：已在跑则 no-op（重复 setDns 不重起）。
+    const mgr = this.systemDnsManager;
+    if (!mgr) return;
+    try {
+      this.dnsInterfaceWatcher = new DnsInterfaceWatcher({
+        // route -n monitor：长驻打印内核路由表变更事件（接口 up/down、地址增删、默认路由切换）。
+        spawnRouteMonitor: () =>
+          spawn('route', ['-n', 'monitor'], { stdio: ['ignore', 'pipe', 'ignore'] }),
+        powerMonitor,
+        // 去抖后的统一 reconcile 入口：门控镜像 setDns（仅 TUN + 未关接管 + marker 在才动手），否则跳过。
+        onTrigger: async () => {
+          if (!shouldReconcileDns(this.currentConfig, mgr.hasMarker())) return;
+          await mgr.reconcileDns();
+        },
+        debounceMs: 1500, // 1.5s：合并插坞站/换网的 RTM_ burst（设计建议 1–2s）。
+        schedule: (fn, ms) => setTimeout(fn, ms),
+        clearSchedule: (h) => clearTimeout(h),
+        onWarn: (level, message) => this.logToManager(level, message),
+      });
+      this.dnsInterfaceWatcher.start();
+      this.logToManager('info', 'DNS 接口 watcher 已启动（热插/换网/唤醒 → 重灌系统 DNS 接管）');
+    } catch (e) {
+      this.dnsInterfaceWatcher = null;
+      this.logToManager(
+        'warn',
+        `启动 DNS 接口 watcher 失败: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
+  /** 停 DNS 接口 watcher（杀 route monitor 子进程 + 反注册 resume + 取消在飞去抖）。幂等、best-effort 不抛。 */
+  private stopDnsInterfaceWatcher(): void {
+    if (!this.dnsInterfaceWatcher) return;
+    try {
+      this.dnsInterfaceWatcher.stop();
+    } catch (e) {
+      this.logToManager(
+        'warn',
+        `停止 DNS 接口 watcher 失败: ${e instanceof Error ? e.message : String(e)}`
+      );
+    } finally {
+      this.dnsInterfaceWatcher = null;
     }
   }
 

--- a/src/main/services/SystemDnsManager.ts
+++ b/src/main/services/SystemDnsManager.ts
@@ -47,6 +47,12 @@ export interface ISystemDnsManager {
   setDns(): Promise<void>;
   /** 停止/切模式 → 还原原始 DNS（marker 在才动手由调用方门控）。 */
   restoreDns(): Promise<void>;
+  /**
+   * 热插重灌：接管激活中（marker 在）时，把「启动后新出现 / 仍未受控」的网络服务也接管为受控 IP。
+   * 幂等（已受控跳过）+ best-effort（单服务失败不阻断其余、绝不抛）+ 防自指（不覆盖既有 marker 的真实原始、
+   * 不把受控 IP 误存成原始）。Win/Linux 无 marker → 自然 no-op，无需 override。
+   */
+  reconcileDns(): Promise<void>;
   /** 同步还原（关机/退出等紧急场景，读 marker 跨会话还原）。 */
   restoreDnsSync(): void;
   /** 是否存在「DNS 由 FlowZ 接管」marker（终态清理门控用）。 */
@@ -237,6 +243,58 @@ export abstract class SystemDnsBase implements ISystemDnsManager {
         this.clearMarker();
       }
     }
+  }
+
+  /**
+   * 热插重灌：接管激活中（marker 在）时，把「启动后新出现 / 仍未受控」的网络服务也接管为受控 IP。
+   * 不变量：① 仅 marker 在才动手（接管未激活时绝不写系统）；② 先写 marker 再 apply（崩溃留 intent 据此还原）；
+   * ③ 只 apply 未受控服务（已受控跳过 → 幂等）；④ best-effort 逐服务，单服务失败不阻断其余、绝不抛；
+   * ⑤ 防自指 + 不覆盖已消失服务的 original（mergedOriginal 以既有 marker.original 为底，仅并入新捕获的真实原始）。
+   */
+  async reconcileDns(): Promise<void> {
+    // 守卫：受控 IP 在 bootstrap-direct → fail-closed 不接管（与 setDns 同口径，纵深防御一次）。
+    if (!isControlledDnsIpValid(this.controlledIp)) return;
+    // marker 不在 = 接管未激活（或 Win/Linux 永不写 marker）→ 绝不擅自接管，直接返回。
+    const marker = SystemDnsBase.readMarker();
+    if (!marker) return;
+
+    let targets: string[];
+    try {
+      targets = await this.listTargets();
+    } catch {
+      return;
+    }
+    if (targets.length === 0) return;
+
+    // 读各服务当前 DNS（best-effort，读失败按 [] 处理）。
+    const current: Record<string, string[]> = {};
+    for (const t of targets) {
+      current[t] = await this.readDns(t).catch(() => []);
+    }
+
+    // 以既有 marker.original 为底，并入当前各服务的「应保存原始」（防自指：已受控的回退既有真实原始）。
+    // 展开顺序保证既有 original 里已消失服务的记录保留（computeOriginalToSave 只覆盖 current 里出现的服务）。
+    const mergedOriginal = {
+      ...marker.original,
+      ...computeOriginalToSave(current, this.controlledIp, marker.original),
+    };
+
+    const isControlled = (ips: string[]) => ips.length === 1 && ips[0] === this.controlledIp;
+    const toApply = targets.filter((t) => !isControlled(current[t]));
+    if (toApply.length === 0) return; // 全部已受控 → 幂等 no-op（不写 marker、不动系统）。
+
+    // 先写 marker（含合并后的真实原始）再 apply：apply 期间崩溃也留 intent，下次启动据此精确还原。
+    this.originalDns = mergedOriginal;
+    this.writeMarker(mergedOriginal);
+
+    for (const t of toApply) {
+      try {
+        await this.applyDns(t, [this.controlledIp]);
+      } catch (e) {
+        this.log('warn', `重灌服务 "${t}" DNS 失败: ${e}`);
+      }
+    }
+    this.log('info', `DNS 重灌：${toApply.length} 个未受控服务接管为 ${this.controlledIp}`);
   }
 
   /**

--- a/src/main/services/__tests__/DnsInterfaceWatcher.test.ts
+++ b/src/main/services/__tests__/DnsInterfaceWatcher.test.ts
@@ -1,0 +1,289 @@
+/**
+ * DnsInterfaceWatcher + shouldReconcileDns 单测（T2c）。
+ * 全离线：jest fake timers + mock spawn 工厂 / powerMonitor / onTrigger / schedule。无真实 spawn/electron。
+ *
+ * 覆盖：
+ *  ① 触发行经去抖后只调一次 onTrigger（burst 合并）。
+ *  ② 门控不满足（非 tun / takeover=false / 无 marker）→ shouldReconcileDns=false → onTrigger 内不 reconcile。
+ *  ③ powerMonitor 'resume' → 触发去抖 onTrigger。
+ *  ④ stop → 杀 route monitor 子进程 + 移除 powerMonitor 监听 + 取消在飞去抖。
+ *  ⑤ spawn 抛错 → 不抛、仅 warn。
+ *  ⑥ 平台/门控真值（shouldReconcileDns）：仅 tun + 未关接管 + marker 在才放行（startDnsInterfaceWatcher 的
+ *     darwin no-op 是 ProxyManager 薄接线层对 process.platform 的判定，逻辑核心 = 此门控真值，于此处覆盖）。
+ */
+
+import { DnsInterfaceWatcher, shouldReconcileDns } from '../DnsInterfaceWatcher';
+import type {
+  DnsInterfaceWatcherDeps,
+  WatchableChildProcess,
+  ResumeMonitor,
+} from '../DnsInterfaceWatcher';
+import type { UserConfig } from '../../../shared/types';
+
+const DEBOUNCE = 1500;
+
+/** 可控的假子进程：暴露 stdout.on 注册的回调 + kill 探针。 */
+function makeFakeChild(): {
+  child: WatchableChildProcess;
+  emitData: (chunk: string) => void;
+  emitError: (err: Error) => void;
+  kill: jest.Mock;
+} {
+  let dataCb: ((chunk: Buffer | string) => void) | null = null;
+  let errCb: ((err: Error) => void) | null = null;
+  const kill = jest.fn(() => true);
+  const child: WatchableChildProcess = {
+    stdout: {
+      on: (_event, listener) => {
+        dataCb = listener;
+      },
+    },
+    on: (event, listener) => {
+      if (event === 'error') errCb = listener as (err: Error) => void;
+      return child;
+    },
+    kill,
+  };
+  return {
+    child,
+    emitData: (chunk) => dataCb?.(chunk),
+    emitError: (err) => errCb?.(err),
+    kill,
+  };
+}
+
+/** 可控 powerMonitor：捕获 resume 监听 + 暴露触发 / removeListener 探针。 */
+function makeFakePowerMonitor(): {
+  pm: ResumeMonitor;
+  fireResume: () => void;
+  on: jest.Mock;
+  removeListener: jest.Mock;
+} {
+  let resumeCb: (() => void) | null = null;
+  const on = jest.fn((event: string, listener: () => void) => {
+    if (event === 'resume') resumeCb = listener;
+  });
+  // 真清回调（模拟真实 electron removeListener 行为）：stop 反注册后 fireResume 不再触达 watcher。
+  const removeListener = jest.fn((event: string, listener: () => void) => {
+    if (event === 'resume' && resumeCb === listener) resumeCb = null;
+  });
+  const pm: ResumeMonitor = {
+    on: on as ResumeMonitor['on'],
+    removeListener: removeListener as ResumeMonitor['removeListener'],
+  };
+  return { pm, fireResume: () => resumeCb?.(), on, removeListener };
+}
+
+/** 组装一个 watcher + 全 mock 依赖（schedule/clearSchedule 走真实 setTimeout/clearTimeout，配 fake timers）。 */
+function setup(overrides?: Partial<DnsInterfaceWatcherDeps>) {
+  const fakeChild = makeFakeChild();
+  const fakePm = makeFakePowerMonitor();
+  const onTrigger = jest.fn(() => Promise.resolve());
+  const onWarn = jest.fn();
+  const spawnRouteMonitor = jest.fn<WatchableChildProcess, []>(() => fakeChild.child);
+
+  const deps: DnsInterfaceWatcherDeps = {
+    spawnRouteMonitor,
+    powerMonitor: fakePm.pm,
+    onTrigger,
+    debounceMs: DEBOUNCE,
+    schedule: (fn, ms) => setTimeout(fn, ms),
+    clearSchedule: (h) => clearTimeout(h),
+    onWarn,
+    ...overrides,
+  };
+  const watcher = new DnsInterfaceWatcher(deps);
+  return { watcher, deps, fakeChild, fakePm, onTrigger, onWarn, spawnRouteMonitor };
+}
+
+const TRIGGER_LINE = 'RTM_IFINFO: iface status change\n';
+
+describe('DnsInterfaceWatcher', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  // ① burst 合并：一个去抖窗口内连发多条触发行 → 只调一次 onTrigger。
+  it('① 触发行 burst 经去抖只调一次 onTrigger', () => {
+    const { watcher, fakeChild, onTrigger } = setup();
+    watcher.start();
+
+    // 插坞站连发多条 RTM_ —— 模拟 burst。
+    fakeChild.emitData('RTM_IFINFO: up\n');
+    fakeChild.emitData('RTM_NEWADDR: addr\n');
+    fakeChild.emitData('RTM_ADD: Add Route: default\n');
+    expect(onTrigger).not.toHaveBeenCalled(); // 去抖窗口未到，尚未触发。
+
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).toHaveBeenCalledTimes(1); // burst 合并为一次。
+  });
+
+  it('① 噪音行不排去抖（不调 onTrigger）', () => {
+    const { watcher, fakeChild, onTrigger } = setup();
+    watcher.start();
+    fakeChild.emitData('got message of size 240 on 2026-06-21\n');
+    fakeChild.emitData('   default link#1 UCSg\n');
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it('① stdout 跨 chunk 半行拼接：分片到达的触发行仍命中', () => {
+    const { watcher, fakeChild, onTrigger } = setup();
+    watcher.start();
+    fakeChild.emitData('RTM_IF'); // 半行，无换行 → 留缓存。
+    fakeChild.emitData('INFO: iface status change\n'); // 补全 + 换行 → 命中。
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  // ② 门控不满足 → onTrigger（内含 shouldReconcileDns 门控）不 reconcile。此处直接验门控真值，
+  //   并验「onTrigger 用门控包裹 reconcile」的组合：门控 false → reconcile 不调。
+  it('② 门控不满足 → reconcile 不被调用', () => {
+    const reconcileDns = jest.fn(() => Promise.resolve());
+    // 模拟 ProxyManager 注入的 onTrigger：门控 false → 不调 reconcile。
+    const gatedTrigger = jest.fn(async () => {
+      if (!shouldReconcileDns({ proxyModeType: 'systemProxy' } as UserConfig, true)) return;
+      await reconcileDns();
+    });
+    const { watcher, fakeChild } = setup({ onTrigger: gatedTrigger });
+    watcher.start();
+    fakeChild.emitData(TRIGGER_LINE);
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(gatedTrigger).toHaveBeenCalledTimes(1); // 去抖确实触发了入口…
+    expect(reconcileDns).not.toHaveBeenCalled(); // …但门控 false 拦下 reconcile。
+  });
+
+  // ③ powerMonitor 'resume' → 去抖 onTrigger。
+  it('③ resume 事件触发去抖 onTrigger', () => {
+    const { watcher, fakePm, onTrigger } = setup();
+    watcher.start();
+    fakePm.fireResume();
+    expect(onTrigger).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('③ resume 与 route 行同窗口 burst → 仍只一次', () => {
+    const { watcher, fakeChild, fakePm, onTrigger } = setup();
+    watcher.start();
+    fakeChild.emitData(TRIGGER_LINE);
+    fakePm.fireResume();
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  // ④ stop → 杀子进程 + 移除 resume 监听 + 取消在飞去抖。
+  it('④ stop 杀子进程 + 反注册 resume + 取消在飞去抖', () => {
+    const { watcher, fakeChild, fakePm, onTrigger } = setup();
+    watcher.start();
+    fakeChild.emitData(TRIGGER_LINE); // 排了一个在飞去抖。
+    watcher.stop();
+
+    expect(fakeChild.kill).toHaveBeenCalledTimes(1); // 杀 route monitor。
+    expect(fakePm.removeListener).toHaveBeenCalledWith('resume', expect.any(Function)); // 反注册 resume。
+
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).not.toHaveBeenCalled(); // 在飞去抖被取消 → stop 后不再触发。
+  });
+
+  it('④ stop 后 resume 不再触发（监听已移除）', () => {
+    const { watcher, fakePm, onTrigger } = setup();
+    watcher.start();
+    watcher.stop(); // 反注册 resume（fake removeListener 真清回调，镜像 electron 行为）。
+    fakePm.fireResume(); // 监听已移除 → 不触达 watcher → 不排去抖。
+    jest.advanceTimersByTime(DEBOUNCE);
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
+  it('④ stop 幂等：未 start 直接 stop 不抛、重复 stop 安全', () => {
+    const { watcher, fakeChild } = setup();
+    expect(() => watcher.stop()).not.toThrow();
+    watcher.start();
+    watcher.stop();
+    watcher.stop();
+    expect(fakeChild.kill).toHaveBeenCalledTimes(1); // 第二次 stop 时 child 已 null，不重复 kill。
+  });
+
+  // ⑤ spawn 抛错 → 不抛、仅 warn；resume 订阅仍生效（spawn 失败不连累唤醒路径）。
+  it('⑤ spawn 抛错 → 不抛、仅 warn', () => {
+    const spawnRouteMonitor = jest.fn(() => {
+      throw new Error('route: command not found');
+    });
+    const { watcher, onWarn, fakePm } = setup({ spawnRouteMonitor });
+    expect(() => watcher.start()).not.toThrow();
+    expect(onWarn).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('启动 DNS 接口 watcher 失败')
+    );
+    // spawn 失败仍订阅 resume（唤醒是独立补接管路径）。
+    expect(fakePm.on).toHaveBeenCalledWith('resume', expect.any(Function));
+  });
+
+  it('⑤ 子进程 error 事件 → 仅 warn 不抛', () => {
+    const { watcher, fakeChild, onWarn } = setup();
+    watcher.start();
+    expect(() => fakeChild.emitError(new Error('route monitor died'))).not.toThrow();
+    expect(onWarn).toHaveBeenCalledWith('warn', expect.stringContaining('子进程错误'));
+  });
+
+  it('⑤ onTrigger reject → 仅 warn 不冒泡', async () => {
+    const onTrigger = jest.fn(() => Promise.reject(new Error('reconcile boom')));
+    const { watcher, fakeChild, onWarn } = setup({ onTrigger });
+    watcher.start();
+    fakeChild.emitData(TRIGGER_LINE);
+    jest.advanceTimersByTime(DEBOUNCE);
+    await Promise.resolve(); // 放行 reject 的 .catch 微任务。
+    await Promise.resolve();
+    expect(onWarn).toHaveBeenCalledWith('warn', expect.stringContaining('DNS 重灌'));
+  });
+
+  // start 幂等：重复 start 不重复 spawn。
+  it('start 幂等：重复 start 只 spawn 一次', () => {
+    const { watcher, spawnRouteMonitor } = setup();
+    watcher.start();
+    watcher.start();
+    expect(spawnRouteMonitor).toHaveBeenCalledTimes(1);
+  });
+
+  // 无 powerMonitor（注入 null）：start/stop 不碰 resume、不抛。
+  it('powerMonitor=null：start/stop 不订阅 resume、不抛', () => {
+    const { watcher } = setup({ powerMonitor: null });
+    expect(() => {
+      watcher.start();
+      watcher.stop();
+    }).not.toThrow();
+  });
+});
+
+// ⑥ 门控真值表（= startDnsInterfaceWatcher 的逻辑核心 + ProxyManager 注入 onTrigger 的门控判定）。
+describe('shouldReconcileDns 门控真值', () => {
+  const tunOn = { proxyModeType: 'tun' } as UserConfig;
+  const tunTakeoverOff = {
+    proxyModeType: 'tun',
+    dnsConfig: { takeoverSystemDns: false },
+  } as UserConfig;
+  const sysProxy = { proxyModeType: 'systemProxy' } as UserConfig;
+  const manual = { proxyModeType: 'manual' } as unknown as UserConfig;
+
+  it('tun + 未关接管 + marker 在 → true', () => {
+    expect(shouldReconcileDns(tunOn, true)).toBe(true);
+  });
+  it('tun + marker 不在 → false（接管未激活，不擅自动手）', () => {
+    expect(shouldReconcileDns(tunOn, false)).toBe(false);
+  });
+  it('tun + takeover=false → false（用户关掉接管开关）', () => {
+    expect(shouldReconcileDns(tunTakeoverOff, true)).toBe(false);
+  });
+  it('systemProxy 模式 → false（系统代理走远程解析，watcher 不改 DNS）', () => {
+    expect(shouldReconcileDns(sysProxy, true)).toBe(false);
+  });
+  it('manual 模式 → false', () => {
+    expect(shouldReconcileDns(manual, true)).toBe(false);
+  });
+  it('config 为 null/undefined → false', () => {
+    expect(shouldReconcileDns(null, true)).toBe(false);
+    expect(shouldReconcileDns(undefined, true)).toBe(false);
+  });
+});

--- a/src/main/services/__tests__/SystemDnsManager.reconcile.test.ts
+++ b/src/main/services/__tests__/SystemDnsManager.reconcile.test.ts
@@ -1,0 +1,193 @@
+/**
+ * SystemDnsBase.reconcileDns() 热插重灌单测。
+ * - mock ../utils/paths.getUserDataPath → 临时目录，让 writeMarker/readMarker 走真实 fs（最贴近实际 marker IO）。
+ * - SystemDnsBase 抽象 → concrete 测试子类 TestDns stub 全部平台原语（listTargets/readDns/applyDns/同步腿/
+ *   readEffectiveResolvers），用可变 fixture 模拟「当前各服务 DNS」。
+ * - jest.spyOn(applyDns) 观测重灌调用；marker 落盘后再读回校验 original（防自指 / 已消失服务保留断言）。
+ * 风格参照 src/shared/__tests__/system-dns.test.ts。
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// userData → 每个测试独立临时目录（beforeEach 重设），marker 真实落盘读回。
+let tmpUserData: string;
+jest.mock('../../utils/paths', () => ({
+  getUserDataPath: () => tmpUserData,
+}));
+
+import { SystemDnsBase, type ISystemDnsManager } from '../SystemDnsManager';
+import { CONTROLLED_TUN_DNS_IP } from '../../../shared/dns';
+import type { SystemDnsMarker } from '../../../shared/system-dns';
+
+const CONTROLLED = CONTROLLED_TUN_DNS_IP; // '8.8.8.8'
+
+/**
+ * concrete 测试子类：用 dnsMap（service → 当前 DNS）驱动 listTargets/readDns；applyDns 写回 dnsMap 模拟真实生效，
+ * 便于「再次 reconcile 看幂等」。所有同步腿/方案B 原语给最小 stub。
+ */
+class TestDns extends SystemDnsBase {
+  constructor(public dnsMap: Record<string, string[]>) {
+    super();
+  }
+  protected async listTargets(): Promise<string[]> {
+    return Object.keys(this.dnsMap);
+  }
+  protected async readDns(target: string): Promise<string[]> {
+    return this.dnsMap[target] ?? [];
+  }
+  /** public hook：applyDns 委托给它 → 测试直接 spy 这个 public 方法（类型干净，避免 protected 的 `as never` 污染）。 */
+  async applyDnsImpl(target: string, ips: string[]): Promise<void> {
+    this.dnsMap[target] = [...ips]; // 模拟真实生效，供二次 reconcile 验幂等
+  }
+  protected async applyDns(target: string, ips: string[]): Promise<void> {
+    await this.applyDnsImpl(target, ips);
+  }
+  protected listTargetsSync(): string[] {
+    return Object.keys(this.dnsMap);
+  }
+  protected applyDnsSync(target: string, ips: string[]): void {
+    this.dnsMap[target] = [...ips];
+  }
+  protected async readEffectiveResolvers(): Promise<string[]> {
+    return [];
+  }
+}
+
+function markerPath(): string {
+  return path.join(tmpUserData, 'system-dns.marker.json');
+}
+function writeMarkerFile(original: Record<string, string[]>): void {
+  const marker: SystemDnsMarker = { controlledIp: CONTROLLED, original, at: Date.now() };
+  fs.writeFileSync(markerPath(), JSON.stringify(marker));
+}
+function readMarkerFile(): SystemDnsMarker | null {
+  try {
+    return JSON.parse(fs.readFileSync(markerPath(), 'utf-8')) as SystemDnsMarker;
+  } catch {
+    return null;
+  }
+}
+
+beforeEach(() => {
+  tmpUserData = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-dns-reconcile-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpUserData, { recursive: true, force: true });
+});
+
+describe('reconcileDns 热插重灌', () => {
+  it('1. marker 不在 → 零 applyDns（接管未激活绝不擅自动手）', async () => {
+    const dns = new TestDns({ 'Wi-Fi': ['192.168.5.1'] });
+    const spy = jest.spyOn(dns, 'applyDnsImpl');
+    await dns.reconcileDns();
+    expect(spy).not.toHaveBeenCalled();
+    expect(readMarkerFile()).toBeNull(); // 不创建 marker
+  });
+
+  it('2. 新增服务（比 marker.original 多、非受控）→ 被 applyDns(controlledIp)，marker.original 并入其真实原始值', async () => {
+    // marker 仅记录 Wi-Fi（接管时已受控）；启动后新插 USB Ethernet 仍是 LAN DNS。
+    writeMarkerFile({ 'Wi-Fi': ['192.168.5.1'] });
+    const dns = new TestDns({ 'Wi-Fi': [CONTROLLED], 'USB Ethernet': ['10.0.0.1'] });
+    const spy = jest.spyOn(dns, 'applyDnsImpl');
+
+    await dns.reconcileDns();
+
+    // 仅新增的未受控服务被接管，已受控 Wi-Fi 不动。
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('USB Ethernet', [CONTROLLED]);
+    expect(dns.dnsMap['USB Ethernet']).toEqual([CONTROLLED]);
+    // marker.original 并入新服务真实原始值，且保留既有 Wi-Fi 记录。
+    const m = readMarkerFile()!;
+    expect(m.original).toEqual({ 'Wi-Fi': ['192.168.5.1'], 'USB Ethernet': ['10.0.0.1'] });
+  });
+
+  it('3. 已受控服务（current === [controlledIp]）→ 跳过不重复 applyDns', async () => {
+    writeMarkerFile({ 'Wi-Fi': ['192.168.5.1'], Ethernet: ['10.0.0.1'] });
+    // Wi-Fi 已受控、Ethernet 仍未受控 → 只重灌 Ethernet。
+    const dns = new TestDns({ 'Wi-Fi': [CONTROLLED], Ethernet: ['10.0.0.1'] });
+    const spy = jest.spyOn(dns, 'applyDnsImpl');
+
+    await dns.reconcileDns();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('Ethernet', [CONTROLLED]);
+    expect(spy).not.toHaveBeenCalledWith('Wi-Fi', expect.anything());
+  });
+
+  it('4. 全部已受控 → 幂等 no-op（零 applyDns、不重写 marker）', async () => {
+    const original = { 'Wi-Fi': ['192.168.5.1'], Ethernet: ['10.0.0.1'] };
+    writeMarkerFile(original);
+    const before = fs.readFileSync(markerPath(), 'utf-8'); // 原始 marker 字节快照（含 at）
+    const dns = new TestDns({ 'Wi-Fi': [CONTROLLED], Ethernet: [CONTROLLED] });
+    const spy = jest.spyOn(dns, 'applyDnsImpl');
+
+    await dns.reconcileDns();
+
+    expect(spy).not.toHaveBeenCalled();
+    // marker 文件逐字节不变 → 全受控时连 marker 都不重写（at 时间戳也不变）。
+    expect(fs.readFileSync(markerPath(), 'utf-8')).toBe(before);
+    expect(readMarkerFile()!.original).toEqual(original);
+  });
+
+  it('5. 防自指：reconcile 后 marker 已是受控值，再 reconcile 不把 8.8.8.8 误存成 original', async () => {
+    // 首轮：Wi-Fi 真实原始 192.168.5.1，未受控 → 接管。
+    writeMarkerFile({ 'Wi-Fi': ['192.168.5.1'] });
+    const dns = new TestDns({ 'Wi-Fi': ['192.168.5.1'] });
+    await dns.reconcileDns();
+    expect(dns.dnsMap['Wi-Fi']).toEqual([CONTROLLED]); // 已生效为受控
+
+    // 二轮：Wi-Fi 当前已是受控值；若朴素采当前值会把 8.8.8.8 误存 original → 永远还原到受控 IP。
+    const spy = jest.spyOn(dns, 'applyDnsImpl');
+    await dns.reconcileDns();
+    expect(spy).not.toHaveBeenCalled(); // 已受控 → 幂等不重灌
+    // marker.original 仍是真实原始 192.168.5.1，绝不被受控 IP 污染。
+    expect(readMarkerFile()!.original).toEqual({ 'Wi-Fi': ['192.168.5.1'] });
+  });
+
+  it('6. 已消失服务（marker.original 有、current 无）→ writeMarker 后 original 仍保留', async () => {
+    // marker 记录 Wi-Fi(已受控) + VPN(接管时受控，启动后服务消失)。
+    writeMarkerFile({ 'Wi-Fi': ['192.168.5.1'], VPN: ['172.16.0.1'] });
+    // current 只剩 Wi-Fi(受控) + 新插 Ethernet(未受控)；VPN 已消失（不在 listTargets）。
+    const dns = new TestDns({ 'Wi-Fi': [CONTROLLED], Ethernet: ['10.0.0.1'] });
+
+    await dns.reconcileDns();
+
+    const m = readMarkerFile()!;
+    // 已消失的 VPN original 必须保留（mergedOriginal 以既有 marker.original 为底，computeOriginalToSave 不覆盖未出现服务）。
+    expect(m.original.VPN).toEqual(['172.16.0.1']);
+    expect(m.original['Wi-Fi']).toEqual(['192.168.5.1']);
+    expect(m.original.Ethernet).toEqual(['10.0.0.1']); // 新增并入
+  });
+
+  it('7. 单服务 applyDns 抛错 → 不阻断其余、不抛', async () => {
+    writeMarkerFile({});
+    const dns = new TestDns({ Bad: ['10.0.0.1'], Good: ['10.0.0.2'] });
+    const spy = jest
+      .spyOn(dns, 'applyDnsImpl')
+      .mockImplementation(async (target: string, ips: string[]) => {
+        if (target === 'Bad') throw new Error('networksetup failed');
+        dns.dnsMap[target] = [...ips];
+      });
+
+    await expect(dns.reconcileDns()).resolves.toBeUndefined(); // best-effort 绝不抛
+
+    // 两个都尝试了；Good 成功重灌，Bad 失败但被吞。
+    expect(spy).toHaveBeenCalledWith('Bad', [CONTROLLED]);
+    expect(spy).toHaveBeenCalledWith('Good', [CONTROLLED]);
+    expect(dns.dnsMap['Good']).toEqual([CONTROLLED]);
+  });
+
+  it('8. Win/Linux 形态（无 marker）→ no-op（任何实现只要 marker 不在都不动手）', async () => {
+    // 模拟 Win/Linux：从不写 marker。即便有未受控服务，reconcile 也因 marker 不在直接返回。
+    const dns = new TestDns({ Ethernet: ['10.0.0.1'] });
+    const spy = jest.spyOn(dns, 'applyDnsImpl');
+
+    const mgr: ISystemDnsManager = dns;
+    await mgr.reconcileDns();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(readMarkerFile()).toBeNull();
+  });
+});

--- a/src/main/services/__tests__/dns-route-events.test.ts
+++ b/src/main/services/__tests__/dns-route-events.test.ts
@@ -1,0 +1,85 @@
+/**
+ * dns-route-events.isDnsReconcileTriggerLine 纯函数单测（T2d）。
+ * 覆盖：各 RTM_ 触发类型 → true；噪音/统计/明细/无关 RTM → false；空行/畸形/非字符串 → false（不抛）。
+ * 行样本仿真实 macOS `route -n monitor` 输出（消息头 + RTM_ 行 + 缩进明细行）。
+ */
+
+import { isDnsReconcileTriggerLine } from '../dns-route-events';
+
+describe('isDnsReconcileTriggerLine — 触发类型命中', () => {
+  it.each([
+    ['RTM_IFINFO: iface status change', 'RTM_IFINFO 接口 up/down'],
+    ['RTM_NEWADDR: address being added to iface', 'RTM_NEWADDR 地址新增'],
+    ['RTM_DELADDR: address being removed from iface', 'RTM_DELADDR 地址删除'],
+    ['RTM_ADD: Add Route: len 220, route flags<UP,GATEWAY,DONE,STATIC>', 'RTM_ADD 路由新增'],
+    ['RTM_DELETE: Delete Route: len 220, route flags<UP,GATEWAY,DONE>', 'RTM_DELETE 路由删除'],
+  ])('「%s」(%s) → true', (line) => {
+    expect(isDnsReconcileTriggerLine(line)).toBe(true);
+  });
+
+  it('带前导空白的触发行仍命中（trim 后判定）', () => {
+    expect(isDnsReconcileTriggerLine('   RTM_IFINFO: iface status change')).toBe(true);
+  });
+
+  it('带数字后缀的版本变体（RTM_IFINFO2 / RTM_NEWADDR2）前缀命中', () => {
+    expect(isDnsReconcileTriggerLine('RTM_IFINFO2: extended iface info')).toBe(true);
+    expect(isDnsReconcileTriggerLine('RTM_NEWADDR2: extended addr info')).toBe(true);
+  });
+});
+
+describe('isDnsReconcileTriggerLine — 噪音/无关 → false', () => {
+  it('统计头 "got message of size" → false', () => {
+    expect(isDnsReconcileTriggerLine('got message of size 240 on 2026-06-21 10:00:00')).toBe(false);
+  });
+
+  it('缩进的地址/标志明细行 → false', () => {
+    expect(isDnsReconcileTriggerLine('   default            link#1             UCSg')).toBe(false);
+    expect(isDnsReconcileTriggerLine('   sockaddrs: <DST,GATEWAY,NETMASK>')).toBe(false);
+    expect(isDnsReconcileTriggerLine('   flags:<UP,GATEWAY,HOST,DONE,STATIC>')).toBe(false);
+  });
+
+  it('非触发类型的 RTM_ 消息（RTM_GET/RTM_LOSING/RTM_MISS/RTM_RESOLVE）→ false', () => {
+    expect(isDnsReconcileTriggerLine('RTM_GET: Report Metrics: len 240')).toBe(false);
+    expect(isDnsReconcileTriggerLine('RTM_LOSING: Kernel Suspects Partitioning: len 240')).toBe(
+      false
+    );
+    expect(isDnsReconcileTriggerLine('RTM_MISS: Lookup failed on this address: len 240')).toBe(
+      false
+    );
+    expect(isDnsReconcileTriggerLine('RTM_RESOLVE: Route created by cloning: len 240')).toBe(false);
+  });
+
+  it('RTM_ 出现在行中部（非首 token）不误命中', () => {
+    expect(isDnsReconcileTriggerLine('comment mentioning RTM_ADD somewhere')).toBe(false);
+  });
+
+  it('前缀相近但非触发类型（RTM_ADDRINFO 不存在；RTM_NEWMADDR 组播地址）按规格判定', () => {
+    // RTM_NEWMADDR（组播成员地址）以 RTM_NEW 起但非 RTM_NEWADDR 前缀 → 不命中。
+    expect(isDnsReconcileTriggerLine('RTM_NEWMADDR: multicast group membership: len 152')).toBe(
+      false
+    );
+    expect(isDnsReconcileTriggerLine('RTM_DELMADDR: multicast group membership: len 152')).toBe(
+      false
+    );
+  });
+});
+
+describe('isDnsReconcileTriggerLine — 空/畸形/非字符串 → false（不抛）', () => {
+  it.each([
+    ['', '空字符串'],
+    ['   ', '纯空白'],
+    ['\n', '纯换行'],
+    ['random garbage line', '无关文本'],
+    [':::::', '只有分隔符'],
+  ])('「%s」(%s) → false', (line) => {
+    expect(isDnsReconcileTriggerLine(line)).toBe(false);
+  });
+
+  it('非字符串入参（null/undefined/number/object）→ false 且不抛', () => {
+    // 防御越界（stdout 解析理论恒给 string，但纯函数须对脏输入鲁棒）。
+    expect(isDnsReconcileTriggerLine(null as unknown as string)).toBe(false);
+    expect(isDnsReconcileTriggerLine(undefined as unknown as string)).toBe(false);
+    expect(isDnsReconcileTriggerLine(123 as unknown as string)).toBe(false);
+    expect(isDnsReconcileTriggerLine({} as unknown as string)).toBe(false);
+  });
+});

--- a/src/main/services/dns-route-events.ts
+++ b/src/main/services/dns-route-events.ts
@@ -1,0 +1,52 @@
+/**
+ * macOS `route -n monitor` 输出行解析（纯函数，无副作用）。
+ *
+ * 用途：DnsInterfaceWatcher 长驻 `route -n monitor`，逐行喂本函数判定「是否值得触发一次 DNS reconcile 的网络变更」。
+ * 命中 → 去抖后调 SystemDnsManager.reconcileDns()，把启动后新出现/换网后未受控的网络服务也接管为受控 DNS。
+ *
+ * route monitor 的每条消息块以 `got message of size N on <ts>` 起头，后跟一行 `RTM_<TYPE>: <描述>`，再跟若干
+ * 缩进的地址/标志明细行。我们只在「接口状态变化 / 地址增删 / 默认路由变化」上触发——这些才意味着链路/解析器可能
+ * 已变（插坞站、切 Wi-Fi、VPN 起落）。纯统计行（"got message of size"）与其它噪音/明细行返回 false。
+ *
+ * 不变量：① 纯函数、无副作用、不抛（畸形/空行/非字符串 → false）；② 只看类型，不解析地址（解析地址非本判定所需，
+ * 且各平台/本地化输出差异大，徒增误判面）。设计见 docs/design/dns-takeover-dynamic-interface.md §四 4.2。
+ */
+
+/**
+ * route monitor 中「值得触发 reconcile」的消息类型：
+ * - RTM_IFINFO：接口 up/down（插拔网卡、Wi-Fi 开关、坞站以太网上下线）。
+ * - RTM_NEWADDR / RTM_DELADDR：接口地址增删（DHCP 续约换 IP、IPv6 SLAAC 增删、VPN 虚拟地址起落）。
+ * - RTM_ADD / RTM_DELETE：路由增删（尤其默认路由切换 = 出口/解析器可能整体易主）。
+ *
+ * 注：RTM_IFINFO2 / RTM_NEWADDR2 等带数字后缀的变体也命中（前缀匹配），覆盖 macOS 不同版本的 sysctl 风格变体。
+ */
+const TRIGGER_RTM_TYPES = [
+  'RTM_IFINFO',
+  'RTM_NEWADDR',
+  'RTM_DELADDR',
+  'RTM_ADD',
+  'RTM_DELETE',
+] as const;
+
+/**
+ * 判定单行 `route -n monitor` 输出是否表示「值得触发 DNS reconcile 的网络变更」。
+ *
+ * 命中：行内出现上述 RTM_ 触发类型（位于行首或紧跟空白后，形如 `RTM_IFINFO: ...`）。
+ * 不命中：纯统计行（"got message of size ..."）、地址/标志明细行、空行、畸形行、非字符串。
+ *
+ * @param line route monitor 的单行文本（可含前后空白）。
+ * @returns true=值得 reconcile；false=噪音/无关/非法。永不抛。
+ */
+export function isDnsReconcileTriggerLine(line: string): boolean {
+  if (typeof line !== 'string') return false;
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+
+  // "got message of size N on <ts>" 是每条消息块的统计头 —— 高频噪音，显式排除（防 RTM_ 前缀误判时的兜底）。
+  if (trimmed.startsWith('got message of size')) return false;
+
+  // 取首 token（RTM 类型行形如 `RTM_IFINFO: <flags>`；冒号/空白分隔）。明细行首 token 是地址族/标志名，不会以 RTM_ 起。
+  const firstToken = trimmed.split(/[\s:]/, 1)[0];
+  // 前缀匹配：覆盖 RTM_IFINFO2 / RTM_NEWADDR2 等带数字后缀的版本变体；非触发类型（RTM_GET/RTM_LOSING/RTM_MISS 等）不命中。
+  return TRIGGER_RTM_TYPES.some((t) => firstToken === t || firstToken.startsWith(t));
+}


### PR DESCRIPTION
TUN 模式启动后新接口热插(切网/插网卡/连 VPN)时自动接管其系统 DNS，防新接口 DNS 泄漏。reconcileDns(仅 marker 在动手/幂等/防自指/best-effort) + DnsInterfaceWatcher(监听接口/路由变化触发)。【待 macOS 真机验证】