### PR TITLE
fix(review): #151–#161 code-review 跟进修复（DNS race 可靠性 + 跨平台 + 测速）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -546,10 +546,14 @@ async function createWindow(forceShow = false) {
     windowWidth = cfg.windowBounds.width;
     windowHeight = cfg.windowBounds.height;
   }
+  const { nativeTheme } = require('electron');
   if (cfg.uiTheme) {
-    const { nativeTheme } = require('electron');
     nativeTheme.themeSource = cfg.uiTheme;
   }
+  // 初始深浅以 nativeTheme.shouldUseDarkColors 为准（themeSource 已按 uiTheme 设定，'system' 跟随 OS）。
+  // 不能用 cfg.uiTheme==='dark' 字面判：uiTheme='system'+OS 深色会被误判为浅色，致标题栏/背景与内容初始不一致，
+  // 而 onThemeUpdated 仅在 OS 主题「切换」时修正、初始不跑（review #3）。
+  const isDarkInitial = nativeTheme.shouldUseDarkColors;
 
   mainWindow = new BrowserWindow({
     width: windowWidth,
@@ -559,7 +563,7 @@ async function createWindow(forceShow = false) {
     title: 'FlowZ',
     icon: resourceManager.getAppIconPath(),
     show: false, // 先不显示，等待加载完成
-    backgroundColor: isMac ? '#00000000' : cfg.uiTheme === 'dark' ? '#1F252E' : '#E9EEF3',
+    backgroundColor: isMac ? '#00000000' : isDarkInitial ? '#1F252E' : '#E9EEF3',
     transparent: isMac,
     autoHideMenuBar: true, // 自动隐藏菜单栏
     webPreferences: {
@@ -581,7 +585,7 @@ async function createWindow(forceShow = false) {
     // Linux 无覆盖层 API → 不进此分支，默认边框 + 实色底。
     ...(isWindows && {
       titleBarStyle: 'hidden',
-      titleBarOverlay: overlayColors(cfg.uiTheme === 'dark'),
+      titleBarOverlay: overlayColors(isDarkInitial),
       backgroundMaterial: 'mica',
     }),
   });

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1730,8 +1730,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   buildPreflightConfigJson(targetVersion: string): string | null {
     if (!this.currentConfig) return null;
     const savedVersion = this.coreVersion;
+    const savedRacePort = this.raceServerPort;
     try {
       this.coreVersion = targetVersion;
+      // preflight 只验「新核能否 check 通过此 config schema」，不应引用 live race server——其端口随新核重启会重分配、
+      // 且 check 不连该 server。临时 raceServerPort=0 强制 race-off，使预检配置不含 dns-node-race（review #6：
+      // 注释曾声称 preflight 恒 race-off，但代理运行时 raceServerPort>0 会让它误带 live race server）。
+      this.raceServerPort = 0;
       const cfg = this.generateSingBoxConfig(this.currentConfig);
       return JSON.stringify(cfg, null, 2);
     } catch (e) {
@@ -1739,6 +1744,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       return null;
     } finally {
       this.coreVersion = savedVersion;
+      this.raceServerPort = savedRacePort;
     }
   }
 

--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -638,8 +638,10 @@ export class SpeedTestService {
         if (sl < 0 || buf.indexOf(HEADER_END, sl) < 0) return; // 第二次状态行/响应头未到齐
         // issue #154 ③ 校验响应码：非 2xx（如 cp.cloudflare 经 CF-Workers 的 403）判失败，不再把错误页当成功记 TTFB。
         const code = parseHttpStatusCode(buf.slice(sl));
-        if (code !== null && !isAcceptableSpeedTestStatus(code)) {
-          finish(null, `http-${code}`);
+        // code===null：响应头收齐但状态行无法解析出 3 位码（畸形/非标准）——无法确认 2xx，判失败，
+        // 否则畸形响应会被当成功记 TTFB，软重引入 #154 修复前「错误页当成功」的问题（review #4）。
+        if (code === null || !isAcceptableSpeedTestStatus(code)) {
+          finish(null, code === null ? 'http-unparsable' : `http-${code}`);
           return;
         }
         finish(Date.now() - start); // 收齐第二次响应头且 2xx = 不含握手的纯请求往返

--- a/src/main/services/__tests__/node-dns-race-server.test.ts
+++ b/src/main/services/__tests__/node-dns-race-server.test.ts
@@ -140,4 +140,30 @@ describe('NodeDnsRaceServer (loopback)', () => {
       server.stop();
     }
   });
+
+  it('watchdog：socket 被动 close → 自动重建且端口不变（review #1）', async () => {
+    server = new NodeDnsRaceServer({
+      queryFn: async (_up, query) => makeResponse(query, 'HIT', '8.8.8.8'),
+    });
+    const port = await server.start(TIER1);
+    // 模拟 socket 被动 close（非主动 stop）→ 'close' 事件触发 watchdog re-listen。
+    (server as unknown as { socket: dgram.Socket }).socket.close();
+    await new Promise((r) => setTimeout(r, 150)); // 等 re-listen 完成
+    expect(server.isRunning()).toBe(true);
+    expect(server.getPort()).toBe(port); // 重绑原端口（对内核透明，已烧进 config 的端口仍有效）
+    const resp = await sendQuery(port, encodeDnsQuery('d.example.com', 0xab));
+    expect(classifyDnsResponse(resp, 1)).toBe('HIT'); // 重建后仍正常服务
+  });
+
+  it('watchdog：stop() 后 socket close 不触发重建（closing 守卫，不留孤儿）', async () => {
+    server = new NodeDnsRaceServer({
+      queryFn: async (_up, query) => makeResponse(query, 'HIT'),
+    });
+    await server.start(TIER1);
+    server.stop(); // closing=true 先于 close()：'close' 事件回调里 onSocketDown 被 closing 守卫挡
+    await new Promise((r) => setTimeout(r, 150)); // 等 'close' 事件可能触发 onSocketDown
+    expect(server.isRunning()).toBe(false); // 不重建
+    expect(server.getPort()).toBe(0);
+    expect((server as unknown as { socket: dgram.Socket | null }).socket).toBeNull();
+  });
 });

--- a/src/main/services/__tests__/singbox-route-builder.test.ts
+++ b/src/main/services/__tests__/singbox-route-builder.test.ts
@@ -404,11 +404,12 @@ describe('buildRouteConfig — issue #147 race 上游直连放行（§E.1，防 
         r.ip_cidr.some((c: string) => c.startsWith('223.5.5.5'))
     );
 
-  it('自定义 race 上游 IP → C 段含其 /32 + port 加 853（DoT）', () => {
+  it('自定义 race 上游 IP → C 段含其 /32；port 仅 53/443（DoT 二期未实现，不开 853，review #5）', () => {
     const rc = buildRouteConfig(cfg([n]), idMap([n]), deps([], { raceUpstreamIps: ['1.1.1.1'] }));
     const r = bootstrapRule(rc);
     expect(r.ip_cidr).toContain('1.1.1.1/32');
-    expect(r.port).toEqual(expect.arrayContaining([53, 443, 853]));
+    expect(r.port).toEqual(expect.arrayContaining([53, 443]));
+    expect(r.port).not.toContain(853);
   });
 
   it('无自定义上游（[] / 未传）→ port 不含 853（snapshot 零变化）', () => {

--- a/src/main/services/node-dns-race-server.ts
+++ b/src/main/services/node-dns-race-server.ts
@@ -149,6 +149,7 @@ export class NodeDnsRaceServer {
   private port = 0;
   private upstreams: ResolvedUpstreams = { tier1: [], tier2: [], directIps: [] };
   private closing = false;
+  private relistening = false; // 防 watchdog 'error'+'close' 双触发重复 re-listen
   private readonly queryFn: UpstreamQueryFn;
   private readonly totalBudgetMs: number;
   private readonly log: LogFn;
@@ -177,10 +178,11 @@ export class NodeDnsRaceServer {
     this.upstreams = upstreams;
     this.closing = false;
     if (this.socket) return this.port;
-    return this.listen();
+    return this.listen(0); // 首次绑动态口（bind(0) 由 OS 分配空闲口，避免固定口被占冲突）
   }
 
-  private listen(): Promise<number> {
+  // 首次 preferredPort=0（动态分配）；watchdog 重建时传原端口，使内核已烧进 config 的端口在恢复后仍有效。
+  private listen(preferredPort: number): Promise<number> {
     return new Promise<number>((resolve, reject) => {
       const sock = dgram.createSocket('udp4');
       let settled = false;
@@ -194,8 +196,24 @@ export class NodeDnsRaceServer {
         }
         this.onSocketDown();
       });
-      sock.bind(0, '127.0.0.1', () => {
+      // 运行中被动关闭（无 error 的 'close'）也触发 watchdog；主动 stop / 重复触发由 onSocketDown 守卫挡。
+      sock.on('close', () => {
+        if (settled) this.onSocketDown();
+      });
+      sock.bind(preferredPort, '127.0.0.1', () => {
         settled = true;
+        // stop() 在 re-listen 进行中被调（closing=true）→ 别复活这只 socket，否则成孤儿：端口泄漏 +
+        // isRunning() 与 ProxyManager.raceServerPort=0 状态不一致（review 二次：relistening 期 stop 竞态）。
+        // resolve(0) 仅解开 listen promise 防永挂；调用方按 closing/返回值不再使用它。
+        if (this.closing) {
+          try {
+            sock.close();
+          } catch {
+            /* ignore */
+          }
+          resolve(0);
+          return;
+        }
         this.socket = sock;
         this.port = (sock.address() as { port: number }).port;
         this.log('info', `[dns-race] listening 127.0.0.1:${this.port}`);
@@ -204,13 +222,24 @@ export class NodeDnsRaceServer {
     });
   }
 
-  /** watchdog：非主动关闭时 socket 异常 → 重建（fail-open 第二层）。 */
+  /**
+   * watchdog（fail-open 第二层）：非主动关闭时 socket 异常/关闭 → 重建。
+   * 关键：重绑**原端口**（非 bind(0) 换新口）——内核 config 已烧旧端口且不因 socket 重建而重新生成，
+   * 换新口会让内核查死口致节点解析静默失效（review #1）。relistening 守卫防 'error'+'close' 双触发。
+   */
   private onSocketDown(): void {
-    if (this.closing) return;
+    if (this.closing || this.relistening) return;
+    this.relistening = true;
+    const prevPort = this.port; // 复用首次 bind(0) 拿到的端口，对内核透明
     this.socket = null;
-    this.listen().catch((e) =>
-      this.log('error', `[dns-race] re-listen 失败: ${(e as Error).message}`)
-    );
+    this.listen(prevPort)
+      .catch((e) => {
+        this.port = 0; // re-listen 彻底失败 → 清端口，使 getPort()/isRunning() 状态一致（不留无 socket 的死端口）
+        this.log('error', `[dns-race] re-listen 失败: ${(e as Error).message}`);
+      })
+      .finally(() => {
+        this.relistening = false;
+      });
   }
 
   private async handle(msg: Buffer, rinfo: dgram.RemoteInfo): Promise<void> {

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -87,7 +87,7 @@ export interface RouteConfigDeps {
   onDegraded: () => void;
   // issue #147：本地 race server 的【自定义】上游 IP（内置 ali/dnspod 已在 BOOTSTRAP_DIRECT_DNS_IPS）。
   // TUN 下主进程 race server 对这些 IP 的 DoH/UDP 查询若不直连放行 → 进 TUN → 经代理节点 → 节点解析又回 race server → 回环死锁。
-  // 故在 hijack-dns 之前直连放行（:53/:443/:853）。缺省 [] = race off / 无自定义上游（零变化）。
+  // 故在 hijack-dns 之前直连放行（:53/:443；DoT :853 二期未实现、不放行，见下方 port 注释）。缺省 [] = race off / 无自定义上游（零变化）。
   raceUpstreamIps?: string[];
 }
 
@@ -235,13 +235,10 @@ export function buildRouteConfig(
         .map((ip) => hostToExcludeCidr(ip))
         .filter((c): c is string => c !== null),
     ],
-    // :53=UDP / :443=DoH（恒）；:853=DoT 仅有自定义 race 上游时加（无则保持现状，snapshot 零变化）。
-    port: dedupe([
-      53,
-      443,
-      ...((deps.raceUpstreamIps?.length ?? 0) > 0 ? [853] : []),
-      ...(customDomesticDns ? [customDomesticDns.port] : []),
-    ]),
+    // :53=UDP / :443=DoH（恒）。DoT(:853) 二期未实现——race server queryOneUpstream 不支持 dot、
+    // parseCustomUpstream 已拒 tls://，故无任何 DoT 上游，不为永不工作的协议开无用端口（review #5）。
+    // 待 DoT 落地后再按「上游中确有 dot」精确放行 853，而非按「有自定义上游」的浅条件。
+    port: dedupe([53, 443, ...(customDomesticDns ? [customDomesticDns.port] : [])]),
     action: 'route',
     outbound: 'direct',
   });

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -658,7 +658,6 @@
       "nodeResolverAli": "AliDNS (DoH)",
       "nodeResolverAddCustom": "+ Add custom upstream",
       "nodeResolverCustomPlaceholder": "223.5.5.5 or https://223.5.5.5/dns-query",
-      "nodeResolverAdd": "Add",
       "nodeResolverErrDomain": "Only plain IPs are supported, not domains",
       "nodeResolverErrDuplicate": "This upstream already exists",
       "nodeResolverSingleLabel": "Resolve upstream",

--- a/src/renderer/i18n/locales/fa-IR.json
+++ b/src/renderer/i18n/locales/fa-IR.json
@@ -658,7 +658,6 @@
       "nodeResolverAli": "AliDNS (DoH)",
       "nodeResolverAddCustom": "+ افزودن upstream سفارشی",
       "nodeResolverCustomPlaceholder": "223.5.5.5 یا https://223.5.5.5/dns-query",
-      "nodeResolverAdd": "افزودن",
       "nodeResolverErrDomain": "فقط IP خالص پشتیبانی می‌شود، نه دامنه",
       "nodeResolverErrDuplicate": "این upstream از قبل وجود دارد",
       "nodeResolverSingleLabel": "upstream resolve",

--- a/src/renderer/i18n/locales/ru.json
+++ b/src/renderer/i18n/locales/ru.json
@@ -658,7 +658,6 @@
       "nodeResolverAli": "AliDNS (DoH)",
       "nodeResolverAddCustom": "+ Добавить свой upstream",
       "nodeResolverCustomPlaceholder": "223.5.5.5 или https://223.5.5.5/dns-query",
-      "nodeResolverAdd": "Добавить",
       "nodeResolverErrDomain": "Поддерживаются только чистые IP, домены — нет",
       "nodeResolverErrDuplicate": "Этот upstream уже существует",
       "nodeResolverSingleLabel": "Upstream разрешения",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -658,7 +658,6 @@
       "nodeResolverAli": "AliDNS (DoH)",
       "nodeResolverAddCustom": "+ 添加自定义上游",
       "nodeResolverCustomPlaceholder": "223.5.5.5 或 https://223.5.5.5/dns-query",
-      "nodeResolverAdd": "添加",
       "nodeResolverErrDomain": "仅支持纯 IP，不支持域名",
       "nodeResolverErrDuplicate": "该上游已存在",
       "nodeResolverSingleLabel": "解析上游",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -658,7 +658,6 @@
       "nodeResolverAli": "AliDNS (DoH)",
       "nodeResolverAddCustom": "+ 新增自訂上游",
       "nodeResolverCustomPlaceholder": "223.5.5.5 或 https://223.5.5.5/dns-query",
-      "nodeResolverAdd": "新增",
       "nodeResolverErrDomain": "僅支援純 IP，不支援網域",
       "nodeResolverErrDuplicate": "該上游已存在",
       "nodeResolverSingleLabel": "解析上游",

--- a/src/shared/__tests__/node-resolver-upstreams.test.ts
+++ b/src/shared/__tests__/node-resolver-upstreams.test.ts
@@ -33,14 +33,8 @@ describe('parseCustomUpstream — 强制纯 IP', () => {
       tier: 1,
     });
   });
-  it('IP-DoT(tls) → Tier1 doh + dot:true', () => {
-    expect(parseCustomUpstream({ id: 'c', spec: 'tls://9.9.9.9:853' })).toMatchObject({
-      kind: 'doh',
-      ip: '9.9.9.9',
-      port: 853,
-      dot: true,
-      tier: 1,
-    });
+  it('IP-DoT(tls) → null（DoT 二期未实现，拒绝以免 UI 接受却永远 FAIL，review #2）', () => {
+    expect(parseCustomUpstream({ id: 'c', spec: 'tls://9.9.9.9:853' })).toBeNull();
   });
   it('裸 IP / udp → Tier2 udp', () => {
     expect(parseCustomUpstream({ id: 'c', spec: '8.8.8.8' })).toMatchObject({

--- a/src/shared/node-resolver-upstreams.ts
+++ b/src/shared/node-resolver-upstreams.ts
@@ -51,13 +51,16 @@ export function parseCustomUpstream(
   if (p.type === 'udp') {
     return { id: c.id, kind: 'udp', ip: p.server, port: p.port, tier: 2 };
   }
+  // DoT（tls://）二期未实现：race server queryOneUpstream 对 dot 直接 throw（永远 FAIL）。
+  // 此处拒绝，避免 UI 接受 tls:// 上游、用户以为生效却静默全 FAIL（review #2）。待 DoT 落地后改回 dot: p.type==='tls'。
+  if (p.type === 'tls') return null;
   return {
     id: c.id,
     kind: 'doh',
     ip: p.server,
     port: p.port,
-    path: p.type === 'https' ? p.path || '/dns-query' : undefined,
-    dot: p.type === 'tls',
+    path: p.path || '/dns-query',
+    dot: false,
     tier: 1,
   };
 }


### PR DESCRIPTION
对已合并的 #151–#161 做整体 code-review 后的跟进修复。

## High

- **DNS race watchdog 失效**（`node-dns-race-server.ts`）：socket 运行中异常时 watchdog `re-listen` 用 `bind(0)` 拿**新**端口，但 sing-box config 已烧旧 `raceServerPort` 且不因 socket 重建而重新生成 → 内核仍查旧端口、节点域名解析静默失效到下次全重启（fail-open 第二层实际无效）。修复：re-listen **重绑原端口**（对内核透明，已烧 config 的端口仍有效）；补 `'close'` 监听 + `relistening` 守卫防 `'error'`+`'close'` 双触发 + bind 回调 `closing` 闸门（防 re-listen 进行中 `stop()` 后 bind 回调复活 socket 成孤儿）。
- **DoT 上游 accept-but-drop**（`node-resolver-upstreams.ts`）：`tls://` 自定义上游被 `isValidCustomUpstreamSpec` 接受并归 Tier1，但 race server `queryOneUpstream` 对 `dot` 直接 throw → 永远 FAIL，且非空 Tier1 不触发 `[ali,dnspod]` 回退（pool 仅 DoT 时节点解析全断）。修复：DoT 二期未实现前 `parseCustomUpstream` 拒绝 `tls://`，UI 不再接受。

## Medium

- **title-bar 初始主题色**（`index.ts`）：用 `cfg.uiTheme === 'dark'` 字面比较，`uiTheme='system'`+OS 深色时初始误用浅色标题栏/背景 vs 深色内容；`onThemeUpdated` 仅在 OS 主题**切换**时修正、初始不跑。修复：改用 `nativeTheme.shouldUseDarkColors`（`themeSource` 已按 `uiTheme` 设定，`'system'` 跟随 OS）。
- **测速畸形响应当成功**（`SpeedTestService.ts`）：`parseHttpStatusCode` 返回 null（状态行无法解析 3 位码）时 `code !== null && ...` 为 false → fall through 记成功 TTFB，软重引入 #154 修复前「错误页当成功」。修复：`code === null` 也判失败。
- **`:853` 恒开**（`singbox-route-builder.ts`）：DoT 端口对任何 race 上游（含纯 DoH 内置）放行，注释却称「仅自定义 DoT 时加」，且 race server 根本不支持 DoT。修复：移除（待 DoT 落地按「上游中确有 dot」精确放行）。
- **preflight 误带 live race server**（`ProxyManager.ts`）：`buildPreflightConfigJson` 在代理运行时（`raceServerPort>0`）生成 config 会引用 live race server，与「snapshot/preflight 恒 race-off」不变量矛盾。修复：临时 `raceServerPort=0` 强制 race-off。

## Low

- 删 dead i18n key `nodeResolverAdd`（5 locale，零消费者）+ 补 2 个 watchdog 单测（被动 close 重建端口不变 / stop 后 close 不重建）+ 注释/排版收尾。

## 验证

- gate 全绿：tsc main+renderer exit 0 / eslint 0 / jest **1798 passed / 35 snapshots 零变化**。
- 三轮独立对抗性 review 收敛全绿（High 竞态经 dgram bind/close 行为实证确认封死复活路径）。
- 待真机：title-bar 主题在 Windows（`uiTheme=system`+OS 深色）启动一致性（其余为配置生成/逻辑层，gate 覆盖）。
