### PR TITLE
fix(proxy): 配置变更重启轴单飞 + 就绪腿让位，根治 Windows TUN 偶发重启风暴 (#176)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowz",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "FlowZ - 简洁现代的跨平台代理客户端",
   "main": "dist/main/main/index.js",
   "scripts": {

--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -148,6 +148,9 @@ export class DiagnosticService {
         })(),
         cronetHealTriggered: this.proxyManager.getCronetHealStats().triggered,
         cronetHealFailed: this.proxyManager.getCronetHealStats().failed,
+        // issue #176：最近一次启动经几次就绪重试才成功。>0 = 起核慢（Windows 重启争用下 wintun 适配器未及时释放），
+        // 区别于「核崩溃自动重启」——便于在报告里把「争用慢起但已自愈」与真崩溃分开。
+        lastStartReadyRetries: this.proxyManager.getLastStartReadyRetries(),
       },
       redactedUserConfig,
       redactedSingboxConfig: redactedSingbox,
@@ -156,7 +159,7 @@ export class DiagnosticService {
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。
       nodeIdentifiers: collectNodeIdentifiers(config),
       hint: wantDeeper
-        ? `当前日志级别为 ${effLevel}，未含 DNS 解析等连接详情，但日志中已出现连接/DNS 类错误。建议到 设置 → 高级 → 诊断 开启「诊断采集」，复现问题后再次导出可获得更完整的根因数据。`
+        ? `当前日志级别为 ${effLevel}，未含 DNS 解析等连接详情，但日志中已出现连接/DNS 类错误。建议到 主页 → 日志 → 诊断 开启「诊断采集」，复现问题后再次导出可获得更完整的根因数据。`
         : undefined,
     };
 

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -89,7 +89,12 @@ import { ruleConditions } from '../../shared/rules';
 import { planCustomRule, buildCustomRuleFiles, condMatcherFields } from './custom-rule-files';
 import { resolveWinTunInterfaceName } from '../../shared/tun-interface';
 import { probeWinTunAdapterPresent, waitForAdapterReleased } from './win-tun-adapter';
-import { probeTcpReachable, waitForCoreReady, CoreStartRetryError } from './core-readiness';
+import {
+  probeTcpReachable,
+  waitForCoreReady,
+  CoreStartRetryError,
+  CoreStartSupersededError,
+} from './core-readiness';
 import coreManifest from '../../shared/core-manifest.json';
 
 /**
@@ -277,6 +282,19 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // trailing 触发时取 this.currentConfig（恒最新），故各 switchMode 分支须先更新 currentConfig。
   private restartDebounceTimer: NodeJS.Timeout | null = null;
   private static readonly RESTART_DEBOUNCE_MS = 1500;
+  // issue #176 配置变更重启轴单飞：lifecycleDepth>0 = 有 start/stop/restart 在飞。去抖重启 trailing 命中时不并发
+  // 起第二条（杜绝「就绪等待中又来重启」叠加 stop/超时/restart 互踩 → wintun 适配器抢放 → 「管理 API 未绑定」假
+  // 超时风暴），只置 restartPending；在飞操作 settle 回 depth 0 时由 endLifecycleOp 排空一次尾随重启（吃最新
+  // currentConfig）。与崩溃轴（isRestarting/lifecycleGeneration）、换核轴（coreSwapInProgress）正交、互不干扰。
+  private lifecycleDepth = 0;
+  private restartPending = false;
+  // issue #176：最近一次 start() 是否因被接管而「静默让位」（未真正起核）。startInternal 入口复位 false，start() 的
+  // supersede 吞掉分支同步置 true。供 attemptAutoRestart 在 await start() 后判别——让位时跳过「自动重启成功」日志与
+  // EVENT_PROXY_STARTED（否则发出与「已让位」矛盾、pid/startTime 陈旧的多余 started 事件）。
+  // 安全契约：读取必须**紧贴**对应的 `await this.start(...)`（之间无 await）——置 true 发生在 start() 让位 catch 的
+  //   同步段、与 promise resolve 之间无让出窗口，故读者恒读到自己那次 start 的让位态，不被并发 start 的入口复位污染。
+  //   成功 start 路径不写 true（入口置 false、成功不改）→ 成功恒 false。新增读者须遵守此「读紧贴 await」约束。
+  private lastStartSuperseded = false;
   // 上次生成时有外化规则因「文件未落盘」降级走 inline（值已在 inline route 规则里、文件无消费者）。
   // 置 true → 热路径(switchMode no-op 分支)改走重启重落盘，防「写文件但无人消费」导致值陈旧。
   private customRuleFilesDegraded = false;
@@ -352,6 +370,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private static readonly CORE_READY_POLL_MS = 500;
   // 管理 API 可连探测（默认 TCP 直连）；注入式便于单测替换桩。
   private coreReadyProbe: (host: string, port: number) => Promise<boolean> = probeTcpReachable;
+  // issue #176 诊断计数：本次启动经几次「就绪重试」才成功（runStartWithRetry 累计）。>0 = 起核慢（多因 Windows
+  // 重启争用下 wintun 适配器未及时释放），与「核崩溃自动重启」（restartCount/AUTO_RESTARTING）是不同轴，纳入诊断
+  // 区分「核崩」vs「争用慢起」。每次 startInternal 复位。
+  private lastStartReadyRetries = 0;
 
   // 自动重启相关
   private autoRestartEnabled: boolean = true;
@@ -405,15 +427,25 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
    * fresh start 无 marker → no-op。
    */
   async start(config: UserConfig, options: { interactive?: boolean } = {}): Promise<void> {
+    this.beginLifecycleOp();
     try {
       await this.startInternal(config, options);
     } catch (e) {
+      // issue #176：本腿在就绪等待期被更新的 start/stop 接管 → 静默让位，**绝不 cleanup**（接管方已拥有/正在
+      //   建立进程与系统代理状态，cleanup 会清掉它的 refs）。镜像 attemptAutoRestart「自动重启已让位」语义。
+      if (e instanceof CoreStartSupersededError) {
+        this.lastStartSuperseded = true; // 供 attemptAutoRestart 判别，跳过让位时的多余 started 事件
+        this.logToManager('info', '启动已让位（检测到更新的启动/停止操作接管）');
+        return;
+      }
       // 启动失败终态收口：① 清进程引用——否则 singboxProcess/pid 仍指向已死进程，下次 start 的内部 stop() 会对
       //   死进程挂 once('exit')（exit 早发过、永不再触发）→ 永挂 → UI 恒「启动中」（修「二次点击卡死」根因 A）。
       //   cleanup 在此只在「最终失败」执行，不影响 retry 成功路径的探针端口。② 清可能残留的系统代理（L-2′）。
       this.cleanup();
       await this.ensureSystemProxyCleared();
       throw e;
+    } finally {
+      this.endLifecycleOp('start');
     }
   }
 
@@ -425,6 +457,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // 被拒时不污染世代。updateCore/applyStagedNow 自身的 start 在 installCoreFromDir 返回后调用（coreSwapInProgress
     // 已清），不受此闸影响。
     this.rejectIfCoreSwapInProgress('启动代理');
+    // issue #176：本次 start 让位标记从干净态开始（被接管时 start() 包装置 true）。
+    this.lastStartSuperseded = false;
     // 生命周期世代 +1：标记一次新的 start 接管（供退避中的 attemptAutoRestart 比对让位，M-2′）。
     this.lifecycleGeneration++;
     // 新启动接管 → 清掉任何陈旧的 supersede-崩溃补发标记（防上一会话遗留的标记误触发补发，M-2′-G1 防陈旧）。
@@ -676,13 +710,23 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     //     内的 beside 保留，此处对其幂等）；mac 静态编入 cronet，ensureCronetReadyForLaunch 内部跳过。热路径仅 stat。
     await this.ensureCronetReadyForLaunch();
 
+    // issue #176 L1.2：快照本次起核世代——就绪/重试腿据此判 supersede 让位。捕获点在本方法上方内部 stop()
+    //   （它会 lifecycleGeneration++）之后，故此值即本次 start 的稳定基线；之后任一外部 start/stop 接管即令其变化。
+    const startGen = this.lifecycleGeneration;
+    let readyRetries = 0; // 本次启动累计的就绪重试次数（onRetry 自增），成功后落 lastStartReadyRetries 供诊断。
+    this.lastStartReadyRetries = 0;
+
     // 5. 启动 sing-box 进程（issue #159 的 wintun 适配器释放门控已下沉至 startSingBoxProcess 顶部，覆盖每次重试腿 + helper/UAC 两支路）
     const runStartWithRetry = (): Promise<void> =>
-      retry(() => this.startSingBoxProcess(), {
+      retry(() => this.startSingBoxProcess(startGen), {
         maxRetries: 2,
         delay: 2000,
         exponentialBackoff: true,
         shouldRetry: (error) => {
+          // issue #176：被更新的 start/stop 接管（CoreStartSupersededError）→ 绝不重试（接管方拥有生命周期）。
+          if (error instanceof CoreStartSupersededError) {
+            return false;
+          }
           // 启动 gate 备用腿（补 check 盲区）：run 阶段 `dependency[X] not found` FATAL（detour/selector 幽灵
           // tag）→ 允许重试一次（onRetry 会解析 tag、pruneTagsClosure 修正重写盘），refFixAttempted 闸保证只修一次。
           if (/dependency\[(.+?)\] not found/i.test(error.message)) {
@@ -716,7 +760,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           return true;
         },
         onRetry: (error, attempt) => {
-          this.logToManager('warn', `启动失败，正在进行第 ${attempt} 次重试: ${error.message}`);
+          readyRetries = attempt; // issue #176 诊断：累计就绪重试次数
+          // issue #176：软化文案——多数是「起核较慢/争用」而非真失败，避免「启动失败」吓到用户（#176 即因此报 bug）。
+          this.logToManager(
+            'warn',
+            `sing-box 起核较慢，正在自动重试（第 ${attempt} 次）: ${error.message}`
+          );
           // 端口被占（含探针端口在 osascript 授权窗口内被抢占）→ 重分配探针端口并重写配置（review P1-4）。
           // retry 在 onRetry 后有 2s+ 退避，足够这段 ms 级异步完成。
           if (/address already in use|in use|bind|eaddrinuse/i.test(error.message)) {
@@ -797,6 +846,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       } else {
         throw err;
       }
+    }
+
+    // issue #176 诊断：起核成功（含经数次就绪重试）。落 lastStartReadyRetries，>0 时记一行——便于把「争用下起得慢
+    //   但已自愈」与「核崩溃自动重启」（restartCount/AUTO_RESTARTING 另一轴）在诊断里区分开。
+    this.lastStartReadyRetries = readyRetries;
+    if (readyRetries > 0) {
+      this.logToManager('info', `sing-box 经 ${readyRetries} 次就绪重试后启动成功`);
     }
 
     // 系统代理单一写者收口（拆双轨）：systemProxy 模式 → 置系统代理（marker + 防自指在 SystemProxyManager 内，
@@ -958,9 +1014,19 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   }
 
   /**
-   * 停止代理
+   * 停止代理。issue #176 单飞外壳：begin/end 包住全程（含内部早退），令在飞期到来的去抖重启置待决而非并发；
+   * 真实停止逻辑在 stopInner。stop 是终态 → endLifecycleOp('stop') 在回到 idle 时丢弃待决重启（停止优先）。
    */
   async stop(opts?: { quitting?: boolean }): Promise<void> {
+    this.beginLifecycleOp();
+    try {
+      await this.stopInner(opts);
+    } finally {
+      this.endLifecycleOp('stop');
+    }
+  }
+
+  private async stopInner(opts?: { quitting?: boolean }): Promise<void> {
     // Phase 2：停止/退出语境一并杀掉残留的瞬态登录核（无孤儿进程）。放早退之前——列表直接点登录时
     // 主核未运行，下方 `!singboxProcess && !singboxPid` 会早退，故在此先收瞬态核。
     this.killAllTailscaleLoginCores();
@@ -1115,14 +1181,52 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
    * 重启代理
    */
   async restart(config: UserConfig, options: { interactive?: boolean } = {}): Promise<void> {
-    await this.stop();
-    // start 腿失败的系统代理清理已下沉进 start() 的 public 包装（L-2′），此处无需再 catch。
-    await this.start(config, options);
+    this.beginLifecycleOp();
+    try {
+      await this.stop();
+      // start 腿失败的系统代理清理已下沉进 start() 的 public 包装（L-2′），此处无需再 catch。
+      await this.start(config, options);
+    } finally {
+      this.endLifecycleOp('restart');
+    }
+  }
+
+  /**
+   * issue #176 单飞：进入一次 lifecycle 操作（start/stop/restart）。与 endLifecycleOp 成对（try/finally）。
+   * lifecycleDepth 是重入计数：restart 内嵌 stop/start 时 depth 会到 2，确保 restart 全程 depth≥1（无 0 缝隙让
+   * 去抖 timer 钻进来并发起第二条）。
+   */
+  private beginLifecycleOp(): void {
+    this.lifecycleDepth++;
+  }
+
+  /**
+   * issue #176 单飞：退出一次 lifecycle 操作。仅在回到 idle（depth 0）时处理待决重启：
+   * - kind='stop'（终态停止：用户断开 / 切模式停止腿外）→ 丢弃 restartPending（停止优先，避免停了又被排空拉起；
+   *   与 stop() 内既有「取消未决去抖 timer」对称）。
+   * - kind='start'/'restart' 收尾 → 有 restartPending 则排空一次尾随重启（吃最新 currentConfig）。
+   * depth>0（仍在更外层操作内，如 restart 内嵌的 stop/start）→ 不处理，留给最外层那次。
+   */
+  private endLifecycleOp(kind: 'start' | 'stop' | 'restart'): void {
+    this.lifecycleDepth = Math.max(0, this.lifecycleDepth - 1);
+    if (this.lifecycleDepth > 0) return;
+    if (kind === 'stop') {
+      this.restartPending = false;
+      return;
+    }
+    if (this.restartPending) {
+      this.restartPending = false;
+      this.scheduleDebouncedRestart();
+    }
   }
 
   /**
    * 去抖重启：连改多条配置合并为一次重启。trailing 触发时取最新 this.currentConfig（调用方须已更新它），
    * 故窗口内的后续切节点(hotSwitch)/no-op/再次结构变更都会被最终那次重启自然纳入。stop()/quit 取消未决重启。
+   *
+   * issue #176 单飞：trailing 触发时若有 lifecycle 操作在飞（lifecycleDepth>0，如上一条重启的 start 还在就绪等待），
+   * **不并发起第二条**（那正是「就绪等待中又来重启」叠加 stop/超时/restart 互踩的风暴根因），只置 restartPending；
+   * 待在飞操作 settle 回 depth 0 时由 endLifecycleOp 排空一次。
    */
   private scheduleDebouncedRestart(): void {
     if (this.restartDebounceTimer) clearTimeout(this.restartDebounceTimer);
@@ -1132,6 +1236,11 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       if (!this.singboxProcess && !this.singboxPid) return;
       const cfg = this.currentConfig;
       if (!cfg) return;
+      // issue #176 单飞：有 start/stop/restart 在飞 → 不并发，置待决，由 endLifecycleOp 在 depth 归 0 时排空。
+      if (this.lifecycleDepth > 0) {
+        this.restartPending = true;
+        return;
+      }
       // helper gate abort / 其它错误内部消化（终态=停止），防 timer 回调 unhandled rejection
       void this.restart(cfg).catch((e) => {
         this.logToManager('warn', `去抖重启结束: ${e instanceof Error ? e.message : String(e)}`);
@@ -3341,7 +3450,7 @@ exit 0
    * macOS 提权 helper 路径：经 socket 让 root daemon 启动 sing-box（免授权）。
    * 成功 resolve；失败 throw（交给 start() 的 retry 决策）。停止/退出/崩溃回收均免授权。
    */
-  private async startViaHelper(): Promise<void> {
+  private async startViaHelper(startGen: number): Promise<void> {
     const helper = this.helperManager!;
     const fs = require('fs');
     if (!fs.existsSync(this.singboxPath)) {
@@ -3379,7 +3488,7 @@ exit 0
     // issue #159：等核真就绪（管理 API 绑定）再判成功，而非「spawn 即 started」。起核期内核死/超时 → 抛可重试
     // 错误交 runStartWithRetry 快速重起（届时 wintun 适配器/端口已释放），替代「假成功 + 10s 健康检查兜底」。
     // watcher/健康检查移到就绪后启动：只监控已确认运行的核，起核期死由本就绪门控直接捕获。
-    await this.waitForCoreReadyOrThrow(res.pid);
+    await this.waitForCoreReadyOrThrow(res.pid, startGen);
 
     this.startLogFileWatcher();
     this.startHealthCheck();
@@ -3395,8 +3504,10 @@ exit 0
    * issue #159：等核真就绪（管理 API 端口可连）再放行。起核期进程死 / 超时未绑 API → 停掉半死核（其 wintun
    * 适配器随即开始释放，给 retry 让路）+ 抛可重试错误（文案不含 nonRetryable 关键词 → runStartWithRetry 会重试）。
    * 无管理 API 端口（异常）→ fail-open 放行（退回旧 spawn 即成行为，绝不卡死启动）。仅 startViaHelper 调用。
+   * issue #176：就绪等待期被更新的 start/stop 接管（startGen≠lifecycleGeneration）→ 抛 CoreStartSupersededError
+   *   静默让位，**不调 stopCore()**（接管方已/正在拆核，本腿再 stopCore 会与之抢放 wintun 适配器、加剧风暴）。
    */
-  private async waitForCoreReadyOrThrow(pid: number): Promise<void> {
+  private async waitForCoreReadyOrThrow(pid: number, startGen: number): Promise<void> {
     const port = this.tailscaleApiPort;
     if (!port) return; // 无管理 API 端口 → 不阻断
     const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -3406,19 +3517,25 @@ exit 0
         isAlive: () => this.isProcessAlive(pid),
         isReady: () => this.coreReadyProbe('127.0.0.1', port),
         sleep,
+        isSuperseded: () => this.lifecycleGeneration !== startGen,
       }
     ).catch(() => 'timeout' as const);
     if (outcome === 'ready') return;
+    // issue #176：被接管 → 静默让位，绝不 stopCore（接管方拥有拆核权，避免抢放适配器）。由 start() 包装吞掉。
+    if (outcome === 'superseded') {
+      throw new CoreStartSupersededError();
+    }
     // 失败：尽力停掉这个起不来的核（best-effort，其 wintun 适配器随即开始释放，给 retry 让路），再抛 CoreStartRetryError
     // ——startSingBoxProcess 的 helper catch 会透传它给 runStartWithRetry 静默重起（而非误判 helper 启动失败弹 UAC/osascript）。
     await this.helperManager?.stopCore().catch(() => {});
     if (outcome === 'dead') {
-      throw new CoreStartRetryError('sing-box 启动期退出（TUN 初始化未完成），将自动重试');
+      throw new CoreStartRetryError('sing-box 启动期退出（TUN 初始化未完成），正在自动重试');
     }
-    throw new CoreStartRetryError('sing-box 启动后未在预期内就绪（管理 API 未绑定），将自动重试');
+    // issue #176：软化文案——「未绑定」多因 Windows 重启争用下 wintun 适配器未及时释放致起核慢，非真失败。
+    throw new CoreStartRetryError('sing-box 起核较慢（管理接口尚未就绪），正在自动重试');
   }
 
-  private async startSingBoxProcess(): Promise<void> {
+  private async startSingBoxProcess(startGen: number): Promise<void> {
     // 复位 helper 启动标志：本次启动尚未确定走 helper 还是直起，由实际启动路径置位（startViaHelper 成功置 true，
     //   直起 UAC/osascript 路径保持 false）。修复 issue #159 就绪门控失败、重试腿回退直起时 startedViaHelper 残留 true
     //   → 后续 stop() 误走 helper 停核分支（停不动→回退提权 taskkill/osascript，降级但自愈）。每次启动腿都从干净态判定。
@@ -3446,10 +3563,10 @@ exit 0
         );
       } else if (await this.helperManager.isReady()) {
         try {
-          return await this.startViaHelper();
+          return await this.startViaHelper(startGen);
         } catch (e) {
           // 起核期未就绪/退出（CoreStartRetryError）≠ helper 启动失败：透传给 runStartWithRetry 静默重起，不回退 osascript。
-          if (e instanceof CoreStartRetryError) throw e;
+          if (e instanceof CoreStartRetryError || e instanceof CoreStartSupersededError) throw e;
           this.logToManager(
             'warn',
             `helper 启动失败，回退 osascript 看护脚本: ${e instanceof Error ? e.message : String(e)}`
@@ -3465,10 +3582,12 @@ exit 0
     // 后台」概念（backgroundDisabled 恒 false），无需该前置判定；未装 helper → isReady=false → 落下方 UAC 路径。
     if (this.needsWindowsUAC() && this.helperManager && (await this.helperManager.isReady())) {
       try {
-        return await this.startViaHelper();
+        return await this.startViaHelper(startGen);
       } catch (e) {
         // 起核期未就绪/退出（CoreStartRetryError）≠ helper 启动失败：透传给 runStartWithRetry 静默重起，不回退 UAC。
-        if (e instanceof CoreStartRetryError) throw e;
+        // issue #176：就绪等待期被接管（CoreStartSupersededError）同样透传让位——绝不回退 UAC 起第二条流抢适配器
+        //   （这是 #176 风暴的 Windows 主路径；与上方 macOS 分支 :3559 对齐）。
+        if (e instanceof CoreStartRetryError || e instanceof CoreStartSupersededError) throw e;
         this.logToManager(
           'warn',
           `helper 服务启动失败，回退 UAC 路径: ${e instanceof Error ? e.message : String(e)}`
@@ -4713,6 +4832,13 @@ exit 0
 
       // 重新启动（崩溃自动重启：interactive:false，禁 helper 引导模态，防崩溃循环弹窗风暴）
       await this.start(this.currentConfig, { interactive: false });
+
+      // issue #176：本腿 start 在就绪等待期被用户手动 start/stop 接管 → start() 已静默让位返回（未真起核），
+      //   不能误报「自动重启成功」+ 发陈旧 started 事件（接管方会自己发终态）。让位时直接退场，finally 复位 isRestarting。
+      if (this.lastStartSuperseded) {
+        this.logToManager('info', '自动重启已让位（start 期被更新的启动/停止操作接管）');
+        return;
+      }
 
       this.logToManager('info', 'sing-box 自动重启成功');
 
@@ -6080,6 +6206,14 @@ exit 0
   /** T2 诊断：本会话 libcronet 自愈触发/失败计数（纳入诊断报告供「库被反复删（疑杀软）」定位）。 */
   getCronetHealStats(): { triggered: number; failed: number } {
     return { triggered: this.cronetHealTriggeredCount, failed: this.cronetHealFailedCount };
+  }
+
+  /**
+   * issue #176 诊断：本次（最近一次）启动经几次就绪重试才成功。>0 = 起核慢（多因 Windows 重启争用下 wintun
+   * 适配器未及时释放），与「核崩溃自动重启」（restartCount）是不同轴——纳入诊断报告区分「核崩」vs「争用慢起」。
+   */
+  getLastStartReadyRetries(): number {
+    return this.lastStartReadyRetries;
   }
 
   /**

--- a/src/main/services/__tests__/core-readiness.test.ts
+++ b/src/main/services/__tests__/core-readiness.test.ts
@@ -66,6 +66,55 @@ describe('waitForCoreReady', () => {
     );
     expect(r).toBe('dead');
   });
+
+  // issue #176：被更新的 start/stop 接管 → superseded，且优先于 ready/dead/timeout，不触发 isReady/isAlive。
+  it('已被接管 → superseded（优先于一切，零 isReady/isAlive 调用）', async () => {
+    let readyCalls = 0;
+    let aliveCalls = 0;
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 300 },
+      {
+        isAlive: () => {
+          aliveCalls++;
+          return true;
+        },
+        isReady: async () => {
+          readyCalls++;
+          return true;
+        },
+        sleep: noSleep,
+        isSuperseded: () => true,
+      }
+    );
+    expect(r).toBe('superseded');
+    expect(readyCalls).toBe(0);
+    expect(aliveCalls).toBe(0);
+  });
+
+  it('等待中途被接管 → superseded（不再误判 timeout/ready）', async () => {
+    let superseded = false;
+    let polls = 0;
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 300 },
+      {
+        isAlive: () => true,
+        isReady: async () => false,
+        sleep: async () => {
+          if (++polls >= 2) superseded = true;
+        },
+        isSuperseded: () => superseded,
+      }
+    );
+    expect(r).toBe('superseded');
+  });
+
+  it('isSuperseded 缺省（undefined）→ 行为不变（向后兼容）', async () => {
+    const r = await waitForCoreReady(
+      { timeoutMs: 900, pollMs: 300 },
+      { isAlive: () => true, isReady: async () => false, sleep: noSleep }
+    );
+    expect(r).toBe('timeout');
+  });
 });
 
 describe('probeTcpReachable', () => {

--- a/src/main/services/__tests__/proxy-manager-restart-singleflight.test.ts
+++ b/src/main/services/__tests__/proxy-manager-restart-singleflight.test.ts
@@ -1,0 +1,230 @@
+/**
+ * ProxyManager 配置变更重启轴「单飞」单测（issue #176）。
+ *
+ * 验证：起核期内（lifecycleDepth>0）到来的去抖重启**不并发**起第二条，只置 restartPending；在飞操作 settle 回
+ * depth 0 时排空一次尾随重启（start/restart 收尾排空、stop 收尾丢弃）。这是 #176「就绪等待中又来重启 → stop/超时/
+ * restart 互踩 → wintun 适配器抢放 → 管理 API 未绑定假超时风暴」的根因修复。
+ *
+ * 私有方法/字段经 `(svc as any)` 直调注入，不启动 sing-box。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-sf176-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFile: jest.fn(),
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import { CoreStartSupersededError } from '../core-readiness';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function makeSvc() {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  const svc: any = new ProxyManager(undefined, undefined, configPath, '/fake/sing-box');
+  return svc;
+}
+
+const DEBOUNCE = (ProxyManager as any).RESTART_DEBOUNCE_MS as number;
+
+/** 让去抖 timer「视核为运行中」并有配置：否则 trailing 回调会早退（!pid / !currentConfig）。 */
+function armRunning(svc: any) {
+  svc.singboxPid = 4321;
+  svc.currentConfig = { proxyModeType: 'tun', servers: [], selectedServerId: 'x' };
+}
+
+describe('issue #176 — 重启单飞 begin/endLifecycleOp', () => {
+  it('beginLifecycleOp 重入计数；endLifecycleOp 递减且不下溢', () => {
+    const svc = makeSvc();
+    expect(svc.lifecycleDepth).toBe(0);
+    svc.beginLifecycleOp();
+    svc.beginLifecycleOp();
+    expect(svc.lifecycleDepth).toBe(2);
+    svc.endLifecycleOp('start');
+    expect(svc.lifecycleDepth).toBe(1);
+    svc.endLifecycleOp('start');
+    expect(svc.lifecycleDepth).toBe(0);
+    // 不下溢
+    svc.endLifecycleOp('start');
+    expect(svc.lifecycleDepth).toBe(0);
+  });
+
+  it('回到 idle（depth 0）且 restartPending → 排空一次尾随重启（start/restart 收尾）', () => {
+    const svc = makeSvc();
+    const sched = jest.spyOn(svc, 'scheduleDebouncedRestart').mockImplementation(() => {});
+    svc.beginLifecycleOp(); // depth 1
+    svc.restartPending = true;
+    svc.endLifecycleOp('restart'); // depth 0 → 排空
+    expect(svc.lifecycleDepth).toBe(0);
+    expect(svc.restartPending).toBe(false);
+    expect(sched).toHaveBeenCalledTimes(1);
+  });
+
+  it("终态停止（kind='stop'）回到 idle → 丢弃 restartPending，不排空", () => {
+    const svc = makeSvc();
+    const sched = jest.spyOn(svc, 'scheduleDebouncedRestart').mockImplementation(() => {});
+    svc.beginLifecycleOp();
+    svc.restartPending = true;
+    svc.endLifecycleOp('stop'); // 停止优先：丢弃待决
+    expect(svc.restartPending).toBe(false);
+    expect(sched).not.toHaveBeenCalled();
+  });
+
+  it('仍在更外层操作内（depth>0）→ 不处理待决（留给最外层）', () => {
+    const svc = makeSvc();
+    const sched = jest.spyOn(svc, 'scheduleDebouncedRestart').mockImplementation(() => {});
+    svc.beginLifecycleOp();
+    svc.beginLifecycleOp(); // depth 2（如 restart 内嵌 stop）
+    svc.restartPending = true;
+    svc.endLifecycleOp('stop'); // depth → 1，仍 >0
+    expect(svc.lifecycleDepth).toBe(1);
+    expect(svc.restartPending).toBe(true); // 未被动到
+    expect(sched).not.toHaveBeenCalled();
+  });
+});
+
+describe('issue #176 — scheduleDebouncedRestart 单飞门控', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('在飞期（depth>0）去抖触发 → 置 restartPending，绝不并发起 restart', () => {
+    const svc = makeSvc();
+    armRunning(svc);
+    const restart = jest.spyOn(svc, 'restart').mockResolvedValue(undefined);
+    svc.lifecycleDepth = 1; // 模拟有 lifecycle 操作在飞
+    svc.scheduleDebouncedRestart();
+    jest.advanceTimersByTime(DEBOUNCE + 10);
+    expect(svc.restartPending).toBe(true);
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it('空闲（depth 0）去抖触发 → 正常起一次 restart（吃 currentConfig）', () => {
+    const svc = makeSvc();
+    armRunning(svc);
+    const restart = jest.spyOn(svc, 'restart').mockResolvedValue(undefined);
+    svc.lifecycleDepth = 0;
+    svc.scheduleDebouncedRestart();
+    jest.advanceTimersByTime(DEBOUNCE + 10);
+    expect(restart).toHaveBeenCalledTimes(1);
+    expect(restart).toHaveBeenCalledWith(svc.currentConfig);
+    expect(svc.restartPending).toBe(false);
+  });
+
+  it('核未运行 → 去抖触发不起 restart（既有早退行为保持）', () => {
+    const svc = makeSvc();
+    svc.singboxPid = null;
+    svc.singboxProcess = null;
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    const restart = jest.spyOn(svc, 'restart').mockResolvedValue(undefined);
+    svc.scheduleDebouncedRestart();
+    jest.advanceTimersByTime(DEBOUNCE + 10);
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it('端到端：在飞期去抖 → 置待决 → settle 排空 → 再触发时空闲 → 起一次 restart', () => {
+    const svc = makeSvc();
+    armRunning(svc);
+    const restart = jest.spyOn(svc, 'restart').mockResolvedValue(undefined);
+
+    // 1) 模拟「上一条重启的 start 还在就绪等待」：depth>0
+    svc.beginLifecycleOp();
+    svc.scheduleDebouncedRestart();
+    jest.advanceTimersByTime(DEBOUNCE + 10);
+    expect(svc.restartPending).toBe(true);
+    expect(restart).not.toHaveBeenCalled();
+
+    // 2) 在飞操作 settle 回 idle → endLifecycleOp 排空（重新 arm 去抖 timer）
+    svc.endLifecycleOp('start');
+    expect(svc.restartPending).toBe(false);
+
+    // 3) 此刻 depth 0，排空的去抖 timer 到点 → 恰好起一次 restart
+    jest.advanceTimersByTime(DEBOUNCE + 10);
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('issue #176 — L1.2 就绪等待腿被接管即让位', () => {
+  it('就绪等待期被接管（startGen≠lifecycleGeneration）→ 抛 CoreStartSupersededError，绝不 stopCore', async () => {
+    const svc = makeSvc();
+    svc.tailscaleApiPort = 9099; // 有管理 API 端口，不走 fail-open 早退
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => false; // 永不就绪
+    const stopCore = jest.fn().mockResolvedValue(undefined);
+    svc.helperManager = { stopCore };
+    // startGen 与当前世代不同 → isSuperseded 首轮即真 → 立即让位
+    const staleGen = svc.lifecycleGeneration - 1;
+    await expect(svc.waitForCoreReadyOrThrow(1234, staleGen)).rejects.toBeInstanceOf(
+      CoreStartSupersededError
+    );
+    expect(stopCore).not.toHaveBeenCalled(); // 接管方拥有拆核权，本腿不抢放适配器
+  });
+
+  it('start() 吞 CoreStartSupersededError：静默让位返回，不 cleanup、不 rethrow、finally 复位 depth、置 lastStartSuperseded', async () => {
+    const svc = makeSvc();
+    jest.spyOn(svc, 'startInternal').mockRejectedValue(new CoreStartSupersededError());
+    const cleanup = jest.spyOn(svc, 'cleanup').mockImplementation(() => {});
+    await expect(svc.start({ proxyModeType: 'tun', servers: [] })).resolves.toBeUndefined();
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(svc.lifecycleDepth).toBe(0);
+    expect(svc.lastStartSuperseded).toBe(true); // 供 attemptAutoRestart 判别
+  });
+
+  // H1（review）：Windows helper-path 就绪让位必须透传 SupersededError，绝不回退 UAC 起第二条流（#176 主路径）。
+  it('H1：Windows UAC helper-path 就绪让位 → 透传 CoreStartSupersededError，不回退 UAC', async () => {
+    const svc = makeSvc();
+    // 非 tun（host=linux 本就跳过 win32&&tun 适配器等待）；走 Windows UAC helper 分支
+    svc.currentConfig = { proxyModeType: 'systemProxy', servers: [] };
+    svc.needsOsascript = () => false;
+    svc.needsWindowsUAC = () => true;
+    svc.helperManager = { isReady: async () => true };
+    const viaHelper = jest
+      .spyOn(svc, 'startViaHelper')
+      .mockRejectedValue(new CoreStartSupersededError());
+    // 若 catch 漏放行（H1 bug）→ 会吞错回退 UAC、不会以 Superseded reject
+    await expect(svc.startSingBoxProcess(0)).rejects.toBeInstanceOf(CoreStartSupersededError);
+    expect(viaHelper).toHaveBeenCalled();
+  });
+});
+
+// M1（review）：自动重启腿的 start 在就绪等待期被接管 → start() 静默让位返回，attemptAutoRestart 不得误报成功/发 started。
+describe('issue #176 — M1 attemptAutoRestart 让位不误报', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('start 让位（lastStartSuperseded）→ 不发 autoRestarted started 事件', async () => {
+    const svc = makeSvc();
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    svc.autoRestartEnabled = true;
+    // start 模拟「被接管让位」：置 flag 并正常返回（不起核、不 bump 世代）
+    jest.spyOn(svc, 'start').mockImplementation(async () => {
+      svc.lastStartSuperseded = true;
+    });
+    const emit = jest.spyOn(svc, 'sendEventToRenderer').mockImplementation(() => {});
+
+    const p = svc.attemptAutoRestart();
+    await jest.advanceTimersByTimeAsync(2100); // 跨过第 1 次退避 2s
+    await p;
+
+    const startedEmits = emit.mock.calls.filter((c: any[]) => c[1] && c[1].autoRestarted === true);
+    expect(startedEmits.length).toBe(0); // 让位 → 不发「自动重启成功」started
+    expect(svc.isRestarting).toBe(false); // finally 复位
+  });
+});

--- a/src/main/services/core-readiness.ts
+++ b/src/main/services/core-readiness.ts
@@ -23,6 +23,20 @@ export class CoreStartRetryError extends Error {
 }
 
 /**
+ * issue #176：本次起核在就绪等待期内被「更新的 start/stop」接管（lifecycleGeneration 变化）的让位标记错误。
+ * 关键区别于 CoreStartRetryError：**不重试、不清理**——接管方拥有进程/系统代理/适配器状态，本腿必须静默退场，
+ * 绝不调 stopCore()/cleanup()（会清掉接管方的 refs）。start() 包装层 instanceof 命中即 return（不 rethrow）。
+ * 背景：旧实现就绪/重试腿不读世代令牌，被去抖重启/用户停止接管后仍烧满 12s + stopCore + retry，与接管流叠加
+ * 抢放 wintun 适配器 → 「管理 API 未绑定」假超时自我放大（Windows TUN 重启风暴根因）。
+ */
+export class CoreStartSupersededError extends Error {
+  constructor(message = 'sing-box 起核已被更新的启动/停止操作接管，本腿让位') {
+    super(message);
+    this.name = 'CoreStartSupersededError';
+  }
+}
+
+/**
  * TCP 可连探测（管理 API 已绑定即就绪）。零提权。连上 → true；超时/拒绝/错误 → false。
  */
 export function probeTcpReachable(host: string, port: number, timeoutMs = 1000): Promise<boolean> {
@@ -42,8 +56,11 @@ export function probeTcpReachable(host: string, port: number, timeoutMs = 1000):
   });
 }
 
-/** ready=就绪；dead=进程已退出（起核期死）；timeout=进程在但管理 API 未在预期内绑定。 */
-export type CoreReadyOutcome = 'ready' | 'dead' | 'timeout';
+/**
+ * ready=就绪；dead=进程已退出（起核期死）；timeout=进程在但管理 API 未在预期内绑定；
+ * superseded=就绪等待期内被更新的 start/stop 接管（issue #176），应静默让位（不重试、不清理）。
+ */
+export type CoreReadyOutcome = 'ready' | 'dead' | 'timeout' | 'superseded';
 
 /** waitForCoreReady 注入依赖（单测可替换为桩）。 */
 export interface CoreReadyDeps {
@@ -52,11 +69,14 @@ export interface CoreReadyDeps {
   /** 管理 API 是否可连（就绪信号）。 */
   isReady: () => Promise<boolean>;
   sleep: (ms: number) => Promise<void>;
+  /** 本次起核是否已被更新的 start/stop 接管（issue #176，可选；缺省视作未接管）。 */
+  isSuperseded?: () => boolean;
 }
 
 /**
- * 轮询等核就绪。每轮：进程死 → 'dead'（立即，不等满 timeout）；API 可连 → 'ready'；否则 sleep。
- * 满 maxPolls 仍未就绪 → 末轮再判一次 → 'timeout'。早退使成功路径仅等到 API 绑定（通常 <1s），不加额外延迟。
+ * 轮询等核就绪。每轮：被接管 → 'superseded'（立即让位，#176）；进程死 → 'dead'（立即，不等满 timeout）；
+ * API 可连 → 'ready'；否则 sleep。满 maxPolls 仍未就绪 → 末轮再判一次 → 'timeout'。
+ * 早退使成功路径仅等到 API 绑定（通常 <1s），不加额外延迟。
  */
 export async function waitForCoreReady(
   opts: { timeoutMs: number; pollMs: number },
@@ -64,13 +84,16 @@ export async function waitForCoreReady(
 ): Promise<CoreReadyOutcome> {
   const pollMs = Math.max(1, opts.pollMs);
   const maxPolls = Math.max(1, Math.ceil(opts.timeoutMs / pollMs));
+  // supersede 先于一切判定：被更新的 start/stop 接管后，本腿继续等就绪/重试毫无意义且有害（抢适配器/撞端口），立即让位。
   // isReady（异步 TCP）先于 isAlive（execSync 探活，阻塞 event loop）：成功路径（API 早绑）即返回，绝不触发阻塞探活。
   // 顺序安全：API 监听随核进程而生灭，端口可连 ⟹ 核存活（端口不会在核死后仍被本核监听）。
   for (let i = 0; i < maxPolls; i++) {
+    if (deps.isSuperseded?.()) return 'superseded';
     if (await deps.isReady()) return 'ready';
     if (!deps.isAlive()) return 'dead';
     await deps.sleep(pollMs);
   }
+  if (deps.isSuperseded?.()) return 'superseded';
   if (await deps.isReady()) return 'ready';
   if (!deps.isAlive()) return 'dead';
   return 'timeout';

--- a/src/renderer/components/settings/diagnostic-section.tsx
+++ b/src/renderer/components/settings/diagnostic-section.tsx
@@ -7,7 +7,8 @@ import { useAppStore } from '@/store/app-store';
 import { api } from '@/ipc/api-client';
 
 /**
- * 设置「高级」诊断节（[[issue-diagnostics-and-support]] P0 + 诊断采集）。
+ * 诊断节（[[issue-diagnostics-and-support]] P0 + 诊断采集）。渲染于「日志」页的「日志与诊断」折叠节
+ * （logs-page.tsx，2026-06 从「设置·高级」迁入；用户路径＝主页 → 日志 → 诊断），文件名/import 路径仍在 settings/ 下未迁。
  * - 导出诊断报告：始终可用，汇集环境/脱敏配置/日志 tail 成单 Markdown。
  * - 诊断采集：临时把 logLevel 拉到 debug 复现问题（快照原级别，结束/重启还原），与导出形成「采集→复现→导出」闭环。
  * 二者关系：导出取已发生的；采集让下次复现记录更详细。还原到采集前快照级别，绝不硬编码。

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -274,6 +274,7 @@ export interface DiagnosticReportInput {
     cronetLibStatus?: string; // libcronet 可用性：available / copy-failed（损坏/拷贝失败）/ no-lib（无内置库）
     cronetHealTriggered?: number; // 本会话 libcronet 自愈触发次数
     cronetHealFailed?: number; // 本会话 libcronet 自愈失败次数（连续失败疑库被反复删/杀软）
+    lastStartReadyRetries?: number; // issue #176：最近一次启动经几次就绪重试（>0=起核慢，多因 Win 重启争用，非核崩）
   };
   redactedUserConfig: unknown;
   redactedSingboxConfig: unknown;
@@ -347,6 +348,11 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
   if (runtime.cronetHealTriggered || runtime.cronetHealFailed) {
     lines.push(
       `- libcronet 自愈：触发 ${runtime.cronetHealTriggered ?? 0} 次 / 失败 ${runtime.cronetHealFailed ?? 0} 次`
+    );
+  }
+  if (runtime.lastStartReadyRetries) {
+    lines.push(
+      `- 最近一次起核经 ${runtime.lastStartReadyRetries} 次就绪重试才成功（起核慢，多因 Windows 重启争用下 wintun 适配器未及时释放；非核崩溃）`
     );
   }
   lines.push('');


### PR DESCRIPTION
## 背景（issue #176）

Windows TUN 模式下密集操作（逐个刷订阅 + 批量测速 + 切节点）时，sing-box 偶发反复重启，日志反复出现：

```
[WARN] 启动失败，正在进行第 1 次重试: sing-box 启动后未在预期内就绪（管理 API 未绑定），将自动重试
```

诊断报告与日志分析确认：**内核没有崩溃**（singbox.log 在最终起来后连续干净运行），重启全部由 app 侧 `配置已更改，调度去抖重启` 驱动。

## 根因

配置变更重启轴 `switchMode → scheduleDebouncedRestart → restart() = stop() + start()` **缺单飞守卫**，且 `startInternal` 的就绪等待腿（`waitForCoreReadyOrThrow`，12s）与内层 `runStartWithRetry` 重试腿**不读 `lifecycleGeneration`**：

1. 一条去抖重启的 `start()` 仍在就绪等待（核未绑定管理 API）时，下一条去抖重启的 `stop()` 杀掉它正在等待的核；
2. 被 supersede 的就绪腿不让位，仍跑满 12s + `stopCore()` + retry，与接管流叠加，在 Windows 上反复抢/放 wintun 适配器 `flowz-tun0`；
3. 适配器来不及释放 → 新核 TUN 初始化阻塞 → 管理 API 晚绑 → 就绪门 12s 假超时 → 「管理 API 未绑定」→ 再补一次重启，自我放大成短时风暴。

崩溃自动重启轴（`isRestarting`/`lifecycleGeneration`）与换核轴（`coreSwapInProgress`）已有守卫，唯独配置变更重启轴是缺口。

## 改动

**单飞（L1.1）** — 新增 `lifecycleDepth`（重入计数）/`restartPending`；`begin/endLifecycleOp` 包裹 `start`/`stop`/`restart` 三入口（`stop` 经新 `stopInner` 内壳，覆盖全部早退）。去抖 trailing 命中时若有 lifecycle 操作在飞则只置 `restartPending` 不并发；在飞操作 settle 回 depth 0 时排空一次尾随重启（`start`/`restart` 收尾排空、终态 `stop` 收尾丢弃）。把 N 条重叠重启坍缩为 1 条。

**就绪/重试腿让位（L1.2）** — `core-readiness` 加 `superseded` 出口 + `isSuperseded` 注入 + `CoreStartSupersededError`。`waitForCoreReadyOrThrow(pid, startGen)` 被接管即抛该错且**不调 `stopCore()`**（接管方拥有拆核权，避免抢放适配器）；`start()` 包装层 `instanceof` 命中即静默让位返回（**不 cleanup、不 rethrow**），并置 `lastStartSuperseded` 供 `attemptAutoRestart` 判别，避免让位后误报「自动重启成功」+ 发陈旧 started 事件。helper-path 两处 catch（macOS / Windows UAC）、retry `shouldRetry`、cronet-heal 均正确放行该错。

**可观测 + 观感（L1.3）** — 新增 `lastStartReadyRetries` 计数纳入诊断报告（>0 = 起核慢，多因 Windows 重启争用下适配器未及时释放；与「核崩溃自动重启」是不同轴，便于区分）；软化「管理 API 未绑定…将自动重试」等 WARN 文案为「起核较慢，正在自动重试」。

**附带修复** — 诊断采集路径注释/报告文案漂移：诊断节 2026-06 已从「设置·高级」迁到「日志」页，更新 `diagnostic-section.tsx` 文件头注释与诊断报告 hint 文案为「主页 → 日志 → 诊断」。

> 去抖窗口维持 1500ms 不变：#176 实测配置变更间隔 ~17s，远超任何去抖窗口，加宽对本 issue 无效且会拖慢单条编辑；真正治重叠的是单飞。

## 测试

- `core-readiness.test.ts`：+4，覆盖 `superseded` 出口（优先于 ready/dead/timeout、中途接管、缺省向后兼容）。
- `proxy-manager-restart-singleflight.test.ts`：新增 12 例，覆盖 begin/end 重入计数与不下溢、去抖单飞门控、端到端「在飞置待决 → settle 排空」、就绪腿让位不 `stopCore`、`start()` 吞让位不 cleanup、Windows helper-path 透传 Superseded 不回退 UAC、`attemptAutoRestart` 让位不误报 started。
- 全量 gate 绿：125 套件 / 1853 测试 / tsc / eslint。

> Windows TUN 拆/起时序硬化（确保旧适配器真释放后再起核）属 runtime 语义、需真机验证，作为后续阶段，不在本 PR。

## 验证状态

本机单测/类型/lint 全绿。属进程生命周期编排逻辑，已由独立审查驱动到无 High/Medium。Windows 真机端到端（连 TUN 后快速切节点/刷订阅/批量测速，确认重启次数与「管理 API 未绑定」重试归零）建议合并前在目标平台抽验。

Close #176 
