### PR TITLE
fix(ui): 提升折叠侧栏分隔线辨识度

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -86,6 +86,10 @@ const settingsNavItems = [
 const isMac = window.electron?.platform === 'darwin';
 const isWindows = window.electron?.platform === 'win32';
 
+// 折叠 icon-rail 分隔线（toggle↓导航 + routing/diagnostics 分组前共用）：bg-muted-foreground/40
+// 跨浅(#e9eef3)/深(#1f252e)主题对比适中、不刺眼；旧 bg-border/50 因 border 色贴近两主题背景、再砍半透明 → 几乎隐形。
+const RAIL_DIVIDER_CLASS = 'mx-auto my-1.5 h-px w-5 bg-muted-foreground/40';
+
 export function Sidebar({
   currentView,
   onViewChange,
@@ -169,7 +173,7 @@ export function Sidebar({
           收起后 toggle 被放大成与导航项同尺寸方块，易被误读为首个导航项 → 分隔澄清「控制≠导航」、
           并使顶部分组节奏与中段(routing/diagnostics 组前分隔)一致。
           展开态 toggle 为 28px 小按钮、形态已区分，不渲染。 */}
-      {collapsed && <div className="mx-auto my-1.5 h-px w-5 bg-border/50" />}
+      {collapsed && <div className={RAIL_DIVIDER_CLASS} />}
 
       {isSettings ? (
         /* ── Settings sub-navigation ── */
@@ -214,7 +218,7 @@ export function Sidebar({
                 {group.label &&
                   (collapsed ? (
                     /* 收起态：分区标题转居中短分隔线，保留分组视觉、不显凌乱 */
-                    <div className="mx-auto my-1.5 h-px w-5 bg-border/50" />
+                    <div className={RAIL_DIVIDER_CLASS} />
                   ) : (
                     <div className="px-3 pb-1 pt-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground select-none">
                       {t(`sidebar.group.${group.label}`)}


### PR DESCRIPTION
## 问题

折叠 icon-rail 的分隔线（toggle↓导航、routing/diagnostics 分组前）用 `bg-border/50`，真机几乎看不见——Mac 深色、Windows 浅色/深色主题同病。

根因:`--border` 色本身就贴近各主题背景（浅色 88%L vs 背景 `#e9eef3`≈94%L;深色 18%L vs 背景 `#1f252e`≈14%L），再叠 `/50` 半透明，等于在相近底色上画半透明细线 → 对比极低、基本隐形。

## 改动

分隔线改用 `bg-muted-foreground/40`:
- 浅色 `--muted-foreground` 40%L（中灰）压在 ~94%L 底 → 适中清晰;
- 深色 60%L（亮灰）压在 ~14%L 底 → 适中清晰;
- `/40` 透明度保留分隔线应有的「轻」，不变成刺眼硬线。

两处分隔线（折叠 toggle 下、各分组折叠态）抽 `RAIL_DIVIDER_CLASS` 常量统一，避免两处字面量各自漂移。

## 验证

gate 绿:tsc（renderer+main）0 / eslint 0。用 token class、无裸 hex（符合 renderer no-restricted-syntax 护栏）。Mac arm64 真机部署确认深色辨识度;Windows 浅/深为同 token 跨主题覆盖。