### PR TITLE
fix(core): Windows 换核覆盖统一——补 reseed 执行 + 现役核迁 userData（修升级不覆盖/重装降级）

### DIFF
--- a/src/main/services/ResourceManager.ts
+++ b/src/main/services/ResourceManager.ts
@@ -58,12 +58,14 @@ export class ResourceManager {
     // Windows 平台需要 .exe 扩展名
     const filename = this.platform === 'win32' ? 'sing-box.exe' : 'sing-box';
 
-    // Windows Portable 模式特殊处理：优先使用 userData 下的核心
-    if (this.platform === 'win32' && process.env.PORTABLE_EXECUTABLE_DIR) {
+    // Windows（portable + 安装版统一）：优先 userData 可写核——换核覆盖跨平台统一模型：现役核恒为可写核、随包核
+    // 只是种子（见 docs/design/core-override-cross-platform-unify）。存在才用、缺失回落随包种子，故首启/迁移永不 brick；
+    // 现役核与安装目录种子解耦后，NSIS 重装覆盖种子不再降级用户已更新到的更新核。
+    if (this.platform === 'win32') {
       const fs = require('fs');
-      const portableCorePath = path.join(app.getPath('userData'), 'core_update', filename);
-      if (fs.existsSync(portableCorePath)) {
-        return portableCorePath;
+      const winCorePath = path.join(app.getPath('userData'), 'core_update', filename);
+      if (fs.existsSync(winCorePath)) {
+        return winCorePath;
       }
     }
 
@@ -102,8 +104,9 @@ export class ResourceManager {
   getSingBoxUpdateTargetPath(): string {
     const filename = this.platform === 'win32' ? 'sing-box.exe' : 'sing-box';
 
-    // Windows Portable 模式特殊处理：更新文件必须写入 userData 才能持久化
-    if (this.platform === 'win32' && process.env.PORTABLE_EXECUTABLE_DIR) {
+    // Windows（portable + 安装版统一）：核更新/换核写入 userData 可写核（与 getSingBoxPath 优先项一致），
+    // 使现役核与安装目录随包种子解耦——重装/升级 NSIS 覆盖种子不再降级用户更新到的更新核（统一模型）。
+    if (this.platform === 'win32') {
       return path.join(app.getPath('userData'), 'core_update', filename);
     }
 
@@ -377,13 +380,18 @@ export class ResourceManager {
       }
       return this.getSingBoxPath();
     }
-    if (this.platform !== 'linux') {
+    // Linux + Windows：userData 可写核（种子 + 版本感知 reseed），其它平台无可写核 → 回落 getSingBoxPath。
+    // Windows 曾在此 no-op（reseed 不执行 → 升级带来更新随包核时旧可写核永不被替换、需手动「重置出厂」）——
+    // 本处统一补齐换核执行（设计见 docs/design/core-override-cross-platform-unify）。原子 rename 规避运行中 .exe
+    // 文件锁（reseed 在 core spawn 之前 + #150 version 探测串行，撞锁概率极低；真失败则诚实 reseedError）。
+    if (this.platform !== 'linux' && this.platform !== 'win32') {
       return this.getSingBoxPath();
     }
 
+    const filename = this.platform === 'win32' ? 'sing-box.exe' : 'sing-box';
     const userDataPath = app.getPath('userData');
     const updateDir = path.join(userDataPath, 'core_update');
-    const targetPath = path.join(updateDir, 'sing-box');
+    const targetPath = path.join(updateDir, filename);
 
     // 检查是否已经有可写核心（force=true 跳过复用、强制用随包核覆盖——§5 最低版本守卫：升级遗留的旧可写核
     // 会被硬切 1.14 的配置 FATAL，须随包 1.14 核覆盖刷新）
@@ -398,7 +406,7 @@ export class ResourceManager {
 
     // 从应用内置的包中复制（force 时 copyFile 覆盖旧核）
     const platformDir = this.getPlatformResourceDir();
-    const sourcePath = path.join(platformDir, 'sing-box');
+    const sourcePath = path.join(platformDir, filename);
 
     if (await this.fileExists(sourcePath)) {
       // 原子替换（写 targetPath.tmp → chmod 0o755 → rename），非原地 copyFile 覆盖：force 重播种时 targetPath

--- a/src/main/services/__tests__/core-reseed-windows.test.ts
+++ b/src/main/services/__tests__/core-reseed-windows.test.ts
@@ -1,0 +1,125 @@
+/**
+ * 换核覆盖跨平台统一 — Windows 单测（设计见 docs/design/core-override-cross-platform-unify）。
+ *
+ * 修复前：Windows 上 ensureWritableCore 是 no-op（reseed 不执行），升级带来更新随包核时旧可写核永不被替换、
+ * 需手动「重置出厂」；且 getSingBoxPath/UpdateTargetPath 只在 portable 才用 userData，安装版现役核耦合安装目录。
+ * 本测固化统一后行为：Windows（portable+安装版）现役核恒为 userData 可写核、随包核只是种子，reseed 真正执行。
+ *
+ * 真实临时目录 + mock electron.app（isPackaged=true → baseDir=process.resourcesPath）+ process.platform='win32'。
+ * 注：跑在 Linux 宿主，'sing-box.exe' 仅为文件名、atomicCopy 走宿主 fs，验的是路径/换核【逻辑】（同 cronet 测 win32）。
+ */
+import * as os from 'os';
+import * as fsSync from 'fs';
+import * as path from 'path';
+
+const ROOT = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-reseed-win-'));
+const RESOURCES = path.join(ROOT, 'resources');
+Object.defineProperty(process, 'resourcesPath', { value: RESOURCES, configurable: true });
+
+jest.mock('electron', () => ({
+  app: { getPath: () => ROOT, getVersion: () => '9.9.9', isPackaged: true, getAppPath: () => ROOT },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ResourceManager } from '../ResourceManager';
+
+const ORIG_PLATFORM = process.platform;
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+
+const WIN_BUNDLE = path.join(RESOURCES, 'win'); // 生产 baseDir=process.resourcesPath → resources/win
+const CORE_UPDATE = path.join(ROOT, 'core_update'); // userData/core_update
+const SOURCE = path.join(WIN_BUNDLE, 'sing-box.exe');
+const TARGET = path.join(CORE_UPDATE, 'sing-box.exe');
+
+function seedBundleCore(content: string): void {
+  fsSync.mkdirSync(WIN_BUNDLE, { recursive: true });
+  fsSync.writeFileSync(SOURCE, content);
+}
+
+beforeEach(() => {
+  fsSync.rmSync(RESOURCES, { recursive: true, force: true });
+  fsSync.rmSync(CORE_UPDATE, { recursive: true, force: true });
+  delete process.env.PORTABLE_EXECUTABLE_DIR; // 验「安装版(非 portable)也走 userData」=统一关键
+  setPlatform('win32');
+});
+
+afterAll(() => {
+  setPlatform(ORIG_PLATFORM);
+  try {
+    fsSync.rmSync(ROOT, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function mkRm(): ResourceManager {
+  const rm = new ResourceManager();
+  rm.setLogManager({ addLog: () => {} } as any);
+  return rm;
+}
+
+describe('ensureWritableCore(win32) — 换核执行不再 no-op', () => {
+  it('force：旧可写核 ← 随包核 原子替换（inode 改变=rename，内容更新，无 .tmp）', async () => {
+    seedBundleCore('NEW-CORE-1.14.0-alpha.34');
+    fsSync.mkdirSync(CORE_UPDATE, { recursive: true });
+    fsSync.writeFileSync(TARGET, 'OLD-CORE-1.14.0-alpha.33'); // 旧可写核（升级前残留）
+    const inodeBefore = fsSync.statSync(TARGET).ino;
+
+    const rm = mkRm();
+    const ret = await rm.ensureWritableCore(true);
+
+    expect(ret).toBe(TARGET); // 返回 userData 可写核（非 no-op 回 bundle）
+    expect(fsSync.readFileSync(TARGET, 'utf-8')).toBe('NEW-CORE-1.14.0-alpha.34'); // 真换了
+    expect(fsSync.statSync(TARGET).ino).not.toBe(inodeBefore); // rename 非原地覆盖
+    expect(fsSync.existsSync(`${TARGET}.tmp`)).toBe(false);
+  });
+
+  it('non-force 且无可写核 → 从随包核播种（首启）', async () => {
+    seedBundleCore('NEW-CORE-1.14.0-alpha.34');
+    expect(fsSync.existsSync(TARGET)).toBe(false);
+
+    const rm = mkRm();
+    const ret = await rm.ensureWritableCore(false);
+
+    expect(ret).toBe(TARGET);
+    expect(fsSync.readFileSync(TARGET, 'utf-8')).toBe('NEW-CORE-1.14.0-alpha.34');
+  });
+
+  it('non-force 且已有可写核 → 复用，不覆盖（不降级用户已装核）', async () => {
+    seedBundleCore('BUNDLED-alpha.34');
+    fsSync.mkdirSync(CORE_UPDATE, { recursive: true });
+    fsSync.writeFileSync(TARGET, 'USER-UPDATED-alpha.35'); // 用户更新到更新核
+
+    const rm = mkRm();
+    const ret = await rm.ensureWritableCore(false);
+
+    expect(ret).toBe(TARGET);
+    expect(fsSync.readFileSync(TARGET, 'utf-8')).toBe('USER-UPDATED-alpha.35'); // 未被随包覆盖
+  });
+});
+
+describe('getSingBoxPath / getSingBoxUpdateTargetPath(win32) — 安装版也走 userData（不再仅 portable）', () => {
+  it('getSingBoxPath：userData 可写核存在 → 用它（无 PORTABLE_EXECUTABLE_DIR 也生效）', () => {
+    seedBundleCore('BUNDLED');
+    fsSync.mkdirSync(CORE_UPDATE, { recursive: true });
+    fsSync.writeFileSync(TARGET, 'WRITABLE');
+    const rm = mkRm();
+    expect(rm.getSingBoxPath()).toBe(TARGET);
+  });
+
+  it('getSingBoxPath：userData 无可写核 → 回落随包种子（首启/迁移不 brick）', () => {
+    seedBundleCore('BUNDLED');
+    const rm = mkRm();
+    expect(rm.getSingBoxPath()).toBe(SOURCE);
+  });
+
+  it('getSingBoxUpdateTargetPath：恒指向 userData 可写核（与现役核解耦安装目录种子）', () => {
+    const rm = mkRm();
+    expect(rm.getSingBoxUpdateTargetPath()).toBe(TARGET);
+  });
+});


### PR DESCRIPTION
将内核换核覆盖逻辑跨平台统一，修复 Windows 上「升级带来更新随包核但不自动覆盖、需手动重置出厂」。

## 根因

- **Windows reseed 是 no-op**：`decideCoreOverride` 正确判定「现役核旧于随包核 → 要换」，但 `ensureWritableCore` 在非 Linux 直接 `return getSingBoxPath()`，**不执行换核**。于是升级（如内核 1.14.0-alpha.33 → 随包 alpha.34）后旧可写核永不被替换，用户必须手动「设置·内核·重置出厂」。
- **Setup（非 portable）现役核耦合安装目录**：`getSingBoxPath` 只在 portable 才查 userData，安装版直接用安装目录随包核 → NSIS 重装无条件覆盖、可把用户更新到的**更新核降级**。

不是 `decideCoreOverride`/`compareSemver` 的问题（同为预览版 alpha.33 < alpha.34 判定正确，现有单测已证 alpha.30<alpha.32 reseed）——纯粹是执行层 Windows 缺失 + 安装版现役核耦合安装器。

## 统一模型

对齐 Linux/macOS 已有模型：**现役核恒为可写核（userData/core_update），随包核只是种子，版本感知 `decideCoreOverride` 为唯一权威**，所有平台/安装方式共用同一策略。

| 现役核 vs 随包核 | 来源 | 动作 |
|---|---|---|
| 现役严格旧于随包（含 alpha.33<alpha.34） | 官方 | 覆盖（reseed） |
| 相等 | 官方 | 保持 |
| 现役严格新于随包（用户手动升过 / 重装带来更旧随包） | 官方 | 保持，不降级 |
| 任意 | fork/自建 | 绝不覆盖；≤基线 warn |

## 改动（仅 ResourceManager.ts + 1 新测试）

- `getSingBoxPath` / `getSingBoxUpdateTargetPath`：Windows 一律优先 `userData/core_update`（去掉仅 portable 限制）；存在才用、缺失回落随包种子（首启/迁移不 brick，有 existsSync 守卫）。
- `ensureWritableCore`：补 win32 分支，走与 Linux 同款 `atomicCopy`(tmp→chmod→rename) reseed（`sing-box.exe`；原子 rename 规避运行中 .exe 文件锁，撞锁则诚实 reseedError、不半残）。
- 不降级双层保证：`decideCoreOverride`(现役新于随包→keep) + non-force `ensureWritableCore` 不覆盖已有可写核。

## 测试

`tsc` / `eslint` / `jest`（全量 1818）全绿；新增 `core-reseed-windows.test.ts`：force reseed(inode 改变=rename) / 首启播种 / non-force 不覆盖用户更新核(alpha.35) / `getSingBoxPath` userData 优先+缺失回落 / `UpdateTargetPath`；显式 unset `PORTABLE_EXECUTABLE_DIR` 验「安装版也走 userData」。

调用面经全量对差核实（CoreUpdateService 备份/落位/回滚、libcronet、测速、spawn 均自洽）。

## 待真机验证（runtime/平台敏感，CI/单测不可覆盖）

1. **Win Setup 不降级**：装 alpha.34 包 → 设置内更新核到 alpha.35（写 userData）→ 重装 alpha.34 包 → 首启仍 alpha.35、不被降级、免「重置出厂」。
2. **Win Setup 自动 reseed**：现役旧核（如 1.13）→ 升级到带 1.14 随包的包 → 首启自动换核到 1.14、过版本闸门。
3. **Win TUN + helper binPath**（既有 TS-H2 限制的延伸，非本次回归）：先更新核到 userData 再装 helper → 服务（LocalSystem）能否起 userData 下的核（LocalSystem 读 LocalAppData 的可达性）。触发面窄（仅 TUN+helper已装+install时点 userData 已有核），不影响系统代理模式与 app 侧 spawn。
