### PR TITLE
fix(i18n): 语言切换提示用语言码而非母语名（修恒显「Switched to English」）

### DIFF
--- a/src/renderer/components/settings/appearance-settings.tsx
+++ b/src/renderer/components/settings/appearance-settings.tsx
@@ -64,9 +64,9 @@ export function AppearanceSettings() {
     localStorage.setItem('app-language', choice);
     i18n.changeLanguage(effective);
     api.config.setLanguage(effective).catch(console.error);
-    toast.success(
-      t('settings.appearance.languageUpdated', { lng: NATIVE_NAMES[effective] ?? effective })
-    );
+    // 用切换后的【实际语言码】强制解析提示文案（lng 是 i18next 保留选项=强制解析语言，必须是语言码而非显示名；
+    // languageUpdated 各 locale 是自描述的「已切换为X」，故提示恒以目标语言显示）。
+    toast.success(t('settings.appearance.languageUpdated', { lng: effective }));
   };
 
   return (


### PR DESCRIPTION
## 问题（macOS 真机发现）

切换界面语言后，无论切到哪种语言，右上角提示**恒显示「Switched to English」**（即便界面已正确切到中文/俄语等）。

## 根因

`t(key, { lng })` 的 `lng` 是 i18next 的**保留选项 = 强制解析语言**，必须是语言**码**（zh-CN/en-US/fa…）。#183 引入「自动选择」时，此处误传了**母语显示名**：

```ts
t('settings.appearance.languageUpdated', { lng: NATIVE_NAMES[effective] ?? effective }) // 'fa' → '简体中文'/'فارسی'...
```

i18next 找不到名为「简体中文」的语言 → 回退 `fallbackLng: 'en-US'` → `languageUpdated` 取 en-US 值「Switched to English」。故不论切到哪种语言提示都是英文。

## 修复

`lng` 改回切换后的**实际语言码** `effective`：

```ts
t('settings.appearance.languageUpdated', { lng: effective })
```

`languageUpdated` 各 locale 是自描述的「已切换为X」/「Switched to X」，故提示随目标语言正确显示（切中文→「已切换为简体中文」，切英文→「Switched to English」，切波斯语→fa 文案）。

## 验证

- macOS arm64 真机：切换各语言提示文案正确（已确认）。
- 纯 renderer / i18next 逻辑，平台无关，三端一致。
- tsc / eslint 干净。