### PR TITLE
fix(proxy): 订阅刷新仅新增未引用节点时免整核重启 (#176 P2-A)

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1320,7 +1320,27 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       return;
     }
 
-    // 其余变化（模式/端口/TUN/规则/节点集合/interrupt 开关 等需重生成配置的项）→ 重启应用。
+    // issue #176 P2-A：订阅刷新「仅新增了未被引用的纯代理节点」（机场加新节点的常见情形，#176 高频触发源：6+
+    //   订阅 autoUpdate）→ 免整核重启。安全模型是**非对称**的（见 canSkipRestartForAddedUnreferenced）：新增未引用
+    //   节点的 route 排除 / DNS rule1 条目缺失**无害**（该节点未承载流量，要被选中才连它、届时 planHotSwitch 经
+    //   currentIdToTagMap 查不到 → 退回重启自然补全）；而删除/改址会让运行核**残留陈旧**条目（旧址被复用为真实目标时
+    //   可致错误直连）→ 必须重启。故只放行「纯新增未引用节点」。externalized 规则值若同窗口变了，与 no-op 分支同款经
+    //   syncCustomRuleFiles 热重载（不重启）/降级则重启。
+    if (
+      this.currentConfig &&
+      this.canSkipRestartForAddedUnreferenced(this.currentConfig, newConfig)
+    ) {
+      this.logToManager(
+        'info',
+        '仅新增未引用节点（订阅刷新等），免重启应用（新节点下次启动/被选中时生效）'
+      );
+      this.currentConfig = newConfig;
+      if (this.customRuleFilesDegraded) this.scheduleDebouncedRestart();
+      else await this.syncCustomRuleFiles(newConfig);
+      return;
+    }
+
+    // 其余变化（模式/端口/TUN/规则/选中或被引用节点集合/interrupt 开关 等需重生成配置的项）→ 重启应用。
     // 去抖合并：先把缓存更新到最新 newConfig（窗口内 hotSwitch/no-op/再次结构变更都对账到它），
     // 再调度 trailing 重启（~1.5s 内连改多条只重启一次，消除「连改 5 条规则=5 次断流」）。
     this.logToManager('info', '配置已更改，调度去抖重启以应用...');
@@ -1468,8 +1488,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
    * （selectedServerId、ghProxyPrefix、ruleResource* 调度、builtinGeoMeta、subscriptions 元数据、
    * mainSessionViaProxy、未被引用的本地资源、servers 的 updatedAt/createdAt 时间戳）。
    * 两配置此键相等 ⇔ 生成的 sing-box 配置等价。供 canHotSwitch（判纯切节点）与 switchMode（判生成无关变更 → 免重启 no-op）共用。
+   *
+   * issue #176 P2-A：可选 serverIds 把 servers 投影过滤到「被引用集」——两配置此「引用归一键」相等 ⇔ 生成配置中
+   *   实际承载流量的部分（选中节点+其 detour 前置链+规则目标+endpoint）逐字节一致，差异只在未引用的惰性 selector
+   *   成员节点（订阅刷新增删的纯代理节点）→ 运行核行为不变、可免重启。不传 serverIds = 全量（原行为，现有调用方不变）。
    */
-  private configGenerationNorm(c: UserConfig): string {
+  private configGenerationNorm(c: UserConfig, serverIds?: ReadonlySet<string>): string {
     // 用户路由（自定义规则 + 应用分流）仅 smart 模式影响生成（global=真·全局忽略用户分流、direct=全直连，均不 emit）。
     // 非 smart 下其内容/增删/编辑/换节点都不改变 sing-box 配置 → 不应翻转 norm（否则运行中编辑规则误触重启断流）。
     const userRoutingActive = (c.proxyMode || 'smart').toLowerCase() === 'smart';
@@ -1552,6 +1576,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         .map((rr) => rr.id)
         .sort(),
       servers: [...c.servers]
+        .filter((s) => !serverIds || serverIds.has(s.id)) // P2-A：传 serverIds 时仅保留被引用节点
         .sort((a, b) => a.id.localeCompare(b.id))
         .map((s) => {
           const copy: Record<string, unknown> = { ...s };
@@ -1560,6 +1585,75 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           return copy;
         }),
     });
+  }
+
+  /**
+   * issue #176 P2-A：「被引用节点」id 集——其定义变化会影响运行核实际行为、故必须随之重启。
+   *   = {选中节点} ∪ {所有启用规则(custom/app)目标}，按 detour（前置代理链）传递闭包展开
+   *   ＋ 保守纳入全部 endpoint 协议节点（WireGuard/Tailscale 可能 force-route 子网/mesh，独立于选中即承载流量）。
+   * 其余「纯代理」节点仅作 selector 惰性成员、不承载任何流量，增删改不改变运行核行为 → 不在此集 → 可免重启。
+   * 安全方向：**过度纳入只会多一次重启、绝不错跳**（漏纳入才会错误免重启致运行核用旧前置参数 → 流量错误/泄漏）。
+   *   故 endpoint 一律纳入、detour 取全闭包、direct 哨兵剔除、悬空 detour 忽略。
+   * 注：custom-endpoint（`customSettings.isEndpoint`）不被 isEndpointProtocol 纳入，但其 `endpointForcedRouteCidrs`
+   *   恒返 []（不 force-route）→ 不会独立于选中承载流量 → 按普通未引用节点处理即安全（新增它经 additions-only
+   *   模型放行、其 route/DNS 条目缺失无害），无需进引用集。
+   */
+  private referencedServerIds(c: UserConfig): Set<string> {
+    const byId = new Map(c.servers.map((s) => [s.id, s]));
+    const R = new Set<string>();
+    const stack: string[] = [];
+    const seed = (id?: string | null): void => {
+      if (id && !isDirectSelection(id)) stack.push(id);
+    };
+    seed(c.selectedServerId);
+    for (const r of c.customRules || []) if (r.enabled) seed(r.targetServerId);
+    for (const a of c.appRules || []) if (a.enabled) seed(a.targetServerId);
+    for (const s of c.servers) if (isEndpointProtocol(s.protocol)) stack.push(s.id); // 保守纳入全部 endpoint
+    while (stack.length) {
+      const id = stack.pop() as string;
+      if (R.has(id)) continue; // 成环/重复保护
+      R.add(id);
+      const s = byId.get(id);
+      if (s?.detour && byId.has(s.detour)) stack.push(s.detour); // detour 前置链传递闭包
+    }
+    return R;
+  }
+
+  /**
+   * issue #176 P2-A：判 next 相对 old 是否「仅新增了未被引用的纯代理节点」——是则可免整核重启（订阅刷新加新节点）。
+   * 非对称安全模型：新增未引用节点 → 其 route 排除/DNS rule1（route-builder/dns-builder 遍历**全部**节点的 address+
+   *   serverName）条目缺失**无害**（节点未承载流量、被选中才连它→届时退回重启补全）；删除/改址/改任一旧节点 →
+   *   运行核**残留陈旧**条目（旧址被复用为真实代理目标时可致错误直连）→ 必须重启。
+   * 全部满足才放行（缺一即重启）：
+   *   ① selectedServerId 未变；② 所有非 servers 的生成相关字段未变（servers 过滤到空集后归一键相等）；
+   *   ③ 旧节点全部原样保留在 next（无删除、无任一旧节点 address/参数改动——含选中/规则目标/detour/endpoint）；
+   *   ④ 新增节点（next\old）全部未被引用（非选中/非规则目标/不在 detour 链/非 endpoint）。
+   */
+  private canSkipRestartForAddedUnreferenced(old: UserConfig, next: UserConfig): boolean {
+    if (old.selectedServerId !== next.selectedServerId) return false; // ①
+    const EMPTY: ReadonlySet<string> = new Set();
+    // ② 非 servers 字段逐字节一致（servers 投影到空 → 仅比对路由/规则/DNS/端口/模式 等非节点字段）
+    if (this.configGenerationNorm(old, EMPTY) !== this.configGenerationNorm(next, EMPTY))
+      return false;
+    const fingerprint = (s: ServerConfig): string => {
+      const c: Record<string, unknown> = { ...s };
+      delete c.updatedAt; // 时间戳不影响生成
+      delete c.createdAt;
+      return this.stableStringify(c);
+    };
+    const oldById = new Map(old.servers.map((s) => [s.id, s]));
+    const newById = new Map(next.servers.map((s) => [s.id, s]));
+    // ③ 旧节点全部原样保留（无删除、无改动；含 address/serverName 与全部协议参数）
+    for (const s of old.servers) {
+      const n = newById.get(s.id);
+      if (!n || fingerprint(n) !== fingerprint(s)) return false;
+    }
+    // ④ 新增节点全部未被引用
+    const refNext = this.referencedServerIds(next);
+    for (const s of next.servers) {
+      if (!oldById.has(s.id) && refNext.has(s.id)) return false;
+    }
+    return true;
   }
 
   /**

--- a/src/main/services/__tests__/proxy-manager-p2a-unreferenced.test.ts
+++ b/src/main/services/__tests__/proxy-manager-p2a-unreferenced.test.ts
@@ -1,0 +1,278 @@
+/**
+ * ProxyManager P2-A：订阅刷新只增删/改「未被引用节点」时免整核重启（issue #176）。
+ *
+ * 安全核心 = referencedServerIds（被引用集）必须涵盖一切会影响运行核实际行为的节点：选中节点 + 其 detour 前置链
+ * 传递闭包 + 所有启用规则目标（+ 各自 detour 链）+ 保守纳入全部 endpoint（WG/Tailscale 可能 force-route 子网）。
+ * 只有「纯代理、非选中、非规则目标、不在 detour 链」的惰性 selector 成员节点变化才免重启。
+ * 漏纳入 = 错误免重启致运行核用旧前置参数（流量错误/泄漏）→ 这里重点测「该重启的仍重启」。
+ *
+ * 私有方法/字段经 `(svc as any)` 直调。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-p2a-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFile: jest.fn(),
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import { DIRECT_SERVER_ID } from '../../../shared/direct-selection';
+import type { UserConfig, ServerConfig, Rule } from '../../../shared/types';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function makeSvc() {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  return new ProxyManager(undefined, undefined, configPath, '/fake/sing-box') as any;
+}
+
+const ss = (id: string, addr = '1.1.1.1', extra: Partial<ServerConfig> = {}): ServerConfig =>
+  ({ id, name: id, protocol: 'shadowsocks', address: addr, port: 8388, ...extra }) as any;
+const wg = (id: string): ServerConfig =>
+  ({
+    id,
+    name: id,
+    protocol: 'wireguard',
+    wireguardSettings: { allowedIPs: ['10.0.0.0/24'] },
+  }) as any;
+
+function cfg(servers: ServerConfig[], over: Partial<UserConfig> = {}): UserConfig {
+  return {
+    servers,
+    selectedServerId: servers[0]?.id ?? null,
+    proxyMode: 'smart',
+    proxyModeType: 'tun',
+    tunConfig: { enable: true } as any,
+    customRules: [],
+    appRules: [],
+    socksPort: 1080,
+    httpPort: 1081,
+    logLevel: 'info',
+    ...over,
+  } as UserConfig;
+}
+
+describe('issue #176 P2-A — referencedServerIds 被引用集（含 detour 闭包 + endpoint）', () => {
+  it('选中节点 + 其 detour 前置链传递闭包（A→B→C 全纳入）', () => {
+    const svc = makeSvc();
+    const c = cfg(
+      [ss('A', '1.1.1.1', { detour: 'B' }), ss('B', '2.2.2.2', { detour: 'C' }), ss('C'), ss('D')],
+      {
+        selectedServerId: 'A',
+      }
+    );
+    const R = svc.referencedServerIds(c);
+    expect([...R].sort()).toEqual(['A', 'B', 'C']); // D 是无关纯代理，不纳入
+  });
+
+  it('规则目标（custom + app）及其 detour 链纳入', () => {
+    const svc = makeSvc();
+    const rule: Rule = {
+      id: 'r1',
+      type: 'domainSuffix',
+      values: ['x.com'],
+      action: 'proxy',
+      enabled: true,
+      targetServerId: 'C',
+    };
+    const c = cfg([ss('A'), ss('B'), ss('C', '3.3.3.3', { detour: 'B' }), ss('D')], {
+      selectedServerId: 'A',
+      customRules: [rule],
+      appRules: [{ appId: 'app1', action: 'proxy', enabled: true, targetServerId: 'D' } as any],
+    });
+    const R = svc.referencedServerIds(c);
+    // A(选中) + C(custom 目标)+B(C 的前置) + D(app 目标)
+    expect([...R].sort()).toEqual(['A', 'B', 'C', 'D']);
+  });
+
+  it('所有 endpoint（WG/TS）一律保守纳入（独立于选中）', () => {
+    const svc = makeSvc();
+    const c = cfg([ss('A'), ss('B'), wg('wg1')], { selectedServerId: 'A' });
+    const R = svc.referencedServerIds(c);
+    expect(R.has('wg1')).toBe(true); // 未选中的 endpoint 也纳入
+    expect(R.has('B')).toBe(false); // 未选中的纯代理不纳入
+  });
+
+  it('direct 哨兵选中 → 不 seed；禁用规则目标 / 悬空 detour / 成环均安全', () => {
+    const svc = makeSvc();
+    const disabled: Rule = {
+      id: 'r1',
+      type: 'domainSuffix',
+      values: ['x'],
+      action: 'proxy',
+      enabled: false,
+      targetServerId: 'B',
+    };
+    const c = cfg(
+      [
+        ss('A', '1.1.1.1', { detour: 'B' }),
+        ss('B', '2.2.2.2', { detour: 'A' }),
+        ss('ghost-src', '4.4.4.4', { detour: 'nope' }),
+      ],
+      {
+        selectedServerId: DIRECT_SERVER_ID, // 直连哨兵：不 seed 任何节点
+        customRules: [disabled], // 禁用规则不 seed
+      }
+    );
+    const R = svc.referencedServerIds(c);
+    expect(R.size).toBe(0); // 无 endpoint、选中=direct、规则禁用 → 空集（成环/悬空 detour 不死循环不抛）
+  });
+});
+
+describe('issue #176 P2-A — configGenerationNorm(serverIds) 过滤', () => {
+  it('传 serverIds → servers 仅保留指定节点；空集 → 仅非节点字段', () => {
+    const svc = makeSvc();
+    const c = cfg([ss('A'), ss('B'), ss('C')], { selectedServerId: 'A' });
+    expect(
+      JSON.parse(svc.configGenerationNorm(c, new Set(['A']))).servers.map((s: any) => s.id)
+    ).toEqual(['A']);
+    expect(JSON.parse(svc.configGenerationNorm(c, new Set())).servers).toEqual([]); // 空集=非节点字段对比
+  });
+});
+
+describe('issue #176 P2-A — canSkipRestartForAddedUnreferenced 非对称安全判据', () => {
+  it('纯新增未引用纯代理节点 → 可免重启', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('B'), ss('Z', '9.9.9.9')], { selectedServerId: 'A' });
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(true);
+  });
+
+  it('删除未引用节点 → 仍重启（残留陈旧 route 排除/DNS 条目，旧址复用可致错误直连）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B'), ss('Z')], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('改未引用节点 address → 仍重启（H1：route 排除/DNS rule1 遍历全节点 address，残留陈旧）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('Z', '9.9.9.9')], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('Z', '5.5.5.5')], { selectedServerId: 'A' }); // Z 地址变
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('改未引用节点任一参数（同址）→ 仍重启（保守：旧节点须逐字节不变）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('Z', '9.9.9.9', { port: 8388 })], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('Z', '9.9.9.9', { port: 9999 })], { selectedServerId: 'A' }); // Z 端口变
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('改选中节点参数 → 仍重启（选中∈旧节点、须不变）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A', '1.1.1.1'), ss('B')], { selectedServerId: 'A' });
+    const b = cfg([ss('A', '8.8.8.8'), ss('B')], { selectedServerId: 'A' });
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('新增的是 endpoint 节点 → 仍重启（endpoint 被引用：可 force-route 子网）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('B'), wg('wg1')], { selectedServerId: 'A' }); // 新增 endpoint
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('新增节点同时被规则指向（被引用）→ 仍重启', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    const rule: Rule = {
+      id: 'r1',
+      type: 'domainSuffix',
+      values: ['x.com'],
+      action: 'proxy',
+      enabled: true,
+      targetServerId: 'Z',
+    };
+    const b = cfg([ss('A'), ss('B'), ss('Z')], { selectedServerId: 'A', customRules: [rule] });
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false); // ②(规则变)与④(Z被引用)双重拦截
+  });
+
+  it('改 selectedServerId → 仍重启（①）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('B')], { selectedServerId: 'B' });
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('改非节点字段（加规则）→ 仍重启（②）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    const rule: Rule = {
+      id: 'r1',
+      type: 'domainSuffix',
+      values: ['x.com'],
+      action: 'direct',
+      enabled: true,
+    };
+    const b = cfg([ss('A'), ss('B')], { selectedServerId: 'A', customRules: [rule] });
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(false);
+  });
+
+  it('新增节点的 detour 指向某旧节点（链未触达选中）→ 仍可免重启（新节点整体未被引用）', () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    const b = cfg([ss('A'), ss('B'), ss('Z', '9.9.9.9', { detour: 'B' })], {
+      selectedServerId: 'A',
+    });
+    // Z 未被选中/规则指向 → 不在引用集；Z.detour=B 不让 Z 被引用（引用是从选中/目标出发的闭包）→ 免重启
+    expect(svc.canSkipRestartForAddedUnreferenced(a, b)).toBe(true);
+  });
+});
+
+describe('issue #176 P2-A — switchMode 集成（运行中）', () => {
+  function running(svc: any, current: UserConfig) {
+    svc.singboxPid = 4321; // 视核为运行中
+    svc.currentConfig = current;
+    svc.currentIdToTagMap = new Map(current.servers.map((s) => [s.id, `tag-${s.id}`]));
+    jest.spyOn(svc, 'syncCustomRuleFiles').mockResolvedValue(undefined);
+  }
+
+  it('订阅刷新加未引用节点 → 免重启（不 scheduleDebouncedRestart，更新 currentConfig）', async () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B')], { selectedServerId: 'A' });
+    running(svc, a);
+    const sched = jest.spyOn(svc, 'scheduleDebouncedRestart').mockImplementation(() => {});
+    const b = cfg([ss('A'), ss('B'), ss('Z', '9.9.9.9')], { selectedServerId: 'A' });
+    await svc.switchMode(b);
+    expect(sched).not.toHaveBeenCalled(); // 免重启
+    expect(svc.currentConfig).toBe(b); // 更新到最新（新节点下次启动生效）
+  });
+
+  it('改选中节点参数 → 仍重启（scheduleDebouncedRestart 被调）', async () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A', '1.1.1.1'), ss('B')], { selectedServerId: 'A' });
+    running(svc, a);
+    const sched = jest.spyOn(svc, 'scheduleDebouncedRestart').mockImplementation(() => {});
+    const b = cfg([ss('A', '8.8.8.8'), ss('B')], { selectedServerId: 'A' });
+    await svc.switchMode(b);
+    expect(sched).toHaveBeenCalledTimes(1);
+  });
+
+  it('删未引用节点 → 仍重启（H1 修正：残留陈旧 route/DNS 条目，不能免重启）', async () => {
+    const svc = makeSvc();
+    const a = cfg([ss('A'), ss('B'), ss('Z')], { selectedServerId: 'A' });
+    running(svc, a);
+    const sched = jest.spyOn(svc, 'scheduleDebouncedRestart').mockImplementation(() => {});
+    const b = cfg([ss('A'), ss('B')], { selectedServerId: 'A' }); // 删 Z
+    await svc.switchMode(b);
+    expect(sched).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 背景（issue #176，承接 P1）

P1（配置变更轴单飞，单独 PR）已根治 Windows TUN 重启**风暴**（串行化 + 让位）。本 PR 进一步**减少触发源**：用户有 6+ 订阅 `autoUpdate`，每次刷新只要节点集变了就整核重启。本改动让「订阅刷新**仅新增了未被引用的纯代理节点**」（机场加新节点的常见情形）免整核重启。

> 注：内容完全不变的刷新本就被既有 no-op 分支拦下；本 PR 新增的是「纯增节点」这一情形的免重启。改址/删节点仍重启（见下，正确）。

## 安全模型（非对称）

route 节点排除规则与 DNS rule1 都遍历**全部**节点的 `address`+`serverName`（设计上为「切节点/detour 前置代理无需重生成配置即被豁免」）。因此对节点集的变更，安全性是**非对称**的：

- **新增未引用节点** → 其 route/DNS 条目在运行核里缺失是**无害**的：该节点未承载任何流量（非选中/非规则目标/不在 detour 链/非 endpoint），要被选中才会连它——届时 `selectedServerId` 改变触发重启补全（`planHotSwitch` 经 `currentIdToTagMap` 查不到也会退回重启兜底）。
- **删除 / 改址 / 改任一旧节点** → 运行核**残留陈旧**条目（旧址被复用为真实代理目标时可致错误直连/泄漏）→ **必须重启**。

## 判据（`canSkipRestartForAddedUnreferenced`，全满足才免重启）

1. `selectedServerId` 未变；
2. 非 `servers` 的生成相关字段逐字节相等（`configGenerationNorm` 新增可选 `serverIds` 过滤，传空集 = 仅比非节点字段）；
3. 旧节点**全部原样保留**在新配置（fingerprint 逐字节，剥 `updatedAt`/`createdAt`）——杜绝删除/改址/改参；
4. 新增节点（new\old）**全部未被引用**——`referencedServerIds` = {选中 ∪ 启用规则目标} 按 `detour` 前置链取**传递闭包** + 保守纳入**全部 endpoint**（WireGuard/Tailscale 可 force-route 子网，独立于选中承载流量）。

四条件分工：① selected + ② 非节点字段 + ③ 全旧节点 fingerprint + ④ 新节点未引用闭包，覆盖所有会改变运行核行为的路径。

## 独立审查（两轮）

- 首轮抓出对称过滤会**漏掉未引用节点的 address 变更**（残留陈旧 route/DNS 条目，旧址复用可致错误直连）→ 改为本 PR 的非对称 additions-only 模型。
- 二轮确认四条件无遗漏引用边、实测所有「新增即被隐式引用」路径（被选中/被规则指向/endpoint/成为既有节点 detour 前置）均被拦下，**0 High / 0 Medium**，可合并。

## 测试

`proxy-manager-p2a-unreferenced`（18 例）：
- `referencedServerIds`：detour 传递闭包 / endpoint 纳入 / direct 哨兵 / 成环 / 悬空 detour；
- `canSkipRestartForAddedUnreferenced` 九条危险反例（删 / 改址 / 改参 / 改选中 / 加 endpoint / 加被规则指向 / 改 `selectedServerId` / 改非节点字段 → 全断言**仍重启**；纯新增未引用 → 免重启）；
- `switchMode` 运行中集成。

gate 全绿：125 套件 / 1856 测试 / tsc / eslint。

## 关系

- 依赖关系：与 P1 PR 逻辑独立（改 `switchMode`/`configGenerationNorm`，不碰 P1 的 start/stop/restart 生命周期）；基于 main，两 PR 可独立合并。
- Windows TUN 拆/起时序硬化（P3）属 runtime 语义、需真机验证，作为后续阶段，不在本 PR。
