### PR TITLE
fix(ui): 应用内 toast 通知下移避开 Windows 标题栏关闭按钮

### DIFF
--- a/src/renderer/components/ui/sonner.tsx
+++ b/src/renderer/components/ui/sonner.tsx
@@ -3,6 +3,11 @@ import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
+// 集成标题栏适配：Windows titleBarOverlay 的最小/最大/关闭按钮在右上 32px 区，top-right toast 用 sonner 默认
+// offset(~24px) 会插进/紧贴关闭按钮 → 下移到 48px（避开 32px 区 + 16px 间隙）。Linux 原生框保险同处理；
+// Mac 红绿灯在左上、top-right 不接缝 → 保持默认 offset。其余边（right）未给沿用 sonner 默认。
+const notMacPlatform = window.electron?.platform !== 'darwin';
+
 const Toaster = ({ richColors, ...props }: ToasterProps) => {
   const { theme } = useTheme();
 
@@ -19,6 +24,7 @@ const Toaster = ({ richColors, ...props }: ToasterProps) => {
       theme={resolvedTheme as 'light' | 'dark'}
       className="toaster group"
       richColors={richColors}
+      offset={notMacPlatform ? { top: '48px' } : undefined}
       toastOptions={{
         classNames: {
           toast:


### PR DESCRIPTION
应用内 toast 通知（sonner，`position="top-right"`）在 **Windows** 集成标题栏下与右上的最小/最大/**关闭按钮接缝**。

## 根因

Windows `titleBarOverlay` 的窗口控制按钮在右上 32px 区，sonner top-right toast 默认 `offset` ~24px → toast 顶部落在 32px 标题栏区内，紧贴/插进关闭按钮。

## 修复

`components/ui/sonner.tsx` 封装加平台条件 `offset`：
- **非 Mac（Windows + Linux 保险）**：`offset={{ top: '48px' }}` 下移，避开 32px 标题栏区 + 留 16px 间隙；`right` 边未给、沿用 sonner 默认。
- **Mac**：红绿灯在左上、top-right 不接缝 → 保持默认 offset（不传）。

Linux 是原生框、系统标题栏在 Electron 视口外，理论不接缝；为保险一并下移（无害）。

## 验证

gate 全绿：tsc renderer exit 0 / eslint 0 / jest 全量绿（117 suites / 1794 tests / 35 snapshots）。Windows 真机手动确认 toast 不再贴关闭按钮。
