### PR TITLE
fix(helper): 根治跨提权态文件属主冲突 + 启动升级弹窗（macOS）

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -49,7 +49,12 @@ import (
 //
 //	签名+清 quarantine，实现 macOS 内核持久化更新（App 升级不覆盖）。**向后兼容**：v1-v4 命令不变，装着 v4 的用户
 //	TUN 启停继续可用，仅内核更新需 v5（无 v5 时 app fallback 一次 osascript）→ 非强制重装、温和提示可升级。
-const protoVersion = "5"
+//
+// v6：start 的 child 退出后自动 chownRuntimeDirs——把 root 跑 sing-box 留下的 tailscale state / dashboard / ui
+//
+//	属主归还登录用户，根治跨提权态属主冲突（root 跑写 root 600 → 登录用户跑读不了 → endpoint post-start FATAL）。
+//	协议命令不变、纯行为增强；旧 v5 helper 仍可用 TUN，仅本根治需 v6 → app 据 proto 检测「可升级」温和提示重装。
+const protoVersion = "6"
 
 var (
 	singboxBin string // 安装时锁定的 sing-box 路径
@@ -143,6 +148,44 @@ func installCore(srcDir, wantHash string) string {
 	_ = exec.Command("/usr/bin/xattr", "-cr", coreDir).Run()
 	_ = exec.Command("/usr/bin/codesign", "--force", "--deep", "-s", "-", sb).Run()
 	return "OK installed"
+}
+
+// chownRuntimeDirs（proto v6 行为）：把 sing-box 运行时写入的 userData 子目录（tailscale state /
+// singbox-dashboard / external_ui）属主**归还登录用户**。helper 以 root 跑 sing-box，tsnet 等会把这些文件
+// 创建成 root 600 → 之后以登录用户（系统代理模式）跑 sing-box 时 open 不了 → endpoint post-start
+// `permission denied` 拖垮整个启动（即便没选 tailscale 节点，它在 endpoints[] 里也会被 post-start）。
+// 每次 child 退出后调用 → 属主恒为登录用户（confDir=app 数据目录、属主即登录用户），根治跨提权态属主冲突，
+// 且**不丢 Tailscale 登录态**（chown 保留 state、非删除）。绝不阻断、单项失败即跳过。
+func chownRuntimeDirs() {
+	if confDir == "" {
+		return
+	}
+	fi, err := os.Stat(confDir)
+	if err != nil {
+		return
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	uid, gid := int(st.Uid), int(st.Gid)
+	if uid == 0 {
+		return // confDir 本身属 root（异常）→ 不动，避免把运行时目录误归到 root
+	}
+	for _, name := range []string{"tailscale", "singbox-dashboard", "ui"} {
+		chownTree(filepath.Join(confDir, name), uid, gid)
+	}
+}
+
+// chownTree：递归 Lchown 整棵树到 (uid,gid)。尽力而为——目录不存在/读不了即跳过，绝不返回错误中断遍历。
+func chownTree(root string, uid, gid int) {
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		_ = os.Lchown(p, uid, gid)
+		return nil
+	})
 }
 
 // cfg 必须位于 confDir 内（清洗后前缀匹配），防止越权指定任意路径作 root 配置。
@@ -335,6 +378,10 @@ func handle(conn net.Conn) {
 		go func() {
 			_ = c.Wait()
 			close(done) // 广播子进程已被收割：terminateChild 据此免 KILL、watchParent 据此退出
+			// proto v6：root 跑的 sing-box 退出后，把运行时目录（tailscale state / dashboard / ui）属主归还
+			// 登录用户 → 下次以登录用户（系统代理模式）跑能直接读、不再 FATAL，且不丢 Tailscale 登录态。
+			// 放 Wait() 之后确保文件已不被 sing-box 占用、属主稳定。
+			chownRuntimeDirs()
 			mu.Lock()
 			if child == c {
 				child, childDone = nil, nil

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1037,6 +1037,32 @@ if (gotTheLock) {
     proxyManager.setHelperManager(helperManager);
     coreUpdateService.setHelperManager(macHelper); // B 块：install-core 仅 macOS（Windows/Linux 得降级实例，不真用）
     proxyManager.setHelperGate(promptHelperGate);
+    // 启动后检测 helper 是否可升级（已装 proto < 期望，如属主根治 v6）→ 发事件让渲染端 toast 主动引导升级
+    // （否则用户不去设置页就不知道要升级、根治不生效）。**跟随渲染端首屏加载完成**再发（+ 短延迟给 React 挂载
+    // + 事件 hook 注册），既不固定长延迟滞后、又不发太早 renderer 没注册监听而丢失；dismiss 已置 / 不可升级 → 不发。
+    const emitHelperUpgradeableIfNeeded = async (): Promise<void> => {
+      try {
+        if (!helperManager) return;
+        const cfg = await configManager.loadConfig().catch(() => null);
+        if (cfg?.helperUpgradePromptDismissed === true) return;
+        const st = await helperManager.getStatus();
+        if (st.upgradeable) {
+          ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_HELPER_UPGRADEABLE, {
+            version: st.version ?? '',
+          });
+        }
+      } catch {
+        /* 静默：升级提示非关键，绝不阻断启动 */
+      }
+    };
+    const fireUpgradeCheck = (): void => {
+      // did-finish-load（HTML/JS 加载完）后再给 ~1.2s 让 React 挂载 + useNativeEventListeners 注册监听，避免丢事件。
+      setTimeout(() => void emitHelperUpgradeableIfNeeded(), 1200);
+    };
+    const wcForUpgrade = mainWindow?.webContents;
+    if (wcForUpgrade && !wcForUpgrade.isLoading()) fireUpgradeCheck();
+    else if (wcForUpgrade) wcForUpgrade.once('did-finish-load', fireUpgradeCheck);
+    else setTimeout(fireUpgradeCheck, 1500); // mainWindow 尚未创建时的兜底
     // 系统代理单一写者：注入同一 singleton（上方 756 创建），enable/clear 统一收口 ProxyManager.start()/终态。
     proxyManager.setSystemProxyManager(systemProxyManager);
     // 系统 DNS 接管单一写者：注入同一 singleton，set（仅 TUN）/restore 统一收口 ProxyManager.start()/终态。

--- a/src/main/services/HelperManager.ts
+++ b/src/main/services/HelperManager.ts
@@ -33,10 +33,10 @@ const PLIST_PATH = `/Library/LaunchDaemons/${LABEL}.plist`;
 const SYSTEM_SUPPORT = '/Library/Application Support/FlowZ';
 const SOCKET_PATH = `${SYSTEM_SUPPORT}/helper.sock`;
 /** 与 helper.go 的 protoVersion 对应。**分级**（v5 起）：proto ≥ MIN_USABLE 即 TUN 功能齐全（可用，不报需修复）；
- *  MIN_USABLE ≤ proto < EXPECTED → upgradeable（v5 加 install-core 内核更新，旧 v4 仍能 TUN，仅温和提示可升级、
- *  不强制重装）；proto < MIN_USABLE 才 needsRepair。
- *  v3=SIGTERM 收割 child；v4=freeport；v5=install-core（root 写受保护目录持久化内核 + 哈希校验防 TOCTOU）。 */
-const EXPECTED_PROTO = '5';
+ *  MIN_USABLE ≤ proto < EXPECTED → upgradeable（旧版仍能 TUN，仅温和提示可升级、不强制重装）；proto < MIN_USABLE 才 needsRepair。
+ *  v3=SIGTERM 收割 child；v4=freeport；v5=install-core（root 写受保护目录持久化内核 + 哈希校验防 TOCTOU）；
+ *  v6=chownRuntimeDirs（root 跑的 sing-box 退出后归还 tailscale/dashboard/ui 属主给登录用户，根治跨提权态属主冲突）。 */
+const EXPECTED_PROTO = '6';
 const MIN_USABLE_PROTO = 4;
 /** launchctl 加载态探测缓存 TTL：getStatus 被首页/设置页高频轮询，避免每次都 spawn launchctl。 */
 const LOADED_PROBE_TTL_MS = 10_000;

--- a/src/main/services/PlatformPrivilegeService.ts
+++ b/src/main/services/PlatformPrivilegeService.ts
@@ -254,6 +254,14 @@ done
 kill -TERM "$SBPID" 2>/dev/null
 for i in $(seq 1 10); do kill -0 "$SBPID" 2>/dev/null || break; sleep 0.5; done
 kill -9 "$SBPID" 2>/dev/null
+# 归还运行时目录属主给登录用户（根治跨提权态属主冲突）：root 跑的 sing-box 把 tailscale state /
+# dashboard / ui 写成 root → 下次以登录用户跑读不了致 endpoint post-start FATAL。CONFDIR(=config 父目录)
+# 属主即登录用户；本看护脚本以 root 跑、有权 chown。与 helper daemon 路径(helper.go chownRuntimeDirs)同口径。
+CONFDIR=$(dirname "$CFG")
+OWNER=$(stat -f %u "$CONFDIR" 2>/dev/null)
+if [ -n "$OWNER" ] && [ "$OWNER" != "0" ]; then
+  for d in tailscale singbox-dashboard ui; do chown -R "$OWNER" "$CONFDIR/$d" 2>/dev/null; done
+fi
 rm -f "$STOPFLAG"
 `;
     require('fs').writeFileSync(this.getWrapperScriptPath(), script, { mode: 0o755 });

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -79,6 +79,7 @@ import {
   tailscaleEndpointInRunningCore,
 } from './tailscale-login-core';
 import { SingBoxApiClient, type TailscaleEndpointStatus } from './singbox-api-client';
+import { reconcileTreeOwnership } from './runtime-ownership';
 import {
   getUserDataPath,
   getSingBoxConfigPath,
@@ -626,6 +627,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     this.gateInvalidNodes.clear();
     this.refFixAttempted = false;
     this.cronetHealAttempted = false; // T2：每次 start 复位 cronet 自愈一次性闸（换核/修好后可再触发一次）
+
+    // 3.7.1 根治跨提权态 state 属主冲突：本次以登录用户(非提权)跑 sing-box 前，归一 tailscale state 属主——
+    //   删掉上次 TUN(root/SYSTEM)跑残留的 root 600 文件，让 tsnet 以登录用户重建。否则 sing-box 以登录用户
+    //   open 不了 root 600 的 tailscaled.* → endpoint post-start `permission denied` → 拖垮**整个**启动
+    //   （即便没选 tailscale 节点，它在 endpoints[] 里也会被 post-start；系统代理模式同样中招）。
+    this.reconcileRuntimeOwnershipBeforeStart();
 
     // 3.8 方案B：DNS 接管激活时,先读接管前的内网 LAN 解析器(私网 IPv4),供 generateDnsConfig 把内网/captive 域名
     //     重定向到它(takeover 把系统 DNS 改公网 8.8.8.8 后 dns-local 解不了内网/可能环)。必须在 generateSingBoxConfig
@@ -1486,9 +1493,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       builtinGeoMeta: null,
       subscriptions: null,
       mainSessionViaProxy: null,
-      // helper 引导「不再提示」纯 UI 偏好，不影响 sing-box 生成 → 运行中勾选不应触发重启断流。
+      // helper 引导/升级「不再提示」纯 UI 偏好，不影响 sing-box 生成 → 运行中勾选不应触发重启断流。
       helperPromptDismissed: null,
       helperDisabledPromptDismissed: null,
+      helperUpgradePromptDismissed: null,
       // fakeIpToggleMigrated 是一次性迁移元数据标记，不影响生成（enableFakeIp 本身仍在 norm 内 → 影响生成保留）。
       //   若不排除：未来某路径重建 dnsConfig 丢标记 → norm 翻转无谓重启，且再次迁移可能覆盖用户手动改的值。
       dnsConfig: c.dnsConfig ? { ...c.dnsConfig, fakeIpToggleMigrated: null } : c.dnsConfig,
@@ -3828,6 +3836,33 @@ exit 0
   }
 
   /**
+   * 启动前归一运行时目录属主(根治跨提权态属主冲突,详见 runtime-ownership)。
+   * 仅在「本次将以登录用户(非提权)运行 sing-box」时执行——提权(root/SYSTEM)路径能读现有 root state,不动以免
+   * 每次 TUN 启动都删 state 致 Tailscale 重登。删掉上次 root 跑残留的 root 600 state → tsnet 以登录用户重建。
+   * POSIX only(Windows 属主模型不同,由 helper 侧 takeown 覆盖,后续治本层)。绝不抛、不阻断启动。
+   */
+  private reconcileRuntimeOwnershipBeforeStart(): void {
+    if (process.platform === 'win32' || typeof process.getuid !== 'function') return;
+    // 本次走提权(osascript/UAC)→ root/elevated 跑,能读现有 root state → 不归一(避免每次 TUN 删 state→Tailscale 重登)。
+    if (this.needsOsascript() || this.needsWindowsUAC()) return;
+    try {
+      const uid = process.getuid();
+      const gid = typeof process.getgid === 'function' ? process.getgid() : uid;
+      const tsRoot = path.join(getUserDataPath(), 'tailscale');
+      const r = reconcileTreeOwnership(tsRoot, uid, gid);
+      if (r.deleted.length > 0 || r.chowned.length > 0) {
+        this.logToManager(
+          'info',
+          `已归一 tailscale state 属主（删 ${r.deleted.length} / chown ${r.chowned.length}）杜绝跨提权态权限冲突` +
+            (r.deleted.length > 0 ? '；若该 Tailscale 节点登录态被清，需重新登录' : '')
+        );
+      }
+    } catch {
+      /* 尽力而为，绝不阻断启动 */
+    }
+  }
+
+  /**
    * 解析进程启动错误
    */
   private parseLaunchError(error: Error): string {
@@ -3854,6 +3889,12 @@ exit 0
       const lowerOutput = errorOutput.toLowerCase();
 
       if (lowerOutput.includes('permission denied') || lowerOutput.includes('access denied')) {
+        // 细分：tailscale tsnet / state 文件的权限错误是「跨提权态 state 属主冲突」(root 跑留下 root 600
+        // state、登录用户跑读不了)，已由启动前 reconcileRuntimeOwnershipBeforeStart 兜底；它**不是** TUN 设备
+        // 提权问题，误报「以管理员运行」会把排查带偏(真机踩坑根因)。给准确提示 + 引导重试。
+        if (/logpolicy|tailscaled|tailscale|state_directory/i.test(errorOutput)) {
+          return `Tailscale 状态文件权限异常（跨提权态属主冲突），已尝试自动归一，请重试启动 [${errorOutput}]`;
+        }
         return `TUN 模式需要管理员权限，请以管理员身份运行应用 [${errorOutput}]`;
       }
 

--- a/src/main/services/__tests__/runtime-ownership.test.ts
+++ b/src/main/services/__tests__/runtime-ownership.test.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { reconcileTreeOwnership } from '../runtime-ownership';
+
+describe('reconcileTreeOwnership — 运行时目录属主归一', () => {
+  let tmp: string;
+  const uid = process.getuid ? process.getuid() : 0;
+  const gid = process.getgid ? process.getgid() : 0;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-own-'));
+  });
+  afterEach(() => {
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('目录不存在 → no-op 空结果', () => {
+    const r = reconcileTreeOwnership(path.join(tmp, 'nope'), uid, gid);
+    expect(r).toEqual({ chowned: [], deleted: [], failed: [] });
+  });
+
+  it('全部已属登录用户 → 不动（无 chown / 删除，文件保留）', () => {
+    fs.mkdirSync(path.join(tmp, 'sub'));
+    fs.writeFileSync(path.join(tmp, 'sub', 'a.txt'), 'x');
+    fs.writeFileSync(path.join(tmp, 'b.txt'), 'y');
+    const r = reconcileTreeOwnership(tmp, uid, gid);
+    expect(r.chowned).toEqual([]);
+    expect(r.deleted).toEqual([]);
+    expect(r.failed).toEqual([]);
+    expect(fs.existsSync(path.join(tmp, 'sub', 'a.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'b.txt'))).toBe(true);
+  });
+
+  it('属主非 target（模拟 root 残留）→ chown 或删除让创建者重建', () => {
+    // 文件实为当前 uid；target 设 uid+1 触发「非 target」分支。
+    // 非 root 环境：chown(→uid+1) EPERM → unlink(父目录可写) → deleted；root 环境：chown 成功 → chowned。
+    fs.writeFileSync(path.join(tmp, 'tailscaled.log.conf'), 'stale-root-600');
+    const r = reconcileTreeOwnership(tmp, uid + 1, gid);
+    expect(r.chowned.length + r.deleted.length).toBe(1);
+    expect(r.failed).toEqual([]);
+    if (r.deleted.length === 1) {
+      // 删除路径：残留被清，交 tsnet 以登录用户重建
+      expect(fs.existsSync(path.join(tmp, 'tailscaled.log.conf'))).toBe(false);
+    }
+  });
+
+  it('嵌套：登录用户拥有的子目录内含「非 target」文件 → 递归进入处理，子目录本身保留', () => {
+    // 镜像真机结构：tailscale/<id>/(登录用户) 下含 root 文件
+    const idDir = path.join(tmp, '802f-id');
+    fs.mkdirSync(idDir);
+    fs.writeFileSync(path.join(idDir, 'tailscaled.state'), 's');
+    const r = reconcileTreeOwnership(tmp, uid + 1, gid);
+    // 子目录(uid)与其内文件(uid)对 target=uid+1 都「非 target」→ 都被处理；至少内层文件被处理一次
+    expect(r.chowned.length + r.deleted.length).toBeGreaterThanOrEqual(1);
+    expect(r.failed).toEqual([]);
+  });
+});

--- a/src/main/services/runtime-ownership.ts
+++ b/src/main/services/runtime-ownership.ts
@@ -1,0 +1,95 @@
+/**
+ * 运行时目录属主归一(根治跨提权态属主冲突)。
+ *
+ * 背景:macOS/Windows 下 TUN 模式经提权(root/SYSTEM)跑 sing-box,tsnet 把 tailscale state 写成 root 600;
+ * 切系统代理(登录用户)再跑时,sing-box 以登录用户运行,open 不了 root 600 的 state 文件 → FATAL
+ * `permission denied`,且 endpoint post-start 失败会拖垮整个启动(即便没选 tailscale 节点)。
+ * Linux 用 setcap(始终登录用户跑)天然免疫。
+ *
+ * 主进程恒以登录用户运行:能 chown 自己拥有的文件(no-op),且对**登录用户可写的父目录**(如 `tailscale/<id>/`)
+ * 能删除其中的 root 残留文件 → 让 tsnet 以登录用户重建。本模块即此「启动前归一」的纯逻辑,绝不抛、尽力而为。
+ *
+ * 仅 POSIX(darwin/linux);Windows 属主模型不同(SYSTEM/ACL),由 helper 侧 takeown 覆盖(后续)。
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ReconcileResult {
+  /** 成功 chown 回 targetUid 的路径(主进程拥有写权限的少数情况)。 */
+  chowned: string[];
+  /** chown 无权(他人 root 文件)后删除的路径(父目录可写时成功),交创建者重建为登录用户。 */
+  deleted: string[];
+  /** 既 chown 不了又删不掉的路径(父目录不可写,如 root 拥有的目录内部)+ 原因。 */
+  failed: { path: string; error: string }[];
+}
+
+/**
+ * 递归归一 `root` 目录树下所有条目的属主到 (targetUid/targetGid):
+ * - 已是 targetUid → 跳过(不动)
+ * - 非 targetUid → 先 chown;无权(EPERM)则在父目录可写时 unlink/rmdir,让属主进程重建为登录用户
+ * 先递归子目录(无论子目录属主),再处理目录本身,保证「先清空再删目录」。
+ */
+export function reconcileTreeOwnership(
+  root: string,
+  targetUid: number,
+  targetGid: number
+): ReconcileResult {
+  const res: ReconcileResult = { chowned: [], deleted: [], failed: [] };
+  // 只归一 root 的**子项**（递归），绝不删除/动 root 自身——它是调用方给定的边界目录（如 `tailscale/`），
+  // 删掉整棵就把所有节点的 state 清光了。root 不存在/读不了 → no-op。
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    return res;
+  }
+  for (const name of entries) {
+    walk(path.join(root, name), targetUid, targetGid, res);
+  }
+  return res;
+}
+
+function walk(p: string, uid: number, gid: number, res: ReconcileResult): void {
+  let st: fs.Stats;
+  try {
+    st = fs.lstatSync(p);
+  } catch {
+    return; // 不存在 → no-op
+  }
+
+  // 目录:先递归处理子项(无论本目录属主——如 `tailscale/<id>/` 本身是登录用户、但内部文件是 root)
+  if (st.isDirectory()) {
+    let entries: string[] = [];
+    try {
+      entries = fs.readdirSync(p);
+    } catch (e) {
+      // 读不了(如 root 拥有且无 o+r 的目录)→ 记失败,不阻断
+      res.failed.push({ path: p, error: errMsg(e) });
+    }
+    for (const name of entries) {
+      walk(path.join(p, name), uid, gid, res);
+    }
+  }
+
+  if (st.uid === uid) return; // 本项已归属登录用户 → 不动
+
+  // 本项属主非登录用户:先试 chown(主进程多半无权改他人 root 文件 → 进 catch)
+  try {
+    fs.chownSync(p, uid, gid);
+    res.chowned.push(p);
+    return;
+  } catch {
+    /* 无权 chown → 尝试删除让创建者重建 */
+  }
+  try {
+    if (st.isDirectory()) fs.rmdirSync(p);
+    else fs.unlinkSync(p);
+    res.deleted.push(p);
+  } catch (e) {
+    res.failed.push({ path: p, error: errMsg(e) });
+  }
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/src/renderer/hooks/use-native-events.ts
+++ b/src/renderer/hooks/use-native-events.ts
@@ -63,6 +63,8 @@ interface NativeEventData {
   speedTestResult: { serverId: string; latency: number };
   // #40 核覆盖 reconcile：本机在用的非官方核 ≤ 随包基线 → 兼容风险提醒（启动时主进程 emit）。
   coreBaselineWarning: { current: string; bundled: string; kind: string };
+  // 提权 helper proto < 期望（如属主根治 v6）：启动后主进程 emit → toast 引导升级（带「升级」action + 「不再提示」）。
+  helperUpgradeable: { version: string };
 }
 
 type NativeEventListener<K extends keyof NativeEventData> = (data: NativeEventData[K]) => void;
@@ -114,6 +116,9 @@ export function useNativeEvent<K extends keyof NativeEventData>(
         break;
       case 'coreBaselineWarning':
         unsubscribe = api.proxy.onCoreBaselineWarning(callback as any);
+        break;
+      case 'helperUpgradeable':
+        unsubscribe = api.helper.onUpgradeable(callback as any);
         break;
       default:
         console.warn(`Unknown event: ${eventName}`);
@@ -343,6 +348,33 @@ function handleCoreBaselineWarning(data: NativeEventData['coreBaselineWarning'])
   });
 }
 
+// 提权 helper 可升级（proto < 期望，如属主根治 v6）→ 启动弹窗引导升级。每会话一次；带「升级」action（直接装、一次授权）
+// + 「不再提示」（持久化 helperUpgradePromptDismissed，下次启动不再发）。
+let helperUpgradeWarnedThisSession = false;
+function handleHelperUpgradeable(_data: NativeEventData['helperUpgradeable']) {
+  if (helperUpgradeWarnedThisSession) return;
+  helperUpgradeWarnedThisSession = true;
+  toast.warning(i18n.t('helper.upgrade.title', '提权助手有新版本'), {
+    description: i18n.t(
+      'helper.upgrade.desc',
+      '新版修复了跨提权态的文件属主冲突（会导致 Tailscale / 启动异常）。建议升级，仅需授权一次。'
+    ),
+    duration: Infinity,
+    action: {
+      label: i18n.t('helper.upgrade.action', '升级'),
+      onClick: () => {
+        void api.helper.install();
+      },
+    },
+    cancel: {
+      label: i18n.t('helper.upgrade.dismiss', '不再提示'),
+      onClick: () => {
+        void api.config.setValue('helperUpgradePromptDismissed', true);
+      },
+    },
+  });
+}
+
 /**
  * Hook to listen to all native events and update store
  */
@@ -360,4 +392,5 @@ export function useNativeEventListeners() {
   useNativeEvent('systemProxyResidual', handleSystemProxyResidual);
   useNativeEvent('speedTestResult', handleSpeedTestResult);
   useNativeEvent('coreBaselineWarning', handleCoreBaselineWarning);
+  useNativeEvent('helperUpgradeable', handleHelperUpgradeable);
 }

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -926,6 +926,11 @@ export const helperApi = {
   async uninstall(): Promise<{ success: boolean; error?: string; status: HelperStatus }> {
     return ipcClient.invoke(IPC_CHANNELS.HELPER_UNINSTALL);
   },
+
+  /** 监听「helper 可升级」事件（启动后主进程检测 proto < 期望时 emit，渲染端 toast 引导升级） */
+  onUpgradeable(listener: (data: { version: string }) => void): () => void {
+    return ipcClient.on(IPC_CHANNELS.EVENT_HELPER_UPGRADEABLE, listener);
+  },
 };
 
 /**

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -141,6 +141,7 @@ export const IPC_CHANNELS = {
   EVENT_CORE_VERSION_CHANGED: 'event:coreVersionChanged',
   EVENT_CORE_AUTO_UPDATE_STATUS: 'event:coreAutoUpdateStatus', // 内核自动更新状态变更（staged 待生效 / 跨带提示）
   EVENT_CORE_BASELINE_WARNING: 'event:coreBaselineWarning', // 非官方核 ≤ 随包基线：启动 reconcile 发兼容风险提醒
+  EVENT_HELPER_UPGRADEABLE: 'event:helperUpgradeable', // 提权 helper proto < 期望（如属主根治 v6）：启动后发，渲染端 toast 引导升级
   EVENT_AUTO_NODE_SWITCHED: 'event:autoNodeSwitched', // 自动换节点成功通知
   EVENT_PROXY_INVALID_NODES: 'proxy:invalid-nodes', // 启动 gate 剔除的非法节点（空数组=清陈旧标灰）
   EVENT_IP_INFO_UPDATED: 'event:ipInfoUpdated', // 出口 IP 信息更新

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -471,6 +471,9 @@ export interface UserConfig {
   // 注：socket 鉴权 token 刻意不放这里——它存独立文件，避免被渲染端整体回写 config 时清零。
   helperPromptDismissed?: boolean;
 
+  // 提权 helper：用户已忽略「helper 可升级」启动弹窗（proto < 期望，如属主根治 v6）。不再每次启动提示；设置页可手动升级。
+  helperUpgradePromptDismissed?: boolean;
+
   // macOS 提权 helper：用户已忽略「后台运行被系统禁用」引导弹窗（不再提示）。设置页 helper 卡保留常驻入口。
   helperDisabledPromptDismissed?: boolean;
 


### PR DESCRIPTION
## 问题（真机暴露）

macOS TUN 模式经 root helper 跑 sing-box，tsnet 把 tailscale state（及 `singbox-dashboard`/`ui`）写成 **root 600**；切系统代理（登录用户）再跑时 `open` 不了 → endpoint post-start **`permission denied`**，**拖垮整个启动**（即便没选 tailscale 节点，它在 `endpoints[]` 里也会被 post-start），且被**误报成「TUN 需要管理员权限」**，排查全被带偏。Linux 用 setcap（始终登录用户跑）天然免疫。

## 三层根治

| 层 | 覆盖 | 实现 |
|---|---|---|
| **M1 启动前 reconcile** | 所有启动路径（兜底崩溃残留） | `runtime-ownership.ts`：以登录用户跑前归一 `tailscale/` 属主——删 root 残留让 tsnet 重建。**仅非提权路径执行**（提权路径能读现有 state、不动，避免每次 TUN 删 state 致 Tailscale 重登） |
| **M2 helper 治本** | helper daemon（proto v6）+ osascript 看护脚本 | root 跑的 sing-box 退出后 `chownRuntimeDirs`：chown `tailscale`/`singbox-dashboard`/`ui` 回登录用户——**无损保留 Tailscale 登录态**（chown 而非删）。目标路径写死、零客户端参数，无越权面 |
| **M3 误映射修正** | 错误提示 | `permission denied` on state 文件 → 准确提示，不再笼统报「TUN 需要管理员」 |

## 启动升级弹窗

helper proto bump **v6** → app 检测「可升级」（`MIN_USABLE(4) ≤ 5 < EXPECTED(6)`，旧 v5 仍可用 TUN、温和提示）+ 启动后 toast 主动引导升级（「升级」直接装 `helper.install` +「不再提示」持久化）。触发**跟随 `did-finish-load`**（不固定盲等）；dismiss 字段并入 `configGenerationNorm` 剔除清单（纯 UI 偏好，运行中勾选**不**触发重启断流）。

## 验证

- gate 绿：tsc(main+renderer) 0 / eslint 0 / jest（runtime-ownership 4 + platform-privilege + helper + config-snapshot 35 快照）全过。
- **Mac 真机闭环**：升级弹窗 → 点升级装 v6 helper → TUN 跑停后 `tailscaled.state`/`singbox-dashboard`/`ui` 均归还登录用户、**state 内容保留（不重登）**；系统代理 reconcile 兜底；误映射修正。
- 双路独立 review 全绿（提权/越权安全 + 弹窗链路/proto 一致），并修一处 norm 剔除遗漏。

## 范围

macOS 专属。Linux 免疫；Windows 独立 proto 谱系 + ACL 模型不同（user 目录文件继承 user ACE，未必 FATAL），待真机有运行时目录 + TS 节点实测再定，不空写。