### PR TITLE
feat(i18n): 语言「自动跟随系统」+ fa-IR 归一为 fa + 下拉按母语名排序

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -483,6 +483,26 @@ if (process.platform === 'darwin') {
   });
 }
 
+/**
+ * OS 偏好语言（有序，BCP47）——i18n「自动跟随系统」用。优先 getPreferredSystemLanguages（Electron 17+，
+ * 返回 OS 设置里的偏好语言列表）；缺失则回退 getSystemLocale（单值）。绝不用 app.getLocale（恒返 app bundle locale=en）。
+ */
+function getPreferredSystemLanguagesSafe(): string[] {
+  try {
+    const langs = app.getPreferredSystemLanguages?.();
+    if (Array.isArray(langs) && langs.length > 0) return langs;
+  } catch {
+    /* 忽略，回退 */
+  }
+  try {
+    const loc = app.getSystemLocale?.();
+    if (loc) return [loc];
+  } catch {
+    /* 忽略 */
+  }
+  return [];
+}
+
 async function createWindow(forceShow = false) {
   // macOS 需要设置应用菜单以启用 Cmd+C/V/X/A 等快捷键
   if (process.platform === 'darwin') {
@@ -572,6 +592,11 @@ async function createWindow(forceShow = false) {
       nodeIntegration: false,
       sandbox: false,
       devTools: isDevelopment, // 仅在开发环境启用开发者工具，生产环境禁用（除非特殊需求）
+      // OS 偏好语言注入 preload（同步、无 IPC 时序问题）：供 i18n「自动跟随系统」解析。
+      //   app.getLocale() 恒返 app bundle locale=en（与系统脱钩，代码多处实证），故必须用 getPreferredSystemLanguages。
+      additionalArguments: [
+        `--flowz-sys-langs=${JSON.stringify(getPreferredSystemLanguagesSafe())}`,
+      ],
     },
     // macOS：集成式窗口（红绿灯内嵌 + sidebar 半透材质）
     ...(isMac && {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -6,12 +6,30 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
 /**
+ * OS 偏好语言（有序）：主进程经 webPreferences.additionalArguments 注入 `--flowz-sys-langs=<JSON>`。
+ * 同步可读、无 IPC 时序问题，供 i18n 初始化「自动跟随系统」用（app.getLocale 恒返 en、不可用）。
+ */
+function readSystemLanguages(): string[] {
+  const PREFIX = '--flowz-sys-langs=';
+  const arg = process.argv.find((a) => a.startsWith(PREFIX));
+  if (!arg) return [];
+  try {
+    const v = JSON.parse(arg.slice(PREFIX.length));
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * 暴露给渲染进程的 Electron API
  */
 const electronAPI = {
   platform: process.platform,
   // CPU 架构（'x64'/'arm64'/...）：渲染层 TLS spoof 等按 arch 门控的特性用（ARM64 不支持）。
   arch: process.arch,
+  // OS 偏好语言（有序，BCP47）：i18n「自动」解析用；空数组=未注入/取不到。
+  systemLanguages: readSystemLanguages(),
   ipcRenderer: {
     /**
      * 调用主进程方法

--- a/src/main/services/TrayManager.ts
+++ b/src/main/services/TrayManager.ts
@@ -10,6 +10,7 @@ import {
 import { LogManager } from './LogManager';
 import { ServerConfig, ProxyMode, ProxyModeType, SubscriptionConfig } from '../../shared/types';
 import { groupServersBySubscription } from '../../shared/server-grouping';
+import { resolveAutoLanguage } from '../../shared/language';
 import { DIRECT_SERVER_ID, isDirectSelection } from '../../shared/direct-selection';
 import { IPC_CHANNELS } from '../../shared/ipc-channels';
 
@@ -100,8 +101,9 @@ export class TrayManager implements ITrayManager {
   private selectedServerId: string | null = null;
   private proxyMode: ProxyMode = 'smart';
   private proxyModeType: ProxyModeType = 'systemProxy';
-  // 应用内语言设置，由渲染进程通过 IPC 同步过来，默认跟随系统
-  private currentLanguage: string = app.getLocale?.() || 'zh-CN';
+  // 应用内语言设置，由渲染进程通过 IPC 同步过来（App mount 即发实际语言）；此为渲染端同步到达前的初值。
+  // 用 getPreferredSystemLanguages 真实跟随系统（绝不用 app.getLocale——恒返 app bundle locale=en，与系统脱钩）。
+  private currentLanguage: string = resolveAutoLanguage(app.getPreferredSystemLanguages?.() ?? []);
 
   // 回调函数
   private onStartProxy?: () => void;

--- a/src/main/services/__tests__/tray-manager-menu.test.ts
+++ b/src/main/services/__tests__/tray-manager-menu.test.ts
@@ -17,7 +17,12 @@ const buildFromTemplate = jest.fn((tpl: any[]) => {
 const imgStub: any = { resize: () => imgStub, isEmpty: () => false };
 
 jest.mock('electron', () => ({
-  app: { getLocale: () => 'zh-CN', isPackaged: false },
+  // currentLanguage 初值改用 getPreferredSystemLanguages（getLocale 恒返 app bundle locale=en 不可用）→ mock 返中文偏好。
+  app: {
+    getLocale: () => 'zh-CN',
+    getPreferredSystemLanguages: () => ['zh-Hans-CN'],
+    isPackaged: false,
+  },
   BrowserWindow: class {},
   Tray: class {
     setToolTip = jest.fn();

--- a/src/renderer/components/settings/appearance-settings.tsx
+++ b/src/renderer/components/settings/appearance-settings.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { SegmentedControl } from '@/components/ui/segmented-control';
 import {
@@ -13,31 +14,59 @@ import i18n from '@/i18n';
 import { useTranslation } from 'react-i18next';
 import { api } from '@/ipc';
 import { SettingsRow } from './settings-row';
+import {
+  AUTO_LANGUAGE,
+  SUPPORTED_LANGUAGES,
+  migrateLanguageCode,
+  resolveEffectiveLanguage,
+} from '../../../shared/language';
 
-// 语言列表：每项以「母语自名」展示，便于使用者识别（不随界面语言翻译）。
-// 新增语言时在此追加一项，并在 src/renderer/i18n/index.ts 注册对应 resources。
-const LANGUAGE_OPTIONS = [
-  { value: 'zh-CN', label: '简体中文' },
-  { value: 'zh-TW', label: '繁體中文' },
-  { value: 'en-US', label: 'English' },
-  { value: 'ru', label: 'Русский' },
-  { value: 'fa-IR', label: 'فارسی' },
-];
+// 各语言「母语自名」（不随界面语言翻译，便于使用者识别）。新增语言时在此与 i18n resources 同步追加。
+const NATIVE_NAMES: Record<string, string> = {
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+  'en-US': 'English',
+  ru: 'Русский',
+  fa: 'فارسی',
+};
+
+// 实际语言按各自母语名排序（auto 另置首位、不参与排序）。
+const REAL_LANGUAGE_OPTIONS = SUPPORTED_LANGUAGES.map((v) => ({
+  value: v,
+  label: NATIVE_NAMES[v],
+})).sort((a, b) => a.label.localeCompare(b.label));
+
+/** main→preload 经 additionalArguments 注入的 OS 偏好语言（auto 解析用）。 */
+function getSystemLanguages(): string[] {
+  const sl = (window as unknown as { electron?: { systemLanguages?: string[] } }).electron
+    ?.systemLanguages;
+  return Array.isArray(sl) ? sl : [];
+}
 
 export function AppearanceSettings() {
   const { t } = useTranslation();
   const { theme, setTheme } = useTheme();
+  // 语言「选择」（auto 或具体码），驱动下拉显示；与 i18n.language（解析后的实际语言）区分。默认 auto。
+  const [langChoice, setLangChoice] = useState<string>(
+    () => migrateLanguageCode(localStorage.getItem('app-language')) ?? AUTO_LANGUAGE
+  );
 
   const handleThemeChange = (value: string) => {
     setTheme(value as 'light' | 'dark' | 'system');
     toast.success(t('settings.appearance.themeUpdated'));
   };
 
-  const handleLanguageChange = (value: string) => {
-    i18n.changeLanguage(value);
-    localStorage.setItem('app-language', value);
-    api.config.setLanguage(value).catch(console.error);
-    toast.success(t('settings.appearance.languageUpdated', { lng: value }));
+  const handleLanguageChange = (choice: string) => {
+    // 选 auto → 按系统偏好解析出实际语言；选具体码 → 即该码。i18n 与 main 都用「实际语言」（main 托盘/对话框
+    // 用 startsWith('zh') 判断，不能收到 'auto'）；localStorage 存「选择」（auto/具体）供下拉回显。
+    const effective = resolveEffectiveLanguage(choice, getSystemLanguages());
+    setLangChoice(choice);
+    localStorage.setItem('app-language', choice);
+    i18n.changeLanguage(effective);
+    api.config.setLanguage(effective).catch(console.error);
+    toast.success(
+      t('settings.appearance.languageUpdated', { lng: NATIVE_NAMES[effective] ?? effective })
+    );
   };
 
   return (
@@ -57,13 +86,15 @@ export function AppearanceSettings() {
           />
         </SettingsRow>
         <SettingsRow label={t('settings.appearance.language')} stacked>
-          <Select value={i18n.language} onValueChange={handleLanguageChange}>
+          <Select value={langChoice} onValueChange={handleLanguageChange}>
             <SelectTrigger className="max-w-xs">
               <SelectValue />
             </SelectTrigger>
             {/* 固定 max-h-96：避免 radix popper 按可用高度算 max-h 造成顶部项命中死区 */}
             <SelectContent className="max-h-96">
-              {LANGUAGE_OPTIONS.map((opt) => (
+              {/* 自动（跟随系统）置首位且为默认 */}
+              <SelectItem value={AUTO_LANGUAGE}>{t('settings.appearance.languageAuto')}</SelectItem>
+              {REAL_LANGUAGE_OPTIONS.map((opt) => (
                 <SelectItem key={opt.value} value={opt.value}>
                   {opt.label}
                 </SelectItem>

--- a/src/renderer/i18n/__tests__/locale-parity.test.ts
+++ b/src/renderer/i18n/__tests__/locale-parity.test.ts
@@ -2,7 +2,7 @@
  * i18n locale 完整性护栏。
  *
  * - en-US 是基准（source of truth）。
- * - 全部受支持 locale（zh-CN/zh-TW/ru/fa-IR）要求与 en-US **精确 parity**：零缺漏、零多余键，
+ * - 全部受支持 locale（zh-CN/zh-TW/ru/fa）要求与 en-US **精确 parity**：零缺漏、零多余键，
  *   且每个含插值占位符的键，占位符集合与 en-US 一致（机翻草稿/漏译也不能漏变量、漏嵌套引用）。
  *   当前 4 个 locale 均已满 parity，本护栏防后续新增键时漏译。
  * - 占位符识别两类：① i18next 插值 {{var}}；② i18next 嵌套引用 $t(key)（变量名/键名含 `.`、`:`、`$`，
@@ -12,7 +12,7 @@ import enUS from '../locales/en-US.json';
 import zhCN from '../locales/zh-CN.json';
 import zhTW from '../locales/zh-TW.json';
 import ru from '../locales/ru.json';
-import faIR from '../locales/fa-IR.json';
+import fa from '../locales/fa.json';
 
 type JsonObject = { [key: string]: unknown };
 
@@ -70,7 +70,7 @@ const allLocales: Record<string, JsonObject> = {
   'zh-CN': zhCN as JsonObject,
   'zh-TW': zhTW as JsonObject,
   ru: ru as JsonObject,
-  'fa-IR': faIR as JsonObject,
+  fa: fa as JsonObject,
 };
 
 describe('i18n locale parity', () => {

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -5,7 +5,12 @@ import zhCN from './locales/zh-CN.json';
 import zhTW from './locales/zh-TW.json';
 import enUS from './locales/en-US.json';
 import ru from './locales/ru.json';
-import faIR from './locales/fa-IR.json';
+import fa from './locales/fa.json';
+import {
+  AUTO_LANGUAGE,
+  migrateLanguageCode,
+  resolveEffectiveLanguage,
+} from '../../shared/language';
 
 const resources = {
   'zh-CN': {
@@ -20,10 +25,17 @@ const resources = {
   ru: {
     translation: ru,
   },
-  'fa-IR': {
-    translation: faIR,
+  fa: {
+    translation: fa,
   },
 };
+
+/** main→preload 经 webPreferences.additionalArguments 同步注入的 OS 偏好语言（无则空）。 */
+function getSystemLanguages(): string[] {
+  const sl = (window as unknown as { electron?: { systemLanguages?: string[] } }).electron
+    ?.systemLanguages;
+  return Array.isArray(sl) ? sl : [];
+}
 
 // RTL 语言集合：以语言前缀匹配（fa / fa-IR / ar / he / ur / ...），新增 RTL 语言时在此追加前缀。
 const RTL_LANGUAGE_PREFIXES = ['fa', 'ar', 'he', 'ur'];
@@ -40,12 +52,19 @@ function applyDocumentDirection(lng: string): void {
   document.documentElement.lang = lng;
 }
 
-// 尝试从 localStorage 获取语言，默认简体中文
-const savedLanguage = localStorage.getItem('app-language') || 'zh-CN';
+// 语言选择（localStorage['app-language']）：'auto'（跟随系统，首装默认）或某具体码。
+// 迁移旧 'fa-IR' → 'fa'（回写，使设置页下拉与持久值一致）。
+const rawChoice = localStorage.getItem('app-language');
+const choice = migrateLanguageCode(rawChoice);
+if (rawChoice === 'fa-IR') localStorage.setItem('app-language', 'fa'); // 回写迁移，使下拉回显与持久值一致
+
+// 有效界面语言：'auto'/未设 → 按系统偏好（getPreferredSystemLanguages）解析；否则用具体码。
+// 注：绝不能用 app.getLocale()（恒返 app bundle locale=en，与系统脱钩）——故系统语言经 additionalArguments 注入。
+const effectiveLanguage = resolveEffectiveLanguage(choice ?? AUTO_LANGUAGE, getSystemLanguages());
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: savedLanguage,
+  lng: effectiveLanguage,
   fallbackLng: 'en-US',
   interpolation: {
     escapeValue: false,

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -431,6 +431,7 @@
       "dark": "Dark",
       "system": "System",
       "language": "Language",
+      "languageAuto": "Auto (follow system)",
       "themeUpdated": "Theme updated",
       "languageUpdated": "Switched to English"
     },

--- a/src/renderer/i18n/locales/fa.json
+++ b/src/renderer/i18n/locales/fa.json
@@ -431,6 +431,7 @@
       "dark": "تیره",
       "system": "سیستم",
       "language": "زبان",
+      "languageAuto": "خودکار (پیرو سیستم)",
       "themeUpdated": "پوسته به‌روزرسانی شد",
       "languageUpdated": "به فارسی تغییر یافت"
     },

--- a/src/renderer/i18n/locales/ru.json
+++ b/src/renderer/i18n/locales/ru.json
@@ -431,6 +431,7 @@
       "dark": "Тёмная",
       "system": "Системная",
       "language": "Язык",
+      "languageAuto": "Авто (системный)",
       "themeUpdated": "Тема обновлена",
       "languageUpdated": "Переключено на русский"
     },

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -431,6 +431,7 @@
       "dark": "深色",
       "system": "跟随系统",
       "language": "语言",
+      "languageAuto": "自动（跟随系统）",
       "themeUpdated": "主题已更新",
       "languageUpdated": "已切换为简体中文"
     },

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -431,6 +431,7 @@
       "dark": "深色",
       "system": "跟隨系統",
       "language": "語言",
+      "languageAuto": "自動（跟隨系統）",
       "themeUpdated": "主題已更新",
       "languageUpdated": "已切換為繁體中文"
     },

--- a/src/shared/__tests__/language.test.ts
+++ b/src/shared/__tests__/language.test.ts
@@ -1,0 +1,81 @@
+/**
+ * shared/language 单测：fa-IR→fa 迁移、系统偏好语言映射、有效语言解析（含 auto/非法回退）。
+ */
+import {
+  AUTO_LANGUAGE,
+  DEFAULT_LANGUAGE,
+  SUPPORTED_LANGUAGES,
+  migrateLanguageCode,
+  resolveAutoLanguage,
+  resolveEffectiveLanguage,
+} from '../language';
+
+describe('migrateLanguageCode', () => {
+  it('fa-IR → fa；其余/空值原样', () => {
+    expect(migrateLanguageCode('fa-IR')).toBe('fa');
+    expect(migrateLanguageCode('zh-CN')).toBe('zh-CN');
+    expect(migrateLanguageCode('auto')).toBe('auto');
+    expect(migrateLanguageCode(null)).toBeNull();
+    expect(migrateLanguageCode(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveAutoLanguage（OS 偏好 → 受支持语言）', () => {
+  it.each([
+    [['zh-Hans-CN'], 'zh-CN'],
+    [['zh-CN'], 'zh-CN'],
+    [['zh-SG'], 'zh-CN'],
+    [['zh'], 'zh-CN'],
+    [['zh-Hant-TW'], 'zh-TW'],
+    [['zh-TW'], 'zh-TW'],
+    [['zh-HK'], 'zh-TW'],
+    [['zh-MO'], 'zh-TW'],
+    [['fa-IR'], 'fa'],
+    [['fa'], 'fa'],
+    [['ru-RU'], 'ru'],
+    [['ru'], 'ru'],
+    [['en-GB'], 'en-US'],
+    [['en'], 'en-US'],
+  ])('%j → %s', (input, expected) => {
+    expect(resolveAutoLanguage(input as string[])).toBe(expected);
+  });
+
+  it('全不匹配 → 回退 en-US', () => {
+    expect(resolveAutoLanguage(['de-DE', 'ja-JP'])).toBe('en-US');
+  });
+
+  it('逐个匹配、命中即止（跳过不支持的，取首个受支持）', () => {
+    expect(resolveAutoLanguage(['de-DE', 'ru-RU', 'zh-CN'])).toBe('ru');
+  });
+
+  it('空/缺失 → en-US', () => {
+    expect(resolveAutoLanguage([])).toBe('en-US');
+    expect(resolveAutoLanguage(null)).toBe('en-US');
+    expect(resolveAutoLanguage(undefined)).toBe('en-US');
+  });
+});
+
+describe('resolveEffectiveLanguage（选择 + 系统 → 实际语言）', () => {
+  it('auto / 未设 → 按系统解析', () => {
+    expect(resolveEffectiveLanguage(AUTO_LANGUAGE, ['fa-IR'])).toBe('fa');
+    expect(resolveEffectiveLanguage(null, ['ru'])).toBe('ru');
+    expect(resolveEffectiveLanguage(undefined, ['zh-Hant-TW'])).toBe('zh-TW');
+  });
+
+  it('具体码 → 用它（fa-IR 先迁移成 fa）', () => {
+    expect(resolveEffectiveLanguage('fa-IR', ['ru'])).toBe('fa');
+    expect(resolveEffectiveLanguage('zh-CN', ['ru'])).toBe('zh-CN');
+    expect(resolveEffectiveLanguage('fa', [])).toBe('fa');
+  });
+
+  it('非法具体码 → 回落系统解析', () => {
+    expect(resolveEffectiveLanguage('klingon', ['ru'])).toBe('ru');
+    expect(resolveEffectiveLanguage('klingon', ['de'])).toBe('en-US');
+  });
+
+  it('常量自洽：DEFAULT 在受支持集、fa 在集、无 fa-IR', () => {
+    expect(SUPPORTED_LANGUAGES).toContain(DEFAULT_LANGUAGE);
+    expect(SUPPORTED_LANGUAGES).toContain('fa');
+    expect(SUPPORTED_LANGUAGES as readonly string[]).not.toContain('fa-IR');
+  });
+});

--- a/src/shared/language.ts
+++ b/src/shared/language.ts
@@ -1,0 +1,67 @@
+/**
+ * 界面语言：受支持语言集 + 「自动（跟随系统）」解析 + 旧码迁移。纯函数，主/渲染/单测共用，零副作用。
+ *
+ * 关键：i18n 资源键用 `fa`（非 `fa-IR`）——与其余「只在消歧时带地区」的口径一致（ru 裸码、zh-CN/zh-TW 必须区分简繁）；
+ * 也与 Chromium/Electron 的 `fa.pak`（无 `fa-IR.pak`）对齐。旧版本存的 `fa-IR` 经 migrateLanguageCode 迁移。
+ */
+
+/** 受支持的界面语言（i18n 资源键）。顺序无语义（UI 自行排序）。 */
+export const SUPPORTED_LANGUAGES = ['zh-CN', 'zh-TW', 'en-US', 'ru', 'fa'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+/** 无匹配时的回退语言（国际通用，亦为 i18n fallbackLng）。 */
+export const DEFAULT_LANGUAGE: SupportedLanguage = 'en-US';
+
+/** 语言选择的「自动（跟随系统）」哨兵值（存 localStorage['app-language']）。 */
+export const AUTO_LANGUAGE = 'auto';
+
+/** 旧语言码迁移：`fa-IR` → `fa`（其余原样返回，含 null/undefined 透传）。 */
+export function migrateLanguageCode(code: string | null | undefined): string | null | undefined {
+  return code === 'fa-IR' ? 'fa' : code;
+}
+
+/** 单个 BCP47 语言码 → 受支持语言；无匹配返 null。按主语言子标签 + 脚本/地区消歧。 */
+function matchSupported(raw: string): SupportedLanguage | null {
+  const l = (raw || '').toLowerCase();
+  if (!l) return null;
+  const primary = l.split(/[-_]/)[0];
+  if (primary === 'zh') {
+    // 繁体：Hant 脚本 或 台/港/澳 地区；其余（Hans/cn/sg/裸 zh）→ 简体。
+    if (l.includes('hant') || /(^|[-_])(tw|hk|mo)([-_]|$)/.test(l)) return 'zh-TW';
+    return 'zh-CN';
+  }
+  if (primary === 'fa') return 'fa';
+  if (primary === 'ru') return 'ru';
+  if (primary === 'en') return 'en-US';
+  return null;
+}
+
+/**
+ * OS 偏好语言有序列表（app.getPreferredSystemLanguages，如 ['zh-Hans-CN','en-US']）→ 受支持语言。
+ * 逐个匹配、命中即止；全不匹配 → DEFAULT_LANGUAGE（en-US）。
+ */
+export function resolveAutoLanguage(
+  preferred: readonly string[] | null | undefined
+): SupportedLanguage {
+  for (const raw of preferred || []) {
+    const m = matchSupported(raw);
+    if (m) return m;
+  }
+  return DEFAULT_LANGUAGE;
+}
+
+/**
+ * 解析有效界面语言：
+ * - choice='auto' / 未设 / 旧 fa-IR 之外的非法值 → 按系统偏好解析；
+ * - choice 是受支持的具体码（fa-IR 先迁移成 fa）→ 用它。
+ */
+export function resolveEffectiveLanguage(
+  choice: string | null | undefined,
+  systemLanguages: readonly string[] | null | undefined
+): SupportedLanguage {
+  const c = migrateLanguageCode(choice);
+  if (!c || c === AUTO_LANGUAGE) return resolveAutoLanguage(systemLanguages);
+  return (SUPPORTED_LANGUAGES as readonly string[]).includes(c)
+    ? (c as SupportedLanguage)
+    : resolveAutoLanguage(systemLanguages);
+}


### PR DESCRIPTION
## 改动

三件事：

### 1. `fa-IR` → `fa`
i18n 资源键 / 文件名 / parity 测试统一改 `fa`：与「只在消歧时带地区」口径一致（`ru` 裸码、`zh-CN`/`zh-TW` 必须区分简繁），并对齐 Chromium 的 `fa.pak`（无 `fa-IR.pak`，少一层 `fa-IR→fa` 回退桥接）。旧 `localStorage['app-language']='fa-IR'` 启动时迁移成 `'fa'` 并回写，老用户设置不丢。

### 2. 自动跟随系统
语言下拉新增「自动（跟随系统）」选项，**置首位且为首装默认**。

- 解析走 OS 偏好语言 `app.getPreferredSystemLanguages()`，经 `webPreferences.additionalArguments` 注入 preload、i18n 初始化**同步读**（零启动闪烁、无 IPC 时序问题）。
- **绝不用 `app.getLocale()`**——它恒返 app bundle locale=`en`、与系统脱钩（代码多处实证：`helper-handlers.ts` / `singbox-dashboard-section.tsx`）。`TrayManager` 初值同步改用 `getPreferredSystemLanguages`。
- 映射：`zh-Hant/TW/HK/MO → zh-TW`；`zh-Hans/CN/SG/裸 zh → zh-CN`；`fa → fa`；`ru → ru`；`en → en-US`；全不匹配 → `en-US`。中文系统首装仍得简体中文。
- **持久化分层**：`localStorage['app-language']` 存「选择」（`auto`/具体码，驱动下拉回显）；i18n 与 `api.config.setLanguage` 用「解析后的实际语言」（main 托盘/对话框用 `startsWith('zh')` 判断，不能收到 `'auto'`）。

### 3. 实际语言按母语名排序
5 种语言按各自母语自名 `localeCompare` 排序；`auto` 独立置首、不参与排序。

## 实现

- 新增 `src/shared/language.ts`（纯函数：`migrateLanguageCode` / `resolveAutoLanguage` / `resolveEffectiveLanguage`）+ 单测。
- locale 全 5 语言补 `settings.appearance.languageAuto`（locale-parity 测试强制 5 语言精确 parity）。

## 测试

- 新增 `shared/__tests__/language.test.ts`（迁移 / 系统偏好映射 / 有效语言解析含 auto/非法回退）；更新 `locale-parity` / `tray-manager-menu` mock。
- gate 全绿：128 套件 / 1895 测试 / 35 快照 / tsc / eslint。
- 独立 review（opus）：无 High / 无 Medium，Low/Nit 已收口。