### PR TITLE
feat(dns): DNS/route 子系统根治 — 国内统一多上游 race + 删 dns-bootstrap-udp + tailnet 解析放宽 + WG preferred_by 归位

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -2593,7 +2593,9 @@ done
         this.lanResolverForDns,
         idToTagMap,
         (level, message) => this.logToManager(level, message),
-        this.raceServerPort
+        this.raceServerPort,
+        // 根治 §3.5：传本轮发射的 endpoint，供 tailnet 按名解析 gate 确认目标 TS endpoint 已发射（防悬空引用 FATAL）。
+        this.pendingEndpoints
       ),
       inbounds: buildInbounds(config, resolvedIps, {
         probeDirectPort: this.probeDirectPort,

--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -23,7 +23,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -115,12 +115,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -240,6 +234,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -694,7 +689,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -774,12 +769,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -881,6 +870,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -1288,7 +1278,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
 }
 `;
 
-exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线） DNS lanResolverForDns 注入（systemProxy）→ 锁 dns-lan server + internalResolverTag=dns-lan 三路拆分 1`] = `
+exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线） DNS lanResolverForDns 注入（systemProxy）→ 锁 dns-lan(type:dhcp 动态) + internalResolverTag=dns-lan 三路拆分 1`] = `
 {
   "config": {
     "dns": {
@@ -1311,7 +1301,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -1402,12 +1392,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       ],
       "servers": [
         {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
-        {
           "path": "/dns-query",
           "server": "223.5.5.5",
           "server_port": 443,
@@ -1448,10 +1432,8 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "type": "fakeip",
         },
         {
-          "server": "192.168.1.1",
-          "server_port": 53,
           "tag": "dns-lan",
-          "type": "udp",
+          "type": "dhcp",
         },
       ],
       "strategy": "ipv4_only",
@@ -1497,6 +1479,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -1928,7 +1911,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -2018,12 +2001,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -2144,6 +2121,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -2574,7 +2552,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -2654,12 +2632,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -2742,6 +2714,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -3174,7 +3147,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -3237,12 +3210,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -3327,6 +3294,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -3758,7 +3726,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -3801,12 +3769,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -3886,6 +3848,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -4317,7 +4280,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -4360,12 +4323,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -4445,6 +4402,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -4883,7 +4841,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -4926,12 +4884,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -5011,6 +4963,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -5441,7 +5394,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -5521,12 +5474,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -5641,6 +5588,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -6071,7 +6019,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -6151,12 +6099,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -6263,6 +6205,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -6693,7 +6636,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -6783,12 +6726,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -6916,6 +6853,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -7346,7 +7284,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -7426,12 +7364,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -7532,6 +7464,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -7962,7 +7895,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -8042,12 +7975,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -8142,6 +8069,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -8632,7 +8560,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -8712,12 +8640,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -8802,6 +8724,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -9208,7 +9131,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -9288,12 +9211,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -9378,6 +9295,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -9808,7 +9726,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -9888,12 +9806,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -9978,6 +9890,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -10381,7 +10294,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -10461,12 +10374,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -10556,6 +10463,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -10989,7 +10897,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -11069,12 +10977,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -11164,6 +11066,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -11596,7 +11499,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -11676,12 +11579,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -11778,6 +11675,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -12222,7 +12120,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -12302,12 +12200,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -12392,6 +12284,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -12822,7 +12715,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -12902,12 +12795,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -13002,6 +12889,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -13451,7 +13339,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -13531,12 +13419,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -13630,6 +13512,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -14060,7 +13943,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -14140,12 +14023,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -14230,6 +14107,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -14660,7 +14538,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -14740,12 +14618,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -14855,6 +14727,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -15289,7 +15162,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -15369,12 +15242,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -15484,6 +15351,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -15933,7 +15801,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -16013,12 +15881,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -16118,6 +15980,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -16562,7 +16425,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -16642,12 +16505,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -16747,6 +16604,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -17192,7 +17050,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -17272,12 +17130,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -17362,6 +17214,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -17792,7 +17645,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -17872,12 +17725,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -17962,6 +17809,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -18399,7 +18247,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -18479,12 +18327,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -18569,6 +18411,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -19006,7 +18849,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -19086,12 +18929,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -19176,6 +19013,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -19579,7 +19417,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -19659,12 +19497,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -19832,6 +19664,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -20267,7 +20100,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -20347,12 +20180,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -20447,6 +20274,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },
@@ -20878,7 +20706,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
             "cloudflare-dns.com",
             "one.one.one.one",
           ],
-          "server": "dns-bootstrap-udp",
+          "server": "dns-bootstrap",
         },
         {
           "domain_suffix": [
@@ -20958,12 +20786,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
       ],
       "servers": [
-        {
-          "server": "223.5.5.5",
-          "server_port": 53,
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-        },
         {
           "path": "/dns-query",
           "server": "223.5.5.5",
@@ -21075,6 +20897,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
       },

--- a/src/main/services/__tests__/config-snapshot.test.ts
+++ b/src/main/services/__tests__/config-snapshot.test.ts
@@ -588,7 +588,7 @@ describe('generateSingBoxConfig — characterization 快照（抽取前锁基线
     ).toMatchSnapshot();
   });
 
-  it('DNS lanResolverForDns 注入（systemProxy）→ 锁 dns-lan server + internalResolverTag=dns-lan 三路拆分', () => {
+  it('DNS lanResolverForDns 注入（systemProxy）→ 锁 dns-lan(type:dhcp 动态) + internalResolverTag=dns-lan 三路拆分', () => {
     expect(
       snap(cfg({ servers: [server({})] }), '1.13.0', 'linux', (svc) => {
         svc.lanResolverForDns = '192.168.1.1';

--- a/src/main/services/__tests__/dns-resolver-baseline.json
+++ b/src/main/services/__tests__/dns-resolver-baseline.json
@@ -3,12 +3,6 @@
     "dns": {
       "servers": [
         {
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-          "server": "223.5.5.5",
-          "server_port": 53
-        },
-        {
           "tag": "dns-bootstrap",
           "type": "https",
           "server": "223.5.5.5",
@@ -67,7 +61,7 @@
             "cloudflare-dns.com",
             "one.one.one.one"
           ],
-          "server": "dns-bootstrap-udp"
+          "server": "dns-bootstrap"
         },
         {
           "domain_suffix": [
@@ -393,12 +387,6 @@
     "dns": {
       "servers": [
         {
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-          "server": "223.5.5.5",
-          "server_port": 53
-        },
-        {
           "tag": "dns-bootstrap",
           "type": "https",
           "server": "223.5.5.5",
@@ -457,7 +445,7 @@
             "cloudflare-dns.com",
             "one.one.one.one"
           ],
-          "server": "dns-bootstrap-udp"
+          "server": "dns-bootstrap"
         },
         {
           "domain_suffix": [
@@ -756,12 +744,6 @@
     "dns": {
       "servers": [
         {
-          "tag": "dns-bootstrap-udp",
-          "type": "udp",
-          "server": "223.5.5.5",
-          "server_port": 53
-        },
-        {
           "tag": "dns-bootstrap",
           "type": "https",
           "server": "223.5.5.5",
@@ -815,7 +797,7 @@
             "cloudflare-dns.com",
             "one.one.one.one"
           ],
-          "server": "dns-bootstrap-udp"
+          "server": "dns-bootstrap"
         },
         {
           "domain_suffix": [

--- a/src/main/services/__tests__/dns-resolver.test.ts
+++ b/src/main/services/__tests__/dns-resolver.test.ts
@@ -260,7 +260,7 @@ describe('Q1 Windows takeover：消除 type:local 死循环（dns-local 改路�
     expect(bankToLocal).toBe(false);
   });
 
-  it('Win+takeover+有 LAN 解析器：内网/captive→dns-lan，银行→dns-domestic，dns-lan server + rule C 直连放行', () => {
+  it('Win+takeover+有 LAN 解析器：内网/captive→dns-lan，银行→dns-domestic，dns-lan(dhcp 动态)+ rule C 直连放行', () => {
     setPlatform('win32');
     const pm = new ProxyManager();
     (pm as any).lanResolverForDns = '192.168.5.1';
@@ -268,8 +268,9 @@ describe('Q1 Windows takeover：消除 type:local 死循环（dns-local 改路�
     expect(lanRule(cfg)?.server).toBe('dns-lan');
     expect(captiveRule(cfg)?.server).toBe('dns-lan');
     expect(bankRule(cfg)?.server).toBe('dns-domestic');
+    // dns-lan 改 type:'dhcp'(动态跟随网关，不再硬编码 lanResolver IP)；lanResolver 仍决定是否建 dns-lan + rule C 放行
     expect(
-      (cfg.dns.servers as AnyCfg[]).some((s) => s.tag === 'dns-lan' && s.server === '192.168.5.1')
+      (cfg.dns.servers as AnyCfg[]).some((s) => s.tag === 'dns-lan' && s.type === 'dhcp')
     ).toBe(true);
     expect(hasRouteDirect(cfg, '192.168.5.1/32')).toBe(true);
   });

--- a/src/main/services/__tests__/singbox-config-helpers.test.ts
+++ b/src/main/services/__tests__/singbox-config-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   stripHostBrackets,
   hostToExcludeCidr,
   getNodeResolverTag,
+  getDomesticResolverTag,
   effectiveCustomRules,
   effectiveAppRules,
   getCustomDomesticDnsEndpoint,
@@ -128,6 +129,27 @@ describe('getNodeResolverTag — issue #147：race on→dns-node-race / off→�
     const sysTun = mk({ ...off('system'), proxyModeType: 'tun' });
     expect(getNodeResolverTag(sysTun, 'dial')).toBe('dns-local'); // dial 不受 INV-1
     expect(getNodeResolverTag(sysTun, 'rule')).toBe('dns-node'); // INV-1
+  });
+});
+
+describe('getDomesticResolverTag — 根治 §3.2：race on→dns-node-race（共用 race）/ off→fallback', () => {
+  const mk = (over: Partial<UserConfig>): UserConfig => over as unknown as UserConfig;
+  it('race on（缺省 resolveNodeDomainsAhead）→ dns-node-race（无视 fallback）', () => {
+    expect(getDomesticResolverTag(mk({ dnsConfig: {} as any }), 'dns-bootstrap')).toBe(
+      'dns-node-race'
+    );
+    expect(getDomesticResolverTag(mk({ dnsConfig: {} as any }), 'dns-domestic')).toBe(
+      'dns-node-race'
+    );
+  });
+  it('race off → fallback（FakeIP direct=dns-bootstrap / 非FakeIP region=dns-domestic）', () => {
+    const off = mk({ dnsConfig: { resolveNodeDomainsAhead: false } as any });
+    expect(getDomesticResolverTag(off, 'dns-bootstrap')).toBe('dns-bootstrap');
+    expect(getDomesticResolverTag(off, 'dns-domestic')).toBe('dns-domestic');
+  });
+  it('config/dnsConfig 缺失 → 视作 race on（与 getNodeResolverTag 同口径 !==false）', () => {
+    expect(getDomesticResolverTag(null, 'dns-bootstrap')).toBe('dns-node-race');
+    expect(getDomesticResolverTag(mk({}), 'dns-domestic')).toBe('dns-node-race');
   });
 });
 

--- a/src/main/services/__tests__/singbox-dns-builder.test.ts
+++ b/src/main/services/__tests__/singbox-dns-builder.test.ts
@@ -43,8 +43,14 @@ const baseConfig = (servers: ServerConfig[], selectedServerId: string | null): U
   }) as unknown as UserConfig;
 
 const noopLog = () => {};
-const build = (config: UserConfig) =>
-  buildDnsConfig(config, 'proxy-selector', null, buildIdToTagMap(config.servers), noopLog);
+const build = (config: UserConfig) => {
+  const idToTagMap = buildIdToTagMap(config.servers);
+  // 根治 §3.5：tailnet gate 放宽后需 pendingEndpoints 含「已发射」endpoint。模拟 tailscale/wireguard 节点全发射。
+  const pendingEndpoints = config.servers
+    .filter((s) => ['tailscale', 'wireguard'].includes(s.protocol.toLowerCase()))
+    .map((s) => ({ type: s.protocol.toLowerCase(), tag: idToTagMap.get(s.id) }) as never);
+  return buildDnsConfig(config, 'proxy-selector', null, idToTagMap, noopLog, 0, pendingEndpoints);
+};
 
 describe('buildDnsConfig — P4b Tailscale 按名解析', () => {
   it('选中 tailscale 节点 + resolveByName → 注入 dns-tailscale server + preferred_by(最前) + endpoint 引用节点 tag', () => {
@@ -88,9 +94,39 @@ describe('buildDnsConfig — P4b Tailscale 按名解析', () => {
     expect(dns.rules!.some((r) => r.preferred_by)).toBe(false);
   });
 
-  it('选中节点非 tailscale → 不注入（即便存在一个 resolveByName 的非选中 tailscale 节点）', () => {
+  it('根治 §3.5：选中非 tailscale 但有 resolveByName 的 TS 已发射 → 仍注入（gate 放宽=组网即生效，不绑主出口）', () => {
     const other = { id: 'p1', name: 'PlainNode', protocol: 'vless' } as unknown as ServerConfig;
     const dns = build(baseConfig([other, tsNode()], 'p1'));
+    const tsServer = dns.servers.find((s) => s.type === 'tailscale');
+    expect(tsServer).toBeDefined();
+    // 引用那个 resolveByName 的 TS（非选中的 p1），证明不再绑主出口
+    expect(tsServer!.endpoint).toBe('MyMeshNode');
+    expect(dns.rules!.some((r) => r.preferred_by?.includes('dns-tailscale'))).toBe(true);
+  });
+
+  it('根治 §3.5：resolveByName 的 TS 未发射（不在 pendingEndpoints）→ 不注入（防悬空引用 FATAL）', () => {
+    const idToTagMap = buildIdToTagMap([tsNode()]);
+    // 不传 pendingEndpoints（默认 []）= TS endpoint 未发射 → tailnet 解析跳过
+    const dns = buildDnsConfig(baseConfig([tsNode()], 'ts1'), 'proxy-selector', null, idToTagMap, noopLog);
+    expect(dns.servers.find((s) => s.type === 'tailscale')).toBeUndefined();
+    expect(dns.rules!.some((r) => r.preferred_by)).toBe(false);
+  });
+
+  it('根治 §3.5：其它节点已发射但该 TS 自身未发射 → 不注入（gate 按该 TS 的 tag，非「pendingEndpoints 非空」）', () => {
+    const ts = tsNode(); // id=ts1, tag=MyMeshNode
+    const wg = { id: 'w1', name: 'WG', protocol: 'wireguard' } as unknown as ServerConfig;
+    const idToTagMap = buildIdToTagMap([wg, ts]);
+    // pendingEndpoints 非空但只含 wg（模拟 TS 被 system-interface/reverseMesh gate 跳过、未发射）→ 仍须跳过 tailnet 解析
+    const pending = [{ type: 'wireguard', tag: idToTagMap.get('w1') } as never];
+    const dns = buildDnsConfig(
+      baseConfig([wg, ts], 'ts1'),
+      'proxy-selector',
+      null,
+      idToTagMap,
+      noopLog,
+      0,
+      pending
+    );
     expect(dns.servers.find((s) => s.type === 'tailscale')).toBeUndefined();
     expect(dns.rules!.some((r) => r.preferred_by)).toBe(false);
   });
@@ -106,6 +142,20 @@ describe('buildDnsConfig — P4b Tailscale 按名解析', () => {
     const tsServer = dns.servers.find((s) => s.type === 'tailscale');
     // 第一个 MyMeshNode 占基名，选中节点 tag = "MyMeshNode (1)"
     expect(tsServer!.endpoint).toBe('MyMeshNode (1)');
+  });
+});
+
+describe('根治 §3.6：dns-bootstrap-udp 已删 + DoH server 域名解析改 IP-DoH', () => {
+  it('dns.servers 无 dns-bootstrap-udp；DoH server 域名(doh.pub)解析 rule 用 dns-bootstrap(IP-DoH 非 UDP53)', () => {
+    const dns = build(baseConfig([tsNode()], 'ts1'));
+    // ① 历史残留 dns-bootstrap-udp server 已删（positive assertion，防未来回退明文 UDP53、违背「IP-DoH 避免 UDP53」自定设计）
+    expect(dns.servers.some((s) => s.tag === 'dns-bootstrap-udp')).toBe(false);
+    // DoH server 自身域名解析 rule 改指 dns-bootstrap（https IP-DoH，抗 UDP53 劫持）
+    const bootRule = dns.rules!.find(
+      (r) => Array.isArray(r.domain) && (r.domain as string[]).includes('doh.pub')
+    );
+    expect(bootRule).toBeDefined();
+    expect(bootRule!.server).toBe('dns-bootstrap');
   });
 });
 

--- a/src/main/services/__tests__/singbox-route-builder-preferred-by.test.ts
+++ b/src/main/services/__tests__/singbox-route-builder-preferred-by.test.ts
@@ -1,0 +1,116 @@
+/**
+ * buildRouteConfig 块0c — preferred_by 试点：endpoint 自声明归位替代手动 ip_cidr force-route（design §14/§14.1）。
+ * 限「非全隧道（无 0/0）」节点：
+ *  - WG 关外网（allowInternet=false，allowedIPs 无 0/0）→ 用 preferred_by（endpoint.Lookup=peer allowed_ips，与 ip_cidr 等价）。
+ *  - WG 全隧道（allowInternet=true）→ 仍 ip_cidr（去 0/0）；preferred_by 会因 0/0 → PreferredAddress 恒 true 抢全局。
+ *  - TS 不选 exit → 试点默认关（TS_PREFERRED_BY_TRIAL=false，routePrefixes 运行时动态 + 语义差异，待真机验）→ 仍 ip_cidr。
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-route-prefby-test-'));
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getAppPath: () => TMP, isPackaged: false },
+  net: {},
+}));
+
+import { buildRouteConfig, type RouteConfigDeps } from '../singbox-route-builder';
+import { getRuleSetRuntimeDir } from '../builtin-geo-rulesets';
+import type { ServerConfig, UserConfig } from '../../../shared/types';
+import type { SingBoxEndpoint } from '../singbox-config-types';
+
+// 种 CN 三件套 + private，避免 smart 模式 geosite dangling 告警污染（与 private-direct.test 同约定；本测不断言告警，仅防噪音）。
+{
+  const dir = getRuleSetRuntimeDir();
+  fs.mkdirSync(dir, { recursive: true });
+  for (const f of [
+    'geosite-private.srs',
+    'geosite-cn.srs',
+    'geosite-geolocation-!cn.srs',
+    'geoip-cn.srs',
+  ]) {
+    fs.writeFileSync(path.join(dir, f), Buffer.from('SRS'));
+  }
+}
+
+const wgNode = (over: Record<string, unknown> = {}): ServerConfig =>
+  ({
+    id: 'w1',
+    name: 'WG',
+    protocol: 'wireguard',
+    address: 'wg.example.com', // 域名（非 IP）→ 不进「节点排除」ip_cidr 块，避免干扰断言
+    port: 51820,
+    wireguardSettings: {
+      privateKey: 'pk',
+      peerPublicKey: 'pub',
+      localAddress: ['10.0.0.2/32'],
+      allowedIPs: ['10.8.0.0/24'],
+      allowInternet: false,
+      ...over,
+    },
+  }) as unknown as ServerConfig;
+
+const tsNode = (over: Record<string, unknown> = {}): ServerConfig =>
+  ({
+    id: 't1',
+    name: 'TS',
+    protocol: 'tailscale',
+    tailscaleSettings: { authKey: 'tskey', allowInternet: false, ...over }, // 不选 exit（无 exitNode）
+  }) as unknown as ServerConfig;
+
+const cfgWith = (servers: ServerConfig[]): UserConfig =>
+  ({
+    proxyMode: 'smart',
+    servers,
+    selectedServerId: servers[0]?.id,
+    customRules: [],
+    appRules: [],
+  }) as unknown as UserConfig;
+
+const idMapOf = (servers: ServerConfig[]): Map<string, string> =>
+  new Map(servers.map((s) => [s.id, s.name]));
+
+const depsWithEndpoints = (tags: string[]): RouteConfigDeps => ({
+  probeDirectPort: null,
+  probeProxyPort: null,
+  lanResolverForDns: null,
+  // 块 0c 仅用 endpoint.tag 判「本轮实际发射」；type 不影响（统一 wireguard 占位）。
+  pendingEndpoints: tags.map((tag) => ({ type: 'wireguard', tag }) as SingBoxEndpoint),
+  log: () => {},
+  onDegraded: () => {},
+});
+
+/** rules 里是否有「preferred_by 含 tag 且 outbound=tag」的归位规则。 */
+const hasPreferredBy = (rc: any, tag: string): boolean =>
+  (rc.rules || []).some(
+    (r: any) => Array.isArray(r.preferred_by) && r.preferred_by.includes(tag) && r.outbound === tag
+  );
+/** rules 里是否有「ip_cidr force-route 到 tag 自身」的规则（区别于 outbound=direct 的节点排除块）。 */
+const hasIpCidrForceRoute = (rc: any, tag: string): boolean =>
+  (rc.rules || []).some(
+    (r: any) => Array.isArray(r.ip_cidr) && r.action === 'route' && r.outbound === tag
+  );
+
+describe('buildRouteConfig 块0c — preferred_by 试点替代 ip_cidr force-route', () => {
+  it('WG 关外网（无 0/0）→ preferred_by 归位，不再手动 ip_cidr force-route', () => {
+    const wg = wgNode({ allowInternet: false, allowedIPs: ['10.8.0.0/24'] });
+    const rc: any = buildRouteConfig(cfgWith([wg]), idMapOf([wg]), depsWithEndpoints(['WG']));
+    expect(hasPreferredBy(rc, 'WG')).toBe(true);
+    expect(hasIpCidrForceRoute(rc, 'WG')).toBe(false);
+  });
+
+  it('WG 全隧道（allowInternet）→ 仍 ip_cidr（去 0/0），不用 preferred_by（防 0/0 抢全局）', () => {
+    const wg = wgNode({ allowInternet: true, allowedIPs: ['10.8.0.0/24'] });
+    const rc: any = buildRouteConfig(cfgWith([wg]), idMapOf([wg]), depsWithEndpoints(['WG']));
+    expect(hasPreferredBy(rc, 'WG')).toBe(false);
+    expect(hasIpCidrForceRoute(rc, 'WG')).toBe(true);
+  });
+
+  it('TS 不选 exit → 试点默认关（TS_PREFERRED_BY_TRIAL=false）仍走 ip_cidr，不用 preferred_by', () => {
+    const ts = tsNode({ allowInternet: false });
+    const rc: any = buildRouteConfig(cfgWith([ts]), idMapOf([ts]), depsWithEndpoints(['TS']));
+    expect(hasPreferredBy(rc, 'TS')).toBe(false);
+    expect(hasIpCidrForceRoute(rc, 'TS')).toBe(true);
+  });
+});

--- a/src/main/services/singbox-config-helpers.ts
+++ b/src/main/services/singbox-config-helpers.ts
@@ -151,6 +151,16 @@ function effectiveSingleResolverId(dns: DnsConfig | undefined): string {
 /** issue #147：本地 race DNS server 的 tag（race on 时 outbound.domain_resolver / 节点域名 rule1 指它）。单一真值。 */
 export const DNS_NODE_RACE_TAG = 'dns-node-race';
 
+/**
+ * race 总开关单一真值（根治 §3.2）：race on（多上游并发解析）当且仅当 resolveNodeDomainsAhead!==false。
+ * ProxyManager 经 effective config（raceServerPort=0 时 withRaceOff 强制 false）反映 race server 是否就绪，故此谓词
+ * 等价「dns-node-race server 已生成」。getNodeResolverTag / getDomesticResolverTag 共用，杜绝两处 gate 漂移，保证
+ * 「返回 dns-node-race ⟺ server 存在」不变量在两条解析路径一致（防悬空引用 FATAL）。
+ */
+export function isNodeRaceOn(config: UserConfig | null | undefined): boolean {
+  return config?.dnsConfig?.resolveNodeDomainsAhead !== false;
+}
+
 export function getNodeResolverTag(
   config: UserConfig | null | undefined,
   ctx: 'dial' | 'rule'
@@ -158,7 +168,7 @@ export function getNodeResolverTag(
   // issue #147：race on（resolveNodeDomainsAhead !== false）→ 指本地 race server（多上游并发，dial 与 rule 同 tag）。
   // 仅 race server 就绪时 config 才为 on（ProxyManager 用 raceServerPort 算 effective config；snapshot/preflight/诊断
   // 等未就绪路径恒 off，不引用 dns-node-race，防 FATAL）。off → 单上游（nodeResolverSingle，逃生/降级，与旧档位等价）。
-  if (config?.dnsConfig?.resolveNodeDomainsAhead !== false) {
+  if (isNodeRaceOn(config)) {
     return DNS_NODE_RACE_TAG;
   }
   const single = effectiveSingleResolverId(config?.dnsConfig);
@@ -169,6 +179,24 @@ export function getNodeResolverTag(
   }
   // 'ali' / 自定义（自定义 server 见 Task#5）/ 缺省：忠实保留两路径各自基线解析器，逐字节回现状。
   return ctx === 'dial' ? 'dns-bootstrap' : 'dns-domestic';
+}
+
+/**
+ * 国内内容域名解析器 → server tag（根治 2026-06-28，对称 getNodeResolverTag；设计 dns-route-subsystem-overhaul §3.2）。
+ * race on（resolveNodeDomainsAhead!==false，ProxyManager 经 effective config 反映 race server 就绪）→ 共用本地 race
+ *   server（dns-node-race，多上游国内 DoH，与节点域名同一 server/上游池/预算）；off/未就绪 → fallback（调用点现状单上游）。
+ * 数据流（子代理确证）：FakeIP 模式国内内容真实解析唯一落在 direct 出口的 default_domain_resolver（fallback=dns-bootstrap）；
+ *   非 FakeIP 模式落在 region-local geosite-cn dns rule（fallback=dns-domestic）。两处 race on 共用同一 race server。
+ * 绝不在 off/未就绪返回 dns-node-race（防悬空引用 FATAL），与 getNodeResolverTag 同口径。
+ */
+export function getDomesticResolverTag(
+  config: UserConfig | null | undefined,
+  fallback: string
+): string {
+  if (isNodeRaceOn(config)) {
+    return DNS_NODE_RACE_TAG;
+  }
+  return fallback;
 }
 
 /**

--- a/src/main/services/singbox-config-types.ts
+++ b/src/main/services/singbox-config-types.ts
@@ -307,6 +307,10 @@ export interface SingBoxRouteRule {
   inbound?: string | string[]; // sing-box 1.13+
   action?: string; // logical 子规则为纯 matcher 无 action；default/logical 外层显式设 'route'
   outbound?: string;
+  // preferred_by（1.11+；route rule matcher）：按 outbound/endpoint tag 反查其 PreferredAddress/PreferredDomain
+  //（WG=peer allowed_ips Lookup / TS=routePrefixes + MagicDNS）命中即路由到该 outbound。块 0c 试点用它让 endpoint
+  // 自声明归位、替代手动 ip_cidr（限非全隧道节点；全隧道含 0/0 会令 PreferredAddress 恒 true 抢全局，仍走 ip_cidr）。
+  preferred_by?: string[];
   sniffer?: string[];
   rewrite_target?: boolean; // sing-box 1.12+
   timeout?: string;

--- a/src/main/services/singbox-dns-builder.ts
+++ b/src/main/services/singbox-dns-builder.ts
@@ -19,11 +19,17 @@ import {
   getRuleSetRuntimeDir as getRuntimeRulesDir,
   isValidSrsFile,
 } from './builtin-geo-rulesets';
-import type { SingBoxDnsConfig, SingBoxDnsServer, SingBoxDnsRule } from './singbox-config-types';
+import type {
+  SingBoxDnsConfig,
+  SingBoxDnsServer,
+  SingBoxDnsRule,
+  SingBoxEndpoint,
+} from './singbox-config-types';
 import {
   isIpv4Host,
   isIpv6Host,
   getNodeResolverTag,
+  getDomesticResolverTag,
   DNS_NODE_RACE_TAG,
   effectiveCustomRules,
   DOMESTIC_BANK_AND_STOCK_DOMAINS,
@@ -48,21 +54,7 @@ const withDotPrefix = (d: string): string[] => [d, `.${d}`];
 // 不会取此前缀；与 ProxyManager.usedTags 内置保留 tag 同理为内部固定 tag）。
 const TS_NAME_DNS_TAG = 'dns-tailscale';
 
-/**
- * 「选中的 mesh tailscale 节点」的 endpoint tag，供按名解析 DNS server 引用。直接读 buildIdToTagMap 产出的
- * idToTagMap（id→唯一 tag 单一真值），不再复刻去重循环——杜绝与 ProxyManager 侧推导漂移（tag 须逐字节一致，
- * 否则 sing-box FATAL）。非选中 / 选中节点非 tailscale → null。
- */
-function selectedTailscaleEndpointTag(
-  config: UserConfig,
-  idToTagMap: Map<string, string>
-): string | null {
-  const selectedId = config.selectedServerId;
-  if (!selectedId) return null;
-  const selected = config.servers.find((s) => s.id === selectedId);
-  if (!selected || selected.protocol.toLowerCase() !== 'tailscale') return null;
-  return idToTagMap.get(selectedId) ?? null;
-}
+// selectedTailscaleEndpointTag 已删（根治 §3.5）：tailnet gate 放宽后由 tsResolveNode 内联 idToTagMap.get 定位，不再绑选中。
 
 /** 内网 / 反向解析后缀（非 .local 组播）：内网域 .lan / .home.arpa + 反查 .arpa。 */
 const INTERNAL_DNS_SUFFIXES = ['.arpa', '.lan', '.home.arpa'];
@@ -76,7 +68,10 @@ export function buildDnsConfig(
   log: DnsLogFn,
   // issue #147：本地 race DNS server 端口（>0 = race 就绪）。生成 dns-node-race server（节点域名 domain_resolver/rule1
   // 指它，getNodeResolverTag）。=0（off/起失败/snapshot/preflight）不生成，节点域名走单上游（getNodeResolverTag 同步降级）。
-  raceServerPort = 0
+  raceServerPort = 0,
+  // 根治 §3.5：本轮实际发射的 endpoint（buildOutbounds 产出）。tailnet 按名解析 gate 用它确认目标 TS endpoint 已发射，
+  // 避免引用未发射 endpoint 致 FATAL。缺省 []（snapshot/preflight 等无 endpoint 上下文 → tailnet 解析不生成）。
+  pendingEndpoints: SingBoxEndpoint[] = []
 ): SingBoxDnsConfig {
   const proxyMode = (config.proxyMode || 'smart').toLowerCase();
 
@@ -140,13 +135,6 @@ export function buildDnsConfig(
   //   它绕过 TUN 不是靠 DNS detour，而是靠 route 规则把 223.5.5.5:443 直连放行（见 generateRouteConfig）。
   //   关键路径（节点域名 / doh.pub / default_domain_resolver）均以它为 resolver，免疫 UDP 53 限速/劫持/投毒。
   const dnsServers: SingBoxDnsServer[] = [
-    {
-      // 引导解析：专门用于解析代理节点的 IP 解析器（UDP，最稳健）
-      tag: 'dns-bootstrap-udp',
-      type: 'udp',
-      server: '223.5.5.5',
-      server_port: 53,
-    },
     {
       // 引导解析（DoH over IP）：关键路径的解析器。server 已是 IP，无需 domain_resolver。
       // 相比 UDP 53，对运营商的 UDP 53 限速/劫持/投毒免疫，避免节点域名解析失败导致断流。
@@ -228,11 +216,16 @@ export function buildDnsConfig(
   }
 
   // 方案B：DNS 接管把系统 DNS 改成公网 8.8.8.8 后，dns-local(type:local) 解不了内网域名(.lan/.home.arpa/内网域)、
-  // 反查(.arpa) 与 captive portal。接管激活且读到内网 LAN 解析器(私网 IPv4)时，建 dns-lan(udp:53 指向它)，把这些
-  // 域名重定向到它解析；其 :53 由 generateRouteConfig rule C 直连放行(防被 hijack-dns 抢走成环)。
+  // 反查(.arpa) 与 captive portal。接管激活且读到内网 LAN 解析器(私网 IPv4)时，建 dns-lan 把这些域名重定向到它解析。
+  // type:'dhcp'(interface 省略=auto，靠 route.auto_detect_interface)：从 DHCP 动态拿当前网关下发的 DNS——
+  //   ① 换网络(默认接口变)经 InterfaceMonitor 自动重 fetch、跟随新网关，无需重生成 config/重启核(修原硬编码 LAN IP
+  //      换网络后指向旧网关失效)；② dhcp 读 DHCP lease 而非系统 resolver，DNS 接管后系统 DNS 被改成受控 IP 也不影响
+  //      (仍拿真实 LAN DNS，优于 type:local)；③ dhcp 用 LocalDialer 直连、不经 route hijack(rule C 的 LAN IP 放行
+  //      退化为首跳冗余兜底)。lanResolver 探测仍保留：决定是否建 dns-lan(无 LAN 解析器=无内网 DNS) + rule C 放行。
+  //   真机验(macOS 接管)：换网络后 dhcp 跟随新网关解内网域名、不成环；sing-box check 已确认 dhcp transport 已编译。
   const lanResolver = lanResolverForDns;
   if (lanResolver) {
-    dnsServers.push({ tag: 'dns-lan', type: 'udp', server: lanResolver, server_port: 53 });
+    dnsServers.push({ tag: 'dns-lan', type: 'dhcp' });
   }
   // Q1 死循环防护（**仅 Windows**）：Win TUN 的 strict_route(WFP) 把所有 :53 逼进 TUN；type:local 经 svchost(Win DNS
   // 客户端，不在 route 直连进程白名单)发出的查询 → 进 TUN → hijack-dns → 命中 dns-local 规则 → 又 svchost → ∞。
@@ -311,7 +304,9 @@ export function buildDnsConfig(
   if (foreign.isDomain) bootstrapDomains.push(foreign.server);
   dnsRules.push({
     domain: dedupe(bootstrapDomains),
-    server: 'dns-bootstrap-udp',
+    // 根治 §3.6：DoH server 自身域名解析统一用 dns-bootstrap（IP-DoH 抗 UDP53 劫持），删原 dns-bootstrap-udp 历史残留
+    // （明文 UDP53，违背同段「引入 IP-DoH 避免 UDP53」自定设计；删前全仓库唯一消费点即此）。
+    server: 'dns-bootstrap',
   } as SingBoxDnsRule);
 
   // 解决 mDNS 和本地反向解析导致的 context deadline exceeded 超时问题。
@@ -459,7 +454,11 @@ export function buildDnsConfig(
           return isValidSrsFile(path.join(runtimeDir, fileName));
         });
         // region-local 与其余侧各自的解析器（reverse 翻转）。
-        const localResolver = region.reverse ? 'dns-remote' : 'dns-domestic';
+        // 根治 §3.2：正向（默认 CN）region-local（geosite-cn 国内内容）解析改走 getDomesticResolverTag（race on→共用
+        // dns-node-race 多上游 / off→dns-domestic）。reverse（回国）不动（国内域名经回国节点 dns-remote，逻辑特殊）。
+        const localResolver = region.reverse
+          ? 'dns-remote'
+          : getDomesticResolverTag(config, 'dns-domestic');
         const fallthroughResolver = region.reverse ? 'dns-domestic' : 'dns-remote';
         if (localGeo.length > 0) {
           dnsRules.push({
@@ -489,22 +488,26 @@ export function buildDnsConfig(
     }
   }
 
-  // P4b ⭐tailnet 按名解析（仅选中此 mesh tailscale 节点为主出口时生效）：注入 tailscale DNS server +
-  // preferred_by 规则。preferred_by 让 tailnet search domain / MagicDNS 短名自动归位到此节点解析——
-  // 替代硬编码后缀。与 doh.pub/google **并存**：仅 preferred_by 命中的 tailnet 名走 dns-tailscale，
-  // 其余域名规则/final 不变（preferred_by 规则置于尾部 catch-all 之前，不影响既有分流字节）。
-  // accept_search_domain 与 preferred_by 强联动：accept_search_domain 提供短名解析能力，preferred_by 决定
-  // 哪些名字优先归它——故二者同开同关（resolveByName 一个开关同时拉起 server.accept_search_domain + 规则）。
+  // P4b ⭐tailnet 按名解析：注入 tailscale DNS server + preferred_by 规则。preferred_by 让 tailnet search domain /
+  // MagicDNS 短名自动归位到此节点解析——替代硬编码后缀。与 doh.pub/google **并存**：仅 preferred_by 命中的 tailnet 名走
+  // dns-tailscale，其余域名规则/final 不变（preferred_by 规则置于尾部 catch-all 之前，不影响既有分流字节）。
+  // accept_search_domain 与 preferred_by 强联动：故二者同开同关（resolveByName 一个开关同时拉起 server + 规则）。
+  // 根治 §3.5：gate 放宽到「resolveByName 开 + 该 TS endpoint 已发射（pendingEndpoints）」——**不再绑 selectedServerId===
+  // 此TS（主出口）**。TS 仅组网/子网路由、用别的节点出网时，MagicDNS 短名访问 tailnet 设备照常生效；preferred_by 只命中
+  // tailnet 名，非主出口注入不干扰主出口 DNS。优先选中的 TS（若它 resolveByName 开且发射），否则第一个候选。
   const tsResolveNode = (() => {
-    const selectedId = config.selectedServerId;
-    if (!selectedId) return null;
-    const sel = config.servers.find((s) => s.id === selectedId);
-    if (!sel || sel.protocol.toLowerCase() !== 'tailscale') return null;
-    if (!sel.tailscaleSettings?.resolveByName) return null;
-    return sel;
+    const emittedTags = new Set(pendingEndpoints.map((e) => e.tag));
+    const candidates = config.servers.filter(
+      (s) =>
+        s.protocol.toLowerCase() === 'tailscale' &&
+        s.tailscaleSettings?.resolveByName &&
+        emittedTags.has(idToTagMap.get(s.id) ?? '')
+    );
+    if (candidates.length === 0) return null;
+    return candidates.find((s) => s.id === config.selectedServerId) ?? candidates[0];
   })();
   if (tsResolveNode) {
-    const epTag = selectedTailscaleEndpointTag(config, idToTagMap);
+    const epTag = idToTagMap.get(tsResolveNode.id) ?? null;
     if (epTag) {
       dnsServers.push({
         tag: TS_NAME_DNS_TAG,

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -25,6 +25,7 @@ import {
   effectiveCustomRules,
   effectiveAppRules,
   getNodeResolverTag,
+  getDomesticResolverTag,
 } from './singbox-config-helpers';
 import { isDirectSelection, resolveGlobalExitTag } from '../../shared/direct-selection';
 
@@ -989,10 +990,13 @@ export function buildOutbounds(
     );
   }
 
-  // 直连出站
+  // 直连出站。domain_resolver：FakeIP 模式下国内内容（geosite-cn→direct）真实 IP 解析的唯一落点——direct 对 fakeip
+  // 反查域名二次解析时用它（无则回退 route.default_domain_resolver=dns-bootstrap）。根治 §3.2（数据流确证）：显式指
+  // getDomesticResolverTag（race on→dns-node-race 多上游国内 race / off→dns-bootstrap=现状），让国内内容享共用 race server。
   outbounds.push({
     type: 'direct',
     tag: 'direct',
+    domain_resolver: getDomesticResolverTag(config, 'dns-bootstrap'),
   });
 
   // 阻断出站

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -18,6 +18,7 @@ import {
   shouldForceRouteSubnets,
   collectRuleTargetedServerIds,
   meshForceRoutedServers,
+  meshNodeCarriesFullTunnel,
 } from '../../shared/endpoint-routes';
 import { cidrOverlapsAny, partitionCidrsByOverlap } from '../../shared/ip';
 import { dedupe } from '../../shared/collections';
@@ -557,6 +558,18 @@ export function buildRouteConfig(
     // 跨 endpoint 去重：同一 CIDR 被多个 endpoint 声明（如两个 Tailscale 节点都含 tailnet 100.64.0.0/10，
     // 或两个 WG 节点 allowedIPs 重叠），sing-box 路由首条命中 → 后者静默失效。按 config.servers 顺序，
     // 先声明者占有该段（隐式优先级），后者重复段跳过 + 累计告警，杜绝「无声误路由到另一节点」。
+    // 试点（design §14）：endpoint 自声明归位（preferred_by）替代手动 ip_cidr force-route。
+    // sing-box 源码确证（2026-06-28，核 SagerNet/sing-box + wireguard-go）裁定 WG 关外网用 / WG 全隧道与 TS 不用：
+    //  · WG 关外网（allowedIPs 无 0/0）：PreferredAddress = endpoint.Lookup = peer allowed_ips（wireguard/endpoint.go），
+    //    与 ip_cidr(endpointForcedRouteCidrs) 镜像等价 + config 静态即就绪 → 安全，用 preferred_by。
+    //  · WG 全隧道（含 0/0）：wireguard-go allowedips trie 的 root cidr=0、commonBits>=0 恒真 → Lookup(任意 IP，含
+    //    fake IP) 恒返回 peer → PreferredAddress 恒 true → preferred_by **会抢全局**。故全隧道刻意不走 preferred_by、
+    //    改 ip_cidr（endpointForcedRouteCidrs 已去 0/0）；!meshNodeCarriesFullTunnel 闸门即此。（真机曾误判「全隧道 WG
+    //    不抢全局」是因全局出口恰为该 WG、抢与不抢结果一致不可区分，非 0/0 不构成 preference——源码确证 0/0 会抢。）
+    //  · TS：PreferredAddress = routePrefixes.Contains（tailscale/endpoint.go），routePrefixes 由 onReconfig 在控制面
+    //    同步后才填（运行时动态 + 就绪窗口），内容是实际 netmap peer/accepted routes（≠ 静态 100.64/10）→ 起核窗口 nil
+    //    返 false、组网段不归位（真机：exit 出网正常但组网 IP/NAT 异常）。故 TS 必走 ip_cidr 静态。
+    const TS_PREFERRED_BY_TRIAL = false;
     const claimedCidrs = new Set<string>();
     let forceRouteConflicts = 0;
     for (const s of config.servers) {
@@ -565,6 +578,16 @@ export function buildRouteConfig(
       // alwaysRouteSubnets=false 且未 engaged（未选中、无规则指向）→ 跳过其 force-route：纯作可选出口，
       // 网段不强加给全局。注意只 gate route.rules，peer.allowed_ips 不变 → 被选中时网段仍可达（engaged→此处放行）。
       if (!shouldForceRouteSubnets(s, config.selectedServerId, ruleTargetedServerIds)) continue;
+      // preferred_by 适用：非全隧道 +（WG 恒 | TS 试点开）。endpoint 自声明 allowed_ips/routePrefixes 归位、免手动 cidr。
+      const proto = s.protocol?.toLowerCase();
+      const usePreferredBy =
+        !meshNodeCarriesFullTunnel(s) &&
+        (proto === 'wireguard' || (proto === 'tailscale' && TS_PREFERRED_BY_TRIAL));
+      if (usePreferredBy) {
+        rules.push({ preferred_by: [tag], action: 'route', outbound: tag });
+        continue;
+      }
+      // 否则（全隧道节点 / TS 试点未开）：手动 ip_cidr force-route（现状，去 0/0 + 跨节点 first-match 去重 + 重复告警）。
       const cidrs = endpointForcedRouteCidrs(s).filter((c) => {
         if (claimedCidrs.has(c)) {
           forceRouteConflicts++;


### PR DESCRIPTION
## 背景

DNS/route 子系统一路叠加、职责未正交化的系统性整理：删冗余 server + 国内解析统一多上游 race + tailnet gate 修正 + route 归位源码确证。

## 改动

### ① 删 dns-bootstrap-udp（历史残留）
DoH server 自身域名解析统一 `dns-bootstrap`(IP-DoH，抗 UDP53 限速/劫持)；原 `dns-bootstrap-udp`(明文 UDP53)与同段「引入 IP-DoH 避免 UDP53」的自定设计矛盾。全仓库唯一消费点(bootstrap 域名 rule)改指 `dns-bootstrap`，223.5.5.5 直连放行按 IP 不按 tag、不受影响。

### ② 国内内容解析统一多上游 race
- 新增 `getDomesticResolverTag` + `isNodeRaceOn` 单一真值（与 `getNodeResolverTag` 共用 race gate，杜绝两处漂移）。
- 数据流确证：FakeIP 模式（默认）下国内内容真实 IP 解析落在 **direct 出口的 `default_domain_resolver`**(原 `dns-bootstrap` 单上游)，而非 `dns-domestic`；故真改点 = `direct.domain_resolver`(FakeIP) + region-local `localResolver`(非-FakeIP) 走共用 `dns-node-race`。
- race off/未就绪降级单上游(FakeIP=`dns-bootstrap` / 非-FakeIP=`dns-domestic`)；`返回 dns-node-race ⟺ raceServerPort>0 ⟺ server 生成` 双向 bijection，绝不悬空引用。

### ③ tailnet 按名解析 gate 放宽
从「`selectedServerId`===此 TS（主出口）」放宽到「`resolveByName` 开 + 该 TS endpoint 已发射(`pendingEndpoints`)」，TS 仅做组网/子网路由、用别的节点出网时 MagicDNS 短名仍可用；`buildDnsConfig` 新增 `pendingEndpoints` 参数，防引用未发射 endpoint 致 sing-box FATAL。

### route 归位（注释纠正，逻辑不变）
sing-box 源码 + Mac 真机三方确证：WG 关外网(allowed_ips 无 0/0)用 `preferred_by` 替代手动 ip_cidr force-route；WG 全隧道(含 0/0 → wireguard-go allowedips trie root cidr=0 恒匹配 → 抢全局) / TS(routePrefixes 为 tsnet 运行时动态 + 就绪窗口、≠静态 100.64/10) 保持 ip_cidr。

### dns-lan 改 type:dhcp
DNS 接管下内网域名解析从 DHCP lease 动态拿当前网关 DNS，换网络经 InterfaceMonitor 自动跟随、无需重生成 config/重启核（修原硬编码 LAN IP 换网后失效）。

## 验证

- **gate**：tsc main+renderer + eslint 0 errors + jest 137 套 / 1990 例。
- **Mac arm64 真机**：core 加载新 config 后 —— 国内内容 `direct.domain_resolver=dns-node-race` + race server 绑定 + baidu/taobao http200 + 出口正常；tailnet 解析在「非主出口 TS(resolveByName)」生效；`dns.servers` 无 `dns-bootstrap-udp`、bootstrap rule = `dns-bootstrap`。
