### PR TITLE
chore: 升级 sing-box 内核到 1.14.0-alpha.35

### DIFF
--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,10 +1,10 @@
 {
-  "bundledCoreVersion": "1.14.0-alpha.34",
+  "bundledCoreVersion": "1.14.0-alpha.35",
   "cronetVersion": "v148.0.7778.96-1",
   "coreArchiveSha256": {
-    "linux": "ed5879ece39a9b10f81b9580ea22c47cba95e6918284cfb23379a4558c955e8d",
-    "win": "bb21d2cf3b8a8b2201604dc5766dbaa0ce2cda3706448c4345b2ecc565c1c9c1",
-    "mac-x64": "e0be209e865c4dd5b7b71f38336165f2c5a83c386dac91f8d66239c80e1a30d6",
-    "mac-arm64": "d3f065faeab9133b68071d5b95be1b62644414dbde124e7e007b3c278a77f8cc"
+    "linux": "b5ed3e0c4af654099812dfa0dd0740ceaa3abf0b02dddf4060c40c3006461e97",
+    "win": "358a2de32c2b94f728233ded0499fb4a25ab23603c3619cb50e9520b23c75595",
+    "mac-x64": "f05aa7a8613578687f338571c1123cc42b9662c200b0bd3de99e80689ffc1a23",
+    "mac-arm64": "59379726b4a3f171cec819a6263645e131b1975a7f4f72c967612d0c3f498422"
   }
 }


### PR DESCRIPTION
## 升级

sing-box 内核 1.14.0-alpha.34 → **1.14.0-alpha.35**（官方 release，2026-06-25）。

只改 `src/shared/core-manifest.json`：`bundledCoreVersion` + 四平台 `coreArchiveSha256`（值 == 官方 release `v1.14.0-alpha.35` 资产 digest，零后处理）。核本体由 `fetch:core` 构建时拉取、不入库。

## 验证

- `npm run fetch:core -- --force`：四平台核（linux/win/mac-x64/mac-arm64）下载 + 压缩包 sha256 全部校验通过（== 官方 release API asset digest）。
- linux 核 `version` = `1.14.0-alpha.35`（Revision ecc4776）、最小 config `check` 通过。
- `tsc -p tsconfig.main.json` + jest 全量 **1981 passed 零回归**。

## alpha.34 → alpha.35 说明

主要是 testing 分支 rebase + 集成（tailscale / usb-ip / api-service 等）+ `Fix http proxy authentication`；**无针对性 TUN/tailscale/wg/route bug 修复**（这些修复 alpha.34 已含）。属常规版本对齐。
