### PR TITLE
fix(config): TLS 引擎按平台门控，跨平台导入的不支持引擎降级为 Go

### DIFF
--- a/src/main/services/__tests__/singbox-outbound-builder.test.ts
+++ b/src/main/services/__tests__/singbox-outbound-builder.test.ts
@@ -19,6 +19,7 @@ import {
   buildProxyOutbound,
   isNodeUsable,
   prunedSelectorDefault,
+  shouldEmitTlsEngine,
 } from '../singbox-outbound-builder';
 import { resourceManager } from '../ResourceManager';
 import type { ServerConfig } from '../../../shared/types';
@@ -478,17 +479,27 @@ describe('buildProxyOutbound — 可选协议设置下发（B 组编辑项）', 
   });
 
   // P3c：TLS engine。仅对 TCP-TLS 协议下发；'go'/空省略；Hy2/TUIC（QUIC）即便设了也不下发。
-  it('tls engine：trojan engine=windows → tls.engine=windows', () => {
-    const ob = buildProxyOutbound(
-      node({
-        protocol: 'trojan',
-        password: 'pw',
-        security: 'tls',
-        tlsSettings: { serverName: 'a.com', engine: 'windows' },
-      }),
-      tags
-    ) as any;
-    expect(ob.tls.engine).toBe('windows');
+  it('tls engine：trojan engine=windows 在 win32 → tls.engine=windows；非 win32 → 降级省略', () => {
+    const orig = process.platform;
+    const make = () =>
+      buildProxyOutbound(
+        node({
+          protocol: 'trojan',
+          password: 'pw',
+          security: 'tls',
+          tlsSettings: { serverName: 'a.com', engine: 'windows' },
+        }),
+        tags
+      ) as any;
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      expect(make().tls.engine).toBe('windows');
+      // 跨平台导入降级：windows 引擎带到 linux/darwin → 落核心默认 Go 栈（不下发），免核 FATAL
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      expect(make().tls.engine).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: orig, configurable: true });
+    }
   });
 
   it('tls engine：engine=go 或未设 → 省略（用核心默认 Go TLS）', () => {
@@ -825,5 +836,37 @@ describe('buildProxyOutbound — TLS spoof（P3a 抗审查）', () => {
     } finally {
       Object.defineProperty(process, 'arch', { value: orig, configurable: true });
     }
+  });
+});
+
+describe('shouldEmitTlsEngine — TLS 引擎平台门控（跨平台导入降级）', () => {
+  const platforms: NodeJS.Platform[] = ['win32', 'darwin', 'linux'];
+
+  it('windows(Schannel) 仅 win32 下发', () => {
+    expect(shouldEmitTlsEngine('windows', 'win32')).toBe(true);
+    expect(shouldEmitTlsEngine('windows', 'darwin')).toBe(false);
+    expect(shouldEmitTlsEngine('windows', 'linux')).toBe(false);
+  });
+
+  it('apple(Network.framework) 仅 darwin 下发', () => {
+    expect(shouldEmitTlsEngine('apple', 'darwin')).toBe(true);
+    expect(shouldEmitTlsEngine('apple', 'win32')).toBe(false);
+    expect(shouldEmitTlsEngine('apple', 'linux')).toBe(false);
+  });
+
+  it('go / 空 / undefined / 未知引擎一律不下发（落核心默认 Go 栈）', () => {
+    for (const p of platforms) {
+      expect(shouldEmitTlsEngine('go', p)).toBe(false);
+      expect(shouldEmitTlsEngine('', p)).toBe(false);
+      expect(shouldEmitTlsEngine(undefined, p)).toBe(false);
+      expect(shouldEmitTlsEngine('bogus', p)).toBe(false);
+    }
+  });
+
+  it('跨平台导入降级回归点：apple 导入非 darwin、windows 导入非 win32 均不下发（免核 FATAL）', () => {
+    expect(shouldEmitTlsEngine('apple', 'win32')).toBe(false);
+    expect(shouldEmitTlsEngine('apple', 'linux')).toBe(false);
+    expect(shouldEmitTlsEngine('windows', 'darwin')).toBe(false);
+    expect(shouldEmitTlsEngine('windows', 'linux')).toBe(false);
   });
 });

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -35,6 +35,22 @@ function isQuicManagedTls(protocol: string): boolean {
   return p === 'hysteria2' || p === 'tuic';
 }
 
+/**
+ * TLS 系统原生栈引擎（tls.engine）是否应在当前平台下发：windows(Schannel) 仅 win32、apple(Network.framework)
+ * 仅 darwin。go / 空 / 未知一律返回 false（go 是核心默认跨平台 Go 栈，无需显式下发）。
+ * 平台兜底（第二道闸）：跨平台导入的配置——如 Mac 节点 engine='apple' 导入 Windows——经此降级，
+ * 非对应平台返回 false → 调用方落 Go 栈，防原样下发 apple/windows 在非对应平台致核 FATAL。
+ * 抽纯函数（传 platform 参数）以便单测，免在测试里 mock process.platform。
+ */
+export function shouldEmitTlsEngine(
+  engine: string | undefined,
+  platform: NodeJS.Platform
+): boolean {
+  if (engine === 'windows') return platform === 'win32';
+  if (engine === 'apple') return platform === 'darwin';
+  return false;
+}
+
 /** 组网节点「不承载全隧道」的原因短语，供诊断 warn 复用（Phase2 system 内核接口 vs 关外网）。 */
 function meshNonFullTunnelReason(server: ServerConfig): string {
   return meshUsesSystemInterface(server) ? 'system 内核接口模式' : '已关闭外网访问';
@@ -382,9 +398,9 @@ export function buildProxyOutbound(
     // TLS 栈引擎（P3c，sing-box 1.14 tls.engine）：windows(Schannel)/apple(Network.framework) 用系统原生栈，
     // ClientHello 指纹更真。仅对 TCP-TLS 协议下发——Hy2/TUIC 走 QUIC 自带 TLS1.3，系统 TCP-TLS 栈不适用，
     // 表单也不对它们暴露此项。'go'/空 = 跨平台 Go TLS（核心默认），无需显式下发。windows/apple 在非对应平台
-    // 运行时 FATAL，由表单按平台过滤可选值兜底。
+    // 运行时 FATAL → shouldEmitTlsEngine 按当前平台门控（表单过滤之外的第二道闸，兜跨平台导入的配置）。
     const tlsEngine = server.tlsSettings?.engine;
-    if (tlsEngine && tlsEngine !== 'go' && !isQuicManagedTls(protocol)) {
+    if (!isQuicManagedTls(protocol) && shouldEmitTlsEngine(tlsEngine, process.platform)) {
       outbound.tls.engine = tlsEngine;
     }
 


### PR DESCRIPTION
## 问题

sing-box `tls.engine` 的 `windows`(Schannel) / `apple`(Network.framework) 是系统原生 TLS 栈,**仅在对应平台可用**,非对应平台运行时核 FATAL。

此前生成层(`singbox-outbound-builder.ts`)对 engine **无平台门控**,代码注释写明"由表单按平台过滤可选值兜底"——但表单过滤只管"显示哪些选项",不改**已存的值**。于是跨平台导入的配置会出问题:

- Mac 上某节点设过 TLS 引擎 = Apple → 导出 backup → 导入 Windows;
- 用户不重新编辑该节点时,`engine='apple'` 原样保留 → 生成时写入 `tls.engine: apple` → **Windows 核 FATAL**。反向同理(Win 的 `windows` 导入 Mac)。

## 改动

抽纯函数 `shouldEmitTlsEngine(engine, platform)`:

```ts
if (engine === 'windows') return platform === 'win32';
if (engine === 'apple') return platform === 'darwin';
return false; // go / 空 / 未知 / 跨平台不匹配 → 一律不下发，落核心默认 Go 栈
```

生成层调用点(`:387`)改为 `!isQuicManagedTls(protocol) && shouldEmitTlsEngine(tlsEngine, process.platform)`——表单过滤之外的**第二道闸**,跨平台导入的不匹配引擎自动降级为 Go,不再致核 FATAL。

抽纯函数(传 platform 参数)便于单测,免在测试里 mock `process.platform`。

## 验证

- 新增单测:全平台 × 全引擎 + 跨平台导入降级回归点(apple→非 darwin、windows→非 win32 均不下发)。
- 现有 `engine=windows` 测试改为显式 mock 平台,顺带断言非 win32 降级。
- gate 绿:tsc(main) 0 / eslint 0 / jest `singbox-outbound-builder` 55 passed / `config-snapshot` 35 快照无回归。

注:Linux 上 TLS 一律走 Go(sing-box 无 Linux 系统原生栈,`tls.engine` 值域仅 go/windows/apple),`shouldEmitTlsEngine` 对 linux 一律返回 false 即此语义。