### PR TITLE
refactor(i18n): 主进程托盘菜单 + 提权对话框硬编码迁移到 5 语 i18n

### DIFF
--- a/src/main/__tests__/i18n.test.ts
+++ b/src/main/__tests__/i18n.test.ts
@@ -5,15 +5,10 @@
 jest.mock('electron', () => ({ app: {} }));
 
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from '../../shared/language';
-import { mt, setMainLanguage, getMainLanguage, type MainMessageKey } from '../i18n';
+import { mt, setMainLanguage, getMainLanguage, MAIN_MESSAGE_KEYS } from '../i18n';
 
-const KEYS: MainMessageKey[] = [
-  'proxyErrorTitle',
-  'proxyErrorBody',
-  'helperDisabledTitle',
-  'helperDisabledBody',
-  'tailscaleAuthBody',
-];
+// 自动覆盖全部文案键（通知 + 托盘 + 对话框 + 未来新增），无需手维护清单。
+const KEYS = MAIN_MESSAGE_KEYS;
 
 afterEach(() => setMainLanguage(DEFAULT_LANGUAGE)); // 复位模块级语言
 

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -276,6 +276,164 @@ const MESSAGES = {
     ru: 'FlowZ — Подключено',
     fa: 'FlowZ — متصل',
   },
+
+  // —— 提权 helper 授权对话框（index.ts）：按钮 ——
+  btnCancel: {
+    'zh-CN': '取消',
+    'zh-TW': '取消',
+    'en-US': 'Cancel',
+    ru: 'Отмена',
+    fa: 'لغو',
+  },
+  btnRepairStart: {
+    'zh-CN': '修复并启动',
+    'zh-TW': '修復並啟動',
+    'en-US': 'Repair & start',
+    ru: 'Исправить и запустить',
+    fa: 'تعمیر و راه‌اندازی',
+  },
+  btnInstallStart: {
+    'zh-CN': '安装并启动',
+    'zh-TW': '安裝並啟動',
+    'en-US': 'Install & start',
+    ru: 'Установить и запустить',
+    fa: 'نصب و راه‌اندازی',
+  },
+  btnUseUac: {
+    'zh-CN': '用 UAC 启动',
+    'zh-TW': '用 UAC 啟動',
+    'en-US': 'Use UAC',
+    ru: 'Запустить через UAC',
+    fa: 'راه‌اندازی با UAC',
+  },
+  btnUseSystemAuth: {
+    'zh-CN': '用系统授权启动',
+    'zh-TW': '用系統授權啟動',
+    'en-US': 'Use system auth',
+    ru: 'С системной авторизацией',
+    fa: 'با احراز هویت سیستم',
+  },
+  btnOpenSystemSettings: {
+    'zh-CN': '打开系统设置',
+    'zh-TW': '開啟系統設定',
+    'en-US': 'Open System Settings',
+    ru: 'Открыть системные настройки',
+    fa: 'باز کردن تنظیمات سیستم',
+  },
+  btnStartThisSession: {
+    'zh-CN': '本次直接启动',
+    'zh-TW': '本次直接啟動',
+    'en-US': 'Start this session',
+    ru: 'Запустить сейчас',
+    fa: 'راه‌اندازی این بار',
+  },
+
+  // —— 对话框：标题 ——
+  dlgWinRepairServiceMsg: {
+    'zh-CN': '修复 Windows 提权服务？',
+    'zh-TW': '修復 Windows 提權服務？',
+    'en-US': 'Repair privileged service?',
+    ru: 'Исправить привилегированную службу?',
+    fa: 'سرویس ممتاز تعمیر شود؟',
+  },
+  dlgWinInstallServiceMsg: {
+    'zh-CN': '安装 Windows 提权服务？',
+    'zh-TW': '安裝 Windows 提權服務？',
+    'en-US': 'Install privileged service?',
+    ru: 'Установить привилегированную службу?',
+    fa: 'سرویس ممتاز نصب شود؟',
+  },
+  dlgMacBgOffMsg: {
+    'zh-CN': '提权助手的「允许在后台」被系统关闭',
+    'zh-TW': '提權助手的「允許在背景」被系統關閉',
+    'en-US': 'Helper "Allow in Background" is off',
+    ru: 'У помощника отключено «Разрешить в фоне»',
+    fa: 'گزینه «اجازه در پس‌زمینه» دستیار خاموش است',
+  },
+  dlgMacRepairHelperMsg: {
+    'zh-CN': '修复提权助手？',
+    'zh-TW': '修復提權助手？',
+    'en-US': 'Repair privileged helper?',
+    ru: 'Исправить привилегированный помощник?',
+    fa: 'دستیار ممتاز تعمیر شود؟',
+  },
+  dlgMacInstallHelperMsg: {
+    'zh-CN': '安装提权助手？',
+    'zh-TW': '安裝提權助手？',
+    'en-US': 'Install privileged helper?',
+    ru: 'Установить привилегированный помощник?',
+    fa: 'دستیار ممتاز نصب شود؟',
+  },
+
+  // —— 对话框：详情（长段落） ——
+  dlgWinRepairDetail: {
+    'zh-CN':
+      '提权服务已安装但未就绪（服务未运行或版本不符）。修复将重装服务，仅需授权一次（UAC）；也可本次用 UAC 启动。',
+    'zh-TW':
+      '提權服務已安裝但未就緒（服務未執行或版本不符）。修復將重裝服務，僅需授權一次（UAC）；也可本次用 UAC 啟動。',
+    'en-US':
+      'The privileged service is installed but not ready. Repair reinstalls it (one UAC prompt); or start with UAC this time.',
+    ru: 'Привилегированная служба установлена, но не готова. Восстановление переустановит её (один запрос UAC); либо запустите через UAC сейчас.',
+    fa: 'سرویس ممتاز نصب شده اما آماده نیست. تعمیر آن را دوباره نصب می‌کند (یک بار درخواست UAC)؛ یا این بار با UAC راه‌اندازی کنید.',
+  },
+  dlgWinInstallDetail: {
+    'zh-CN':
+      '安装后 Windows TUN 模式启停代理免每次 UAC（装服务需管理员授权一次）；也可本次用 UAC 启动。',
+    'zh-TW':
+      '安裝後 Windows TUN 模式啟停代理免每次 UAC（裝服務需管理員授權一次）；也可本次用 UAC 啟動。',
+    'en-US':
+      'After install, Windows TUN start/stop no longer needs UAC each time (installing the service needs one admin prompt); or start with UAC this time.',
+    ru: 'После установки запуск/остановка TUN в Windows больше не требует UAC каждый раз (установка службы требует одного запроса администратора); либо запустите через UAC сейчас.',
+    fa: 'پس از نصب، شروع/توقف TUN در ویندوز دیگر هر بار به UAC نیاز ندارد (نصب سرویس یک بار درخواست مدیر دارد)؛ یا این بار با UAC راه‌اندازی کنید.',
+  },
+  dlgMacBgOffDetail: {
+    'zh-CN':
+      '请在「系统设置 > 通用 > 登录项与扩展」重新打开 FlowZ 的「允许在后台」开关，然后回到 FlowZ 重新点击启动即可（届时免授权直接走提权助手）。\n「本次直接启动」会以系统管理员授权方式运行（弹一次密码框），不依赖后台开关；但之后每次启停都需授权，建议尽快去系统设置打开开关。',
+    'zh-TW':
+      '請在「系統設定 > 一般 > 登入項目與擴充功能」重新打開 FlowZ 的「允許在背景」開關，然後回到 FlowZ 重新點擊啟動即可（屆時免授權直接走提權助手）。\n「本次直接啟動」會以系統管理員授權方式執行（彈一次密碼框），不依賴背景開關；但之後每次啟停都需授權，建議盡快去系統設定打開開關。',
+    'en-US':
+      'Open System Settings → General → Login Items & Extensions and turn the "Allow in Background" toggle back on for FlowZ, then return to FlowZ and start again (no authorization needed then).\n"Start this session" runs with system administrator authorization (one password prompt) and does not depend on the toggle; each start/stop will prompt afterwards, so re-enabling the toggle is recommended.',
+    ru: 'Откройте «Системные настройки → Основные → Объекты входа и расширения» и снова включите переключатель «Разрешить в фоне» для FlowZ, затем вернитесь в FlowZ и запустите снова (тогда авторизация не нужна).\n«Запустить сейчас» работает с авторизацией системного администратора (один запрос пароля) и не зависит от переключателя; после этого каждый запуск/остановка будет запрашивать пароль, поэтому рекомендуется снова включить переключатель.',
+    fa: 'به «تنظیمات سیستم ← عمومی ← موارد ورود و افزونه‌ها» بروید و کلید «اجازه در پس‌زمینه» را برای FlowZ دوباره روشن کنید، سپس به FlowZ بازگردید و دوباره راه‌اندازی کنید (آنگاه به احراز هویت نیازی نیست).\n«راه‌اندازی این بار» با احراز هویت مدیر سیستم اجرا می‌شود (یک بار درخواست رمز) و به این کلید وابسته نیست؛ اما پس از آن هر شروع/توقف درخواست رمز می‌کند، بنابراین روشن کردن دوباره کلید توصیه می‌شود.',
+  },
+  dlgMacRepairNoteOff: {
+    'zh-CN':
+      '\n注意：若系统设置「允许在后台」开关已被关闭，此修复不会恢复该开关；请到「系统设置 > 通用 > 登录项与扩展」手动重新开启。',
+    'zh-TW':
+      '\n注意：若系統設定「允許在背景」開關已被關閉，此修復不會恢復該開關；請到「系統設定 > 一般 > 登入項目與擴充功能」手動重新開啟。',
+    'en-US':
+      '\nNote: if the "Allow in Background" toggle was turned off in System Settings, this repair will NOT restore it; re-enable it manually under System Settings → General → Login Items & Extensions.',
+    ru: '\nПримечание: если переключатель «Разрешить в фоне» был выключен в системных настройках, это восстановление НЕ включит его; включите его вручную в «Системные настройки → Основные → Объекты входа и расширения».',
+    fa: '\nتوجه: اگر کلید «اجازه در پس‌زمینه» در تنظیمات سیستم خاموش شده باشد، این تعمیر آن را بازنمی‌گرداند؛ آن را به‌صورت دستی در «تنظیمات سیستم ← عمومی ← موارد ورود و افزونه‌ها» دوباره فعال کنید.',
+  },
+  dlgMacRepairPathMismatchDetail: {
+    'zh-CN':
+      '检测到应用位置已变更，提权助手仍指向旧路径而无法生效。修复将重新登记当前路径，仅需授权一次；也可本次用系统授权启动。',
+    'zh-TW':
+      '偵測到應用位置已變更，提權助手仍指向舊路徑而無法生效。修復將重新登記目前路徑，僅需授權一次；也可本次用系統授權啟動。',
+    'en-US':
+      'The app was moved and the helper still points to the old path. Repair re-registers the current path (one authorization); or start with system auth this time.',
+    ru: 'Приложение было перемещено, а помощник всё ещё указывает на старый путь. Восстановление заново зарегистрирует текущий путь (одна авторизация); либо запустите с системной авторизацией сейчас.',
+    fa: 'برنامه جابه‌جا شده و دستیار هنوز به مسیر قدیمی اشاره می‌کند. تعمیر مسیر فعلی را دوباره ثبت می‌کند (یک بار احراز هویت)؛ یا این بار با احراز هویت سیستم راه‌اندازی کنید.',
+  },
+  dlgMacRepairUpgradeDetail: {
+    'zh-CN':
+      '提权助手需要更新到新版本（功能改进）。修复将重新安装，仅需授权一次；也可本次用系统授权启动。',
+    'zh-TW':
+      '提權助手需要更新到新版本（功能改進）。修復將重新安裝，僅需授權一次；也可本次用系統授權啟動。',
+    'en-US':
+      'The privileged helper needs updating to a newer version. Repair reinstalls it (one authorization); or start with system auth this time.',
+    ru: 'Привилегированный помощник нужно обновить до новой версии. Восстановление переустановит его (одна авторизация); либо запустите с системной авторизацией сейчас.',
+    fa: 'دستیار ممتاز باید به نسخه جدیدتری به‌روزرسانی شود. تعمیر آن را دوباره نصب می‌کند (یک بار احراز هویت)؛ یا این بار با احراز هویت سیستم راه‌اندازی کنید.',
+  },
+  dlgMacInstallDetail: {
+    'zh-CN': '安装后 TUN 模式启停代理免每次系统授权；也可本次用系统授权启动。',
+    'zh-TW': '安裝後 TUN 模式啟停代理免每次系統授權；也可本次用系統授權啟動。',
+    'en-US':
+      'After install, TUN start/stop no longer needs system authorization each time; or start with system auth this time.',
+    ru: 'После установки запуск/остановка TUN больше не требует системной авторизации каждый раз; либо запустите с системной авторизацией сейчас.',
+    fa: 'پس از نصب، شروع/توقف TUN دیگر هر بار به احراز هویت سیستم نیاز ندارد؛ یا این بار با احراز هویت سیستم راه‌اندازی کنید.',
+  },
 } satisfies Record<string, Record<SupportedLanguage, string>>;
 
 /** 主进程文案键（自 MESSAGES 自动派生，无需手维护 union）。 */

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -3,12 +3,14 @@
  *
  * 背景：渲染端用 i18next（locales/*.json）做 5 语，但**主进程没有 i18next 实例**——IPC 只同步 currentLanguage
  * 字符串过来。历史上主进程用户串走「zh/en 二元」土办法（TrayManager.t / native dialog），fa/ru/zh-TW 用户看到英文，
- * 部分串甚至纯中文。本模块给主进程一个真 5 语出口：中央语言持有点 + 文案目录，桌面通知等任意主进程服务调 mt() 即可。
+ * 部分串甚至纯中文。本模块给主进程一个真 5 语出口：中央语言持有点 + 文案目录，桌面通知/托盘/对话框等调 mt() 即可。
  *
  * 设计：
  * - 文案主进程私有（渲染端从不显示这些串，故不复用 renderer 的 locale JSON——且 tsconfig.main 也 import 不到它）。
  * - 语言持有点由 index.ts 在启动（系统偏好）+ APP_SET_LANGUAGE（渲染端同步）两处 setMainLanguage 写入。
  * - 缺键/未知语言 → 回退 DEFAULT_LANGUAGE，绝不抛。
+ * - MESSAGES 用 `satisfies Record<string, Record<SupportedLanguage,string>>`：编译期强制每键 5 语齐全，
+ *   且 `MainMessageKey = keyof typeof MESSAGES` 自动派生 key 联合类型（新增键无需手维护 union）。
  */
 import {
   SUPPORTED_LANGUAGES,
@@ -17,16 +19,9 @@ import {
   type SupportedLanguage,
 } from '../shared/language';
 
-/** 主进程文案键。新增主进程用户可见串时在此扩展（编译期强制 5 语齐全）。 */
-export type MainMessageKey =
-  | 'proxyErrorTitle'
-  | 'proxyErrorBody'
-  | 'helperDisabledTitle'
-  | 'helperDisabledBody'
-  | 'tailscaleAuthBody';
-
-/** key → 各受支持语言文案。Record<SupportedLanguage,...> 保证编译期 5 语不缺。 */
-const MESSAGES: Record<MainMessageKey, Record<SupportedLanguage, string>> = {
+/** key → 各受支持语言文案。satisfies 保证每键 5 语齐全；新增主进程用户可见串在此扩展。 */
+const MESSAGES = {
+  // —— 桌面通知（notify-user 出口） ——
   proxyErrorTitle: {
     'zh-CN': 'FlowZ 代理出错',
     'zh-TW': 'FlowZ 代理出錯',
@@ -62,7 +57,229 @@ const MESSAGES: Record<MainMessageKey, Record<SupportedLanguage, string>> = {
     ru: 'Завершите вход в браузере, чтобы присоединиться к сети',
     fa: 'برای پیوستن به شبکه، ورود را در مرورگر کامل کنید',
   },
-};
+
+  // —— 托盘菜单（TrayManager） ——
+  trayStatusError: {
+    'zh-CN': '连接异常',
+    'zh-TW': '連線異常',
+    'en-US': 'Connection Error',
+    ru: 'Ошибка подключения',
+    fa: 'خطای اتصال',
+  },
+  trayStatusConnected: {
+    'zh-CN': '已连接',
+    'zh-TW': '已連線',
+    'en-US': 'Connected',
+    ru: 'Подключено',
+    fa: 'متصل',
+  },
+  trayStatusDisconnected: {
+    'zh-CN': '已断开',
+    'zh-TW': '已斷開',
+    'en-US': 'Disconnected',
+    ru: 'Отключено',
+    fa: 'قطع شد',
+  },
+  trayTimeout: {
+    'zh-CN': '超时',
+    'zh-TW': '逾時',
+    'en-US': 'Timeout',
+    ru: 'Таймаут',
+    fa: 'فرصت تمام شد',
+  },
+  trayDirect: {
+    'zh-CN': '直连',
+    'zh-TW': '直連',
+    'en-US': 'Direct',
+    ru: 'Напрямую',
+    fa: 'مستقیم',
+  },
+  trayNoServers: {
+    'zh-CN': '未配置服务器',
+    'zh-TW': '未設定伺服器',
+    'en-US': 'No Servers Configured',
+    ru: 'Серверы не настроены',
+    fa: 'هیچ سروری پیکربندی نشده',
+  },
+  trayMesh: {
+    'zh-CN': '组网',
+    'zh-TW': '組網',
+    'en-US': 'Mesh',
+    ru: 'Меш-сеть',
+    fa: 'شبکه مش',
+  },
+  trayCustomNodes: {
+    'zh-CN': '自建节点',
+    'zh-TW': '自建節點',
+    'en-US': 'Custom Nodes',
+    ru: 'Свои узлы',
+    fa: 'نُدهای سفارشی',
+  },
+  trayManageServers: {
+    'zh-CN': '管理服务器',
+    'zh-TW': '管理伺服器',
+    'en-US': 'Manage Servers',
+    ru: 'Управление серверами',
+    fa: 'مدیریت سرورها',
+  },
+  trayGlobalProxy: {
+    'zh-CN': '全局代理',
+    'zh-TW': '全域代理',
+    'en-US': 'Global Proxy',
+    ru: 'Глобальный прокси',
+    fa: 'پروکسی سراسری',
+  },
+  traySmartRouting: {
+    'zh-CN': '智能分流',
+    'zh-TW': '智慧分流',
+    'en-US': 'Smart Routing',
+    ru: 'Умная маршрутизация',
+    fa: 'مسیریابی هوشمند',
+  },
+  trayDirectMode: {
+    'zh-CN': '直连模式',
+    'zh-TW': '直連模式',
+    'en-US': 'Direct Connection',
+    ru: 'Прямое подключение',
+    fa: 'اتصال مستقیم',
+  },
+  traySystemProxy: {
+    'zh-CN': '系统代理',
+    'zh-TW': '系統代理',
+    'en-US': 'System Proxy',
+    ru: 'Системный прокси',
+    fa: 'پروکسی سیستم',
+  },
+  trayTun: {
+    'zh-CN': 'TUN 网卡',
+    'zh-TW': 'TUN 網卡',
+    'en-US': 'TUN',
+    ru: 'TUN',
+    fa: 'TUN',
+  },
+  trayLocalOnly: {
+    'zh-CN': '仅本地',
+    'zh-TW': '僅本機',
+    'en-US': 'Local Only',
+    ru: 'Только локально',
+    fa: 'فقط محلی',
+  },
+  trayOpenMainWindow: {
+    'zh-CN': '打开主窗口',
+    'zh-TW': '開啟主視窗',
+    'en-US': 'Open Main Window',
+    ru: 'Открыть главное окно',
+    fa: 'باز کردن پنجره اصلی',
+  },
+  trayDisableProxy: {
+    'zh-CN': '禁用代理',
+    'zh-TW': '停用代理',
+    'en-US': 'Disable Proxy',
+    ru: 'Отключить прокси',
+    fa: 'غیرفعال‌سازی پروکسی',
+  },
+  trayEnableProxy: {
+    'zh-CN': '启用代理',
+    'zh-TW': '啟用代理',
+    'en-US': 'Enable Proxy',
+    ru: 'Включить прокси',
+    fa: 'فعال‌سازی پروکسی',
+  },
+  traySelectServer: {
+    'zh-CN': '选择服务器',
+    'zh-TW': '選擇伺服器',
+    'en-US': 'Select Server',
+    ru: 'Выбрать сервер',
+    fa: 'انتخاب سرور',
+  },
+  trayTakeover: {
+    'zh-CN': '接管方式',
+    'zh-TW': '接管方式',
+    'en-US': 'Takeover',
+    ru: 'Перехват',
+    fa: 'نحوه تصاحب',
+  },
+  trayRouting: {
+    'zh-CN': '分流策略',
+    'zh-TW': '分流策略',
+    'en-US': 'Routing',
+    ru: 'Маршрутизация',
+    fa: 'مسیریابی',
+  },
+  trayLightweightMode: {
+    'zh-CN': '进入轻量模式',
+    'zh-TW': '進入輕量模式',
+    'en-US': 'Enter Lightweight Mode',
+    ru: 'Лёгкий режим',
+    fa: 'حالت سبک',
+  },
+  trayPrivacyMode: {
+    'zh-CN': '进入隐私模式',
+    'zh-TW': '進入隱私模式',
+    'en-US': 'Enter Privacy Mode',
+    ru: 'Режим конфиденциальности',
+    fa: 'حالت حریم خصوصی',
+  },
+  trayOpenSettings: {
+    'zh-CN': '打开设置',
+    'zh-TW': '開啟設定',
+    'en-US': 'Open Settings',
+    ru: 'Открыть настройки',
+    fa: 'باز کردن تنظیمات',
+  },
+  trayCheckUpdates: {
+    'zh-CN': '检查更新',
+    'zh-TW': '檢查更新',
+    'en-US': 'Check for Updates',
+    ru: 'Проверить обновления',
+    fa: 'بررسی به‌روزرسانی',
+  },
+  trayQuit: {
+    'zh-CN': '退出',
+    'zh-TW': '結束',
+    'en-US': 'Quit',
+    ru: 'Выход',
+    fa: 'خروج',
+  },
+  trayTestingSpeed: {
+    'zh-CN': '测速中...',
+    'zh-TW': '測速中...',
+    'en-US': 'Testing Speed...',
+    ru: 'Проверка скорости...',
+    fa: 'در حال تست سرعت...',
+  },
+  traySpeedTest: {
+    'zh-CN': '服务器测速',
+    'zh-TW': '伺服器測速',
+    'en-US': 'Speed Test',
+    ru: 'Тест скорости',
+    fa: 'تست سرعت',
+  },
+  trayTooltipDisconnected: {
+    'zh-CN': 'FlowZ - 未连接',
+    'zh-TW': 'FlowZ - 未連線',
+    'en-US': 'FlowZ - Disconnected',
+    ru: 'FlowZ — Отключено',
+    fa: 'FlowZ — قطع شد',
+  },
+  trayTooltipConnecting: {
+    'zh-CN': 'FlowZ - 连接中...',
+    'zh-TW': 'FlowZ - 連線中...',
+    'en-US': 'FlowZ - Connecting...',
+    ru: 'FlowZ — Подключение...',
+    fa: 'FlowZ — در حال اتصال...',
+  },
+  trayTooltipConnected: {
+    'zh-CN': 'FlowZ - 已连接',
+    'zh-TW': 'FlowZ - 已連線',
+    'en-US': 'FlowZ - Connected',
+    ru: 'FlowZ — Подключено',
+    fa: 'FlowZ — متصل',
+  },
+} satisfies Record<string, Record<SupportedLanguage, string>>;
+
+/** 主进程文案键（自 MESSAGES 自动派生，无需手维护 union）。 */
+export type MainMessageKey = keyof typeof MESSAGES;
 
 let currentLang: SupportedLanguage = DEFAULT_LANGUAGE;
 
@@ -84,3 +301,6 @@ export function mt(key: MainMessageKey): string {
 
 /** 受支持语言数（供测试校验 parity）。 */
 export const MAIN_I18N_LANG_COUNT = SUPPORTED_LANGUAGES.length;
+
+/** 全部文案键（供测试遍历校验）。 */
+export const MAIN_MESSAGE_KEYS = Object.keys(MESSAGES) as MainMessageKey[];

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -113,7 +113,7 @@ const MESSAGES = {
     'zh-TW': '自建節點',
     'en-US': 'Custom Nodes',
     ru: 'Свои узлы',
-    fa: 'نُدهای سفارشی',
+    fa: 'گره‌های سفارشی',
   },
   trayManageServers: {
     'zh-CN': '管理服务器',
@@ -370,7 +370,7 @@ const MESSAGES = {
     'zh-CN':
       '提权服务已安装但未就绪（服务未运行或版本不符）。修复将重装服务，仅需授权一次（UAC）；也可本次用 UAC 启动。',
     'zh-TW':
-      '提權服務已安裝但未就緒（服務未執行或版本不符）。修復將重裝服務，僅需授權一次（UAC）；也可本次用 UAC 啟動。',
+      '提權服務已安裝但未就緒（服務未執行或版本不符）。修復將重新安裝服務，僅需授權一次（UAC）；也可本次用 UAC 啟動。',
     'en-US':
       'The privileged service is installed but not ready. Repair reinstalls it (one UAC prompt); or start with UAC this time.',
     ru: 'Привилегированная служба установлена, но не готова. Восстановление переустановит её (один запрос UAC); либо запустите через UAC сейчас.',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -214,7 +214,7 @@ let ipInfoService: IpInfoService | null = null;
 let ruleResourceManager: RuleResourceManager | null = null;
 let ruleResourceScheduler: RuleResourceScheduler | null = null;
 let helperManager: IPrivilegedHelper | null = null;
-let currentLanguage = 'zh-CN'; // 渲染端 APP_SET_LANGUAGE 同步的最近语言；经 setMainLanguage 喂主进程 i18n（mt() 据此取文案，含空值保留旧值的兜底）
+let currentLanguage = 'zh-CN'; // 渲染端 APP_SET_LANGUAGE 同步的最近语言；经 setMainLanguage 喂主进程 i18n（mt() 据此取文案）。空值由 handler 的 lang||currentLanguage 兜底保留旧值（不传空给 setMainLanguage）
 
 /**
  * helper 引导对话框（注入 ProxyManager.setHelperGate，由 start() 在 darwin+TUN+helper 未就绪+未 dismiss

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -214,7 +214,7 @@ let ipInfoService: IpInfoService | null = null;
 let ruleResourceManager: RuleResourceManager | null = null;
 let ruleResourceScheduler: RuleResourceScheduler | null = null;
 let helperManager: IPrivilegedHelper | null = null;
-let currentLanguage = 'zh-CN'; // 渲染端 APP_SET_LANGUAGE 同步，供主进程 native dialog 文案选语言
+let currentLanguage = 'zh-CN'; // 渲染端 APP_SET_LANGUAGE 同步的最近语言；经 setMainLanguage 喂主进程 i18n（mt() 据此取文案，含空值保留旧值的兜底）
 
 /**
  * helper 引导对话框（注入 ProxyManager.setHelperGate，由 start() 在 darwin+TUN+helper 未就绪+未 dismiss
@@ -230,22 +230,17 @@ async function promptHelperGate(
     mainWindow.show();
     mainWindow.focus();
   }
-  const zh = currentLanguage.toLowerCase().startsWith('zh');
   if (process.platform === 'win32') {
     // Windows：无「允许在后台」概念（backgroundDisabled 恒 false）。needsRepair(已装未就绪) → 修复；未装 → 安装。
     // 任一路径仅弹一次 UAC（装服务需管理员授权）；「用 UAC 启动」= 本次回退 buildWindowsUacLaunchCommand（每次 UAC）。
     if (hs.needsRepair) {
       const { response } = await dialog.showMessageBox({
         type: 'question',
-        buttons: zh
-          ? ['修复并启动', '用 UAC 启动', '取消']
-          : ['Repair & start', 'Use UAC', 'Cancel'],
+        buttons: [mt('btnRepairStart'), mt('btnUseUac'), mt('btnCancel')],
         defaultId: 0,
         cancelId: 2,
-        message: zh ? '修复 Windows 提权服务？' : 'Repair privileged service?',
-        detail: zh
-          ? '提权服务已安装但未就绪（服务未运行或版本不符）。修复将重装服务，仅需授权一次（UAC）；也可本次用 UAC 启动。'
-          : 'The privileged service is installed but not ready. Repair reinstalls it (one UAC prompt); or start with UAC this time.',
+        message: mt('dlgWinRepairServiceMsg'),
+        detail: mt('dlgWinRepairDetail'),
       });
       if (response === 2) return 'abort';
       if (response === 0) await helperManager.install().catch(() => {});
@@ -253,15 +248,11 @@ async function promptHelperGate(
     }
     const { response } = await dialog.showMessageBox({
       type: 'question',
-      buttons: zh
-        ? ['安装并启动', '用 UAC 启动', '取消']
-        : ['Install & start', 'Use UAC', 'Cancel'],
+      buttons: [mt('btnInstallStart'), mt('btnUseUac'), mt('btnCancel')],
       defaultId: 0,
       cancelId: 2,
-      message: zh ? '安装 Windows 提权服务？' : 'Install privileged service?',
-      detail: zh
-        ? '安装后 Windows TUN 模式启停代理免每次 UAC（装服务需管理员授权一次）；也可本次用 UAC 启动。'
-        : 'After install, Windows TUN start/stop no longer needs UAC each time (installing the service needs one admin prompt); or start with UAC this time.',
+      message: mt('dlgWinInstallServiceMsg'),
+      detail: mt('dlgWinInstallDetail'),
     });
     if (response === 2) return 'abort';
     if (response === 0) await helperManager.install().catch(() => {});
@@ -276,15 +267,11 @@ async function promptHelperGate(
     //  - 取消。
     const { response } = await dialog.showMessageBox({
       type: 'question',
-      buttons: zh
-        ? ['打开系统设置', '本次直接启动', '取消']
-        : ['Open System Settings', 'Start this session', 'Cancel'],
+      buttons: [mt('btnOpenSystemSettings'), mt('btnStartThisSession'), mt('btnCancel')],
       defaultId: 0,
       cancelId: 2,
-      message: zh ? '提权助手的「允许在后台」被系统关闭' : 'Helper "Allow in Background" is off',
-      detail: zh
-        ? '请在「系统设置 > 通用 > 登录项与扩展」重新打开 FlowZ 的「允许在后台」开关，然后回到 FlowZ 重新点击启动即可（届时免授权直接走提权助手）。\n「本次直接启动」会以系统管理员授权方式运行（弹一次密码框），不依赖后台开关；但之后每次启停都需授权，建议尽快去系统设置打开开关。'
-        : 'Open System Settings → General → Login Items & Extensions and turn the "Allow in Background" toggle back on for FlowZ, then return to FlowZ and start again (no authorization needed then).\n"Start this session" runs with system administrator authorization (one password prompt) and does not depend on the toggle; each start/stop will prompt afterwards, so re-enabling the toggle is recommended.',
+      message: mt('dlgMacBgOffMsg'),
+      detail: mt('dlgMacBgOffDetail'),
     });
     if (response === 0) {
       await shell.openExternal(LOGIN_ITEMS_SETTINGS_URL).catch(() => {});
@@ -303,26 +290,15 @@ async function promptHelperGate(
     //  - pathMismatch：应用被移动，plist 烧录路径失效；
     //  - 否则（!ready）：多为协议版本升级（如 v2→v3），已装 helper 需重装到新版本。
     // 诚实化：此「修复」=重装，**不会**恢复系统设置里「允许在后台」开关；若开关被关需到系统设置手动开启（Bug2 文案）。
-    const noteOff = zh
-      ? '\n注意：若系统设置「允许在后台」开关已被关闭，此修复不会恢复该开关；请到「系统设置 > 通用 > 登录项与扩展」手动重新开启。'
-      : '\nNote: if the "Allow in Background" toggle was turned off in System Settings, this repair will NOT restore it; re-enable it manually under System Settings → General → Login Items & Extensions.';
     const detail =
-      (zh
-        ? hs.pathMismatch
-          ? '检测到应用位置已变更，提权助手仍指向旧路径而无法生效。修复将重新登记当前路径，仅需授权一次；也可本次用系统授权启动。'
-          : '提权助手需要更新到新版本（功能改进）。修复将重新安装，仅需授权一次；也可本次用系统授权启动。'
-        : hs.pathMismatch
-          ? 'The app was moved and the helper still points to the old path. Repair re-registers the current path (one authorization); or start with system auth this time.'
-          : 'The privileged helper needs updating to a newer version. Repair reinstalls it (one authorization); or start with system auth this time.') +
-      noteOff;
+      (hs.pathMismatch ? mt('dlgMacRepairPathMismatchDetail') : mt('dlgMacRepairUpgradeDetail')) +
+      mt('dlgMacRepairNoteOff');
     const { response } = await dialog.showMessageBox({
       type: 'question',
-      buttons: zh
-        ? ['修复并启动', '用系统授权启动', '取消']
-        : ['Repair & start', 'Use system auth', 'Cancel'],
+      buttons: [mt('btnRepairStart'), mt('btnUseSystemAuth'), mt('btnCancel')],
       defaultId: 0,
       cancelId: 2,
-      message: zh ? '修复提权助手？' : 'Repair privileged helper?',
+      message: mt('dlgMacRepairHelperMsg'),
       detail,
     });
     if (response === 2) return 'abort'; // 取消：不启动
@@ -332,15 +308,11 @@ async function promptHelperGate(
   // 未安装 → 安装并启动
   const { response } = await dialog.showMessageBox({
     type: 'question',
-    buttons: zh
-      ? ['安装并启动', '用系统授权启动', '取消']
-      : ['Install & start', 'Use system auth', 'Cancel'],
+    buttons: [mt('btnInstallStart'), mt('btnUseSystemAuth'), mt('btnCancel')],
     defaultId: 0,
     cancelId: 2,
-    message: zh ? '安装提权助手？' : 'Install privileged helper?',
-    detail: zh
-      ? '安装后 TUN 模式启停代理免每次系统授权；也可本次用系统授权启动。'
-      : 'After install, TUN start/stop no longer needs system authorization each time; or start with system auth this time.',
+    message: mt('dlgMacInstallHelperMsg'),
+    detail: mt('dlgMacInstallDetail'),
   });
   if (response === 2) return 'abort'; // 取消：不启动
   if (response === 0) await helperManager.install().catch(() => {}); // 装好后 start 走 helper 零提权

--- a/src/main/services/TrayManager.ts
+++ b/src/main/services/TrayManager.ts
@@ -10,7 +10,7 @@ import {
 import { LogManager } from './LogManager';
 import { ServerConfig, ProxyMode, ProxyModeType, SubscriptionConfig } from '../../shared/types';
 import { groupServersBySubscription } from '../../shared/server-grouping';
-import { resolveAutoLanguage } from '../../shared/language';
+import { mt, setMainLanguage } from '../i18n';
 import { DIRECT_SERVER_ID, isDirectSelection } from '../../shared/direct-selection';
 import { IPC_CHANNELS } from '../../shared/ipc-channels';
 
@@ -101,9 +101,8 @@ export class TrayManager implements ITrayManager {
   private selectedServerId: string | null = null;
   private proxyMode: ProxyMode = 'smart';
   private proxyModeType: ProxyModeType = 'systemProxy';
-  // 应用内语言设置，由渲染进程通过 IPC 同步过来（App mount 即发实际语言）；此为渲染端同步到达前的初值。
-  // 用 getPreferredSystemLanguages 真实跟随系统（绝不用 app.getLocale——恒返 app bundle locale=en，与系统脱钩）。
-  private currentLanguage: string = resolveAutoLanguage(app.getPreferredSystemLanguages?.() ?? []);
+  // 语言：托盘文案经 mt() 走主进程 i18n 中央语言持有点（index.ts 启动按系统偏好初始化 + APP_SET_LANGUAGE 同步），
+  // 故本类不再自持 currentLanguage——setLanguage 只负责同步持有点并触发重渲染。
 
   // 回调函数
   private onStartProxy?: () => void;
@@ -271,17 +270,9 @@ export class TrayManager implements ITrayManager {
    * 设置应用语言（由主进程根据渲染进程 IPC 调用）
    */
   setLanguage(lang: string): void {
-    this.currentLanguage = lang;
+    setMainLanguage(lang); // 同步主进程 i18n 持有点（mt() 据此取文案）
     // 重新渲染菜单以应用新语言
     this.updateTrayMenu(this.isProxyRunning);
-  }
-
-  /**
-   * 获取本地化字符串（主进程托盘菜单用）
-   * 根据应用语言配置决定显示中文还是英文
-   */
-  private t(zh: string, en: string): string {
-    return this.currentLanguage.startsWith('zh') ? zh : en;
   }
 
   /**
@@ -305,13 +296,13 @@ export class TrayManager implements ITrayManager {
     let statusLabel: string;
     let statusState: 'connected' | 'disconnected' | 'error';
     if (data.hasError) {
-      statusLabel = this.t('连接异常', 'Connection Error');
+      statusLabel = mt('trayStatusError');
       statusState = 'error';
     } else if (data.isProxyRunning) {
-      statusLabel = this.t('已连接', 'Connected');
+      statusLabel = mt('trayStatusConnected');
       statusState = 'connected';
     } else {
-      statusLabel = this.t('已断开', 'Disconnected');
+      statusLabel = mt('trayStatusDisconnected');
       statusState = 'disconnected';
     }
 
@@ -329,7 +320,7 @@ export class TrayManager implements ITrayManager {
         latency !== undefined
           ? latency !== null
             ? ` [${latency}ms]`
-            : ` [${this.t('超时', 'Timeout')}]`
+            : ` [${mt('trayTimeout')}]`
           : '';
       // 超长只截「名字」，保「（协议）[延迟]」完整——延迟是选节点的关键信息，不应被尾部截断吃掉。
       const suffix = `（${proto}）${latencyStr}`;
@@ -346,7 +337,7 @@ export class TrayManager implements ITrayManager {
 
     // 「直连」置顶项（全局直连哨兵，#73）：与首页节点选择同概念、同步；选中即 proxy-selector→direct（热切换）。
     serverSubmenu.push({
-      label: this.t('直连', 'Direct'),
+      label: mt('trayDirect'),
       type: 'radio' as const,
       checked: isDirectSelection(data.selectedServerId),
       click: () => this.handleSelectServer(DIRECT_SERVER_ID),
@@ -355,7 +346,7 @@ export class TrayManager implements ITrayManager {
 
     if (data.servers.length === 0) {
       serverSubmenu.push({
-        label: this.t('未配置服务器', 'No Servers Configured'),
+        label: mt('trayNoServers'),
         enabled: false,
       });
       serverSubmenu.push({ type: 'separator' });
@@ -368,11 +359,7 @@ export class TrayManager implements ITrayManager {
         // 多来源：每个订阅/自建/组网一个子菜单
         for (const g of groups) {
           serverSubmenu.push({
-            label: g.isMesh
-              ? this.t('组网', 'Mesh')
-              : g.isManual
-                ? this.t('自建节点', 'Custom Nodes')
-                : g.name,
+            label: g.isMesh ? mt('trayMesh') : g.isManual ? mt('trayCustomNodes') : g.name,
             submenu: g.servers.map(buildServerItem),
           });
         }
@@ -382,15 +369,15 @@ export class TrayManager implements ITrayManager {
 
     // 添加"管理服务器"选项
     serverSubmenu.push({
-      label: this.t('管理服务器', 'Manage Servers'),
+      label: mt('trayManageServers'),
       click: () => this.handleManageServers(),
     });
 
     // 代理模式标签映射
     const proxyModeLabels: Record<ProxyMode, string> = {
-      global: this.t('全局代理', 'Global Proxy'),
-      smart: this.t('智能分流', 'Smart Routing'),
-      direct: this.t('直连模式', 'Direct Connection'),
+      global: mt('trayGlobalProxy'),
+      smart: mt('traySmartRouting'),
+      direct: mt('trayDirectMode'),
     };
 
     // 构建代理模式子菜单
@@ -405,9 +392,9 @@ export class TrayManager implements ITrayManager {
 
     // 接管方式（systemProxy/tun/manual）子菜单——无需打开主窗口即可切换
     const proxyModeTypeLabels: Record<ProxyModeType, string> = {
-      systemProxy: this.t('系统代理', 'System Proxy'),
-      tun: this.t('TUN 网卡', 'TUN'),
-      manual: this.t('仅本地', 'Local Only'),
+      systemProxy: mt('traySystemProxy'),
+      tun: mt('trayTun'),
+      manual: mt('trayLocalOnly'),
     };
     const proxyModeTypeSubmenu: MenuItemConstructorOptions[] = (
       ['systemProxy', 'tun', 'manual'] as ProxyModeType[]
@@ -426,13 +413,11 @@ export class TrayManager implements ITrayManager {
       },
       { type: 'separator' },
       {
-        label: this.t('打开主窗口', 'Open Main Window'),
+        label: mt('trayOpenMainWindow'),
         click: () => this.handleShowWindow(),
       },
       {
-        label: data.isProxyRunning
-          ? this.t('禁用代理', 'Disable Proxy')
-          : this.t('启用代理', 'Enable Proxy'),
+        label: data.isProxyRunning ? mt('trayDisableProxy') : mt('trayEnableProxy'),
         click: () => {
           if (data.isProxyRunning) {
             this.handleStopProxy();
@@ -443,32 +428,32 @@ export class TrayManager implements ITrayManager {
       },
       { type: 'separator' },
       {
-        label: this.t('选择服务器', 'Select Server'),
+        label: mt('traySelectServer'),
         submenu: serverSubmenu,
       },
       {
-        label: this.t('接管方式', 'Takeover'),
+        label: mt('trayTakeover'),
         submenu: proxyModeTypeSubmenu,
       },
       {
-        label: this.t('分流策略', 'Routing'),
+        label: mt('trayRouting'),
         submenu: proxyModeSubmenu,
       },
       { type: 'separator' },
       {
-        label: this.t('进入轻量模式', 'Enter Lightweight Mode'),
+        label: mt('trayLightweightMode'),
         click: () => this.handleLightweightMode(),
       },
       {
-        label: this.t('进入隐私模式', 'Enter Privacy Mode'),
+        label: mt('trayPrivacyMode'),
         click: () => this.handleEnterPrivacyMode(),
       },
       {
-        label: this.t('打开设置', 'Open Settings'),
+        label: mt('trayOpenSettings'),
         click: () => this.handleOpenSettings(),
       },
       {
-        label: this.t('检查更新', 'Check for Updates'),
+        label: mt('trayCheckUpdates'),
         click: () => this.handleCheckUpdate(),
       },
       { type: 'separator' },
@@ -479,7 +464,7 @@ export class TrayManager implements ITrayManager {
       },
       { type: 'separator' },
       {
-        label: this.t('退出', 'Quit'),
+        label: mt('trayQuit'),
         click: () => this.handleQuit(),
       },
     ]);
@@ -727,9 +712,9 @@ export class TrayManager implements ITrayManager {
    */
   private getSpeedTestLabel(): string {
     if (this.isSpeedTesting) {
-      return this.t('测速中...', 'Testing Speed...');
+      return mt('trayTestingSpeed');
     }
-    return this.t('服务器测速', 'Speed Test');
+    return mt('traySpeedTest');
   }
 
   /**
@@ -774,9 +759,9 @@ export class TrayManager implements ITrayManager {
     if (!this.tray) return;
 
     const tooltips: Record<TrayIconState, string> = {
-      idle: this.t('FlowZ - 未连接', 'FlowZ - Disconnected'),
-      connecting: this.t('FlowZ - 连接中...', 'FlowZ - Connecting...'),
-      connected: this.t('FlowZ - 已连接', 'FlowZ - Connected'),
+      idle: mt('trayTooltipDisconnected'),
+      connecting: mt('trayTooltipConnecting'),
+      connected: mt('trayTooltipConnected'),
     };
 
     const tooltip = tooltips[this.currentState];

--- a/src/main/services/__tests__/tray-manager-menu.test.ts
+++ b/src/main/services/__tests__/tray-manager-menu.test.ts
@@ -48,6 +48,7 @@ jest.mock('../ResourceManager', () => ({
 }));
 
 import { TrayManager, type TrayMenuData } from '../TrayManager';
+import { setMainLanguage } from '../../i18n';
 
 const makeLogger = () => ({ addLog: jest.fn() }) as any;
 
@@ -77,6 +78,9 @@ beforeEach(() => {
   lastTemplate = [];
   buildFromTemplate.mockClear();
   getTrayIconPath.mockClear();
+  // 托盘文案改走主进程 i18n（mt 读中央语言持有点）。真机由 index.ts 启动按系统偏好初始化；
+  // 测试显式设中文（对应本套 mock 的 zh-Hans-CN 系统偏好），以断言中文标签。
+  setMainLanguage('zh-CN');
 });
 
 describe('TrayManager 菜单状态映射 (#75)', () => {


### PR DESCRIPTION
> ⚠️ **依赖 #187**（stacked 其上，复用其 `src/main/i18n.ts`）。请**先合 #187**；之后本 PR diff 会自动收敛为纯迁移内容。当前 diff 暂含 #187 的提交。

## 背景
主进程无 i18next（IPC 只同步 currentLanguage 字符串），历史上用户可见串走 zh/en 二元硬编码（`TrayManager.t` × 31）甚至纯中文，fa/ru/zh-TW 用户看到英文。#187 引入了 `src/main/i18n.ts`（5 语文案目录 + 中央语言持有点 + `mt()`）。本 PR 把剩余主进程硬编码全部迁过去。

## 改动
- **i18n.ts 结构升级**：`MESSAGES satisfies Record<string, Record<SupportedLanguage,string>>` 编译期强制每键 5 语齐全；`MainMessageKey = keyof typeof MESSAGES` 自动派生 key 类型；导出 `MAIN_MESSAGE_KEYS` 供测试遍历。
- **托盘菜单（31 标签）**：`TrayManager` 全部 `this.t(zh,en)` → `mt(key)`；移除自持 `currentLanguage` 与私有 `t()`；`setLanguage` 改为 `setMainLanguage(lang)` 同步中央持有点 + 重渲染。
- **提权 helper 授权对话框（19 串）**：`index.ts` 的 Win 修复/安装 + macOS 后台开关/路径修复/升级/安装各 dialog 的 `zh ? A : B` → `mt(key)`，移除 `const zh`；detail 组合（pathMismatch 分流 + noteOff 追加）逻辑不变。
- 每键 5 语：zh-CN/en-US 取自原代码逐字保真，新增 zh-TW/ru/fa。

## 测试
- `i18n.test.ts` 改用 `MAIN_MESSAGE_KEYS` 自动覆盖全部 55 键的 5 语 parity；`tray-manager-menu.test.ts` 适配 `setMainLanguage`。
- 全量 gate 绿：tsc(main+renderer) / jest 130 套 1909 测试 / eslint。
- 独立 review：31 托盘 + 19 对话框串 **zh-CN/en 与原文字节级保真**、映射对位、对话框分支/response 逻辑等价、无残留硬编码，全绿。

## 待真机验证
托盘菜单在 Mac 真机的多语言渲染（runtime-critical）。