### PR TITLE
fix: naive:// 链接被「从 URL 导入」预检误挡（协议白名单收敛为单一真值）

### DIFF
--- a/src/main/services/ProtocolParser.ts
+++ b/src/main/services/ProtocolParser.ts
@@ -20,6 +20,7 @@ import type {
   LogLevel,
 } from '../../shared/types';
 import { normalizeDuration } from '../../shared/duration';
+import { isSupportedShareUrl } from '../../shared/protocol-url-schemes';
 import type { LogManager } from './LogManager';
 
 export interface IProtocolParser {
@@ -66,24 +67,7 @@ export class ProtocolParser implements IProtocolParser {
    * 检查 URL 是否为支持的协议
    */
   isSupported(url: string): boolean {
-    return (
-      url.startsWith('vless://') ||
-      url.startsWith('trojan://') ||
-      url.startsWith('hysteria2://') ||
-      url.startsWith('hy2://') ||
-      url.startsWith('ss://') ||
-      url.startsWith('anytls://') ||
-      url.startsWith('tuic://') ||
-      url.startsWith('naive://') ||
-      url.startsWith('http2://') ||
-      url.startsWith('naive+https://') ||
-      url.startsWith('vmess://') ||
-      url.startsWith('socks5://') ||
-      url.startsWith('socks://') ||
-      url.startsWith('s5://') ||
-      url.startsWith('http://') ||
-      url.startsWith('https://')
-    );
+    return isSupportedShareUrl(url);
   }
 
   /**

--- a/src/renderer/components/settings/import-url-dialog.tsx
+++ b/src/renderer/components/settings/import-url-dialog.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Loader2, Link, Server, Check, X, Edit2 } from 'lucide-react';
 import { parseProtocolUrl, addServerFromUrl } from '@/bridge/api-wrapper';
+import { isSupportedShareUrl } from '@shared/protocol-url-schemes';
 import type { ServerConfig } from '@/bridge/types';
 import { useTranslation } from 'react-i18next';
 
@@ -42,26 +43,6 @@ export function ImportUrlDialog({ open, onOpenChange, onImportSuccess }: ImportU
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editingName, setEditingName] = useState('');
 
-  const isValidUrl = (u: string) => {
-    return (
-      u.startsWith('vless://') ||
-      u.startsWith('vmess://') ||
-      u.startsWith('trojan://') ||
-      u.startsWith('hysteria2://') ||
-      u.startsWith('hy2://') ||
-      u.startsWith('ss://') ||
-      u.startsWith('anytls://') ||
-      u.startsWith('tuic://') ||
-      u.startsWith('http2://') ||
-      u.startsWith('naive+https://') ||
-      u.startsWith('socks5://') ||
-      u.startsWith('socks://') ||
-      u.startsWith('s5://') ||
-      u.startsWith('http://') ||
-      u.startsWith('https://')
-    );
-  };
-
   const handleParseUrl = async () => {
     const input = url.trim();
     if (!input) {
@@ -85,7 +66,7 @@ export function ImportUrlDialog({ open, onOpenChange, onImportSuccess }: ImportU
     const failed: { line: string; error: string }[] = [];
 
     for (const line of lines) {
-      if (!isValidUrl(line)) {
+      if (!isSupportedShareUrl(line)) {
         failed.push({ line, error: t('importUrl.invalidProtocol', 'Unsupported protocol') });
         continue;
       }
@@ -205,7 +186,7 @@ export function ImportUrlDialog({ open, onOpenChange, onImportSuccess }: ImportU
     setEditingIndex(null);
   };
 
-  const hasAnyValidUrl = url.split(/\r?\n/).some((l) => isValidUrl(l.trim()));
+  const hasAnyValidUrl = url.split(/\r?\n/).some((l) => isSupportedShareUrl(l.trim()));
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/shared/__tests__/protocol-url-schemes.test.ts
+++ b/src/shared/__tests__/protocol-url-schemes.test.ts
@@ -1,0 +1,20 @@
+import { SUPPORTED_URL_SCHEMES, isSupportedShareUrl } from '../protocol-url-schemes';
+
+describe('isSupportedShareUrl', () => {
+  it.each(SUPPORTED_URL_SCHEMES.map((s) => `${s}://x`))('支持 %s', (u) =>
+    expect(isSupportedShareUrl(u)).toBe(true)
+  );
+
+  // naive:// 曾仅后端支持、前端漏列，单独锁回归（issue #191）
+  it('支持裸 naive://', () => expect(isSupportedShareUrl('naive://u:p@h:443#n')).toBe(true));
+
+  it.each(['ftp://x', 'wireguard://x', 'tailscale://x', 'foobar', ''])('不支持 %s', (u) =>
+    expect(isSupportedShareUrl(u)).toBe(false)
+  );
+
+  // http 前缀不得误命中 https（前缀精确匹配回归）
+  it('http:// 与 https:// 各自精确匹配', () => {
+    expect(isSupportedShareUrl('https://x')).toBe(true);
+    expect(isSupportedShareUrl('http://x')).toBe(true);
+  });
+});

--- a/src/shared/protocol-url-schemes.ts
+++ b/src/shared/protocol-url-schemes.ts
@@ -1,0 +1,33 @@
+/**
+ * 分享链接支持的协议 scheme 单一真值。
+ * 前端导入预检（import-url-dialog 的 isSupportedShareUrl）与后端解析
+ * （ProtocolParser.isSupported）共用此列表，避免两处白名单各自维护导致漂移
+ * （naive:// 曾仅后端支持、前端漏列，撞 issue #191 导入语境）。
+ */
+export const SUPPORTED_URL_SCHEMES = [
+  'vless',
+  'vmess',
+  'trojan',
+  'hysteria2',
+  'hy2',
+  'ss',
+  'anytls',
+  'tuic',
+  'naive',
+  'http2',
+  'naive+https',
+  'socks5',
+  'socks',
+  's5',
+  'http',
+  'https',
+] as const;
+
+/**
+ * 判断字符串是否为受支持的协议分享链接。
+ * 前缀精确匹配 `<scheme>://`：'http' → 'http://' 不会误命中 'https://'
+ * （后者不以 'http://' 开头），故列表顺序无关。
+ */
+export function isSupportedShareUrl(url: string): boolean {
+  return SUPPORTED_URL_SCHEMES.some((scheme) => url.startsWith(`${scheme}://`));
+}


### PR DESCRIPTION
## 问题

「从 URL 导入」对话框的前端预检会把 `naive://` 分享链接判为「不支持的协议」，链接在解析之前就被挡掉，无法导入；而后端 `ProtocolParser.isSupported` / `parseNaive` 一直支持 `naive://`。

## 根因

前端 `import-url-dialog.tsx` 的本地 `isValidUrl` 与后端 `ProtocolParser.isSupported` **各维护一份协议 scheme 白名单副本**，两份内容漂移，前端漏列了 `naive://`（后端有）。

## 修复

抽出单一真值 `src/shared/protocol-url-schemes.ts`：

- `SUPPORTED_URL_SCHEMES` — 受支持的分享链接 scheme 列表
- `isSupportedShareUrl(url)` — 前缀精确匹配 `<scheme>://`

前端预检与后端 `isSupported` 改为共用此函数，后续新增协议只改一处，不再漂移。`isSupported` 方法签名保留（`IProtocolParser` 接口不变）。

## 变更

- 新增 `src/shared/protocol-url-schemes.ts`（单一真值）
- `ProtocolParser.isSupported` 委托给共享函数
- `import-url-dialog.tsx` 删除本地 `isValidUrl`，复用 `isSupportedShareUrl`
- 新增 `src/shared/__tests__/protocol-url-schemes.test.ts`：锁全 scheme + `naive://` 回归 + `http`/`https` 前缀不互撞 + 反例

## 验证

- `jest`（protocol-parser 回归 + 新 shared 单测）：全部通过
- `eslint` / `tsc -p tsconfig.main.json` / `tsc -p tsconfig.json`：全绿

排查 #191（导入格式）时发现的相邻一致性问题。
