### PR TITLE
fix(ui): 折叠侧栏 toggle 与导航之间补分隔线

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -165,6 +165,12 @@ export function Sidebar({
         </button>
       </div>
 
+      {/* 折叠态：toggle(控制) 与下方导航(目标) 之间补一条边界线，与组间分隔同款。
+          收起后 toggle 被放大成与导航项同尺寸方块，易被误读为首个导航项 → 分隔澄清「控制≠导航」、
+          并使顶部分组节奏与中段(routing/diagnostics 组前分隔)一致。
+          展开态 toggle 为 28px 小按钮、形态已区分，不渲染。 */}
+      {collapsed && <div className="mx-auto my-1.5 h-px w-5 bg-border/50" />}
+
       {isSettings ? (
         /* ── Settings sub-navigation ── */
         <>


### PR DESCRIPTION
## 背景

折叠侧栏（icon-rail）中段已用短分隔线给导航做语义分组（导航 | 路由 | 诊断），唯独顶部「控制 → 导航」这条边界缺失。

折叠态下 toggle 按钮被刻意放大成**与导航项同尺寸的方块**（Mac 52、Win/Linux 44），和首个导航项 home 同列、同尺寸、同样式，易被误读为「第一个导航项」。但它实为控制按钮（开关 rail 宽度，点击不跳页），与 home/server 这类导航目标本质不同类。

## 改动

在 toggle 容器与导航之间补一条与组间同款短分隔线（`mx-auto my-1.5 h-px w-5 bg-border/50`），**仅折叠态渲染**：
- 澄清「控制 ≠ 导航」的语义层级；
- 使顶部分组节奏与中段（routing/diagnostics 组前分隔）一致、对称。

展开态 toggle 为 28px 小按钮、形态已与导航项明显不同，**不渲染**该分隔线（避免顶部显碎）。放在共用位置，主导航与设置子导航折叠态一致生效。复用现成短线样式，零新增样式。

## 验证

gate 绿：tsc（renderer+main）exit 0 / eslint 0。纯视觉条件渲染、复用既有 class（无裸 hex，符合 renderer no-restricted-syntax 护栏）。真机视觉由 Mac 端观察确认。