### PR TITLE
fix(core): 换核改原子 rename 根除 ETXTBSY，修复随包核替换失败致无法启动（#150）

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -62,7 +62,11 @@ import {
   meshAlwaysRoutesSubnets,
   endpointForcedRouteCidrs,
 } from '../../shared/endpoint-routes';
-import { classifyCoreBuild, decideCoreOverride } from '../../shared/core-build';
+import {
+  classifyCoreBuild,
+  decideCoreOverride,
+  classifyReseedResult,
+} from '../../shared/core-build';
 import { retry } from '../utils/retry';
 import { coreVersionAtLeast } from '../../shared/version';
 import { parseTailscaleAuthLine } from '../../shared/tailscale';
@@ -305,6 +309,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private probeProxyPort: number | null = null;
   private configPath: string;
   private singboxPath: string;
+  // `sing-box version` 探测串行链（issue #150）：所有版本探测（启动检测/换核重读/CoreUpdate 检查/关于页）汇流
+  // 此处串行排队，确保任一时刻至多一个 version 子进程 execve 内核二进制——缩小与启动期换核写盘并发执行的 race 窗口。
+  private versionProbeChain: Promise<unknown> = Promise.resolve();
   private logManager: ILogManager | null = null;
   // 隐私模式 provider（index 注入 getPrivacyMode）：隐私开 → sing-box 日志级别抬到 ≥warn，不记访问域名/SNI。
   private privacyProvider: () => boolean = () => false;
@@ -470,10 +477,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       const coreKind = classifyCoreBuild(this.coreVersionLine || `version ${this.coreVersion}`);
       const { reseed, warn } = decideCoreOverride(coreKind, this.coreVersion, bundledCore);
       if (reseed) {
+        const before = this.coreVersion;
         this.logToManager(
           'info',
-          `官方内核 ${this.coreVersion} 旧于随包基线 ${bundledCore}，用随包核替换...`
+          `官方内核 ${before} 旧于随包基线 ${bundledCore}，用随包核替换...`
         );
+        let reseedError = '';
         try {
           // §5 两平台统一经 ensureWritableCore(true)：linux force 覆盖可写核；darwin 经注入的 helper installCore
           // 重播种随包核到受保护目录（root-only，helper 上方 maybePromptHelperGate 已引导在位）。临时目录复制 +
@@ -484,10 +493,23 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
             installCore: (seedDir) => (this.helperManager as HelperManager).installCore(seedDir),
           });
         } catch (e) {
-          this.logToManager('warn', `随包内核刷新失败: ${(e as Error)?.message ?? e}`);
+          reseedError = (e as Error)?.message ?? String(e);
         }
-        this.coreVersion = await this.getCoreVersion(true);
-        this.logToManager('info', `内核已用随包版刷新至 ${this.coreVersion}`);
+        // 诚实校验（issue #150 + review F1）：重读活二进制确认换核「真的」生效。用 getCoreVersionLine(true)
+        // ——其探测失败返回 ''、**不回落随包基线**；绝不用 getCoreVersion（探测失败会回落 bundledCoreVersion，
+        // 把「重读失败」伪装成「换核成功」→ 闸门误放行、带旧核硬跑退回死循环）。探测失败/版本未达基线 → 保守
+        // 保留换核前旧版本、判未生效，由下方版本闸门明确终止（而非谎报成功）。
+        const lineAfter = await this.getCoreVersionLine(true);
+        const { version, applied } = classifyReseedResult(lineAfter, before, bundledCore);
+        this.coreVersion = version;
+        if (applied) {
+          this.logToManager('info', `内核已用随包版刷新至 ${this.coreVersion}`);
+        } else {
+          this.logToManager(
+            'warn',
+            `随包内核刷新未生效（仍为 ${this.coreVersion}，期望 ≥ ${bundledCore}）${reseedError ? `：${reseedError}` : ''}；请退出代理后在「设置 · 内核 · 重置到出厂」手动切回随包核`
+          );
+        }
       }
       if (warn) {
         this.logToManager(
@@ -1685,8 +1707,22 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     }
   }
 
-  /** spawn `sing-box version` 取原始第一行（含 fork 后缀，不截 X.Y.Z）。失败抛出，由调用方按各自缓存策略处理。 */
+  /**
+   * spawn `sing-box version` 取原始第一行（含 fork 后缀，不截 X.Y.Z）。失败抛出，由调用方按各自缓存策略处理。
+   * 串行化（issue #150）：所有版本探测排到 versionProbeChain，确保任一时刻至多一个 version 子进程 execve 内核
+   * 二进制——并发探测会同时占用二进制，与启动期换核写盘并发执行放大 race（旧实现 + 原地 copyFile 即 ETXTBSY）。
+   * 链只承载排序、不传播失败（catch→undefined），避免一次探测失败卡死后续所有探测；调用方仍拿到 run 的真实结果/异常。
+   */
   private async spawnCoreVersionFirstLine(): Promise<string> {
+    const run = this.versionProbeChain
+      .catch(() => undefined)
+      .then(() => this.doSpawnCoreVersionFirstLine());
+    this.versionProbeChain = run.catch(() => undefined);
+    return run;
+  }
+
+  /** 实际 spawn `sing-box version`（不含串行排队）；仅供 spawnCoreVersionFirstLine 经 versionProbeChain 调用。 */
+  private async doSpawnCoreVersionFirstLine(): Promise<string> {
     const execAsync = require('util').promisify(require('child_process').exec);
     const { stdout } = await execAsync(`"${this.singboxPath}" version`);
     return String(stdout).split('\n')[0]?.trim() || '';

--- a/src/main/services/ResourceManager.ts
+++ b/src/main/services/ResourceManager.ts
@@ -401,8 +401,11 @@ export class ResourceManager {
     const sourcePath = path.join(platformDir, 'sing-box');
 
     if (await this.fileExists(sourcePath)) {
-      await fs.copyFile(sourcePath, targetPath);
-      await fs.chmod(targetPath, 0o755); // 赋予可执行权限
+      // 原子替换（写 targetPath.tmp → chmod 0o755 → rename），非原地 copyFile 覆盖：force 重播种时 targetPath
+      // 可能正被运行中的 sing-box 执行，原地 O_TRUNC 打开会 ETXTBSY（text file busy）致覆盖失败、旧核残留
+      //（issue #150）。rename 只把旧 inode unlink（在用进程继续持有旧 inode 不受影响），文件名指向全新核 →
+      // 根除 ETXTBSY。与 ensureCronetHealthy 的 libcronet 写盘同款原子语义。
+      await this.atomicCopy(sourcePath, targetPath);
     }
 
     // naive 节点需要 libcronet 与 sing-box 同目录（purego 加载），随核心一并放过去

--- a/src/main/services/__tests__/core-reseed-atomic.test.ts
+++ b/src/main/services/__tests__/core-reseed-atomic.test.ts
@@ -1,0 +1,120 @@
+/**
+ * ensureWritableCore 原子换核单测（issue #150：内核替换 ETXTBSY 根因修复）。
+ *
+ * 验 ResourceManager.ensureWritableCore(force=true) 走原子替换（写 targetPath.tmp → chmod → rename）而非
+ * 原地 copyFile 覆盖：原地 O_TRUNC 打开正被执行的旧核会 ETXTBSY（text file busy）→ 替换失败、旧核残留；
+ * rename 只 unlink 旧 inode（在用进程不受影响）、文件名指向全新核 → 规避 ETXTBSY。
+ *
+ * 关键不变量（实现无关，直击回归）：换核后 target 的 **inode 改变**（rename 换 inode；原地 copyFile 保持 inode），
+ * 即证明走的是 rename 而非原地覆盖。设计：真实临时目录承载内置 bundle + 可写核目录，仅 mock electron.app + 平台。
+ */
+
+import * as os from 'os';
+import * as fsSync from 'fs';
+import * as path from 'path';
+
+const ROOT = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-reseed-test-'));
+const RESOURCES = path.join(ROOT, 'resources');
+Object.defineProperty(process, 'resourcesPath', { value: RESOURCES, configurable: true });
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => ROOT, // userData → ROOT（core_update 落于 ROOT/core_update）
+    getVersion: () => '9.9.9',
+    isPackaged: true, // 生产模式：baseDir=process.resourcesPath
+    getAppPath: () => ROOT,
+  },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ResourceManager } from '../ResourceManager';
+
+const ORIG_PLATFORM = process.platform;
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+
+const LINUX_BUNDLE = path.join(RESOURCES, 'linux');
+const CORE_UPDATE = path.join(ROOT, 'core_update');
+const SOURCE = path.join(LINUX_BUNDLE, 'sing-box');
+const TARGET = path.join(CORE_UPDATE, 'sing-box');
+
+function seedBundleCore(content: string): void {
+  fsSync.mkdirSync(LINUX_BUNDLE, { recursive: true });
+  fsSync.writeFileSync(SOURCE, content);
+  fsSync.chmodSync(SOURCE, 0o755);
+}
+
+beforeEach(() => {
+  fsSync.rmSync(RESOURCES, { recursive: true, force: true });
+  fsSync.rmSync(CORE_UPDATE, { recursive: true, force: true });
+  setPlatform('linux');
+});
+
+afterAll(() => {
+  setPlatform(ORIG_PLATFORM);
+  try {
+    fsSync.rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function mkRm(): ResourceManager {
+  const rm = new ResourceManager();
+  rm.setLogManager({ addLog: () => {} } as any); // 静默日志，避免 console 噪音
+  return rm;
+}
+
+describe('ensureWritableCore(force=true) — 原子替换换核（issue #150）', () => {
+  it('旧核已在位 → 用随包核覆盖：内容更新为新核，且 inode 改变（证明 rename 非原地 copyFile）', async () => {
+    seedBundleCore('NEW-CORE-1.14.0-alpha.33');
+    // 预置一个旧核（模拟用户装的官方 1.13.13 残留可写核）
+    fsSync.mkdirSync(CORE_UPDATE, { recursive: true });
+    fsSync.writeFileSync(TARGET, 'OLD-CORE-1.13.13');
+    fsSync.chmodSync(TARGET, 0o755);
+    const inodeBefore = fsSync.statSync(TARGET).ino;
+
+    const rm = mkRm();
+    const ret = await rm.ensureWritableCore(true);
+
+    expect(ret).toBe(TARGET);
+    // 内容已替换为新核
+    expect(fsSync.readFileSync(TARGET, 'utf-8')).toBe('NEW-CORE-1.14.0-alpha.33');
+    // inode 改变 = 走 rename（原子换 inode）而非原地 O_TRUNC 覆盖 → 根除 ETXTBSY
+    expect(fsSync.statSync(TARGET).ino).not.toBe(inodeBefore);
+    // 可执行位保留（POSIX 语义；Windows 宿主无 0o111 执行位、chmod 只动只读属性，跳过——该断言仅类 Unix 宿主有意义）
+    if (ORIG_PLATFORM !== 'win32') expect(fsSync.statSync(TARGET).mode & 0o111).not.toBe(0);
+    // 不留半残 .tmp
+    expect(fsSync.existsSync(`${TARGET}.tmp`)).toBe(false);
+  });
+
+  it('目标不存在 → 首次播种：经 tmp+rename 落位，内容正确、可执行、无残留 .tmp', async () => {
+    seedBundleCore('NEW-CORE-1.14.0-alpha.33');
+    expect(fsSync.existsSync(TARGET)).toBe(false);
+
+    const rm = mkRm();
+    const ret = await rm.ensureWritableCore(true);
+
+    expect(ret).toBe(TARGET);
+    expect(fsSync.readFileSync(TARGET, 'utf-8')).toBe('NEW-CORE-1.14.0-alpha.33');
+    // 可执行位保留（POSIX-only，Windows 宿主跳过——见上）
+    if (ORIG_PLATFORM !== 'win32') expect(fsSync.statSync(TARGET).mode & 0o111).not.toBe(0);
+    expect(fsSync.existsSync(`${TARGET}.tmp`)).toBe(false);
+  });
+
+  it('残留 .tmp 不阻断换核（copyFile 覆盖 tmp 后 rename）', async () => {
+    seedBundleCore('NEW-CORE-1.14.0-alpha.33');
+    fsSync.mkdirSync(CORE_UPDATE, { recursive: true });
+    fsSync.writeFileSync(`${TARGET}.tmp`, 'STALE-LEFTOVER'); // 上次崩溃残留
+
+    const rm = mkRm();
+    await rm.ensureWritableCore(true);
+
+    expect(fsSync.readFileSync(TARGET, 'utf-8')).toBe('NEW-CORE-1.14.0-alpha.33');
+    expect(fsSync.existsSync(`${TARGET}.tmp`)).toBe(false);
+  });
+});

--- a/src/main/services/__tests__/core-version-probe-serial.test.ts
+++ b/src/main/services/__tests__/core-version-probe-serial.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `sing-box version` 探测串行化单测（issue #150：缩小并发探测与启动期换核写盘的 race 窗口）。
+ *
+ * 所有版本探测（startInternal 检测/换核重读/CoreUpdateService 检查/关于页）汇流 ProxyManager.spawnCoreVersionFirstLine，
+ * 经 versionProbeChain 串行排队 → 任一时刻至多一个 version 子进程 execve 内核二进制。并发探测会同时占用二进制，
+ * 与原地 copyFile 换核并发即 ETXTBSY 高发；串行化把「同时占用」收敛为「逐个占用」。
+ *
+ * 全 mock、零真进程：mock child_process.exec 记录在飞并发数，断言并发 N 次 getCoreVersion(force) → maxInFlight===1。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-ver-serial-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {
+    static isSupported() {
+      return false;
+    }
+  },
+  shell: { openExternal: jest.fn(() => Promise.resolve()) },
+  net: {},
+  session: {},
+}));
+
+jest.mock('../ResourceManager', () => ({
+  resourceManager: {
+    ensureWritableCore: jest.fn(async () => '/fake/sing-box'),
+    getSingBoxPath: jest.fn(() => '/fake/sing-box'),
+  },
+}));
+
+// child_process.exec mock：每次「在飞」追踪并发峰值；setTimeout 制造 await 间隙——未串行则并发调用会重叠。
+// spread 真实模块保留 execFile/spawn 等（SystemProxyManager 等在模块加载期 promisify(execFile)，缺则 import 即崩）。
+jest.mock('child_process', () => {
+  const actual = jest.requireActual('child_process');
+  let inFlight = 0;
+  let maxInFlight = 0;
+  let calls = 0;
+  return {
+    ...actual,
+    exec: (_cmd: string, cb: (e: unknown, r: { stdout: string }) => void) => {
+      calls += 1;
+      inFlight += 1;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+      setTimeout(() => {
+        inFlight -= 1;
+        cb(null, { stdout: 'sing-box version 1.14.0-alpha.33 (go1.25)\n environment ...' });
+      }, 5);
+    },
+    __stats: () => ({ calls, maxInFlight }),
+    __reset: () => {
+      inFlight = 0;
+      maxInFlight = 0;
+      calls = 0;
+    },
+  };
+});
+
+import { ProxyManager } from '../ProxyManager';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function makeSvc(): any {
+  const mainWindow: any = { isDestroyed: () => false, webContents: { send: jest.fn() } };
+  return new ProxyManager(
+    { addLog: jest.fn() } as any,
+    mainWindow,
+    path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`),
+    '/fake/sing-box'
+  );
+}
+
+describe('spawnCoreVersionFirstLine 串行化（issue #150）', () => {
+  beforeEach(() => {
+    require('child_process').__reset();
+  });
+
+  it('并发 5 次 getCoreVersion(force) → 全部 spawn 但任一时刻至多 1 个在飞', async () => {
+    const svc = makeSvc();
+    const results = await Promise.all([
+      svc.getCoreVersion(true),
+      svc.getCoreVersion(true),
+      svc.getCoreVersion(true),
+      svc.getCoreVersion(true),
+      svc.getCoreVersion(true),
+    ]);
+    const stats = require('child_process').__stats();
+    expect(stats.calls).toBe(5); // force=true 不吃缓存，5 次真探测
+    expect(stats.maxInFlight).toBe(1); // 串行化关键断言：绝不并发 execve 内核
+    // 解析结果正确（不因串行而损坏）
+    for (const r of results) expect(r).toBe('1.14.0-alpha.33');
+  });
+
+  it('一次探测失败不毒化链：后续探测仍正常排队执行', async () => {
+    const svc = makeSvc();
+    const cp = require('child_process');
+    // 第一次 exec 抛错（回调 err），其余正常
+    let first = true;
+    const orig = cp.exec;
+    cp.exec = (cmd: string, cb: (e: unknown, r?: { stdout: string }) => void) => {
+      if (first) {
+        first = false;
+        setTimeout(() => cb(new Error('boom')), 5);
+        return;
+      }
+      orig(cmd, cb as any);
+    };
+
+    const failed = await svc.getCoreVersion(true); // 失败 → 回落随包基线（不抛）
+    const ok = await svc.getCoreVersion(true); // 链未被毒化 → 正常解析
+    expect(typeof failed).toBe('string');
+    expect(ok).toBe('1.14.0-alpha.33');
+
+    cp.exec = orig;
+  });
+});

--- a/src/shared/__tests__/core-build.test.ts
+++ b/src/shared/__tests__/core-build.test.ts
@@ -4,7 +4,13 @@
  * 样本：官方基线（1.13.13 实测）+ 官方预发布/dev + fork 后缀（reF1nd/nekolsd，源码确证）+ 边界（官方跨版本不误报）。
  */
 
-import { classifyCoreBuild, decideCoreOverride, extractVersionToken } from '../core-build';
+import {
+  classifyCoreBuild,
+  decideCoreOverride,
+  extractVersionToken,
+  reseedApplied,
+  classifyReseedResult,
+} from '../core-build';
 
 describe('extractVersionToken', () => {
   it('从完整 version 行提取 token', () => {
@@ -96,5 +102,61 @@ describe('decideCoreOverride — 核覆盖决策（官方/fork/unknown × </=/> 
   it('unknown → 同 fork：绝不重播种；≤ 内置 → 警告', () => {
     expect(decideCoreOverride('unknown', '1.13.0', B)).toEqual({ reseed: false, warn: true });
     expect(decideCoreOverride('unknown', '1.15.0', B)).toEqual({ reseed: false, warn: false });
+  });
+});
+
+describe('reseedApplied — reseed 是否真生效（诚实失败判据，issue #150）', () => {
+  const B = '1.14.0-alpha.33'; // 随包(内置)基线
+
+  it('换核失败：版本仍 < 基线（旧核被占用 ETXTBSY 未替换）→ 未生效', () => {
+    // issue #150 实况：基线 1.14.0-alpha.33，活核仍 1.13.13 → 绝不能判成功
+    expect(reseedApplied('1.13.13', B)).toBe(false);
+    expect(reseedApplied('1.14.0-alpha.30', B)).toBe(false);
+  });
+
+  it('换核成功：版本 == 基线 → 生效', () => {
+    expect(reseedApplied(B, B)).toBe(true);
+  });
+
+  it('版本 > 基线（已是更新核）→ 视为生效', () => {
+    expect(reseedApplied('1.14.0', B)).toBe(true); // release > 同版 prerelease
+    expect(reseedApplied('1.15.0', B)).toBe(true);
+  });
+});
+
+describe('classifyReseedResult — reseed 校验（含 F1：探测失败不得伪装成功）', () => {
+  const B = '1.14.0-alpha.33'; // 随包(内置)基线
+  const BEFORE = '1.13.13'; // 换核前旧官方核
+
+  it('F1 核心：换核后重读探测失败（lineAfter=空）→ 保守保留旧版本、判未生效', () => {
+    // 绝不能因探测失败而回落基线 → 否则版本闸门误放行、带旧核硬跑退回死循环
+    expect(classifyReseedResult('', BEFORE, B)).toEqual({ version: BEFORE, applied: false });
+    expect(classifyReseedResult('   ', BEFORE, B)).toEqual({ version: BEFORE, applied: false });
+    expect(classifyReseedResult('sing-box', BEFORE, B)).toEqual({
+      version: BEFORE,
+      applied: false,
+    });
+  });
+
+  it('换核成功：lineAfter 报随包基线版本 → 判生效、记录新版本', () => {
+    expect(classifyReseedResult('sing-box version 1.14.0-alpha.33 (go1.25)', BEFORE, B)).toEqual({
+      version: '1.14.0-alpha.33',
+      applied: true,
+    });
+  });
+
+  it('换核未生效：旧核仍可跑、lineAfter 报旧版本 → 判未生效、记录旧版本（仍 < 基线）', () => {
+    // issue #150 主路径：ETXTBSY 只阻写不阻执行，重读拿到真实旧 1.13.13
+    expect(classifyReseedResult('sing-box version 1.13.13', BEFORE, B)).toEqual({
+      version: BEFORE,
+      applied: false,
+    });
+  });
+
+  it('换核后已是更新官方核（> 基线）→ 判生效', () => {
+    expect(classifyReseedResult('sing-box version 1.14.0', BEFORE, B)).toEqual({
+      version: '1.14.0',
+      applied: true,
+    });
   });
 });

--- a/src/shared/core-build.ts
+++ b/src/shared/core-build.ts
@@ -70,3 +70,39 @@ export function decideCoreOverride(
   // fork / unknown：尊重用户选择，绝不覆盖；≤ 基线时提醒兼容风险（含同版 fork——后缀分支可能缺新特性）。
   return { reseed: false, warn: cmp <= 0 };
 }
+
+/**
+ * reseed（随包核替换）是否「真的」生效（纯函数）：换核后重读活二进制版本 ≥ 随包基线即判生效。
+ * 旧核被运行中 sing-box 进程占用（Linux ETXTBSY）/ 写盘失败时版本不变（仍 < 基线）→ 判未生效，
+ * 调用方据此诚实上报失败、绝不谎报「刷新成功」（issue #150）。
+ * @param versionAfter   换核后重读的活二进制版本（X.Y.Z[-suffix]）
+ * @param bundledVersion 随包(内置)核版本 = 基线（reseed 成功后活核应 == 该版本）
+ */
+export function reseedApplied(versionAfter: string, bundledVersion: string): boolean {
+  return compareSemver(versionAfter, bundledVersion) >= 0;
+}
+
+/**
+ * 判定 reseed 结果（纯函数，issue #150 review F1）：换核后取活二进制版本行 + 换核前版本 + 基线，
+ * 给出「应记录的当前版本」与「是否真生效」。
+ *
+ * 关键：lineAfter 必须来自**探测失败置空**的读法（如 getCoreVersionLine，失败返回 ''），**绝不**用
+ * 探测失败会回落随包基线的读法（getCoreVersion）——否则「重读 spawn 失败」会被回落值伪装成「换核成功」，
+ * 令版本闸门误放行、带旧核硬跑退回死循环。
+ *  - lineAfter 解析不出版本（探测失败/脏行）→ 保守保留换核前旧版本 `before`、判未生效（诚实失败）。
+ *  - 解析出版本 → 该版本即当前版本，是否生效 = reseedApplied(版本, 基线)。
+ *
+ * @param lineAfter      换核后 `sing-box version` 原始第一行（探测失败为 ''）
+ * @param before         换核前活核版本（reseed 仅在官方 < 基线时触发，故必为真实可解析旧版本）
+ * @param bundledVersion 随包(内置)核版本 = 基线
+ */
+export function classifyReseedResult(
+  lineAfter: string,
+  before: string,
+  bundledVersion: string
+): { version: string; applied: boolean } {
+  const versionAfter = extractVersionToken(lineAfter);
+  // 须解析出形如 X.Y… 的真实版本 token；空（探测失败）/ 非数字开头（脏行、如裸 'sing-box'）→ 保守保留旧版本、判未生效。
+  if (!versionAfter || !/^\d/.test(versionAfter)) return { version: before, applied: false };
+  return { version: versionAfter, applied: reseedApplied(versionAfter, bundledVersion) };
+}


### PR DESCRIPTION
## 问题（#150）

新装 4.1.0（linux）点连接无法启动，提示「sing-box 版本太低」。日志关键段：

```
检测到 sing-box 核心版本: 1.13.13
官方内核 1.13.13 旧于随包基线 1.14.0-alpha.33，用随包核替换...
WARN:随包内核刷新失败: ETXTBSY: text file is busy,
     copyfile '.../resources/linux/sing-box' -> '.../core_update/sing-box'
内核已用随包版刷新至 1.13.13        ← 谎报成功，版本其实没变
```

每次点连接重复同一失败，永久卡死。

## 根因

- 换核时机在**启动代理时**（`ProxyManager.startInternal`），非 app 启动。
- `ResourceManager.ensureWritableCore`(force) 用裸 `fs.copyFile` **原地 O_TRUNC 覆盖** `core_update/sing-box`，而该二进制此刻正被并发的 `sing-box version` 探测 execve → Linux 返 **ETXTBSY（text file busy）** → 覆盖失败、旧核残留。
- reseed 块的失败被吞，随后**无条件**打印「内核已用随包版刷新至 X」，重读的还是没换成的旧核（1.13.13）→ 版本闸门 `coreVersionAtLeast(…,1,14)` 判 <1.14 抛「版本太低」。

## 改动

1. **原子 rename 换核（根治 ETXTBSY）** — `ensureWritableCore` 的 `fs.copyFile` 改为复用已有 `atomicCopy`（写 `target.tmp` → `chmod 0o755` → `rename`）。`rename(2)` 只把旧 inode unlink（在用进程继续持有旧 inode 照常运行），文件名指向全新核——**从不写忙 inode**，根除 ETXTBSY。与 libcronet 写盘同款原子语义。
2. **reseed 诚实失败上报** — 换核后重读活二进制，仅当真升到 ≥ 基线才打「刷新至 X」；否则打 warn「刷新未生效（仍为 X，期望 ≥ 基线）…请退出代理后在『设置·内核·重置到出厂』手动切回随包核」，不再谎报。后续若仍 <1.14 由版本闸门明确终止。
   - 校验用 `getCoreVersionLine`（探测失败返回 `''`、**不回落随包基线**），而非 `getCoreVersion`（其探测失败会回落 `bundledCoreVersion`，会把「重读失败」伪装成「换核成功」→ 版本闸门误放行、带旧核硬跑退回死循环）。新增纯函数 `reseedApplied` / `classifyReseedResult` 承载判据。
3. **`sing-box version` 探测串行化** — `spawnCoreVersionFirstLine` 拆为串行 wrapper（`versionProbeChain` 排队）+ 实际 spawn。所有版本探测（启动检测 / 换核重读 / 内核更新检查 / 关于页，均汇流于此）排队，任一时刻至多一个 `sing-box version` 子进程 execve 内核，缩小并发执行与换核写盘的竞争窗口。

## 测试

`tsc` / `eslint` / `jest`（全量 1747）全绿；新增：

- `core-build.test.ts` — `reseedApplied` / `classifyReseedResult` 纯函数（含「探测失败不得伪装成功」边界）。
- `core-reseed-atomic.test.ts` — `ensureWritableCore(force)` 换核后 **inode 改变** 断言（证走 rename 而非原地覆盖）+ 首次播种 + 残留 .tmp 不阻断。
- `core-version-probe-serial.test.ts` — 并发 5 次 `getCoreVersion(force)` → `maxInFlight===1`；一次探测失败不毒化链。

## 待人工验证（Linux 真机）

- 旧 1.13.13 可写核 + 点连接 → 应原子换成随包核、连接成功（非 ETXTBSY 死循环）。
- 换核瞬间打开「关于」页查版本 → 不报 ETXTBSY（串行链跨服务 race 缓解的真机确认）。
