### PR TITLE
fix: 消除两类 OOM 边缘风险（GitHub JSON 字节上限 + connMap size 上限）

### DIFF
--- a/src/main/services/RuleResourceManager.ts
+++ b/src/main/services/RuleResourceManager.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import * as fssync from 'fs';
 import * as path from 'path';
 import { getRuleResourcesPath } from '../utils/paths';
+import { MAX_GITHUB_JSON_BYTES } from '../utils/http-limits';
 import { applyGhProxy, ghMirrorUrl, normalizeGhProxyPrefix } from '../../shared/gh-proxy';
 import {
   mrdRawUrl,
@@ -723,7 +724,19 @@ export class RuleResourceManager {
           reject(new Error(`http ${status}`));
           return;
         }
-        res.on('data', (c: Buffer) => chunks.push(c));
+        let received = 0;
+        res.on('data', (c: Buffer) => {
+          received += c.length;
+          // OOM 防护（审计 #1）：GitHub git-trees JSON 被劫持/WAF 可回灌 GB 级 → chunks 无界 + Buffer.concat 峰值放大；
+          // 两个 ?recursive=1 请求经 Promise.all 并发各持一份，更需上限。超 16MiB 即中止（catalog tree 实际 < 数 MB）。
+          if (received > MAX_GITHUB_JSON_BYTES) {
+            clearTimeout(overall);
+            req.abort();
+            reject(new Error('response too large'));
+            return;
+          }
+          chunks.push(c);
+        });
         res.on('end', () => {
           clearTimeout(overall);
           try {

--- a/src/main/services/StatsService.ts
+++ b/src/main/services/StatsService.ts
@@ -16,6 +16,10 @@ import type {
 // 流推送间隔：1s（纳秒，int64）。对齐旧轮询 1s 节奏（首页速率/连接数体感）。
 const STATUS_INTERVAL_NS = 1_000_000_000;
 const CONNECTIONS_INTERVAL_NS = 1_000_000_000;
+// OOM 安全网（审计 #3）：sing-box 系统性漏发 CLOSED（UDP/QUIC NAT 超时回收高发）时 connMap 漏删条目单调累积。
+// 正常活跃连接数 << 此值；仅异常累积时硬上限驱逐最旧条目兜底防 OOM。刻意不用 TTL 清扫——会误清合法长连接
+// （VPN/大下载 > TTL 仍活，被删后 UPDATE 帧 connection=null 无法补建 → 丢到下次 reset），size 上限更安全。
+const MAX_CONN_MAP_SIZE = 50_000;
 
 /** 数值规整：string/number → number，非有限值 → undefined（避免 NaN 进 UI 差分）。 */
 function num(v: unknown): number | undefined {
@@ -290,6 +294,13 @@ export class StatsService {
           if (ev?.connection) this.connMap.set(id, ev.connection);
           break;
       }
+    }
+    // OOM 安全网（审计 #3）：超硬上限按插入顺序（JS Map 迭代序=最早插入、最可能是漏删的死连接）驱逐最旧，
+    // 不依赖上游 CLOSED 事件完整性。正常 connMap.size << 上限，此循环不触发。
+    while (this.connMap.size > MAX_CONN_MAP_SIZE) {
+      const oldest = this.connMap.keys().next().value;
+      if (oldest === undefined) break;
+      this.connMap.delete(oldest);
     }
     // 活动连接数由本流的 connMap.size 维护（Status 的 connectionsIn/Out 核不填 → 首页恒 0 的根因）；在可见性
     // 短路前更新，使下一次 Status onUpdate 广播到的计数恒为真实活跃连接数。

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import { LogManager } from './LogManager';
 import type { UpdateInfo, UpdateCheckResult, UpdateProgress } from '../../shared/types/update';
 import { APP_USER_AGENT } from '../../shared/constants';
+import { MAX_GITHUB_JSON_BYTES } from '../utils/http-limits';
 import { getUserDataPath } from '../utils/paths';
 import { system32 } from '../utils/win-system32';
 import { compareSemver } from '../../shared/version';
@@ -663,7 +664,23 @@ export class UpdateService {
 
       request.on('response', (res) => {
         let data = '';
-        res.on('data', (chunk) => (data += chunk.toString()));
+        res.on('data', (chunk) => {
+          // 已收口（超限/超时/错误）后忽略 drain 中的残帧：abort 不同步停止 res，
+          // 已 buffer 的帧仍会触发 data，若继续累加会徒增内存峰值。
+          if (settled) return;
+          data += chunk.toString();
+          // OOM 防护（审计 #2）：GitHub api 被劫持/WAF 接管可回灌 GB 级响应撞 V8 堆/512MB string 上限。
+          // 启动后 5s 自动检查更新即可被诱发。超 16MiB 即 abort + 单点收口 finish（releases JSON 实际 < 数 MB）。
+          if (data.length > MAX_GITHUB_JSON_BYTES) {
+            try {
+              request.abort();
+            } catch {
+              /* ignore */
+            }
+            finish(new Error('GitHub 响应过大（疑似被劫持/WAF 拦截）'));
+            return;
+          }
+        });
         res.on('end', () => {
           if (res.statusCode === 200) {
             try {

--- a/src/main/services/__tests__/stats-service-gating.test.ts
+++ b/src/main/services/__tests__/stats-service-gating.test.ts
@@ -260,6 +260,22 @@ describe('StatsService 流式门控（gRPC streams）', () => {
       expect(conns).toHaveLength(1);
       expect(conns[0].id).toBe('conn-2');
     });
+
+    it('OOM 安全网（审计 #3）：connMap 超 50k 硬上限时驱逐最旧条目（漏 CLOSED 兜底）', () => {
+      const { service, mock } = setup({ withVisible: true, visible: false }); // 不可见省 50k 列表物化开销
+      service.start();
+      // 模拟 sing-box 系统性漏发 CLOSED → 50001 条 NEW 累积超上限
+      const events = Array.from({ length: 50_001 }, (_, i) => ({
+        type: 'NEW' as const,
+        id: `conn-${i}`,
+        connection: { ...RAW_CONN, id: `conn-${i}` },
+      }));
+      mock.pushConn({ reset: true, events });
+      // 硬上限驱逐最旧（Map 插入序）：size 收敛到 50000，最早的 conn-0 被驱逐、最新的保留
+      expect((service as any).connMap.size).toBe(50_000);
+      expect((service as any).connMap.has('conn-0')).toBe(false);
+      expect((service as any).connMap.has('conn-50000')).toBe(true);
+    });
   });
 
   describe('缺省行为（未注入 isWindowVisible）', () => {

--- a/src/main/services/core-downloader.ts
+++ b/src/main/services/core-downloader.ts
@@ -17,6 +17,7 @@ import { APP_USER_AGENT } from '../../shared/constants';
 import { ghMirrorUrl, normalizeGhProxyPrefix } from '../../shared/gh-proxy';
 import { createIdleTimeout, parseExpectedBytes } from './download-hardening';
 import { powershellPath } from '../utils/win-system32';
+import { MAX_GITHUB_JSON_BYTES } from '../utils/http-limits';
 import { findSuitableSingboxAsset } from './singbox-asset';
 
 export class CoreDownloader {
@@ -75,7 +76,23 @@ export class CoreDownloader {
 
       request.on('response', (res) => {
         let data = '';
-        res.on('data', (chunk) => (data += chunk.toString()));
+        res.on('data', (chunk) => {
+          // 已收口（超限/超时/错误）后忽略 drain 中的残帧：abort 不同步停止 res，
+          // 已 buffer 的帧仍会触发 data，若继续累加会徒增内存峰值。
+          if (settled) return;
+          data += chunk.toString();
+          // OOM 防护（审计 #2）：GitHub api 被劫持/WAF 接管可回灌 GB 级响应撞 V8 堆/512MB string 上限。
+          // 超 16MiB 即 abort + 单点收口 finish（releases JSON 实际 < 数 MB；与超时同路径）。
+          if (data.length > MAX_GITHUB_JSON_BYTES) {
+            try {
+              request.abort();
+            } catch {
+              /* ignore */
+            }
+            finish(new Error('GitHub 响应过大（疑似被劫持/WAF 拦截）'));
+            return;
+          }
+        });
         res.on('end', () => {
           if (res.statusCode === 200) {
             try {

--- a/src/main/utils/http-limits.ts
+++ b/src/main/utils/http-limits.ts
@@ -1,0 +1,13 @@
+/**
+ * GitHub API JSON 响应字节上限（OOM 防护，issue: OOM 审计 #1/#2）。
+ *
+ * 背景：core-downloader / UpdateService / RuleResourceManager 三处经 net.request 抓 GitHub API JSON
+ * （releases / git-trees catalog），res.on('data') 累加 data/chunks 时**无字节上限**。当 api.github.com
+ * 或其加速镜像被劫持 / 被中间设备或 WAF 接管，可在超时窗口内回灌 GB 级响应体 → 字符串/Buffer 无界累加
+ * + Buffer.concat/toString/JSON.parse 峰值多重放大 → 撞 V8 max string length(~512MB) / 堆上限 → 主进程
+ * FATAL OOM（启动后 5s 自动检查更新即可被诱发，无需用户交互）。
+ *
+ * GitHub releases / catalog tree JSON 实际体量 < 数 MB，16MiB 上限足够正常使用 + 截断恶意灌流。
+ * 与同仓现成护栏一致（WarpService data.length>1MB / IpInfoService body.length>8KB 即 destroy/abort）。
+ */
+export const MAX_GITHUB_JSON_BYTES = 16 * 1024 * 1024;


### PR DESCRIPTION
## 背景

对整个项目做了一次 OOM 内存风险审计（5 维度并行铺开 + 逐候选对抗验证：无界结构 / 监听器累积 / 定时器句柄进程 / IO buffer & IPC / 闭包保活 & 渲染端泄漏）。21 个候选经对抗验证收敛为 3 个确认风险，其余 18 个为假阳性（核心 I/O 路径多已有 MAX_SIZE 闸门，内存治理本就扎实）。3 个确认风险均为条件性边缘风险（外部劫持 / 上游缺陷诱发，非常态泄漏），本 PR 修复之。

## #1/#2 GitHub API JSON 抓取无字节上限（Medium）

`core-downloader` / `UpdateService` / `RuleResourceManager` 三处 `net.request` 抓 GitHub JSON，`res.on('data')` 累加无字节上限。`api.github.com` / 加速镜像被劫持或 WAF 接管回灌 GB 级响应时，`toString` / `Buffer.concat` / `JSON.parse` 峰值多重放大 → 撞 V8 max string length(~512MB) / 堆 → 主进程 FATAL OOM。**启动后 5s 自动检查更新即可被诱发**（无需用户交互）；catalog 两个 `?recursive=1` 经 `Promise.all` 并发各持一份无界 buffer 叠加峰值。

修复：三处加共享 16MiB 字节上限（`MAX_GITHUB_JSON_BYTES`，`src/main/utils/http-limits.ts`），超限即 `abort` + 按各自机制收口（`finish` 单点收口 / `reject`）。`data` 回调加 `settled` 守卫——`abort` 不同步停止 `res`，收口后忽略已 buffer 的 drain 残帧、不再累加。对齐同仓现成护栏（`WarpService` 1MB / `IpInfoService` 8KB）。releases / catalog JSON 实际 < 数 MB，16MiB 余量充足不误伤。

## #3 StatsService.connMap 缺 size 上限（Low）

7x24 长跑 + sing-box 系统性漏发 `CLOSED`（UDP/QUIC NAT 超时回收高发）时，`connMap` 仅靠 `CLOSED→delete` / `reset→clear`，无独立兜底 → 漏删条目单调累积可达数十万级 → OOM。

修复：`onConnectionEvents` 末尾加硬 size 上限 LRU（`MAX_CONN_MAP_SIZE = 50_000`），超限按 JS Map 插入序（= 最早插入、最可能漏删的死连接）驱逐最旧。**刻意舍 TTL**：TTL 清扫会误清合法长连接（VPN / 大下载 > TTL 仍活），被删后 UPDATE 帧的 `connection` 字段实测为 null 无法补建 → 活连接丢失到下次 reset。size 上限正常 <<50k 不触发、不误清，纯异常兜底。补驱逐单测（注入 50001 NEW 验证收敛到 50000、最旧被删、最新保留）。

## 验证

gate 全绿：tsc main exit 0 / eslint 0 / 相关单测全过（含新增 #3 驱逐 case）。两类修复经独立 agent 对抗审查全绿（字节上限收口/abort 语义、size 上限驱逐目标/取舍/回归）。