### PR TITLE
fix(ui): 设置页「返回应用」移至底部、与「设置」对齐

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -161,8 +161,19 @@ export function Sidebar({
       {isSettings ? (
         /* ── Settings sub-navigation ── */
         <>
-          {/* Back button */}
-          <div className="px-2 pb-2 app-region-no-drag">
+          {/* Settings sub-nav items */}
+          <nav className="flex-1 app-region-no-drag space-y-[6px] overflow-hidden">
+            {settingsNavItems.map((item) =>
+              renderNavItem(
+                item,
+                () => onSettingsSectionChange(item.id),
+                settingsSection === item.id
+              )
+            )}
+          </nav>
+
+          {/* 返回应用：置底——镜像主导航「设置」置底（同款 pb-4 + space-y-[6px] 无 px，按钮宽度/位置与「设置」对齐）。 */}
+          <div className="pb-4 app-region-no-drag space-y-[6px]">
             <button
               onClick={() => onViewChange(settingsReturnView)}
               title={collapsed ? t('settings.nav.back', '返回应用') : undefined}
@@ -180,17 +191,6 @@ export function Sidebar({
               )}
             </button>
           </div>
-
-          {/* Settings sub-nav items */}
-          <nav className="flex-1 app-region-no-drag space-y-[6px] overflow-hidden">
-            {settingsNavItems.map((item) =>
-              renderNavItem(
-                item,
-                () => onSettingsSectionChange(item.id),
-                settingsSection === item.id
-              )
-            )}
-          </nav>
         </>
       ) : (
         /* ── Main navigation ── */


### PR DESCRIPTION
## 改动
设置子导航的「返回应用」从**顶部移到底部**，镜像主导航「设置」置底——进设置/出设置入口在同一位置，对称、布局更协调。

并去掉该按钮 wrapper 多余的 `px-2`（改为与「设置」同款 `pb-4 ... space-y-[6px]`），使「返回应用」按钮的**宽度/位置与「设置」按钮完全对齐**（原先因多 8px 缩进而不对称）。

展开/收起态均一致：收起栏里「返回应用」与其它图标同为 44px 居中方块。

## 验证
- typecheck + lint 绿；独立 review 零 Low/Nit。
- **真机实测**：Mac + Windows 双端确认「返回应用」置底、与「设置」同宽同位、折叠态正常。