### PR TITLE
fix: CF-Workers 节点测速超时修复（默认端点/响应码/失败诊断）+ 节点列表自动隐藏滚动条（#154）

### DIFF
--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -18,7 +18,12 @@ import type { ServerConfig } from '../../shared/types';
 import type { LogManager } from './LogManager';
 import { resourceManager } from './ResourceManager';
 import { getUserDataPath } from '../utils/paths';
-import { resolveSpeedTestTarget, type SpeedTestTarget } from '../../shared/speed-test';
+import {
+  resolveSpeedTestTarget,
+  parseHttpStatusCode,
+  isAcceptableSpeedTestStatus,
+  type SpeedTestTarget,
+} from '../../shared/speed-test';
 import { isEndpointProtocol, isSpeedTestable } from '../../shared/endpoint-routes';
 import { normalizeDuration } from '../../shared/duration';
 
@@ -242,6 +247,19 @@ export class SpeedTestService {
       if (latency !== null) ok++;
       onProgress?.(tested, ok, total);
     };
+    // issue #154 ③：失败原因计数（reason→次数）+ 末尾分布日志，把「为何全超时」从玄学变可定位
+    //（http-403=目标拒绝/查测速地址、connect-timeout=连不上、unusable=naive 缺库、core-not-ready=临时核没起）。
+    const failReasons = new Map<string, number>();
+    const noteFail = (reason: string) =>
+      failReasons.set(reason, (failReasons.get(reason) ?? 0) + 1);
+    const logFailDist = () => {
+      if (failReasons.size === 0) return;
+      const dist = [...failReasons.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([r, n]) => `${r}×${n}`)
+        .join('，');
+      this.logManager.addLog('info', `测速失败原因分布：${dist}`, 'SpeedTest');
+    };
     let singboxProcess: ChildProcess | null = null;
     let configFilePath: string | null = null;
 
@@ -255,10 +273,14 @@ export class SpeedTestService {
       if (ob) usable.push({ server: s, tag, outbound: ob });
       else {
         results.set(s.id, null);
+        noteFail('unusable'); // naive 缺 libcronet / 构造异常 → 不可测节点
         report(s.id, null);
       }
     }
-    if (usable.length === 0) return results;
+    if (usable.length === 0) {
+      logFailDist();
+      return results;
+    }
 
     // 解析测速端点（一次，预热+正式共用）；非法 testUrl 经 resolveSpeedTestTarget 回落默认 generate_204。
     const target = resolveSpeedTestTarget(testUrl);
@@ -312,6 +334,7 @@ export class SpeedTestService {
         );
         for (const u of usable) {
           results.set(u.server.id, null);
+          noteFail('core-not-ready'); // 临时 sing-box 未就绪：整批不可测
           report(u.server.id, null);
         }
         return results;
@@ -324,12 +347,13 @@ export class SpeedTestService {
       //    每测完一个节点立即回调 onResult（UI 流式显示），不等队列。
       await this.runWithLimit(usable, SpeedTestService.PROXY_TEST_CONCURRENCY, async (u) => {
         const port = serverPortMap.get(u.server.id)!;
-        const latency = await this.measureViaTunnel(
+        const { latency, reason } = await this.measureViaTunnel(
           port,
           SpeedTestService.MEASURE_TIMEOUT_MS,
           target
         );
         results.set(u.server.id, latency);
+        if (latency === null) noteFail(reason ?? 'unknown'); // ③ 记失败模式
         report(u.server.id, latency);
       });
     } catch (error) {
@@ -338,10 +362,12 @@ export class SpeedTestService {
       for (const u of usable) {
         if (!results.has(u.server.id)) {
           results.set(u.server.id, null);
+          noteFail('exception');
           report(u.server.id, null);
         }
       }
     } finally {
+      logFailDist(); // ③ 末尾打失败原因分布（normal/not-ready/catch 路径都经 finally）
       // 清理临时进程
       if (singboxProcess && !singboxProcess.killed) {
         singboxProcess.kill('SIGTERM');
@@ -399,10 +425,16 @@ export class SpeedTestService {
     // 必须有 direct 出站（sing-box 启动要求）
     outbounds.push({ type: 'direct', tag: 'direct' });
 
+    // ① 解析不变量（issue #154，localhost 实验确证，见 docs/design/speedtest-remote-resolve-154.md）：
+    //   测速【目标域名】（如 www.gstatic.com）由【每个被测节点的出口】远程解析——sing-box 把域名 ATYP=domain
+    //   透传给代理出站，**不经本机 AliDNS**。dns-direct/default_domain_resolver 仅用于解析【节点 server 地址】
+    //   （域名 server 节点需要；IP-server 节点不触发）。这一不变量使端点选择与「任播/国内镜像/geo 调度」全脱钩
+    //   （故默认得以用非任播的 gstatic），且各节点量到的是自身真实路径、无「解析点≠出口」错配。
+    //   ⚠️ 勿在此引入 sniff / outbound.domain_strategy / 针对目标的本地解析——会把目标解析拉回本机、破坏该不变量。
     const config: Record<string, unknown> = {
       log: { level: 'warn' },
       dns: {
-        // sing-box 1.13+ 要求显式 type；出站 domain_resolver 与 default_domain_resolver 均指向本 tag
+        // sing-box 1.13+ 要求显式 type；仅解析节点 server 地址（见上「解析不变量」），不解析测速目标。
         servers: [{ tag: 'dns-direct', type: 'udp', server: '223.5.5.5', server_port: 53 }],
       },
       inbounds,
@@ -505,23 +537,25 @@ export class SpeedTestService {
     proxyPort: number,
     timeout: number,
     target: SpeedTestTarget
-  ): Promise<number | null> {
+  ): Promise<{ latency: number | null; reason?: string }> {
     return new Promise((resolve) => {
       // 持有所有已建立句柄，finish 时统一 destroy（防 fd/socket 泄漏：大订阅并发 32 时累积）。
       let connectReq: http.ClientRequest | null = null;
       let tunnel: net.Socket | null = null;
       let tlsSock: tls.TLSSocket | null = null;
       let done = false;
-      const finish = (v: number | null) => {
+      // issue #154 ③：latency=null 时带 reason（connect-/http-/tunnel-/timeout 等），供 testServersViaProxy 汇总
+      // 失败原因分布——把「玄学超时」变成可定位（如 http-403=目标拒绝、connect-timeout=连不上）。
+      const finish = (latency: number | null, reason?: string) => {
         if (done) return;
         done = true;
         clearTimeout(timer);
         tlsSock?.destroy();
         tunnel?.destroy();
         connectReq?.destroy();
-        resolve(v);
+        resolve({ latency, reason });
       };
-      const timer = setTimeout(() => finish(null), timeout);
+      const timer = setTimeout(() => finish(null, 'timeout'), timeout);
 
       // CONNECT 始终显式 host:port（标准端口也带，避免非标端口拼接歧义）。
       const connectHost = `${target.host}:${target.port}`;
@@ -533,14 +567,14 @@ export class SpeedTestService {
         headers: { Host: connectHost },
         timeout,
       });
-      connectReq.on('error', () => finish(null));
-      connectReq.on('timeout', () => finish(null));
+      connectReq.on('error', () => finish(null, 'connect-error'));
+      connectReq.on('timeout', () => finish(null, 'connect-timeout'));
       // CONNECT 非 2xx（如 502）实测仍走 'connect'（携带 statusCode），由下方 statusCode 判定兜 null；
       // 'response' 仅兜「代理把 CONNECT 降级成普通 HTTP 响应」的边缘情况，避免挂到总超时。
-      connectReq.on('response', () => finish(null));
+      connectReq.on('response', () => finish(null, 'connect-downgraded'));
       connectReq.on('connect', (res, socket) => {
         if (res.statusCode !== 200) {
-          finish(null); // finish 内统一 destroy socket
+          finish(null, `connect-${res.statusCode}`); // finish 内统一 destroy socket
           return;
         }
         tunnel = socket;
@@ -551,7 +585,7 @@ export class SpeedTestService {
             { socket, servername: target.host, rejectUnauthorized: false },
             () => this.measureWarmRtt(tlsSock!, target, finish)
           );
-          tlsSock.on('error', () => finish(null));
+          tlsSock.on('error', () => finish(null, 'tls-error'));
         } else {
           this.measureWarmRtt(socket, target, finish);
         }
@@ -573,7 +607,7 @@ export class SpeedTestService {
   private measureWarmRtt(
     conn: net.Socket | tls.TLSSocket,
     target: SpeedTestTarget,
-    finish: (v: number | null) => void
+    finish: (latency: number | null, reason?: string) => void
   ): void {
     const HEADER_END = '\r\n\r\n';
     const request =
@@ -602,11 +636,17 @@ export class SpeedTestService {
         // （自配非 204 端点 + header/body 分段时，body 残余会先入清空后的 buf；不从 HTTP/ 起算会把它误当第二次）。
         const sl = buf.indexOf('HTTP/');
         if (sl < 0 || buf.indexOf(HEADER_END, sl) < 0) return; // 第二次状态行/响应头未到齐
-        finish(Date.now() - start); // 收齐第二次响应头 = 不含握手的纯请求往返
+        // issue #154 ③ 校验响应码：非 2xx（如 cp.cloudflare 经 CF-Workers 的 403）判失败，不再把错误页当成功记 TTFB。
+        const code = parseHttpStatusCode(buf.slice(sl));
+        if (code !== null && !isAcceptableSpeedTestStatus(code)) {
+          finish(null, `http-${code}`);
+          return;
+        }
+        finish(Date.now() - start); // 收齐第二次响应头且 2xx = 不含握手的纯请求往返
       }
     });
-    conn.on('error', () => finish(null));
-    conn.on('end', () => finish(null)); // 对端在测完前关闭 → 失败
+    conn.on('error', () => finish(null, 'tunnel-error'));
+    conn.on('end', () => finish(null, 'early-close')); // 对端在测完前关闭 → 失败
     conn.write(request); // 第一次（暖身，丢弃计时）
   }
 

--- a/src/main/services/__tests__/speed-test-warm-ttfb.test.ts
+++ b/src/main/services/__tests__/speed-test-warm-ttfb.test.ts
@@ -84,6 +84,8 @@ interface MockOpts {
   closeAfterFirst?: boolean;
   /** 第一次响应头之后再补发的残余字节（独立 chunk，模拟分片/CDN 多次 write）；不应被当作第二次首字节计时。 */
   firstTrailer?: string;
+  /** 无 body 时的响应状态码（默认 204）；用于 ③ 校验响应码用例（如 403 模拟目标拒绝）。两次响应同此码。 */
+  status?: number;
 }
 
 interface MockProxy {
@@ -121,7 +123,7 @@ function serveOrigin(stream: net.Socket | tls.TLSSocket, opts: MockOpts): void {
             stream.write(
               body
                 ? `HTTP/1.1 200 OK\r\nContent-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`
-                : 'HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n'
+                : `HTTP/1.1 ${opts.status ?? 204} X\r\nContent-Length: 0\r\n\r\n`
             );
           }
           if (isFirst && opts.firstTrailer) {
@@ -196,10 +198,17 @@ type Measurable = {
     proxyPort: number,
     timeout: number,
     target: ReturnType<typeof resolveSpeedTestTarget>
-  ): Promise<number | null>;
+  ): Promise<{ latency: number | null; reason?: string }>;
 };
 
 const svc = new SpeedTestService(mockLog) as unknown as Measurable;
+
+/** 计时用例只关心 latency：解包 .latency，保留既有断言不变。 */
+const measureLatency = (
+  port: number,
+  timeout: number,
+  target: ReturnType<typeof resolveSpeedTestTarget>
+) => svc.measureViaTunnel(port, timeout, target).then((r) => r.latency);
 
 const HTTP_TARGET = resolveSpeedTestTarget('http://speedtest.local/generate_204');
 const HTTPS_TARGET = resolveSpeedTestTarget('https://speedtest.local/generate_204');
@@ -209,7 +218,7 @@ describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-d
     // connect 100 + first 250 → 若误计冷启动会是 ~350+；只计第二次应 ≈60。
     const proxy = await startMockProxy({ connectDelay: 100, firstDelay: 250, secondDelay: 60 });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      const latency = await measureLatency(proxy.port, 8000, HTTP_TARGET);
       expect(latency).not.toBeNull();
       expect(latency!).toBeGreaterThanOrEqual(40); // 确在量第二次（secondDelay=60）
       expect(latency!).toBeLessThan(200); // 远低于 connect(100)+first(250)，证明握手/暖身不计入
@@ -226,7 +235,7 @@ describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-d
       tls: true,
     });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTPS_TARGET);
+      const latency = await measureLatency(proxy.port, 8000, HTTPS_TARGET);
       expect(latency).not.toBeNull();
       expect(latency!).toBeGreaterThanOrEqual(40);
       expect(latency!).toBeLessThan(200); // TLS 握手 + connect + first 均排除
@@ -244,7 +253,7 @@ describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-d
       firstTrailer: 'X-Leftover: stray-bytes-without-header-end\r\n',
     });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      const latency = await measureLatency(proxy.port, 8000, HTTP_TARGET);
       expect(latency).not.toBeNull();
       expect(latency!).toBeGreaterThanOrEqual(50); // ≈secondDelay(100)，证明残余未被计为第二次
       expect(latency!).toBeLessThan(260);
@@ -262,7 +271,7 @@ describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-d
       firstBody: 'part-a\r\n\r\npart-b',
     });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      const latency = await measureLatency(proxy.port, 8000, HTTP_TARGET);
       expect(latency).not.toBeNull();
       expect(latency!).toBeGreaterThanOrEqual(50); // ≈secondDelay(100)，证明第一次 body 残余未被计入
       expect(latency!).toBeLessThan(260);
@@ -281,7 +290,7 @@ describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-d
       splitFirstHeaderBody: true,
     });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 8000, HTTP_TARGET);
+      const latency = await measureLatency(proxy.port, 8000, HTTP_TARGET);
       expect(latency).not.toBeNull();
       expect(latency!).toBeGreaterThanOrEqual(50); // ≈secondDelay(100)，证明后到的 body 残余未被计为第二次
       expect(latency!).toBeLessThan(260);
@@ -290,33 +299,49 @@ describe('SpeedTestService.measureViaTunnel（warm RTT，对齐 mihomo unified-d
     }
   });
 
-  it('CONNECT 非 200（代理不可达）→ null', async () => {
+  it('CONNECT 非 200（代理不可达）→ null + reason connect-*（③）', async () => {
     const proxy = await startMockProxy({ failConnect: true });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 500, HTTP_TARGET);
+      const { latency, reason } = await svc.measureViaTunnel(proxy.port, 500, HTTP_TARGET);
       expect(latency).toBeNull();
+      // Node 对 CONNECT 非 2xx 视版本走 'connect'(带 statusCode→connect-502) 或 'response'(→connect-downgraded)
+      expect(reason).toMatch(/^connect-/);
     } finally {
       await proxy.close();
     }
   });
 
-  it('对端在第二次前关闭（不支持 keep-alive）→ null（不挂起）', async () => {
+  it('对端在第二次前关闭（不支持 keep-alive）→ null + reason early-close（③）', async () => {
     const proxy = await startMockProxy({ firstDelay: 10, closeAfterFirst: true });
     try {
-      const latency = await svc.measureViaTunnel(proxy.port, 500, HTTP_TARGET);
+      const { latency, reason } = await svc.measureViaTunnel(proxy.port, 500, HTTP_TARGET);
       expect(latency).toBeNull();
+      expect(reason).toBe('early-close');
     } finally {
       await proxy.close();
     }
   });
 
-  it('整体超时（请求迟迟不响应）→ null', async () => {
+  it('整体超时（请求迟迟不响应）→ null + reason timeout（③）', async () => {
     const proxy = await startMockProxy({ firstDelay: 5000 }); // 远超下方 timeout
     try {
       const start = Date.now();
-      const latency = await svc.measureViaTunnel(proxy.port, 200, HTTP_TARGET);
+      const { latency, reason } = await svc.measureViaTunnel(proxy.port, 200, HTTP_TARGET);
       expect(latency).toBeNull();
+      expect(reason).toBe('timeout');
       expect(Date.now() - start).toBeLessThan(1500); // 在总超时附近返回，不等 5s
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('目标返回非 2xx（如 CF-Workers 撞 cp.cloudflare 的 403）→ null + reason http-403（③ 校验响应码）', async () => {
+    // 隧道建立、两次响应均收齐，但状态码 403 → 不再当成功记 TTFB，判失败并带 http-403。
+    const proxy = await startMockProxy({ firstDelay: 5, secondDelay: 5, status: 403 });
+    try {
+      const { latency, reason } = await svc.measureViaTunnel(proxy.port, 2000, HTTP_TARGET);
+      expect(latency).toBeNull();
+      expect(reason).toBe('http-403');
     } finally {
       await proxy.close();
     }

--- a/src/renderer/components/layout/main-layout.tsx
+++ b/src/renderer/components/layout/main-layout.tsx
@@ -1,5 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { Sidebar } from './sidebar';
+import { attachAutoHideScrollbar } from '../../lib/auto-hide-scrollbar';
 
 interface MainLayoutProps {
   currentView: string;
@@ -19,6 +20,14 @@ export function MainLayout({
   onSettingsSectionChange,
   children,
 }: MainLayoutProps) {
+  // 自动隐藏滚动条（issue #154）：滚动时给主内容容器加 is-scrolling，停滚后移除；配合 index.css 的
+  // .main-content-card 滚动条样式（默认透明、悬停/滚动时显细淡 thumb），非突兀且自动隐藏。
+  const mainRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    const el = mainRef.current;
+    if (!el) return;
+    return attachAutoHideScrollbar(el);
+  }, []);
   return (
     <div className="flex h-screen w-full overflow-hidden app-shell">
       <Sidebar
@@ -27,7 +36,10 @@ export function MainLayout({
         settingsSection={settingsSection}
         onSettingsSectionChange={onSettingsSectionChange}
       />
-      <main className="flex-1 overflow-auto flex flex-col relative z-10 main-content-card transition-all duration-300">
+      <main
+        ref={mainRef}
+        className="flex-1 overflow-auto flex flex-col relative z-10 main-content-card transition-all duration-300"
+      >
         {/* 集成标题栏拖拽区：Mac(hiddenInset) h-9；Windows(titleBarOverlay 按钮在右上) 32px 与覆盖层等高、给按钮让位。 */}
         {isMac && <div className="h-9 flex-shrink-0 app-region-drag" />}
         {isWindows && <div className="h-[32px] flex-shrink-0 app-region-drag" />}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -203,6 +203,34 @@
     background: transparent;
   }
 
+  /* 主内容区可视滚动条（issue #154）：全局 ::-webkit-scrollbar width:0 隐藏了所有滚动条，节点/规则等长列表
+     用户无法感知"还有更多"也无法拖动。仅对主滚动容器 .main-content-card 恢复一条**细的、自动隐藏、不突兀**的滚动条：
+       - 默认 thumb 透明（完全隐形，零干扰）；
+       - 鼠标悬停内容区 或 正在滚动(.is-scrolling，由 main-layout 滚动事件加/移)时才显细淡 thumb，停止交互即隐藏；
+       - thumb 上再悬停加深，便于拖动；content-box+透明描边使可见宽度更细。
+     刻意不设 scrollbar-width/scrollbar-color：Chromium 121+ 一旦显式设 scrollbar-width 会忽略 ::-webkit-scrollbar
+     伪元素样式，致此处自定义自动隐藏失效。仅用 webkit 伪元素（Electron=Chromium，足够）。 */
+  .main-content-card::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  .main-content-card::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .main-content-card::-webkit-scrollbar-thumb {
+    background-color: transparent; /* 默认隐藏：不突兀 */
+    border-radius: 9999px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+  .main-content-card:hover::-webkit-scrollbar-thumb,
+  .main-content-card.is-scrolling::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--muted-foreground) / 0.4); /* 交互时显示：细而淡 */
+  }
+  .main-content-card::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.6); /* 悬停 thumb 上更明显，便于拖动 */
+  }
+
   /* ── Sidebar styles ── */
   /* macOS: transparent so system vibrancy (frosted glass) shows through */
   html.platform-darwin .sidebar {
@@ -213,7 +241,7 @@
   /* 内容卡片对应的边角处需要展示 sidebar 背景颜色，必须与 app-shell 完全一致 */
   html.platform-win32 .sidebar,
   html.platform-linux .sidebar {
-    background: #E9EEF3; /* 硬编码和 app-shell 保持一致，避免 CSS 变量在 GPU 缓存失效时出现色差 */
+    background: #e9eef3; /* 硬编码和 app-shell 保持一致，避免 CSS 变量在 GPU 缓存失效时出现色差 */
   }
 
   html.platform-darwin.dark .sidebar {
@@ -222,7 +250,7 @@
 
   html.platform-win32.dark .sidebar,
   html.platform-linux.dark .sidebar {
-    background: #1F252E; /* 硬编码，和 app-shell dark 一致 */
+    background: #1f252e; /* 硬编码，和 app-shell dark 一致 */
   }
 
   .nav-item {
@@ -342,7 +370,7 @@
     pointer-events: none;
     z-index: 1;
     /* 默认：Windows/Linux 使用 sidebar 亮色 */
-    background: #E9EEF3;
+    background: #e9eef3;
   }
 
   /* 顶部内切角：方块右下角圆弧 = 卡片左上角圆弧的镜像 */
@@ -362,7 +390,7 @@
   html.platform-win32.dark .main-content-card::after,
   html.platform-linux.dark .main-content-card::before,
   html.platform-linux.dark .main-content-card::after {
-    background: #1F252E;
+    background: #1f252e;
   }
 
   /* macOS：sidebar 是透明毛玻璃，内切角透明让 vibrancy 穿透
@@ -410,19 +438,19 @@
 
   html.platform-win32 .app-shell,
   html.platform-linux .app-shell {
-    background: #E9EEF3;
+    background: #e9eef3;
   }
 
   /* Must be fully opaque (no rgba) to prevent GPU semi-transparent layer repaint artifacts */
   html.platform-win32.dark .app-shell,
   html.platform-linux.dark .app-shell {
-    background: #1F252E;
+    background: #1f252e;
   }
 
   /* Dark sidebar must exactly match app-shell bg so box-shadow corner masking is seamless */
   html.platform-win32.dark .sidebar,
   html.platform-linux.dark .sidebar {
-    background: #1F252E;
+    background: #1f252e;
   }
 
   /* ──────────────────────────────────────────────────────────────

--- a/src/renderer/lib/__tests__/auto-hide-scrollbar.test.ts
+++ b/src/renderer/lib/__tests__/auto-hide-scrollbar.test.ts
@@ -1,0 +1,83 @@
+/**
+ * attachAutoHideScrollbar 单测（issue #154 自动隐藏滚动条）。
+ * node 环境 + mock 元素 + fake timers，不依赖 jsdom：验「滚动加 is-scrolling / idle 后移除 / 防抖只留一个定时器 /
+ * 清理移监听+清定时器+移类」。
+ */
+import { attachAutoHideScrollbar, type ScrollableEl } from '../auto-hide-scrollbar';
+
+function mockEl() {
+  let scrollHandler: (() => void) | null = null;
+  const el: ScrollableEl & {
+    fire: () => void;
+    add: jest.Mock;
+    remove: jest.Mock;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+  } = {
+    addEventListener: jest.fn((type: string, h: unknown) => {
+      if (type === 'scroll') scrollHandler = h as () => void;
+    }) as unknown as jest.Mock,
+    removeEventListener: jest.fn() as unknown as jest.Mock,
+    classList: { add: jest.fn(), remove: jest.fn() },
+    fire: () => scrollHandler?.(),
+    get add() {
+      return this.classList.add as jest.Mock;
+    },
+    get remove() {
+      return this.classList.remove as jest.Mock;
+    },
+  };
+  return el;
+}
+
+describe('attachAutoHideScrollbar', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('滚动 → 加 is-scrolling；idle 后 → 移除', () => {
+    const el = mockEl();
+    attachAutoHideScrollbar(el, 900);
+    el.fire();
+    expect(el.classList.add).toHaveBeenCalledWith('is-scrolling');
+    expect(el.classList.remove).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(900);
+    expect(el.classList.remove).toHaveBeenCalledWith('is-scrolling');
+  });
+
+  it('连续滚动防抖：只保留最后一个定时器，未到 idle 不移除', () => {
+    const el = mockEl();
+    attachAutoHideScrollbar(el, 900);
+    el.fire();
+    jest.advanceTimersByTime(500);
+    el.fire(); // 重置定时器
+    jest.advanceTimersByTime(500); // 距上次滚动仅 500 < 900
+    expect(el.classList.remove).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(400); // 累计 900 自上次滚动
+    expect(el.classList.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('清理函数：移监听 + 清未触发的定时器（不再移除类） + 立即移除类一次', () => {
+    const el = mockEl();
+    const cleanup = attachAutoHideScrollbar(el, 900);
+    el.fire(); // 起一个定时器
+    cleanup();
+    expect(el.removeEventListener).toHaveBeenCalled();
+    // 清理时立即移一次类（收尾）
+    expect(el.classList.remove).toHaveBeenCalledWith('is-scrolling');
+    const removeCallsAfterCleanup = (el.classList.remove as jest.Mock).mock.calls.length;
+    // 定时器已被清，推进时间不再触发额外移除
+    jest.advanceTimersByTime(2000);
+    expect((el.classList.remove as jest.Mock).mock.calls.length).toBe(removeCallsAfterCleanup);
+  });
+
+  it('默认 idleMs=900', () => {
+    const el = mockEl();
+    attachAutoHideScrollbar(el);
+    el.fire();
+    jest.advanceTimersByTime(899);
+    expect(el.classList.remove).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(el.classList.remove).toHaveBeenCalledWith('is-scrolling');
+  });
+});

--- a/src/renderer/lib/auto-hide-scrollbar.ts
+++ b/src/renderer/lib/auto-hide-scrollbar.ts
@@ -1,0 +1,46 @@
+/**
+ * 自动隐藏滚动条（issue #154）：滚动时给容器加 `is-scrolling` 类、停止滚动 idleMs 后移除。
+ * 配合 index.css 的 `.main-content-card.is-scrolling::-webkit-scrollbar-thumb`：默认 thumb 透明（不突兀），
+ * 仅在悬停或正在滚动时显示细淡滚动条，停止交互即隐藏。
+ *
+ * 形状最小化（非硬绑 HTMLElement）以便在 node 测试环境下用 mock + fake timers 单测，不依赖 jsdom。
+ */
+
+export interface ScrollableEl {
+  addEventListener: HTMLElement['addEventListener'];
+  removeEventListener: HTMLElement['removeEventListener'];
+  classList: Pick<DOMTokenList, 'add' | 'remove'>;
+}
+
+const CLASS = 'is-scrolling';
+const DEFAULT_IDLE_MS = 900;
+
+/**
+ * 给可滚动元素挂上「滚动即显、停滚 idleMs 后隐」的自动隐藏行为。返回清理函数（移除监听 + 清定时器）。
+ * @param el      滚动容器（HTMLElement 兼容本接口）
+ * @param idleMs  停止滚动后保留显示的毫秒数（默认 900ms）
+ */
+export function attachAutoHideScrollbar(
+  el: ScrollableEl,
+  idleMs: number = DEFAULT_IDLE_MS
+): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const onScroll = (): void => {
+    el.classList.add(CLASS);
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      el.classList.remove(CLASS);
+      timer = null;
+    }, idleMs);
+  };
+  // passive：仅读不阻断滚动，避免影响滚动性能
+  el.addEventListener('scroll', onScroll, { passive: true });
+  return () => {
+    el.removeEventListener('scroll', onScroll);
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    el.classList.remove(CLASS);
+  };
+}

--- a/src/shared/__tests__/speed-test.test.ts
+++ b/src/shared/__tests__/speed-test.test.ts
@@ -5,18 +5,24 @@
  * 这是「测速地址可设置」的后端核心：SpeedTestService.measureViaTunnel 据 target.https 决定 CONNECT 隧道上是否先
  * 做 TLS 握手，再发两次 GET 只计第二次（warm RTT）。FS/网络层（实际请求）属集成层、真机验证，不在此测。
  */
-import { parseSpeedTestUrl, resolveSpeedTestTarget, DEFAULT_SPEED_TEST_URL } from '../speed-test';
+import {
+  parseSpeedTestUrl,
+  resolveSpeedTestTarget,
+  DEFAULT_SPEED_TEST_URL,
+  parseHttpStatusCode,
+  isAcceptableSpeedTestStatus,
+} from '../speed-test';
 
 describe('parseSpeedTestUrl（测速 URL 解析）', () => {
   it('默认 generate_204 (http) → host/path/port 正确', () => {
     const r = parseSpeedTestUrl(DEFAULT_SPEED_TEST_URL);
     expect(r).toEqual({
       https: false,
-      host: 'cp.cloudflare.com',
+      host: 'www.gstatic.com',
       port: 80,
       path: '/generate_204',
-      hostHeader: 'cp.cloudflare.com',
-      absoluteUri: 'http://cp.cloudflare.com/generate_204',
+      hostHeader: 'www.gstatic.com',
+      absoluteUri: 'http://www.gstatic.com/generate_204',
     });
   });
 
@@ -71,18 +77,47 @@ describe('parseSpeedTestUrl（测速 URL 解析）', () => {
 
 describe('resolveSpeedTestTarget（非法回落默认）', () => {
   it('undefined → 默认 generate_204', () => {
-    expect(resolveSpeedTestTarget(undefined).host).toBe('cp.cloudflare.com');
+    expect(resolveSpeedTestTarget(undefined).host).toBe('www.gstatic.com');
     expect(resolveSpeedTestTarget(undefined).path).toBe('/generate_204');
   });
 
   it('非法 → 默认', () => {
-    expect(resolveSpeedTestTarget('garbage').host).toBe('cp.cloudflare.com');
+    expect(resolveSpeedTestTarget('garbage').host).toBe('www.gstatic.com');
     expect(resolveSpeedTestTarget('').https).toBe(false);
   });
 
   it('合法 https → 用该端点（不回落）', () => {
-    // host 用非默认值（example.com），使「命中传入端点」与「回落默认 cp.cloudflare.com」可区分。
+    // host 用非默认值（example.com），使「命中传入端点」与「回落默认 www.gstatic.com」可区分。
     expect(resolveSpeedTestTarget('https://example.com/generate_204').https).toBe(true);
     expect(resolveSpeedTestTarget('https://example.com/generate_204').host).toBe('example.com');
+  });
+});
+
+describe('parseHttpStatusCode（③ 响应状态码解析）', () => {
+  it('从状态行解析状态码', () => {
+    expect(parseHttpStatusCode('HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n')).toBe(204);
+    expect(parseHttpStatusCode('HTTP/1.1 200 OK\r\n\r\n')).toBe(200);
+    expect(parseHttpStatusCode('HTTP/1.1 403 Forbidden\r\n\r\n')).toBe(403);
+    expect(parseHttpStatusCode('HTTP/2 502 Bad Gateway\r\n')).toBe(502); // HTTP/2 无小版本号
+  });
+  it('非状态行 / 脏输入 → null', () => {
+    expect(parseHttpStatusCode('')).toBeNull();
+    expect(parseHttpStatusCode('X-Leftover: stray\r\n')).toBeNull(); // 非 HTTP/ 起头
+    expect(parseHttpStatusCode('HTTP/1.1 99 Bad\r\n')).toBeNull(); // 非三位/越界
+    expect(parseHttpStatusCode('HTTP/1.1 6xx\r\n')).toBeNull();
+  });
+});
+
+describe('isAcceptableSpeedTestStatus（③ 仅 2xx 判成功）', () => {
+  it('2xx → true', () => {
+    expect(isAcceptableSpeedTestStatus(200)).toBe(true);
+    expect(isAcceptableSpeedTestStatus(204)).toBe(true);
+    expect(isAcceptableSpeedTestStatus(299)).toBe(true);
+  });
+  it('非 2xx → false（3xx/4xx/5xx）', () => {
+    expect(isAcceptableSpeedTestStatus(301)).toBe(false);
+    expect(isAcceptableSpeedTestStatus(403)).toBe(false); // cp.cloudflare 经 CF-Workers 实况
+    expect(isAcceptableSpeedTestStatus(502)).toBe(false);
+    expect(isAcceptableSpeedTestStatus(199)).toBe(false);
   });
 });

--- a/src/shared/speed-test.ts
+++ b/src/shared/speed-test.ts
@@ -7,11 +7,16 @@
  */
 
 /**
- * 默认测速端点：cp.cloudflare.com generate_204（全球任播、无国内 CDN 镜像，对 WARP/海外/国内出口一致可达）。
- * 不用 gstatic：www.gstatic.com 有国内 CDN 镜像，AliDNS(223.5.5.5) 等国内 DNS 会解析到国内镜像 IP（如 180.163.150.162），
- * WARP 等海外全隧道出口连不上该国内 IP → 测速恒超时（Mac 真机实证：换 cp.cloudflare 后 WARP 多节点秒通 204）。
+ * 默认测速端点：www.gstatic.com generate_204（204 空响应，连接可立即复用）。
+ *
+ * 为何不用 cp.cloudflare.com（曾用，issue #154）：CF-Workers / 优选IP 节点（FlowZ 用户里占大头）对 cp.cloudflare
+ * 这个 Cloudflare 自家端点测速会失败——reporter 实证「把测速地址换成非 CF 端点即恢复正常」。
+ * 为何 gstatic 的国内 CDN 镜像在此不成问题：测速目标域名由【每个被测节点的出口】远程解析，**不经本机 AliDNS**
+ * （localhost 实验确证 sing-box 把域名 ATYP=domain 透传给出站，见 docs/design/speedtest-remote-resolve-154.md）——
+ * 故各节点拿到本区域 IP，目标是否任播 / 有无国内镜像均与测速无关，海外出口绝不会被钉到国内镜像 IP。
+ * 端点选择由此从「必须任播的脆弱依赖」降级为「次要、用户可在设置自配」。
  */
-export const DEFAULT_SPEED_TEST_URL = 'http://cp.cloudflare.com/generate_204';
+export const DEFAULT_SPEED_TEST_URL = 'http://www.gstatic.com/generate_204';
 
 export interface SpeedTestTarget {
   https: boolean;
@@ -57,4 +62,24 @@ export function parseSpeedTestUrl(raw: string | undefined | null): SpeedTestTarg
  */
 export function resolveSpeedTestTarget(raw?: string | null): SpeedTestTarget {
   return parseSpeedTestUrl(raw) ?? DEFAULT_TARGET;
+}
+
+/**
+ * 从 HTTP 响应（含状态行 `HTTP/1.1 204 ...`）解析状态码（纯函数，issue #154 ③ 校验响应码）。
+ * 入参应从第二次响应的 `HTTP/` 状态行起算的缓冲；解析不出 → null（调用方按「无法判定」处理）。
+ */
+export function parseHttpStatusCode(responseHead: string): number | null {
+  if (!responseHead) return null;
+  const m = responseHead.match(/^HTTP\/\d(?:\.\d)?\s+(\d{3})\b/i);
+  if (!m) return null;
+  const code = Number(m[1]);
+  return Number.isInteger(code) && code >= 100 && code <= 599 ? code : null;
+}
+
+/**
+ * 测速目标响应是否「可接受为成功」：仅 2xx（含 generate_204 的 204 / 自配端点的 200）。
+ * 非 2xx（3xx 重定向 / 4xx 如 cp.cloudflare 经 CF-Workers 的 403 / 5xx）判失败——堵住「错误页被当成功记 TTFB」。
+ */
+export function isAcceptableSpeedTestStatus(code: number): boolean {
+  return code >= 200 && code <= 299;
 }


### PR DESCRIPTION
修复 #154 的两个子问题（节点测速全「超时」、节点列表无滚动条）。第三个子问题（排序不保存）已由 #153 修复。

## 测速全「超时」但连接正常

**现象**：100+ 个 CF-Workers（优选IP）节点测速全「超时」（成功 0/N），但浏览正常；reporter 实证「把测速地址换成非 CF 端点即恢复正常」。

**根因**：默认测速目标 `cp.cloudflare.com` 对 CF-Workers 节点失败；且测速失败只报「超时」、一个原因都不记，排查无从下手。

**改动**：
1. **默认端点 `cp.cloudflare.com` → `www.gstatic.com/generate_204`**。测速目标域名由【每个被测节点的出口】远程解析（用 localhost sing-box 实验确证：sing-box 把域名 `ATYP=domain` 透传给出站、**不经本机 AliDNS**），故端点选择与任播/geo 调度/国内镜像全脱钩——换非任播的 gstatic 安全，且各节点量到的是自身真实路径。
2. **校验响应码**：第二次响应非 2xx（如 cp.cloudflare 经 CF-Workers 的 403）判失败，不再把错误页当成功记 TTFB（新增纯函数 `parseHttpStatusCode` / `isAcceptableSpeedTestStatus`）。
3. **失败原因诊断**：`measureViaTunnel` 返回 `{latency, reason}`，逐节点区分 `connect-* / http-<code> / tunnel-error / early-close / timeout / unusable / core-not-ready`；测速末尾打**「测速失败原因分布」**日志，把「为何全超时」从玄学变可定位。

设计原则「让测速成为真实流量的忠实缩影」：目标在节点出口解析（不在本机）、校验真实响应、时延口径仍是 warm TTFB（mihomo unified-delay，天然排除 DNS+握手）。未做多端点回退（避免膨胀），单端点 + 诚实诊断即可。

## 节点列表无滚动条

全局 `::-webkit-scrollbar{width:0}` 隐藏了所有滚动条，长列表（100+ 节点/规则）无法感知「还有更多」也无法拖动。仅对主滚动容器 `.main-content-card` 恢复一条**细的、不突兀、自动隐藏**的滚动条：默认 thumb 透明，悬停或正在滚动时才显、停滚约 900ms 后隐；thumb 上悬停加深便于拖动。刻意不设 `scrollbar-width`（Chromium 121+ 设了会忽略 `::-webkit-scrollbar` 伪元素样式）。

## 测试

`tsc` / `eslint` / `prettier` / `jest`（全量 1777）全绿；新增：
- `parseHttpStatusCode` / `isAcceptableSpeedTestStatus` 边界；默认端点 gstatic。
- `measureViaTunnel` 集成（本地 mock CONNECT 代理）：**403 → `http-403`** 走完整隧道、失败 reason 断言（connect-/early-close/timeout）。
- `attachAutoHideScrollbar`：滚动加类 / idle 移除 / 防抖 / cleanup 释放。

## 待真机验证（runtime 网络，CI/单测不可覆盖）
- CF-Workers 节点用 gstatic 端点实测秒通 204、不再全超时。
- 多区域出口节点测出合理且分区域的延迟（无「解析点≠出口」错配）。
- 失败时日志「测速失败原因分布」准确（如 `http-403×N`）。
- 长列表滚动条悬停/滚动时出现、停滚约 900ms 隐，且不影响其它滚动区。

Close #147 
Close #158 
