### PR TITLE
fix(server): 修复节点页多选批量删除只删 1 个

### DIFF
--- a/src/main/ipc/handlers/server-handlers.ts
+++ b/src/main/ipc/handlers/server-handlers.ts
@@ -27,6 +27,30 @@ export function registerServerHandlers(
   // WARP 待注销队列（删除带 warpDevice 凭据的节点 → 入队；成功注册后机会式 drain）。
   // 进程内单例：与 startup-tasks 启动 drain 共用同一实例，使串行链（opChain）覆盖全部触发点、杜绝跨实例并发写。
   const warpDeregisterQueue = getWarpDeregisterQueue(logManager);
+
+  // 删除单个服务器后的「非配置副作用」（Tailscale state 清理 + WARP 远端注销入队），单删 / 批删共用。
+  // 抽出复用，保证批量删除不丢这两项副作用（否则 CF 端留孤儿设备、Tailscale 登录目录残留）。
+  const runServerRemovalSideEffects = async (removed: ServerConfig): Promise<void> => {
+    // Tailscale 节点 → 清其持久 state 目录 <userData>/tailscale/<id>（best-effort，不阻断删除）。
+    if (removed?.protocol?.toLowerCase() === 'tailscale') {
+      await fs.rm(tailscaleStateDir(removed.id), { recursive: true, force: true }).catch(() => {});
+    }
+
+    // WARP 节点 → 带自删凭据（warpDevice.token+deviceId）则入待注销队列，后台机会式 drain 远端注销。
+    // 判据=token 存在与否（零误判，不靠端点启发式）：本特性前的旧 WARP 节点无 warpDevice → 跳过入队、
+    // 仅删本地、不报错（注定孤儿、无凭可注销，已接受的历史债）。
+    const warpDevice = removed?.wireguardSettings?.warpDevice;
+    if (warpDevice?.token && warpDevice?.deviceId) {
+      await warpDeregisterQueue
+        .enqueue({
+          deviceId: warpDevice.deviceId,
+          token: warpDevice.token,
+          enqueuedAt: Date.now(),
+        })
+        .catch(() => {}); // 入队失败不阻断删除（本地已删，凭据丢失=退化为旧节点孤儿，可接受）
+    }
+  };
+
   // 解析协议 URL
   registerIpcHandler<{ url: string }, ServerConfig>(
     IPC_CHANNELS.SERVER_PARSE_URL,
@@ -119,27 +143,34 @@ export function registerServerHandlers(
       }
 
       await configManager.saveConfig(config);
+      await runServerRemovalSideEffects(removed);
+    }
+  );
 
-      // Tailscale 节点删除 → 清其持久 state 目录 <userData>/tailscale/<id>（best-effort，不阻断删除）。
-      if (removed?.protocol?.toLowerCase() === 'tailscale') {
-        await fs
-          .rm(tailscaleStateDir(args.serverId), { recursive: true, force: true })
-          .catch(() => {});
+  // 批量删除服务器：一次 loadConfig → 过滤掉全部 ids → 命中选中清 selectedServerId → 一次 saveConfig，
+  // 再逐个跑删除副作用。单次配置写避免「N 个并发单删各读旧配置、末次写覆盖前面」的竞态（净删 1 个）。
+  // 不存在的 id 静默跳过（幂等）。返回实际删除数。
+  registerIpcHandler<{ serverIds: string[] }, number>(
+    IPC_CHANNELS.SERVER_DELETE_BATCH,
+    async (_event: IpcMainInvokeEvent, args: { serverIds: string[] }) => {
+      const idSet = new Set(args.serverIds);
+      const config = await configManager.loadConfig();
+      const removed = config.servers.filter((s) => idSet.has(s.id));
+      if (removed.length === 0) return 0;
+
+      config.servers = config.servers.filter((s) => !idSet.has(s.id));
+
+      // 选中节点在删除集合内（'__direct__' 哨兵不是真实 id，不会命中）→ 清除选中，
+      // 否则 ConfigManager.validateConfig 会因 selectedServerId 指向不存在节点而抛错。
+      if (config.selectedServerId && idSet.has(config.selectedServerId)) {
+        config.selectedServerId = null;
       }
 
-      // WARP 节点删除 → 若带自删凭据（warpDevice.token 存在）则把 {deviceId, token, enqueuedAt} 入待注销队列，
-      // 后台机会式 drain 远端注销（删除恒瞬时、不内联调网络，不阻断）。判据=token 存在与否（零误判，不靠端点启发式）：
-      // 本特性前的旧 WARP 节点无 warpDevice → 跳过入队、仅删本地、不报错（注定孤儿、无凭可注销，已接受的历史债）。
-      const warpDevice = removed?.wireguardSettings?.warpDevice;
-      if (warpDevice?.token && warpDevice?.deviceId) {
-        await warpDeregisterQueue
-          .enqueue({
-            deviceId: warpDevice.deviceId,
-            token: warpDevice.token,
-            enqueuedAt: Date.now(),
-          })
-          .catch(() => {}); // 入队失败不阻断删除（本地已删，凭据丢失=退化为旧节点孤儿，可接受）
+      await configManager.saveConfig(config);
+      for (const r of removed) {
+        await runServerRemovalSideEffects(r);
       }
+      return removed.length;
     }
   );
 

--- a/src/main/services/__tests__/server-delete-batch.test.ts
+++ b/src/main/services/__tests__/server-delete-batch.test.ts
@@ -1,0 +1,139 @@
+/**
+ * SERVER_DELETE_BATCH 批量删除 handler 单测。
+ *
+ * 收敛目标（修复「多选删除只删 1 个」的根因 = N 个并发单删各读旧配置、末次写覆盖前面）：
+ *  1. 原子性：一次 saveConfig 写回剩余节点（不是 per-id 多写）。
+ *  2. selectedServerId：命中删除集合 → 清 null（否则 validateConfig 抛「指向不存在节点」）；不命中 → 不动。
+ *  3. 副作用与单删等价：每个被删 Tailscale 节点 rm 其 state 目录；每个带凭据的 WARP 节点入待注销队列。
+ *  4. 幂等：不存在的 id 静默跳过；空集合不写配置、返回 0。
+ *
+ * 隔离：mock electron(ipcMain.handle 捕获 handler) + fs/promises(rm) + tailscale-state + WarpDeregisterQueue
+ *   + ProtocolParser/ConfigManager/WarpService（仅作签名占位，避免加载重依赖）。
+ */
+import { IPC_CHANNELS } from '../../../shared/ipc-channels';
+
+const handleSpy = jest.fn();
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: any[]) => handleSpy(...args),
+    removeHandler: jest.fn(),
+  },
+}));
+
+const rmSpy = jest.fn().mockResolvedValue(undefined);
+jest.mock('fs/promises', () => ({
+  rm: (...args: any[]) => rmSpy(...args),
+}));
+
+jest.mock('../tailscale-state', () => ({
+  tailscaleStateDir: (id: string) => `/state/${id}`,
+}));
+
+const enqueueSpy = jest.fn().mockResolvedValue(undefined);
+jest.mock('../WarpDeregisterQueue', () => ({
+  getWarpDeregisterQueue: () => ({ enqueue: (...a: any[]) => enqueueSpy(...a) }),
+}));
+
+// 下列仅在 server-handlers 顶部作值导入 / 函数签名占位，删除路径不触达其实现 → 占位 class 即可。
+jest.mock('../ProtocolParser', () => ({ ProtocolParser: class {} }));
+jest.mock('../ConfigManager', () => ({ ConfigManager: class {} }));
+jest.mock('../WarpService', () => ({ WarpService: class {} }));
+
+function makeConfig() {
+  return {
+    selectedServerId: 's2' as string | null,
+    servers: [
+      { id: 's1', name: 'A', protocol: 'vless' },
+      { id: 's2', name: 'B', protocol: 'tailscale' },
+      {
+        id: 's3',
+        name: 'C',
+        protocol: 'wireguard',
+        wireguardSettings: { warpDevice: { token: 'tok', deviceId: 'dev' } },
+      },
+      { id: 's4', name: 'D', protocol: 'vmess' },
+    ],
+  };
+}
+
+const loadConfigSpy = jest.fn();
+const saveConfigSpy = jest.fn().mockResolvedValue(undefined);
+const configManager = { loadConfig: loadConfigSpy, saveConfig: saveConfigSpy } as any;
+
+let batchHandler: (event: any, args: { serverIds: string[] }) => Promise<any>;
+
+beforeAll(() => {
+  const { registerServerHandlers } = require('../../ipc/handlers/server-handlers');
+  registerServerHandlers({} as any, configManager);
+  const call = handleSpy.mock.calls.find((c) => c[0] === IPC_CHANNELS.SERVER_DELETE_BATCH);
+  if (!call) throw new Error('SERVER_DELETE_BATCH handler 未注册');
+  batchHandler = call[1];
+});
+
+beforeEach(() => {
+  loadConfigSpy.mockImplementation(async () => makeConfig());
+  saveConfigSpy.mockClear();
+  rmSpy.mockClear();
+  enqueueSpy.mockClear();
+});
+
+// registerIpcHandler 把 handler 包成返回 ApiResponse {success,data} → 解包 data。
+async function invoke(serverIds: string[]): Promise<number> {
+  const res = await batchHandler({}, { serverIds });
+  return res.data;
+}
+
+describe('SERVER_DELETE_BATCH', () => {
+  it('一次 saveConfig 删除全部入参节点（非未选中节点）', async () => {
+    const count = await invoke(['s1', 's3', 's4']);
+    expect(count).toBe(3);
+    expect(saveConfigSpy).toHaveBeenCalledTimes(1);
+    const saved = saveConfigSpy.mock.calls[0][0];
+    expect(saved.servers.map((s: any) => s.id)).toEqual(['s2']);
+  });
+
+  it('未命中选中节点 → selectedServerId 不变', async () => {
+    await invoke(['s1', 's4']);
+    expect(saveConfigSpy.mock.calls[0][0].selectedServerId).toBe('s2');
+  });
+
+  it('命中选中节点 → selectedServerId 清 null', async () => {
+    await invoke(['s2']);
+    expect(saveConfigSpy.mock.calls[0][0].selectedServerId).toBeNull();
+  });
+
+  it('每个被删 WARP 节点入待注销队列（副作用与单删等价）', async () => {
+    await invoke(['s3']);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: 'dev', token: 'tok' })
+    );
+  });
+
+  it('每个被删 Tailscale 节点清其 state 目录', async () => {
+    await invoke(['s2']);
+    expect(rmSpy).toHaveBeenCalledWith('/state/s2', expect.objectContaining({ recursive: true }));
+  });
+
+  it('非 WARP/非 TS 节点不触发任何副作用', async () => {
+    await invoke(['s1', 's4']);
+    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(rmSpy).not.toHaveBeenCalled();
+  });
+
+  it('不存在的 id 静默跳过、只删真实命中', async () => {
+    const count = await invoke(['s1', 'ghost']);
+    expect(count).toBe(1);
+    expect(saveConfigSpy.mock.calls[0][0].servers.map((s: any) => s.id)).toEqual([
+      's2',
+      's3',
+      's4',
+    ]);
+  });
+
+  it('空集合：不写配置、返回 0', async () => {
+    const count = await invoke([]);
+    expect(count).toBe(0);
+    expect(saveConfigSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/settings/server-list.tsx
+++ b/src/renderer/components/settings/server-list.tsx
@@ -153,6 +153,12 @@ export function ServerList({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isSelecting, setIsSelecting] = useState(false);
 
+  // 选中项里「可删除」的（排除订阅节点——删了下次同步会回来，维持不可批删）。
+  // 批量删除按钮的计数 / disabled / 实际删除集合统一以它为准（计数==实际删除）。
+  const deletableSelected = Array.from(selectedIds).filter(
+    (id) => !servers.find((s) => s.id === id)?.subscriptionId
+  );
+
   const handleDelete = (serverId: string) => {
     onDeleteServer(serverId);
     setSelectedIds((prev) => {
@@ -163,10 +169,12 @@ export function ServerList({
   };
 
   const handleBatchDelete = () => {
+    // 只删可删项；优先走一次性批量回调（onDeleteServers），避免逐个 onDeleteServer 并发竞态致只删 1 个。
+    if (deletableSelected.length === 0) return;
     if (onDeleteServers) {
-      onDeleteServers(Array.from(selectedIds));
+      onDeleteServers(deletableSelected);
     } else {
-      selectedIds.forEach((id) => onDeleteServer(id));
+      deletableSelected.forEach((id) => onDeleteServer(id));
     }
     setSelectedIds(new Set());
     setIsSelecting(false);
@@ -255,10 +263,6 @@ export function ServerList({
       setSelectedIds(new Set(filteredServers.map((s) => s.id)));
     }
   };
-
-  const deletableSelected = Array.from(selectedIds).filter(
-    (id) => !servers.find((s) => s.id === id)?.subscriptionId
-  );
 
   // 操作按钮组（ServerCard/ServerRow 透传给 ServerActions）的运行期上下文
   const actions: ServerActionsContext = {

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -291,6 +291,13 @@ export const serverApi = {
   },
 
   /**
+   * 批量删除服务器（一次配置写，避免并发单删竞态）。返回实际删除数。
+   */
+  async deleteBatch(serverIds: string[]): Promise<number> {
+    return ipcClient.invoke(IPC_CHANNELS.SERVER_DELETE_BATCH, { serverIds });
+  },
+
+  /**
    * Phase 2 按需登录：拉起瞬态登录核取交互登录 URL（主进程自动开浏览器 + 系统通知）。
    * started=false 时 reason 说明（alreadyLoggedIn / inMainCore / alreadyRunning），渲染端据此提示。
    */

--- a/src/renderer/pages/server-page.tsx
+++ b/src/renderer/pages/server-page.tsx
@@ -48,6 +48,7 @@ export function ServerPage() {
   const {
     updatingSubId,
     deleteServer: handleDeleteServer,
+    deleteServers: handleDeleteServers,
     selectServer: handleSelectServer,
     cloneServer: handleCloneServer,
     importSuccess: handleImportSuccess,
@@ -334,6 +335,7 @@ export function ServerPage() {
             onAddServer={handleAddServer}
             onEditServer={handleEditServer}
             onDeleteServer={handleDeleteServer}
+            onDeleteServers={handleDeleteServers}
             onCloneServer={handleCloneServer}
             onSelectServer={handleSelectServer}
             onImportClick={() => setIsImportDialogOpen(true)}
@@ -348,6 +350,7 @@ export function ServerPage() {
             onAddServer={handleAddServer}
             onEditServer={handleEditServer}
             onDeleteServer={handleDeleteServer}
+            onDeleteServers={handleDeleteServers}
             onCloneServer={handleCloneServer}
             onSelectServer={handleSelectServer}
             onImportClick={() => setIsImportDialogOpen(true)}
@@ -432,6 +435,7 @@ export function ServerPage() {
                   onAddServer={() => {}}
                   onEditServer={handleEditServer}
                   onDeleteServer={handleDeleteServer}
+                  onDeleteServers={handleDeleteServers}
                   onCloneServer={handleCloneServer}
                   onSelectServer={handleSelectServer}
                   onImportClick={() => setIsImportDialogOpen(true)}

--- a/src/renderer/pages/use-server-actions.ts
+++ b/src/renderer/pages/use-server-actions.ts
@@ -22,6 +22,7 @@ export function useServerActions() {
   const config = useAppStore((s) => s.config);
   const saveConfig = useAppStore((s) => s.saveConfig);
   const deleteServerStore = useAppStore((s) => s.deleteServer);
+  const deleteServersStore = useAppStore((s) => s.deleteServers);
   const loadConfig = useAppStore((s) => s.loadConfig);
   const [updatingSubId, setUpdatingSubId] = useState<string | null>(null);
 
@@ -30,6 +31,19 @@ export function useServerActions() {
   const deleteServer = async (serverId: string) => {
     try {
       await deleteServerStore(serverId);
+      toast.success(t('servers.deleteSuccess'));
+    } catch (error) {
+      toast.error(t('servers.deleteFail'), {
+        description: error instanceof Error ? error.message : t('servers.deleteFailDesc'),
+      });
+    }
+  };
+
+  // 批量删除（一次后端配置写，避免并发单删竞态致只删 1 个）。订阅节点的过滤在调用方（server-list）完成。
+  const deleteServers = async (serverIds: string[]) => {
+    if (serverIds.length === 0) return;
+    try {
+      await deleteServersStore(serverIds);
       toast.success(t('servers.deleteSuccess'));
     } catch (error) {
       toast.error(t('servers.deleteFail'), {
@@ -153,6 +167,7 @@ export function useServerActions() {
   return {
     updatingSubId,
     deleteServer,
+    deleteServers,
     selectServer,
     saveServer,
     cloneServer,

--- a/src/renderer/store/app-store.ts
+++ b/src/renderer/store/app-store.ts
@@ -145,6 +145,7 @@ interface AppState {
 
   // Server Management Actions
   deleteServer: (serverId: string) => Promise<void>;
+  deleteServers: (serverIds: string[]) => Promise<number>;
 
   // Custom Rules Actions
   addCustomRule: (rule: Rule) => Promise<void>;
@@ -454,6 +455,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       await get().loadConfig();
     } catch (error) {
       console.error('[Store] Exception deleting server:', error);
+      throw error; // 调用点 catch + toast
+    }
+  },
+
+  deleteServers: async (serverIds) => {
+    try {
+      const count = await api.server.deleteBatch(serverIds);
+      await get().loadConfig();
+      return count;
+    } catch (error) {
+      console.error('[Store] Exception batch-deleting servers:', error);
       throw error; // 调用点 catch + toast
     }
   },

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -31,6 +31,7 @@ export const IPC_CHANNELS = {
   SERVER_ADD: 'server:add',
   SERVER_UPDATE: 'server:update',
   SERVER_DELETE: 'server:delete',
+  SERVER_DELETE_BATCH: 'server:deleteBatch',
   SERVER_GET_ALL: 'server:getAll',
   SERVER_SPEED_TEST: 'server:speedTest',
   WARP_REGISTER: 'warp:register', // Cloudflare WARP 设备注册 → 生成 WireGuard 草稿


### PR DESCRIPTION
## 问题
节点页（自建 / 组网）多选 N 个节点后点批量删除，**只删除了 1 个**；批量复制正常。

## 根因
页面从未向 `ServerList` 传 `onDeleteServers` 批量回调，`handleBatchDelete` 退化为 `selectedIds.forEach(onDeleteServer)`：N 个未 await 的并发单删各自 `loadConfig` 读到**同一份旧配置** → 各删 1 个 → `saveConfig` 写回，**末次写入覆盖前面** → 净删 1 个。复制是纯读、无副作用故正常。

## 修复
- 新增 `SERVER_DELETE_BATCH` IPC：一次 `loadConfig` → 过滤掉全部 id → 命中则清 `selectedServerId` → **一次 `saveConfig`**，再逐个跑删除副作用。单次配置写从根上消除竞态。
- 抽出 `runServerRemovalSideEffects`（Tailscale state 目录清理 + WARP 远端注销入队），单删 / 批删**共用**，保证批量删除不丢这两项副作用（否则 Cloudflare 端留孤儿 WARP 设备、Tailscale 登录目录残留）。
- 接通 `api-client.deleteBatch` → `store.deleteServers` → `useServerActions.deleteServers` → 页面 3 处 `ServerList` 的 `onDeleteServers`。
- `server-list` 的批量删除改为删 `deletableSelected`（计数==实际删除）；**订阅节点维持不可批删**。

## 行为
N 个自建 / 组网节点多选删除 → 一次性全部删除；删到当前选中节点时正确清空选中；删 WARP 节点照常入远端注销队列；删 Tailscale 节点照常清 state 目录。

## 测试
新增 `server-delete-batch.test.ts`（8 例）：原子性（单次 saveConfig）、`selectedServerId` 命中/未命中、WARP 入队 + Tailscale rm 副作用 parity、非 WARP/TS 不触发副作用、不存在 id 幂等跳过、空集合返回 0 不写配置。main + renderer typecheck、lint、相关 16 套件（224 测试）全绿。

Close #149 