### PR TITLE
fix(routing): direct 模式 geosite-private 误报「缺少本地副本」

### DIFF
--- a/src/main/services/__tests__/singbox-route-builder-private-direct.test.ts
+++ b/src/main/services/__tests__/singbox-route-builder-private-direct.test.ts
@@ -1,0 +1,106 @@
+/**
+ * buildRouteConfig — geosite-private 私网域名直连规则的「模式门控对称性」专项单测。
+ *
+ * 修复背景（非对称门控误报）：bypassLAN 的私网**域名**直连规则引用 `rule_set: geosite-private`，原仅受
+ * `bypassLAN !== false` 门控、在 direct 模式也发射；而 rule_set **定义注入块**受 `proxyMode !== 'direct'`
+ * 门控、direct 模式整块跳过 → geosite-private 成悬空引用被末尾剪枝，误报「geosite-private 缺少本地副本」
+ * （实为模式门控不对称，文件并不缺）。修复=给该引用补 `proxyMode !== 'direct'` 守卫，与定义块对齐。
+ *
+ * 本测以「文件确实存在」（写 SRS 魔数到运行时目录）为前提，锁住：
+ *  - smart 模式：仍发射 geosite-private 规则 + 注入定义 → 无 dangling 告警（正向对照，证明修复未误伤）。
+ *  - direct 模式：不发射 geosite-private 规则 + 无任何「缺少本地副本」告警（修复点）。
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-route-private-test-'));
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getAppPath: () => TMP, isPackaged: false },
+  net: {},
+}));
+
+import { buildRouteConfig, type RouteConfigDeps } from '../singbox-route-builder';
+import { getRuleSetRuntimeDir } from '../builtin-geo-rulesets';
+import type { ServerConfig, UserConfig } from '../../../shared/types';
+
+// 种运行时本地副本（写 SRS 魔数即过 isValidSrsFile）——模拟「文件确实存在」，使「修复后 direct 仍不发射」
+// 与「文件缺失才不发射」可区分（否则测试空过、证不出门控修复）。
+// 除 geosite-private 外补 CN 三件套：smart 模式默认地区分流(cn)引用 geosite-cn/!cn/geoip-cn 做国内直连，
+// 不种则它们在 smart 真 dangling、污染「smart 无告警」对照（与 dns-resolver.test 同样的 3 件套播种约定）。
+{
+  const dir = getRuleSetRuntimeDir();
+  fs.mkdirSync(dir, { recursive: true });
+  for (const f of [
+    'geosite-private.srs',
+    'geosite-cn.srs',
+    'geosite-geolocation-!cn.srs',
+    'geoip-cn.srs',
+  ]) {
+    fs.writeFileSync(path.join(dir, f), Buffer.from('SRS'));
+  }
+}
+
+const proxyNode = (id = 'p1', name = 'HK'): ServerConfig =>
+  ({
+    id,
+    name,
+    protocol: 'vless',
+    address: 'a.example.com',
+    port: 443,
+    uuid: 'u1',
+  }) as ServerConfig;
+
+const cfg = (proxyMode: 'smart' | 'global' | 'direct'): UserConfig =>
+  ({
+    proxyMode,
+    servers: [proxyNode()],
+    selectedServerId: 'p1',
+    customRules: [],
+    appRules: [],
+    // bypassLAN 缺省 → !== false → 私网直连块启用（含 geosite-private 引用）。
+  }) as unknown as UserConfig;
+
+const idMap = (): Map<string, string> => new Map([['p1', 'HK']]);
+
+/** 捕获 deps.log 的 (level, message)，供断言「缺少本地副本」是否出现。 */
+const capturingDeps = (): { deps: RouteConfigDeps; logs: string[] } => {
+  const logs: string[] = [];
+  const deps: RouteConfigDeps = {
+    probeDirectPort: null,
+    probeProxyPort: null,
+    lanResolverForDns: null,
+    pendingEndpoints: [],
+    log: (_level, message) => logs.push(message),
+    onDegraded: () => {},
+  };
+  return { deps, logs };
+};
+
+/** 路由规则里是否存在「rule_set 引用了 geosite-private」（字符串或数组形式均算）。 */
+const refsGeositePrivate = (rc: any): boolean =>
+  (rc.rules || []).some((r: any) => {
+    const rs = r.rule_set;
+    return rs === 'geosite-private' || (Array.isArray(rs) && rs.includes('geosite-private'));
+  });
+
+describe('buildRouteConfig — geosite-private 模式门控对称性', () => {
+  it('smart 模式（文件存在）：发射 geosite-private 直连规则 + 注入定义 + 无 dangling 告警', () => {
+    const { deps, logs } = capturingDeps();
+    const rc: any = buildRouteConfig(cfg('smart'), idMap(), deps);
+
+    expect(refsGeositePrivate(rc)).toBe(true);
+    // 定义必须同时注入（否则会 dangling）。
+    expect((rc.rule_set || []).some((rs: any) => rs.tag === 'geosite-private')).toBe(true);
+    expect(logs.some((m) => m.includes('缺少本地副本'))).toBe(false);
+  });
+
+  it('direct 模式（文件存在）：不发射 geosite-private 规则 + 无「缺少本地副本」告警（修复点）', () => {
+    const { deps, logs } = capturingDeps();
+    const rc: any = buildRouteConfig(cfg('direct'), idMap(), deps);
+
+    // 引用与定义在 direct 模式同生共灭：都不存在 → 不会被末尾剪枝误报。
+    expect(refsGeositePrivate(rc)).toBe(false);
+    expect(logs.some((m) => m.includes('缺少本地副本'))).toBe(false);
+  });
+});

--- a/src/main/services/builtin-geo-rulesets.ts
+++ b/src/main/services/builtin-geo-rulesets.ts
@@ -195,6 +195,9 @@ export async function seedBuiltinRuleSets(opts?: {
     if (!reason) continue;
     try {
       if (!fssync.existsSync(src)) continue; // 出厂文件缺失（异常打包）→ 跳过，由网络更新兜底
+      // src 本身损坏（404/空文件污染打包）→ 跳过：seed 只校验 dest，不校验 src 会把坏文件原样种进运行时目录，
+      // 之后 route builder isValidSrsFile(dest) 失败 → 智能/全局模式真悬空引用。校验 src 魔数，坏的留给网络更新兜底。
+      if (!isValidSrsFile(src)) continue;
       await fsp.mkdir(runtimeDir, { recursive: true });
       const tmp = `${dest}.seed-${process.pid}-${seedCounter++}`;
       await fsp.copyFile(src, tmp);

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -612,7 +612,13 @@ export function buildRouteConfig(
     // 私有/本地**域名**直连（geosite-private，补 ip_cidr 的域名盲区，如路由器后台域）。geosite-private 由
     // BUILTIN_GEO_RULESETS 随包 bundle + 自动更新 fswatch 热加载；仅在本地 .srs 有效时加规则，缺失则跳过
     // （不引用不存在的 rule_set，避免 FATAL）——与上面 getLocalGeoRuleSets 的缺失即跳过一致。
-    if (isValidSrsFile(path.join(getRuntimeRulesDir(), 'geosite-private.srs'))) {
+    // **必须 proxyMode !== 'direct'**：下方 rule_set 定义注入块受 `proxyMode !== 'direct'` 门控，direct 模式整块跳过、
+    // 不注入 geosite-private 的本地定义；若此处仍引用，则成悬空引用被末尾剪枝，误报「geosite-private 缺少本地副本」
+    // （实为模式门控不对称，文件并不缺）。direct 模式本就 final:direct，私网域名无需此规则——故与定义块对齐门控。
+    if (
+      proxyMode !== 'direct' &&
+      isValidSrsFile(path.join(getRuntimeRulesDir(), 'geosite-private.srs'))
+    ) {
       rules.push({ rule_set: 'geosite-private', action: 'route', outbound: 'direct' });
     }
   }


### PR DESCRIPTION
## 现象

直连（direct）模式启动代理时日志告警，但 `geosite-private` 是随包内置、文件并不缺：

```
WARN 规则资源：geosite-private 缺少本地副本，已跳过引用它的规则以避免代理启动失败
（在「规则资源」页下载后自动恢复；应用分流仍按进程名生效）
```

## 根因：非对称模式门控

`singbox-route-builder.ts` 里对 `geosite-private` 的处理受**不同**条件门控：

| 处理 | 门控 | direct 模式 |
|---|---|---|
| bypassLAN 私网**域名**直连规则 → 引用 `rule_set: geosite-private` | 仅 `config.bypassLAN !== false` | **发射** |
| rule_set 定义注入块（注入 geosite-private 的 type:local 定义） | `proxyMode !== 'direct'` | **整块跳过** |

direct 模式下引用被发射、定义被跳过 → 成悬空引用 → 末尾 fail-closed 剪枝剪掉规则并打误导性告警。
智能/全局模式两处用同一 `isValidSrsFile(runtime)`、同生共灭，永不 dangling，故该告警 ⟺ direct 模式。
「下载后恢复」提示在 direct 模式也是错的（定义块仍被门控跳过，下载不会让它恢复）。

## 修复

- **singbox-route-builder**：给 geosite-private 引用补 `proxyMode !== 'direct'` 守卫，与定义注入块对齐。
  direct 本就 `final:direct`、私网域名无需此规则；引用/定义同生共灭，不再悬空。
- **builtin-geo-rulesets**：`seedBuiltinRuleSets` 拷贝前补校验 src 的 SRS 魔数（原仅校验 dest）。
  坏的随包 src（404/空文件污染打包）不再被原样种进运行时目录致智能/全局模式真 dangling。对当前合法随包文件零行为变化。

## 完整性审计

direct 模式定义注入块整块跳过，故任何 direct 仍发射的 `rule_set` 引用都会同样 dangling。审计全部 `rule_set` 发射：

| 来源 | 门控 | direct 可达 |
|---|---|---|
| app 分流 / 自定义 rule-set | `proxyMode === 'smart'` | 否 |
| 地区 geo | `smart && region.enabled` | 否 |
| geosite-private（bypassLAN） | 已补 `proxyMode !== 'direct'` | 否（已修） |

geosite-private 是唯一活在「direct 也跑」的块里的 geo `rule_set` 引用，无其他资源受影响。

## 测试

新增 `singbox-route-builder-private-direct.test.ts`（以「文件确实存在」为前提）：
- smart：仍发射 geosite-private 规则 + 注入定义 + 无 dangling 告警（正向对照，证未误伤）。
- direct：不发射 geosite-private 规则 + 无「缺少本地副本」告警（修复点）。

gate：typecheck 0、eslint 0、`src/main/services/__tests__` 80 套件 / 1205 测试 / 35 快照全绿（既有 config-snapshot 快照零变化）。
macOS arm64 真机验证通过：直连模式连接后不再出现 geosite-private 告警，私网域名仍正常直连。