### PR TITLE
fix(ui): 折叠 toggle 对齐导航项 + 设置页满宽跟随窗口

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -152,9 +152,16 @@ export function Sidebar({
         <button
           onClick={toggleCollapsed}
           title={collapsed ? t('sidebar.expand', '展开侧栏') : t('sidebar.collapse', '收起侧栏')}
-          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
+          className={`flex items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground ${
+            collapsed ? (isMac ? 'h-[52px] w-[52px]' : 'h-[44px] w-[44px]') : 'h-7 w-7'
+          }`}
         >
-          <PanelLeft className="h-[18px] w-[18px] rtl-mirror" strokeWidth={1.8} />
+          {/* 折叠态与导航项(.nav-item.collapsed)同尺寸方块+图标，使 icon-rail 顶部 toggle 与下方导航整齐对齐
+              （Mac 52/26、Win·Linux 44/22）；展开态保持 28/18 小巧 toggle。 */}
+          <PanelLeft
+            className={`${collapsed ? (isMac ? 'h-[26px] w-[26px]' : 'h-[22px] w-[22px]') : 'h-[18px] w-[18px]'} rtl-mirror`}
+            strokeWidth={1.8}
+          />
         </button>
       </div>
 

--- a/src/renderer/pages/settings-page.tsx
+++ b/src/renderer/pages/settings-page.tsx
@@ -54,10 +54,10 @@ export function SettingsPage({ activeSection }: SettingsPageProps) {
   const meta = sectionTitles[activeSection] ?? sectionTitles.general;
 
   return (
-    // 设置/表单页：居中窄列（max-w-[720px] mx-auto）。表单控件定宽，满宽会让「标签左·控件右」中间空一大条；
-    // 居中窄列让控件填满列、两侧对称留白（macOS 系统设置 / Win11 Fluent 同款，刻意整洁）。
-    // 密集列表页（规则/节点/连接）仍满宽，分而治之。
-    <div className="mx-auto max-w-[720px] space-y-6">
+    // 设置页满宽跟随窗口（用户选定：自动缩放、不居中留白）。跟随 main-layout container(max-w-1400)：
+    // 窗口 < 1400 铺满、> 1400 由 container 统一居中。SettingsRow「标签左·控件右」在宽窗口会拉开，
+    // 是用户知情的取舍（换取大屏不浪费空间）；与密集列表页（规则/节点/连接）满宽行为一致。
+    <div className="space-y-6">
       <PageHeader
         title={t(meta.titleKey, meta.defaultTitle)}
         description={t(meta.descKey, meta.defaultDesc)}


### PR DESCRIPTION
Mac 真机验证发现的两处侧栏 / 设置 UI 修复。

## 1. 折叠 toggle 对齐导航项

#163 放大了折叠态**导航项**，漏了侧栏顶部的折叠/缩放 toggle 按钮（PanelLeft）——折叠后 toggle（28/18px）比导航项（52/44px 方块）小一圈，破坏 icon-rail 整齐。

修复：折叠态 toggle 按钮与导航项**同尺寸**——Mac 52/26px、Win·Linux 44/22px；展开态保持 28/18px 小巧 toggle。原则：折叠态侧栏是「图标栏(icon-rail)」，toggle 与导航项须同一套视觉、不论平台。

## 2. 设置页满宽跟随窗口

设置页 `max-w-[720px] mx-auto` 居中窄列，大窗口下两侧大量留白。修复：去掉 `max-w-720` → 满宽跟随 `main-layout` container（`max-w-1400`），窗口 < 1400 铺满、> 1400 由 container 统一居中，与密集列表页（规则/节点/连接）一致。

`SettingsRow`「标签左·控件右」满宽下会拉开距离——知情取舍，换大屏不浪费空间。

## 验证

gate 全绿：tsc renderer exit 0 / eslint 0 / jest 117 suites / 1794 tests / 35 snapshots。Mac 真机手动确认 toggle 对齐 + 设置页满宽。
