### PR TITLE
feat(server): 节点排序记忆 + 测速排序空结果优雅降级

### DIFF
--- a/src/renderer/components/settings/__tests__/server-list-helpers.test.ts
+++ b/src/renderer/components/settings/__tests__/server-list-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   tailscaleNeedsLogin,
   tailscaleLoginUiState,
   tailscaleStatusChecking,
+  sortServers,
 } from '../server-list-helpers';
 
 // 仅取 tailscaleNeedsLogin 用到的字段，避免引 @/bridge/types（jest 无 @ 别名）。
@@ -95,5 +96,50 @@ describe('tailscaleLoginUiState（表单登录区三态）', () => {
 
   it('有 id、未登录、已填 authKey（pre-auth）→ none（不显交互登录区）', () => {
     expect(tailscaleLoginUiState(true, false, true)).toBe('none');
+  });
+});
+
+describe('sortServers（含测速空结果优雅降级）', () => {
+  const srv = (id: string, name: string, protocol = 'vless', address = '') =>
+    ({ id, name, protocol, address }) as any;
+  const ids = (list: any[]) => list.map((s) => s.id);
+
+  it('name 升/降序', () => {
+    const list = [srv('1', 'C'), srv('2', 'A'), srv('3', 'B')];
+    expect(ids(sortServers(list, 'name', 'asc', {}))).toEqual(['2', '3', '1']);
+    expect(ids(sortServers(list, 'name', 'desc', {}))).toEqual(['1', '3', '2']);
+  });
+
+  it('latency 全无结果（latencyMap 空）→ 退化为名称升序（空测速=稳定默认序，非原始插入序）', () => {
+    const list = [srv('1', 'C'), srv('2', 'A'), srv('3', 'B')];
+    expect(ids(sortServers(list, 'latency', 'asc', {}))).toEqual(['2', '3', '1']);
+    // desc 下「全空」仍按名称升序（无结果不随 order 翻转，保证稳定）
+    expect(ids(sortServers(list, 'latency', 'desc', {}))).toEqual(['2', '3', '1']);
+  });
+
+  it('latency 部分有结果 → 已测按延迟在前，未测沉底且按名称', () => {
+    const list = [srv('1', 'Z'), srv('2', 'A'), srv('3', 'M'), srv('4', 'B')];
+    // 1=80ms, 3=20ms 已测（按延迟在前）；2(A)、4(B) 未测沉底、按名称升序
+    const lat = { '1': 80, '3': 20 };
+    expect(ids(sortServers(list, 'latency', 'asc', lat))).toEqual(['3', '1', '2', '4']);
+  });
+
+  it('latency 失败(-1) 视同无结果沉底（不当作 0/最快）', () => {
+    const list = [srv('1', 'A'), srv('2', 'B')];
+    expect(ids(sortServers(list, 'latency', 'asc', { '1': -1, '2': 50 }))).toEqual(['2', '1']);
+  });
+
+  it('latency 全有结果 → 纯延迟序（asc 快在前 / desc 慢在前）', () => {
+    const list = [srv('1', 'A'), srv('2', 'B'), srv('3', 'C')];
+    const lat = { '1': 90, '2': 30, '3': 60 };
+    expect(ids(sortServers(list, 'latency', 'asc', lat))).toEqual(['2', '3', '1']);
+    expect(ids(sortServers(list, 'latency', 'desc', lat))).toEqual(['1', '3', '2']);
+  });
+
+  it('不修改入参数组（返回新数组）', () => {
+    const list = [srv('1', 'B'), srv('2', 'A')];
+    const out = sortServers(list, 'name', 'asc', {});
+    expect(out).not.toBe(list);
+    expect(ids(list)).toEqual(['1', '2']); // 原数组次序不变
   });
 });

--- a/src/renderer/components/settings/__tests__/use-server-sort-store.test.ts
+++ b/src/renderer/components/settings/__tests__/use-server-sort-store.test.ts
@@ -1,0 +1,85 @@
+/**
+ * 节点排序偏好持久化单测：localStorage 往返（跨 Tab/重启记忆）+ 损坏值回落 + 函数式 setSortOrder。
+ * testEnvironment=node 无 localStorage → 注入内存 mock；直接测导出的纯 load/save（避免 require）。
+ */
+import {
+  loadServerSortPref,
+  saveServerSortPref,
+  useServerSortStore,
+} from '../use-server-sort-store';
+
+function makeLocalStorageMock(seed: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...seed };
+  return {
+    getItem: (k: string): string | null => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    _store: store,
+  };
+}
+
+describe('排序偏好持久化（loadServerSortPref / saveServerSortPref）', () => {
+  afterEach(() => {
+    delete (global as any).localStorage;
+  });
+
+  it('无持久值 → 默认 name/asc', () => {
+    (global as any).localStorage = makeLocalStorageMock();
+    expect(loadServerSortPref()).toEqual({ sortKey: 'name', sortOrder: 'asc' });
+  });
+
+  it('无 localStorage（未注入）→ 不抛、回落默认', () => {
+    expect(loadServerSortPref()).toEqual({ sortKey: 'name', sortOrder: 'asc' });
+  });
+
+  it('读回已持久化偏好（跨重启记忆）', () => {
+    (global as any).localStorage = makeLocalStorageMock({
+      'flowz.serverSort': JSON.stringify({ sortKey: 'protocol', sortOrder: 'desc' }),
+    });
+    expect(loadServerSortPref()).toEqual({ sortKey: 'protocol', sortOrder: 'desc' });
+  });
+
+  it('save → load 往返', () => {
+    (global as any).localStorage = makeLocalStorageMock();
+    saveServerSortPref('latency', 'desc');
+    expect(loadServerSortPref()).toEqual({ sortKey: 'latency', sortOrder: 'desc' });
+  });
+
+  it('损坏 JSON → 回落默认', () => {
+    (global as any).localStorage = makeLocalStorageMock({ 'flowz.serverSort': '{bad json' });
+    expect(loadServerSortPref().sortKey).toBe('name');
+  });
+
+  it('非法字段值 → 回落默认', () => {
+    (global as any).localStorage = makeLocalStorageMock({
+      'flowz.serverSort': JSON.stringify({ sortKey: 'bogus', sortOrder: 'sideways' }),
+    });
+    expect(loadServerSortPref().sortKey).toBe('name');
+  });
+});
+
+describe('useServerSortStore setter', () => {
+  afterEach(() => {
+    delete (global as any).localStorage;
+  });
+
+  it('setSortKey + 函数式 setSortOrder 更新状态并持久化', () => {
+    const mock = makeLocalStorageMock();
+    (global as any).localStorage = mock;
+    useServerSortStore.getState().setSortKey('latency');
+    useServerSortStore.getState().setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+    expect(useServerSortStore.getState().sortKey).toBe('latency');
+    expect(useServerSortStore.getState().sortOrder).toBe('desc');
+    expect(JSON.parse(mock._store['flowz.serverSort'])).toEqual({
+      sortKey: 'latency',
+      sortOrder: 'desc',
+    });
+  });
+});

--- a/src/renderer/components/settings/server-list-helpers.ts
+++ b/src/renderer/components/settings/server-list-helpers.ts
@@ -14,6 +14,41 @@ export type ViewMode = 'card' | 'list';
 export type SortKey = 'name' | 'protocol' | 'latency' | 'address';
 export type SortOrder = 'asc' | 'desc';
 
+/**
+ * 节点列表排序（纯函数，供 useServerFilter 调用 + 单测）。
+ * latency 排序对「无有效测速结果」优雅降级：无结果节点**始终沉底**（与 asc/desc 无关），
+ * 两者都无结果 → 按名称升序——空测速=稳定的默认序（体感等同默认排序），但排序偏好仍保留，
+ * 测速一回来已测节点自动按延迟浮顶。测速结果（latencyMap）刻意不持久化：延迟易过期，
+ * 陈旧值会把已挂节点显示成「最快」而误导，故只持久化排序偏好、不持久化结果。
+ */
+export function sortServers(
+  list: ServerConfigWithId[],
+  sortKey: SortKey,
+  sortOrder: SortOrder,
+  latencyMap: Record<string, number>
+): ServerConfigWithId[] {
+  // undefined=从未测速，-1=测速失败/超时 → 均视作「无有效结果」。
+  const realLatency = (id: string): number | null => {
+    const v = latencyMap[id];
+    return v === undefined || v === -1 ? null : v;
+  };
+  return [...list].sort((a, b) => {
+    if (sortKey === 'latency') {
+      const la = realLatency(a.id);
+      const lb = realLatency(b.id);
+      if (la === null && lb === null) return a.name.localeCompare(b.name);
+      if (la === null) return 1; // 无结果沉底（不随 asc/desc 翻转）
+      if (lb === null) return -1;
+      return sortOrder === 'asc' ? la - lb : lb - la;
+    }
+    let cmp = 0;
+    if (sortKey === 'name') cmp = a.name.localeCompare(b.name);
+    else if (sortKey === 'protocol') cmp = a.protocol.localeCompare(b.protocol);
+    else if (sortKey === 'address') cmp = (a.address || '').localeCompare(b.address || '');
+    return sortOrder === 'asc' ? cmp : -cmp;
+  });
+}
+
 /** ServerActions 所需的运行期上下文（测速态 + 各操作 handler），由 ServerCard/ServerRow 透传给 ServerActions。 */
 export interface ServerActionsContext {
   testingServerIds: Set<string>;

--- a/src/renderer/components/settings/use-server-filter.ts
+++ b/src/renderer/components/settings/use-server-filter.ts
@@ -6,16 +6,20 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getSortedProtocolOptions } from './shared/protocol-options';
-import type { ServerConfigWithId, SortKey, SortOrder } from './server-list-helpers';
+import { sortServers, type ServerConfigWithId } from './server-list-helpers';
+import { useServerSortStore } from './use-server-sort-store';
 
 export function useServerFilter(servers: ServerConfigWithId[], latencyMap: Record<string, number>) {
   const { t, i18n } = useTranslation();
 
-  // 搜索 / 过滤 / 排序
+  // 搜索 / 过滤每实例本地态（切 Tab/页面清空是预期行为）；
+  // 排序偏好提到共享持久 store（跨 Tab/页面/重启记忆，修「排序无记忆」）。
   const [searchQuery, setSearchQuery] = useState('');
   const [filterProtocol, setFilterProtocol] = useState<string>('all');
-  const [sortKey, setSortKey] = useState<SortKey>('name');
-  const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+  const sortKey = useServerSortStore((s) => s.sortKey);
+  const sortOrder = useServerSortStore((s) => s.sortOrder);
+  const setSortKey = useServerSortStore((s) => s.setSortKey);
+  const setSortOrder = useServerSortStore((s) => s.setSortOrder);
 
   // 过滤 + 排序
   // 协议筛选项按【当前分组实际存在的协议】动态生成：订阅组不再列 WG/WARP/Tailscale 等不可能出现的协议，
@@ -51,24 +55,8 @@ export function useServerFilter(servers: ServerConfigWithId[], latencyMap: Recor
       list = list.filter((s) => s.protocol.toLowerCase() === filterProtocol);
     }
 
-    // 排序
-    list = [...list].sort((a, b) => {
-      let cmp = 0;
-      if (sortKey === 'name') {
-        cmp = a.name.localeCompare(b.name);
-      } else if (sortKey === 'protocol') {
-        cmp = a.protocol.localeCompare(b.protocol);
-      } else if (sortKey === 'address') {
-        cmp = (a.address || '').localeCompare(b.address || '');
-      } else if (sortKey === 'latency') {
-        const getVal = (v: number | undefined) =>
-          v === undefined ? Infinity : v === -1 ? Infinity - 1 : v;
-        const la = getVal(latencyMap[a.id]);
-        const lb = getVal(latencyMap[b.id]);
-        cmp = la - lb;
-      }
-      return sortOrder === 'asc' ? cmp : -cmp;
-    });
+    // 排序（latency 对无测速结果优雅降级：无结果沉底、全空按名称，见 sortServers）
+    list = sortServers(list, sortKey, sortOrder, latencyMap);
 
     return list;
   }, [servers, searchQuery, filterProtocol, sortKey, sortOrder, latencyMap]);

--- a/src/renderer/components/settings/use-server-sort-store.ts
+++ b/src/renderer/components/settings/use-server-sort-store.ts
@@ -1,0 +1,62 @@
+/**
+ * 节点排序偏好（sortKey/sortOrder）的持久化 store。
+ *
+ * 为何独立 store + localStorage：
+ *  - 排序是「用户意图」，应跨 Tab / 页面 / 重启记忆——原先在 useServerFilter 里是每实例 useState，
+ *    切 Tab/页面即重挂重置（用户反馈「排序无记忆」的根因）。提到共享 store 后全 Tab 同步、刷新即用。
+ *  - 存 localStorage 而非 UserConfig：UserConfig 改动会触发 CONFIG_CHANGED→switchMode 重启代理，
+ *    改个排序绝不能重连；localStorage 是纯渲染端视图态，零 IPC、零重启。
+ *  - 仅持久化排序偏好，不持久化测速结果（latencyMap）——见 sortServers 注释（陈旧延迟会误导）。
+ */
+import { create } from 'zustand';
+import type { SortKey, SortOrder } from './server-list-helpers';
+
+const STORAGE_KEY = 'flowz.serverSort';
+const VALID_KEYS: readonly SortKey[] = ['name', 'protocol', 'latency', 'address'];
+const DEFAULT_KEY: SortKey = 'name';
+const DEFAULT_ORDER: SortOrder = 'asc';
+
+// 导出供单测直接验证（避免 isolateModules+require：renderer 测试禁 require）。
+export function loadServerSortPref(): { sortKey: SortKey; sortOrder: SortOrder } {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const p = JSON.parse(raw);
+      if (VALID_KEYS.includes(p?.sortKey) && (p?.sortOrder === 'asc' || p?.sortOrder === 'desc')) {
+        return { sortKey: p.sortKey, sortOrder: p.sortOrder };
+      }
+    }
+  } catch {
+    /* 无 localStorage / 解析失败 / 损坏值 → 回落默认 */
+  }
+  return { sortKey: DEFAULT_KEY, sortOrder: DEFAULT_ORDER };
+}
+
+export function saveServerSortPref(sortKey: SortKey, sortOrder: SortOrder): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ sortKey, sortOrder }));
+  } catch {
+    /* 持久化失败（隐私模式/storage 禁用）不阻断 → 退化为会话内记忆 */
+  }
+}
+
+interface ServerSortState {
+  sortKey: SortKey;
+  sortOrder: SortOrder;
+  setSortKey: (key: SortKey) => void;
+  // 兼容函数式 updater（server-list 的「点同一列切换 asc/desc」用 (o) => ... 形式）。
+  setSortOrder: (order: SortOrder | ((prev: SortOrder) => SortOrder)) => void;
+}
+
+export const useServerSortStore = create<ServerSortState>((set, get) => ({
+  ...loadServerSortPref(),
+  setSortKey: (key) => {
+    saveServerSortPref(key, get().sortOrder);
+    set({ sortKey: key });
+  },
+  setSortOrder: (order) => {
+    const next = typeof order === 'function' ? order(get().sortOrder) : order;
+    saveServerSortPref(get().sortKey, next);
+    set({ sortOrder: next });
+  },
+}));


### PR DESCRIPTION
## 背景
节点页支持按 名称/协议/延迟/地址 排序，但排序选项**无记忆**：切换 Tab / 切换页面就恢复默认排序。

## 变更
**1. 排序记忆**
`sortKey/sortOrder` 原是 `useServerFilter` 的每实例 `useState`，每个 Tab 的 ServerList 各持一份、重挂即重置。改为提到共享持久 store `useServerSortStore`（`localStorage`，key `flowz.serverSort`）：跨 Tab / 页面 / 重启都记忆。
- 存 **localStorage 而非 UserConfig**：UserConfig 改动会触发 `CONFIG_CHANGED → switchMode` 重启代理，改个排序绝不能重连；localStorage 是纯渲染端视图态，零 IPC、零重启。
- 仅排序记忆；搜索 / 协议筛选仍每实例（切页清空是预期行为）。

**2. 测速排序的空结果优雅降级**
抽出纯函数 `sortServers`。按延迟排序时：
- **无有效测速结果的节点始终沉底**（与 asc/desc 无关）；
- 两节点都无结果 → 按名称升序——即「未测速时整列=稳定的默认序」，体感等同默认排序，但**排序偏好不丢**，测速一回来已测节点自动按延迟浮顶；
- 顺带修旧实现 `Infinity - 1 === Infinity` 导致「测速失败(-1)」与「从未测速(undefined)」无法区分的问题。
- **测速结果（latencyMap）刻意不持久化**：延迟易过期，陈旧值会把已挂节点显示成「最快」而误导——只持久化偏好、不持久化结果。

## 为什么不「取上一次结果」也不「硬恢复默认」
取上一次=陈旧延迟误导；硬恢复默认=丢用户偏好需重选。本方案让偏好持久 + 比较器降级，意图与运行期事实各归其位、测速回来自动复用。

## 测试
- `sortServers`：name 升降序、全空→名称序、部分有→已测在前未测沉底、失败(-1)沉底、全有→纯延迟序、不改入参。
- 排序偏好：localStorage 往返、无 storage 不抛、损坏/非法值回落默认、函数式 `setSortOrder`。
- renderer typecheck、lint、settings/server 相关 5 套件（57 测试）全绿。