### PR TITLE
feat(ui): 跨平台窗口风格统一 + 折叠侧栏

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -529,6 +529,13 @@ async function createWindow(forceShow = false) {
   }
 
   const isMac = process.platform === 'darwin';
+  const isWindows = process.platform === 'win32';
+  // 集成标题栏覆盖层（Windows）：透明底融进内容/Mica、随主题切换重设按钮符号色。height 32 = Win11 原生标题栏高。
+  const overlayColors = (dark: boolean) => ({
+    color: '#00000000', // 透明：覆盖层融进内容/Mica，避免突兀的底块
+    symbolColor: dark ? '#E6EDF3' : '#1F2937',
+    height: 32,
+  });
 
   // 单次 loadConfig 读取窗口尺寸 + 主题（loadConfig 内部 catch 兜默认配置、绝不抛，无需 try/catch）。
   // 注意：transparent 仅 macOS 启用，Win/Linux 启用会侧边栏透明 + 鼠标事件穿透（Electron 已知问题）。
@@ -552,7 +559,7 @@ async function createWindow(forceShow = false) {
     title: 'FlowZ',
     icon: resourceManager.getAppIconPath(),
     show: false, // 先不显示，等待加载完成
-    backgroundColor: isMac ? '#00000000' : cfg.uiTheme === 'dark' ? '#0B0F14' : '#E9EEF3',
+    backgroundColor: isMac ? '#00000000' : cfg.uiTheme === 'dark' ? '#1F252E' : '#E9EEF3',
     transparent: isMac,
     autoHideMenuBar: true, // 自动隐藏菜单栏
     webPreferences: {
@@ -562,11 +569,20 @@ async function createWindow(forceShow = false) {
       sandbox: false,
       devTools: isDevelopment, // 仅在开发环境启用开发者工具，生产环境禁用（除非特殊需求）
     },
-    // macOS 特定配置
+    // macOS：集成式窗口（红绿灯内嵌 + sidebar 半透材质）
     ...(isMac && {
       titleBarStyle: 'hiddenInset',
       vibrancy: 'sidebar',
       visualEffectState: 'active',
+    }),
+    // Windows：集成式标题栏（隐藏原生栏 + 右上覆盖层按钮，对齐 Mac）+ Win11 Mica 材质。
+    // Mica 仅作窗口/侧栏底（壁纸微染），内容卡片实色不透。窗口 backgroundColor 取实色主题色作兜底：
+    // 物理屏+透明效果 → Mica；RDP/透明关 → DWM 回落该实色 #1F252E/#E9EEF3（不会黑）。
+    // Linux 无覆盖层 API → 不进此分支，默认边框 + 实色底。
+    ...(isWindows && {
+      titleBarStyle: 'hidden',
+      titleBarOverlay: overlayColors(cfg.uiTheme === 'dark'),
+      backgroundMaterial: 'mica',
     }),
   });
 
@@ -581,7 +597,12 @@ async function createWindow(forceShow = false) {
     const onThemeUpdated = () => {
       if (mainWindow && !mainWindow.isDestroyed()) {
         const isDark = nativeTheme.shouldUseDarkColors;
-        mainWindow.setBackgroundColor(isDark ? '#0B0F14' : '#E9EEF3');
+        // 实色底：Win/Linux 同步原生窗口背景（深色取 macOS 风格中灰 #1F252E），修 GPU 待机后圆角黑色伪影。
+        mainWindow.setBackgroundColor(isDark ? '#1F252E' : '#E9EEF3');
+        // Windows 集成标题栏：覆盖层按钮颜色随主题切换重设。
+        if (isWindows) {
+          mainWindow.setTitleBarOverlay(overlayColors(isDark));
+        }
       }
     };
     nativeTheme.on('updated', onThemeUpdated);

--- a/src/renderer/components/layout/main-layout.tsx
+++ b/src/renderer/components/layout/main-layout.tsx
@@ -28,7 +28,7 @@ export function MainLayout({
         onSettingsSectionChange={onSettingsSectionChange}
       />
       <main className="flex-1 overflow-auto flex flex-col relative z-10 main-content-card transition-all duration-300">
-        {/* 集成标题栏拖拽区：Mac(hiddenInset) h-9；Windows(titleBarOverlay 按钮在右上) 40px 与覆盖层等高、给按钮让位。 */}
+        {/* 集成标题栏拖拽区：Mac(hiddenInset) h-9；Windows(titleBarOverlay 按钮在右上) 32px 与覆盖层等高、给按钮让位。 */}
         {isMac && <div className="h-9 flex-shrink-0 app-region-drag" />}
         {isWindows && <div className="h-[32px] flex-shrink-0 app-region-drag" />}
         <div

--- a/src/renderer/components/layout/main-layout.tsx
+++ b/src/renderer/components/layout/main-layout.tsx
@@ -10,6 +10,7 @@ interface MainLayoutProps {
 }
 
 const isMac = window.electron?.platform === 'darwin';
+const isWindows = window.electron?.platform === 'win32';
 
 export function MainLayout({
   currentView,
@@ -27,10 +28,12 @@ export function MainLayout({
         onSettingsSectionChange={onSettingsSectionChange}
       />
       <main className="flex-1 overflow-auto flex flex-col relative z-10 main-content-card transition-all duration-300">
+        {/* 集成标题栏拖拽区：Mac(hiddenInset) h-9；Windows(titleBarOverlay 按钮在右上) 40px 与覆盖层等高、给按钮让位。 */}
         {isMac && <div className="h-9 flex-shrink-0 app-region-drag" />}
+        {isWindows && <div className="h-[32px] flex-shrink-0 app-region-drag" />}
         <div
           className="container mx-auto px-6 pb-6 app-region-no-drag max-w-[1400px]"
-          style={{ paddingTop: isMac ? '0' : '24px' }}
+          style={{ paddingTop: isMac || isWindows ? '0' : '24px' }}
         >
           {children}
         </div>

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -82,6 +82,7 @@ const settingsNavItems = [
 ];
 
 const isMac = window.electron?.platform === 'darwin';
+const isWindows = window.electron?.platform === 'win32';
 
 export function Sidebar({
   currentView,
@@ -115,10 +116,13 @@ export function Sidebar({
   };
 
   return (
-    <div className="w-[240px] sidebar h-full flex flex-col relative z-20 select-none">
-      {/* macOS traffic light spacer */}
+    <div className="w-[184px] sidebar h-full flex flex-col relative z-20 select-none">
+      {/* 集成标题栏顶部拖拽区：Mac 让出红绿灯(52)、Windows 让出覆盖层按钮(右上, 40 与 overlay 等高)、可拖窗。
+          Linux 无集成标题栏(默认边框) → 仅留 16px 间距。 */}
       {isMac ? (
         <div className="h-[52px] flex-shrink-0 app-region-drag" />
+      ) : isWindows ? (
+        <div className="h-[32px] flex-shrink-0 app-region-drag" />
       ) : (
         <div className="h-4 flex-shrink-0" />
       )}

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   ScrollText,
   FolderDown,
   Activity,
+  PanelLeft,
 } from 'lucide-react';
 
 // 自定义的分流图标（完整连贯的 Y 型，不带断点）
@@ -39,6 +40,7 @@ function FlowSplitIcon(props: any) {
 }
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/store/app-store';
+import { useSidebarStore } from './use-sidebar-store';
 
 interface SidebarProps {
   currentView: string;
@@ -93,8 +95,14 @@ export function Sidebar({
   const { t } = useTranslation();
   // F27：设置页「返回」回到进入前的来源视图（默认 home）
   const settingsReturnView = useAppStore((s) => s.settingsReturnView);
+  // 折叠态(icon-rail)：收起仅图标 + hover tooltip；持久化见 use-sidebar-store。
+  const collapsed = useSidebarStore((s) => s.collapsed);
+  const toggleCollapsed = useSidebarStore((s) => s.toggleCollapsed);
 
   const isSettings = currentView === 'settings';
+
+  // 收起宽度：Mac 取 80px —— 红绿灯约 72px 宽，留 ~8px 余量避免绿灯顶到内容边；Win/Linux 无此约束 → 更紧凑 56px。
+  const railWidth = isMac ? 'w-[80px]' : 'w-[56px]';
 
   const renderNavItem = (
     item: { id: string; icon: React.ElementType },
@@ -102,23 +110,30 @@ export function Sidebar({
     isActive: boolean
   ) => {
     const Icon = item.icon;
+    const label = isSettings ? t(`settings.nav.${item.id}`, item.id) : t(`sidebar.${item.id}`);
     return (
-      <button key={item.id} onClick={onClick} className={`nav-item${isActive ? ' active' : ''}`}>
+      <button
+        key={item.id}
+        onClick={onClick}
+        title={collapsed ? label : undefined}
+        className={`nav-item${isActive ? ' active' : ''}${collapsed ? ' collapsed' : ''}`}
+      >
         <span className="nav-item-indicator" />
         <Icon
-          className="h-[16px] w-[16px] flex-shrink-0"
+          className={`${collapsed ? 'h-[22px] w-[22px]' : 'h-[16px] w-[16px]'} flex-shrink-0`}
           strokeWidth={isActive ? 2.2 : 1.8}
           style={{ color: isActive ? 'hsl(var(--primary))' : 'hsl(var(--muted-foreground))' }}
         />
-        <span>{isSettings ? t(`settings.nav.${item.id}`, item.id) : t(`sidebar.${item.id}`)}</span>
+        {!collapsed && <span>{label}</span>}
       </button>
     );
   };
 
   return (
-    <div className="w-[184px] sidebar h-full flex flex-col relative z-20 select-none">
-      {/* 集成标题栏顶部拖拽区：Mac 让出红绿灯(52)、Windows 让出覆盖层按钮(右上, 40 与 overlay 等高)、可拖窗。
-          Linux 无集成标题栏(默认边框) → 仅留 16px 间距。 */}
+    <div
+      className={`${collapsed ? railWidth : 'w-[184px]'} sidebar h-full flex flex-col relative z-20 select-none transition-[width] duration-300 ease-out`}
+    >
+      {/* 集成标题栏顶部条：Mac 让出红绿灯(52)、Windows 让出覆盖层按钮(32)、可拖窗；Linux 默认边框。 */}
       {isMac ? (
         <div className="h-[52px] flex-shrink-0 app-region-drag" />
       ) : isWindows ? (
@@ -127,6 +142,22 @@ export function Sidebar({
         <div className="h-4 flex-shrink-0" />
       )}
 
+      {/* 折叠 toggle：独立一行置于顶部条下方。
+          —— 不放进顶部条：Mac 收起栏被窗口锚定的红绿灯(~72px)几乎占满，toggle 在栏内会飘出到内容区（布局奇怪）；
+          —— 不放进拖拽区：下方是普通 no-drag 内容，天然可点（无需 Electron drag/no-drag 兜底）。
+          展开左对齐(齐导航项)、收起居中。 */}
+      <div
+        className={`flex px-2 py-1 app-region-no-drag ${collapsed ? 'justify-center' : 'justify-start'}`}
+      >
+        <button
+          onClick={toggleCollapsed}
+          title={collapsed ? t('sidebar.expand', '展开侧栏') : t('sidebar.collapse', '收起侧栏')}
+          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
+        >
+          <PanelLeft className="h-[18px] w-[18px] rtl-mirror" strokeWidth={1.8} />
+        </button>
+      </div>
+
       {isSettings ? (
         /* ── Settings sub-navigation ── */
         <>
@@ -134,16 +165,19 @@ export function Sidebar({
           <div className="px-2 pb-2 app-region-no-drag">
             <button
               onClick={() => onViewChange(settingsReturnView)}
-              className="nav-item"
+              title={collapsed ? t('settings.nav.back', '返回应用') : undefined}
+              className={`nav-item${collapsed ? ' collapsed' : ''}`}
               style={{ color: 'hsl(var(--muted-foreground))' }}
             >
               <ChevronLeft
-                className="h-4 w-4 flex-shrink-0 rtl-mirror"
+                className={`${collapsed ? 'h-[22px] w-[22px]' : 'h-4 w-4'} flex-shrink-0 rtl-mirror`}
                 style={{ color: 'hsl(var(--muted-foreground))' }}
               />
-              <span style={{ color: 'hsl(var(--muted-foreground))' }}>
-                {t('settings.nav.back', '返回应用')}
-              </span>
+              {!collapsed && (
+                <span style={{ color: 'hsl(var(--muted-foreground))' }}>
+                  {t('settings.nav.back', '返回应用')}
+                </span>
+              )}
             </button>
           </div>
 
@@ -164,11 +198,15 @@ export function Sidebar({
           <nav className="flex-1 pb-2 app-region-no-drag overflow-hidden">
             {mainNavGroups.map((group, gi) => (
               <div key={gi} className="space-y-[6px]">
-                {group.label && (
-                  <div className="px-3 pb-1 pt-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground select-none">
-                    {t(`sidebar.group.${group.label}`)}
-                  </div>
-                )}
+                {group.label &&
+                  (collapsed ? (
+                    /* 收起态：分区标题转居中短分隔线，保留分组视觉、不显凌乱 */
+                    <div className="mx-auto my-1.5 h-px w-5 bg-border/50" />
+                  ) : (
+                    <div className="px-3 pb-1 pt-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground select-none">
+                      {t(`sidebar.group.${group.label}`)}
+                    </div>
+                  ))}
                 {group.items.map((item) =>
                   renderNavItem(item, () => onViewChange(item.id), currentView === item.id)
                 )}

--- a/src/renderer/components/layout/use-sidebar-store.ts
+++ b/src/renderer/components/layout/use-sidebar-store.ts
@@ -1,0 +1,38 @@
+/**
+ * 侧栏折叠态(icon-rail)持久化 store。
+ * collapsed 存 localStorage、跨 Tab/重启记忆；与排序偏好同模式——纯渲染端视图态，
+ * 不进 UserConfig（避免 CONFIG_CHANGED→重启代理）。
+ */
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'flowz.sidebarCollapsed';
+
+function loadCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function saveCollapsed(v: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, v ? '1' : '0');
+  } catch {
+    /* 隐私模式 / storage 禁用 → 退化为会话内记忆 */
+  }
+}
+
+interface SidebarState {
+  collapsed: boolean;
+  toggleCollapsed: () => void;
+}
+
+export const useSidebarStore = create<SidebarState>((set, get) => ({
+  collapsed: loadCollapsed(),
+  toggleCollapsed: () => {
+    const next = !get().collapsed;
+    saveCollapsed(next);
+    set({ collapsed: next });
+  },
+}));

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -66,6 +66,8 @@
     "ruleResources": "Rule Resources",
     "rules": "Rules",
     "settings": "Settings",
+    "collapse": "Collapse sidebar",
+    "expand": "Expand sidebar",
     "group": {
       "routing": "Routing",
       "diagnostics": "Diagnostics"

--- a/src/renderer/i18n/locales/fa-IR.json
+++ b/src/renderer/i18n/locales/fa-IR.json
@@ -66,6 +66,8 @@
     "ruleResources": "منابع قوانین",
     "rules": "قوانین",
     "settings": "تنظیمات",
+    "collapse": "جمع کردن نوار کناری",
+    "expand": "باز کردن نوار کناری",
     "group": {
       "routing": "مسیریابی",
       "diagnostics": "عیب‌یابی"

--- a/src/renderer/i18n/locales/ru.json
+++ b/src/renderer/i18n/locales/ru.json
@@ -66,6 +66,8 @@
     "ruleResources": "Ресурсы правил",
     "rules": "Правила",
     "settings": "Настройки",
+    "collapse": "Свернуть панель",
+    "expand": "Развернуть панель",
     "group": {
       "routing": "Маршрутизация",
       "diagnostics": "Диагностика"

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -66,6 +66,8 @@
     "ruleResources": "规则资源",
     "rules": "路由规则",
     "settings": "设置",
+    "collapse": "收起侧栏",
+    "expand": "展开侧栏",
     "group": {
       "routing": "分流",
       "diagnostics": "诊断"

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -66,6 +66,8 @@
     "ruleResources": "規則資源",
     "rules": "路由規則",
     "settings": "設定",
+    "collapse": "收合側欄",
+    "expand": "展開側欄",
     "group": {
       "routing": "分流",
       "diagnostics": "診斷"

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -103,14 +103,17 @@
     background: transparent;
   }
 
-  /* Windows / Linux: use a solid background so vibrancy is not needed */
-  html.platform-win32,
-  html.platform-win32 body,
-  html.platform-win32 #root,
+  /* Linux: 实色底（无材质） */
   html.platform-linux,
   html.platform-linux body,
   html.platform-linux #root {
     background: hsl(var(--background)) !important;
+  }
+  /* Windows: 透明底，透出 Mica（物理屏）或窗口 backgroundColor 实色兜底（RDP/透明关，DWM 回落 #1F252E/#E9EEF3，不黑） */
+  html.platform-win32,
+  html.platform-win32 body,
+  html.platform-win32 #root {
+    background: transparent !important;
   }
 
   body {
@@ -219,7 +222,7 @@
 
   html.platform-win32.dark .sidebar,
   html.platform-linux.dark .sidebar {
-    background: #0B0F14; /* 硬编码，和 app-shell dark 一致 */
+    background: #1F252E; /* 硬编码，和 app-shell dark 一致 */
   }
 
   .nav-item {
@@ -336,7 +339,7 @@
   html.platform-win32.dark .main-content-card::after,
   html.platform-linux.dark .main-content-card::before,
   html.platform-linux.dark .main-content-card::after {
-    background: #0B0F14;
+    background: #1F252E;
   }
 
   /* macOS：sidebar 是透明毛玻璃，内切角透明让 vibrancy 穿透
@@ -390,13 +393,13 @@
   /* Must be fully opaque (no rgba) to prevent GPU semi-transparent layer repaint artifacts */
   html.platform-win32.dark .app-shell,
   html.platform-linux.dark .app-shell {
-    background: #0B0F14;
+    background: #1F252E;
   }
 
   /* Dark sidebar must exactly match app-shell bg so box-shadow corner masking is seamless */
   html.platform-win32.dark .sidebar,
   html.platform-linux.dark .sidebar {
-    background: #0B0F14;
+    background: #1F252E;
   }
 
   /* ──────────────────────────────────────────────────────────────
@@ -450,4 +453,14 @@
   html[dir='rtl'] .rtl-mirror {
     transform: scaleX(-1);
   }
+}
+
+/* ── Windows Mica：win32 侧栏/外壳/内切角透明 → 物理屏透出 Mica、RDP 回落窗口实色底；内容卡片仍实色。
+      刻意放在所有 @layer 之外：非 layered 规则优先级高于上方全部 layered win32 实色规则，
+      免去逐条拆改重复的 win32.dark/light 实色规则（含 220+397 两处重复的侧栏规则）。 ── */
+html.platform-win32 .sidebar,
+html.platform-win32 .app-shell,
+html.platform-win32 .main-content-card::before,
+html.platform-win32 .main-content-card::after {
+  background: transparent;
 }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -247,6 +247,29 @@
     -webkit-font-smoothing: antialiased;
   }
 
+  /* 收起态(icon-rail)：收成「居中方块按钮」（44px），替代满宽 pill —— 宽 rail 里满宽高亮会显得空旷别扭。
+     图标居中、标签由 JSX 不渲染（hover 走 title 浮标）。 */
+  .nav-item.collapsed {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+    gap: 0;
+    width: 44px;
+    height: 44px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  /* 收起态选中：参考微信图标栏——以图标着色为主、背景框收敛（更自然，不显空旷） */
+  .nav-item.collapsed.active {
+    background: hsl(var(--primary) / 0.12);
+  }
+
+  /* 收起态隐藏左侧 active 指示条：它绝对定位 left:-6px，在「居中方块按钮」里会飘成孤立左条；选中由上面的背景框 + 图标着色表达 */
+  .nav-item.collapsed .nav-item-indicator {
+    display: none;
+  }
+
   .nav-item:hover {
     background: hsl(var(--primary) / 0.07);
     color: hsl(var(--foreground));

--- a/src/renderer/pages/settings-page.tsx
+++ b/src/renderer/pages/settings-page.tsx
@@ -54,9 +54,10 @@ export function SettingsPage({ activeSection }: SettingsPageProps) {
   const meta = sectionTitles[activeSection] ?? sectionTitles.general;
 
   return (
-    // 流式满宽：内容随窗口拖动自适应充满内容区（仅受全局 main 容器 max-w-[1400px] 约束），与规则/节点等其它页一致；
-    // 不再限 max-w-2xl(672)——固定窄列会在宽窗右侧留白（用户反馈：自适应充满比留白更美观）。
-    <div className="space-y-6">
+    // 设置/表单页：居中窄列（max-w-[720px] mx-auto）。表单控件定宽，满宽会让「标签左·控件右」中间空一大条；
+    // 居中窄列让控件填满列、两侧对称留白（macOS 系统设置 / Win11 Fluent 同款，刻意整洁）。
+    // 密集列表页（规则/节点/连接）仍满宽，分而治之。
+    <div className="mx-auto max-w-[720px] space-y-6">
       <PageHeader
         title={t(meta.titleKey, meta.defaultTitle)}
         description={t(meta.descKey, meta.defaultDesc)}


### PR DESCRIPTION
两步走（各自独立提交，便于审阅/回滚）：

## Step 1 — 跨平台窗口风格统一 + 协调配色
- **集成式标题栏（按平台、按实际可实现）**：macOS `hiddenInset` + `vibrancy:'sidebar'`；Windows `titleBarStyle:'hidden'` + `titleBarOverlay`（透明、对齐 Mac 风格）+ Win11 `backgroundMaterial:'mica'`；Linux 默认边框 + 实色。
- **Mica 实色兜底**：win32 侧栏/外壳/窗口底透明 → 物理屏透出 Mica；窗口 `backgroundColor` 取实色主题色，透明效果关 / 远程桌面下 DWM **回落实色（不黑）**。内容卡片始终实色，文字清晰。
- **协调深色配色**：侧栏/外壳/内切角 `#0B0F14 → #1F252E`（macOS 风中灰），构成「侧栏（最浅）→ 内容 → 卡片」层次梯度。
- 设置/表单页**居中窄列**（`max-w-[720px]`）；侧栏 240 → 184。

## Step 2 — 折叠侧栏 icon-rail
- 顶部 toggle 一键折叠：展开 184px ↔ 收起（Mac 80px 留红绿灯余量 / Win·Linux 56px），平滑宽度动画、内容区自适应。
- 收起态参考图标栏风格：44px 居中方块按钮 + 22px 图标 + 选中收敛 + 分区转居中短分隔 + hover 出标签（i18n 全 5 语言）。
- 折叠态持久化（localStorage，跨重启记忆；纯渲染端视图态，不进 UserConfig 故不触发重启代理）。

## 验证
- **真机实测**：Mac（vibrancy 侧栏、红绿灯右侧布局、折叠动画）+ Windows（远程桌面下实色兜底显 #1F252E 不黑、集成标题栏、折叠）均通过。
- Mac/Windows 不受影响项已回归确认；Linux 默认边框 + 实色保持不变。
- typecheck + lint + 全量单测（1747 测试，含 locale-parity 一致性）全绿；两轮独立 review 零 Low/Nit。

> 注：节点排序记忆是独立的 PR #153，不在本 PR。