### PR TITLE
规则资源自动更新失败日志带原因明细（timeout/http/invalid_content）

### DIFF
--- a/src/main/services/RuleResourceScheduler.ts
+++ b/src/main/services/RuleResourceScheduler.ts
@@ -17,10 +17,28 @@ import * as path from 'path';
 import type { ConfigManager } from './ConfigManager';
 import type { LogManager } from './LogManager';
 import type { RuleResourceManager } from './RuleResourceManager';
-import type { UserConfig } from '../../shared/types';
+import type { UserConfig, RuleResourceDownloadResult } from '../../shared/types';
 import { getRuleResourcesPath } from '../utils/paths';
 import { BUILTIN_GEO_RULESETS, getRuleSetRuntimeDir, builtinIdFor } from './builtin-geo-rulesets';
 import { BackoffTracker } from './backoff-tracker';
+
+/**
+ * 把规则资源更新结果汇总成日志数据：成功数 + 失败明细（`资源名: errorCode`）。errorCode 在 results 里本就有，
+ * 此前汇总只记「失败 N」把它丢了 → 排查时无从判断 timeout / http 4xx / invalid_content。纯函数，便于单测。
+ */
+export function formatRuleUpdateSummary(results: RuleResourceDownloadResult[]): {
+  ok: number;
+  failed: number;
+  failures: string[];
+} {
+  let ok = 0;
+  const failures: string[] = [];
+  for (const r of results) {
+    if (r.ok) ok++;
+    else failures.push(`${r.name || r.id || '?'}: ${r.errorCode || r.error || 'unknown'}`);
+  }
+  return { ok, failed: failures.length, failures };
+}
 
 export class RuleResourceScheduler {
   private tickTimer: ReturnType<typeof setInterval> | null = null;
@@ -131,21 +149,20 @@ export class RuleResourceScheduler {
       if (staleIds.length === 0) return;
 
       const results = await this.ruleResourceManager.updateMany(staleIds, { silent: true });
-      let ok = 0;
-      let failed = 0;
+      // 退避记账（用 r.id）：成功清退避、失败指数退避。
       for (const r of results) {
-        if (r.ok) {
-          ok++;
-          if (r.id) this.backoff.recordSuccess(r.id);
-        } else {
-          failed++;
-          if (r.id) this.backoff.recordFailure(r.id, now);
-        }
+        if (!r.id) continue;
+        if (r.ok) this.backoff.recordSuccess(r.id);
+        else this.backoff.recordFailure(r.id, now);
       }
+      // 汇总日志带失败明细（资源名: errorCode），原只记「失败 N」无从判断 timeout / http 4xx / invalid_content，
+      // 排查得靠猜（启动补更撞起核初期网络/代理未就绪的暂态尤甚）。
+      const { ok, failed, failures } = formatRuleUpdateSummary(results);
       if (ok > 0 || failed > 0) {
+        const detail = failures.length > 0 ? `（失败: ${failures.join('；')}）` : '';
         this.logManager.addLog(
           'info',
-          `[${reason}] 规则资源自动更新：成功 ${ok}，失败 ${failed}`,
+          `[${reason}] 规则资源自动更新：成功 ${ok}，失败 ${failed}${detail}`,
           'RuleResScheduler'
         );
       }

--- a/src/main/services/__tests__/RuleResourceScheduler.test.ts
+++ b/src/main/services/__tests__/RuleResourceScheduler.test.ts
@@ -1,0 +1,50 @@
+/**
+ * RuleResourceScheduler.formatRuleUpdateSummary 单测：汇总日志带失败明细（资源名: errorCode）。
+ * 纯函数，免 mock scheduler 的 configManager/ruleResourceManager/定时器全套依赖。
+ */
+jest.mock('electron', () => ({
+  app: { getPath: () => '/fake/userData', getAppPath: () => '/fake/app', isPackaged: false },
+}));
+
+import { formatRuleUpdateSummary } from '../RuleResourceScheduler';
+import type { RuleResourceDownloadResult } from '../../../shared/types';
+
+const r = (over: Partial<RuleResourceDownloadResult>): RuleResourceDownloadResult => ({
+  ok: false,
+  ...over,
+});
+
+describe('formatRuleUpdateSummary', () => {
+  it('全成功 → ok=N、failed=0、无失败明细', () => {
+    expect(formatRuleUpdateSummary([r({ ok: true }), r({ ok: true })])).toEqual({
+      ok: 2,
+      failed: 0,
+      failures: [],
+    });
+  });
+
+  it('有失败 → 明细「资源名: errorCode」（排查 timeout / http / invalid_content 不再靠猜）', () => {
+    const res = formatRuleUpdateSummary([
+      r({ ok: true }),
+      r({ ok: false, name: 'geoip-ir', errorCode: 'timeout' }),
+      r({ ok: false, name: 'geosite-cn', errorCode: 'invalid_content' }),
+    ]);
+    expect(res.ok).toBe(1);
+    expect(res.failed).toBe(2);
+    expect(res.failures).toEqual(['geoip-ir: timeout', 'geosite-cn: invalid_content']);
+  });
+
+  it('errorCode 缺 → 退到 error；都缺 → unknown；name 缺 → 退到 id 再退到 ?', () => {
+    expect(formatRuleUpdateSummary([r({ ok: false, name: 'x', error: 'boom' })]).failures).toEqual([
+      'x: boom',
+    ]);
+    expect(formatRuleUpdateSummary([r({ ok: false, id: 'rid' })]).failures).toEqual([
+      'rid: unknown',
+    ]);
+    expect(formatRuleUpdateSummary([r({ ok: false })]).failures).toEqual(['?: unknown']);
+  });
+
+  it('空 results → 全 0', () => {
+    expect(formatRuleUpdateSummary([])).toEqual({ ok: 0, failed: 0, failures: [] });
+  });
+});


### PR DESCRIPTION
## 现象

规则资源自动更新（启动补更/周期巡检）失败时，日志只记「成功 X，失败 Y」，不带原因 → 排查无从判断是 `timeout` / `http 4xx` / `invalid_content`（errorCode 在更新结果里本就有，被汇总时丢弃）。启动补更常撞起核初期网络/代理未就绪的暂态，缺原因尤其难诊断。

## 改动

汇总日志带失败明细 `（失败: 资源名: errorCode）`，例如：

```
[启动补更] 规则资源自动更新：成功 0，失败 1（失败: geoip-ir: timeout）
```

抽纯函数 `formatRuleUpdateSummary` 便于单测；退避记账逻辑保持等价。

## 验证

gate 全绿；新增 4 例单测锁定格式（含 errorCode→error→unknown、name→id→? 的兜底链）。
