### PR TITLE
fix(build): electronLanguages 对齐 i18n 支持的 5 种语言

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -10,7 +10,7 @@
     "dist/**/*",
     "package.json"
   ],
-  "electronLanguages": ["zh-CN", "en-US"],
+  "electronLanguages": ["zh-CN", "zh-TW", "en-US", "ru", "fa"],
   "asar": true,
   "win": {
     "target": [


### PR DESCRIPTION
## 背景

渲染端 i18n 实际支持 **5 种界面语言**：`zh-CN` / `zh-TW` / `en-US` / `ru` / `fa-IR`（`fa-IR` 还带 RTL 处理，见 `src/renderer/i18n/index.ts`）。

但 `electron-builder.json` 的 `electronLanguages` 只配了最初的 `["zh-CN", "en-US"]`，导致打包时 Chromium 原生 UI 的本地化资源（`locales/*.pak`，作用于右键菜单 / 错误页 / 文件选择器等**原生控件**）只保留这 2 个。

## 后果

界面设为 **俄语 / 繁中 / 波斯语** 时：FlowZ 自身 UI 文案（renderer i18n）已翻译，但**浏览器原生控件回退英文**（无对应 pak）。`fa-IR` 是 **RTL**，FlowZ UI 右到左、原生控件却英文 LTR，不一致更明显。

> `.pak`（Chromium 原生 UI）与 renderer i18n（FlowZ 自身 UI）是两套独立系统；前者由 `electronLanguages` 决定，没跟上后者新增的 3 种语言。

## 改动

`electronLanguages: ["zh-CN", "en-US"]` → `["zh-CN", "zh-TW", "en-US", "ru", "fa"]`，与 i18n 对齐。

locale 码说明（已核 Electron 42 `dist/locales` 实际提供）：
- 波斯语用 **`fa`**（Chromium/Electron 仅提供 `fa.pak`，无 `fa-IR.pak`；app 的 `fa-IR` 经 Chromium `fa-IR → fa` 回退命中）。
- 繁中 `zh-TW`、俄语 `ru`、简中 `zh-CN`、英文 `en-US` 均与 app 键直接对应。

5 个码在 `node_modules/electron/dist/locales/` 均存在（`zh-CN/zh-TW/en-US/ru/fa.pak`），构建会从默认 ~55 个 pak 中保留这 5 个。

## 代价

约 +1.5–3MB（每 pak ~0.5–1MB），换取原生控件与界面语言一致（尤其 `fa-IR` RTL 用户体验）。