### PR TITLE
fix(update-network): 审计修复 M1/M2/L1/L2（全量 review 2026-06-28）

### DIFF
--- a/src/main/__tests__/icon-protocol.test.ts
+++ b/src/main/__tests__/icon-protocol.test.ts
@@ -1,0 +1,106 @@
+/**
+ * icon-protocol 单测（node env）：mock electron protocol（捕获 handler）+ session.fetch + node dns。
+ * 覆盖 M2：flowz-icon:// 首跳 + 逐跳 redirect SSRF guard；协议限制；URL 解码往返。
+ * proxyRunning=false → viaProxy 恒 false（direct），cfgMsvpCache 不影响判定，故跨用例无污染。
+ */
+let capturedHandler: ((req: { url: string }) => Promise<Response>) | null = null;
+const mockRegisterSchemes = jest.fn();
+jest.mock('electron', () => ({
+  protocol: {
+    registerSchemesAsPrivileged: (...a: unknown[]) => mockRegisterSchemes(...a),
+    handle: (_scheme: string, h: (req: { url: string }) => Promise<Response>) => {
+      capturedHandler = h;
+    },
+  },
+}));
+const mockLookup = jest.fn();
+jest.mock('dns', () => ({ promises: { lookup: (...a: unknown[]) => mockLookup(...a) } }));
+
+import { registerIconProtocol } from '../icon-protocol';
+import { iconProxySrc } from '../../shared/icon-proxy';
+
+function makeResp(opts: { status?: number; location?: string }): Response {
+  const status = opts.status ?? 200;
+  const headers = new Map<string, string>();
+  if (opts.location) headers.set('location', opts.location);
+  return {
+    status,
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    body: { cancel: jest.fn().mockResolvedValue(undefined) },
+  } as unknown as Response;
+}
+
+describe('icon-protocol flowz-icon://', () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    capturedHandler = null;
+    mockFetch = jest.fn();
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '1.2.3.4' }]); // 默认公网解析
+    registerIconProtocol({
+      updateNetwork: { sessionFor: jest.fn().mockResolvedValue({ fetch: mockFetch }) } as never,
+      proxyRunningProvider: () => false, // viaProxy 恒 false（direct）
+      updateInPortProvider: () => null,
+      configProvider: () => Promise.resolve({} as never),
+      logManager: { addLog: jest.fn() } as never,
+    });
+  });
+
+  const call = (realUrl: string) => capturedHandler!({ url: iconProxySrc(realUrl) });
+
+  it('https 公网图标 → 经 session.fetch 拉取，返 200', async () => {
+    mockFetch.mockResolvedValue(makeResp({ status: 200 }));
+    const r = await call('https://cdn.example.com/icon.png');
+    expect(mockFetch).toHaveBeenCalled();
+    expect(r.status).toBe(200);
+  });
+
+  it('还原后非 http(s) 协议 → 400，不发起 fetch', async () => {
+    const r = await capturedHandler!({
+      url: `flowz-icon://i/${encodeURIComponent('ftp://x/y')}`,
+    });
+    expect(r.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('首跳 host 解析到内网 → 403（SSRF），不发起 fetch', async () => {
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '10.0.0.5' }]);
+    const r = await call('https://evil.example.com/icon.png');
+    expect(r.status).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('M2：30x 重定向到内网 → 403（逐跳 guard 复检 Location）', async () => {
+    mockFetch.mockResolvedValueOnce(makeResp({ status: 302, location: 'https://internal.evil/x' }));
+    mockLookup.mockReset();
+    mockLookup
+      .mockResolvedValueOnce([{ address: '1.2.3.4' }]) // 首跳 guard：公网
+      .mockResolvedValueOnce([{ address: '169.254.169.254' }]); // 重定向目标：内网（云元数据）
+    const r = await call('https://cdn.example.com/icon.png');
+    expect(r.status).toBe(403);
+  });
+
+  it('M2：30x 到公网 → 续跳拉取成功（200）', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        makeResp({ status: 301, location: 'https://cdn2.example.com/icon.png' })
+      )
+      .mockResolvedValueOnce(makeResp({ status: 200 }));
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '1.2.3.4' }]); // 全程公网
+    const r = await call('https://cdn.example.com/icon.png');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(r.status).toBe(200);
+  });
+
+  it('URL 编解码往返：含 query 的图标 URL 无损还原后拉取', async () => {
+    mockFetch.mockResolvedValue(makeResp({ status: 200 }));
+    await call('https://raw.example.com/a/b.json?x=1&y=2');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://raw.example.com/a/b.json?x=1&y=2',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
+});

--- a/src/main/icon-protocol.ts
+++ b/src/main/icon-protocol.ts
@@ -38,6 +38,18 @@ export interface IconProtocolDeps {
 let cfgMsvpCache: { value: boolean | undefined; expiry: number } | null = null;
 const CFG_CACHE_TTL_MS = 1000;
 
+// 图标代理重定向上限（M2）：与订阅链路同口径，redirect:'manual' 自管链、逐跳过 SSRF guard。
+const MAX_ICON_REDIRECTS = 5;
+
+/** 释放响应体，避免重定向丢弃上一跳 body 时 socket/内存泄漏。 */
+async function drainBody(r: Response): Promise<void> {
+  try {
+    await r.body?.cancel();
+  } catch {
+    /* ignore */
+  }
+}
+
 /** app ready 后注册 flowz-icon:// handler（经 update-in 统一会话拉取图标，回退 direct）。 */
 export function registerIconProtocol(deps: IconProtocolDeps): void {
   protocol.handle(ICON_PROXY_SCHEME, async (request) => {
@@ -74,20 +86,49 @@ export function registerIconProtocol(deps: IconProtocolDeps): void {
     }
     if (viaProxy && port <= 0) viaProxy = false;
 
+    const lookupFn = (h: string) => dnsPromises.lookup(h, { all: true });
     // SSRF：图标 URL 部分来自用户手动输入 → 拦内网/回环/link-local；仅实际经代理（socks）时豁免 FlowZ
     // FakeIP（系统 DNS 把公网域名解析成假 IP，核按域名 socks5h 重解析、本机内网不可达），直连不豁免。
     try {
-      await assertHostAllowed(target, (h) => dnsPromises.lookup(h, { all: true }), viaProxy);
+      await assertHostAllowed(target, lookupFn, viaProxy); // 首跳 guard
     } catch {
       return new Response(null, { status: 403 });
     }
 
+    // M2：redirect:'manual' 自管重定向链——每跳 Location 重跑 SSRF guard（含 DNS 解析）通过才续跳，最多
+    // MAX_ICON_REDIRECTS 跳。默认 follow 会让首跳过 guard 后 30x 到内网不复检（direct 模式下用户自输入 URL
+    // 借此 SSRF）。首跳 target 已在上方 guard 过；循环内复检后续每一跳。
     try {
       const ses = await deps.updateNetwork.sessionFor(viaProxy, port);
-      // SSRF 残留（与 ssrf-guard 的 TOCTOU 注释同级）：Session.fetch 默认 follow redirect，重定向目标不再过
-      // assertHostAllowed。viaProxy 时 redirect 由远端节点 socks5h 解析、本机内网不可达（安全）；仅 direct
-      // 模式（代理未运行/关）下用户自输入 URL 经 30x 重定向到内网才有窄 SSRF 窗口（同 guard 既有 residual）。
-      return await ses.fetch(target.toString(), { headers: { 'User-Agent': APP_USER_AGENT } });
+      let currentUrl = target.toString();
+      let response: Response | null = null;
+      for (let hop = 0; hop <= MAX_ICON_REDIRECTS; hop++) {
+        response = await ses.fetch(currentUrl, {
+          headers: { 'User-Agent': APP_USER_AGENT },
+          redirect: 'manual',
+        });
+        const loc =
+          response.status >= 300 && response.status < 400 ? response.headers.get('location') : null;
+        if (!loc) break; // 非 30x（或无 Location）→ 终态响应
+        await drainBody(response); // 释放上一跳 body
+        if (hop >= MAX_ICON_REDIRECTS) return new Response(null, { status: 502 }); // 超重定向上限
+        let nextObj: URL;
+        try {
+          nextObj = new URL(loc, currentUrl); // 相对 Location 以当前 URL 为基准解析
+        } catch {
+          return new Response(null, { status: 400 });
+        }
+        if (nextObj.protocol !== 'https:' && nextObj.protocol !== 'http:') {
+          return new Response(null, { status: 400 });
+        }
+        try {
+          await assertHostAllowed(nextObj, lookupFn, viaProxy); // 重定向目标过同一 guard（含 DNS 解析）
+        } catch {
+          return new Response(null, { status: 403 });
+        }
+        currentUrl = nextObj.toString();
+      }
+      return response ?? new Response(null, { status: 502 });
     } catch (e) {
       deps.logManager.addLog('warn', `图标代理拉取失败: ${e}`, 'IconProtocol');
       return new Response(null, { status: 502 });

--- a/src/main/ipc/handlers/subscription-handlers.ts
+++ b/src/main/ipc/handlers/subscription-handlers.ts
@@ -4,7 +4,6 @@ import type { SubscriptionConfig } from '../../../shared/types';
 import { registerIpcHandler } from '../ipc-handler';
 import { SubscriptionService, SubscriptionUpdateResult } from '../../services/SubscriptionService';
 import { ConfigManager } from '../../services/ConfigManager';
-import { localProxyPort } from '../../../shared/proxy-ports';
 import { resolveSubscriptionViaProxy } from '../../../shared/subscription-proxy';
 import { randomUUID } from 'crypto';
 
@@ -108,7 +107,6 @@ export function registerSubscriptionHandlers(
           subscription.url,
           subscription.id,
           resolveSubscriptionViaProxy(config.subscriptionProxyPolicy, subscription.updateViaProxy),
-          localProxyPort(config),
           subscription.userAgent ?? config.subscriptionUserAgent
         );
         const fetchedServers = result.servers;

--- a/src/main/services/RuleResourceManager.ts
+++ b/src/main/services/RuleResourceManager.ts
@@ -98,8 +98,9 @@ export class RuleResourceManager {
     }
     // viaProxy 但 update-in 端口不可用（核未起/未分配）→ 直连兜底，不 pin 到无效端口
     if (viaProxy && updateInPort <= 0) viaProxy = false;
-    // sessionFor 内部 setProxy 极罕见可能 reject；兜底 undefined 守住 fetchBuffer/fetchJson 的「永不 reject」契约。
-    return this.updateNetwork.sessionFor(viaProxy, updateInPort).catch(() => undefined);
+    // sessionFor 内部 setProxy 极罕见可能 reject → sessionForOrDirect 回落强制直连会话（绝不落 default session，
+    // M1：对齐 CoreDownloader）；连 direct 也 reject（几乎不可能）才最终兜底 undefined 守 fetchBuffer/fetchJson 「永不 reject」契约。
+    return this.updateNetwork.sessionForOrDirect(viaProxy, updateInPort).catch(() => undefined);
   }
 
   // 串行化所有 load-modify-save，防并发批次/删除/setGhProxy 在 load→save 窗口内交错丢写（review P2-1）

--- a/src/main/services/SubscriptionScheduler.ts
+++ b/src/main/services/SubscriptionScheduler.ts
@@ -17,7 +17,6 @@ import type { ConfigManager } from './ConfigManager';
 import type { LogManager } from './LogManager';
 import { SubscriptionService } from './SubscriptionService';
 import type { UserConfig } from '../../shared/types';
-import { localProxyPort } from '../../shared/proxy-ports';
 import { resolveSubscriptionViaProxy } from '../../shared/subscription-proxy';
 import { BackoffTracker } from './backoff-tracker';
 
@@ -159,7 +158,6 @@ export class SubscriptionScheduler {
             sub.url,
             sub.id,
             subViaProxy,
-            localProxyPort(config),
             sub.userAgent ?? config.subscriptionUserAgent
           );
           fetched.push({

--- a/src/main/services/SubscriptionService.ts
+++ b/src/main/services/SubscriptionService.ts
@@ -503,7 +503,6 @@ export class SubscriptionService {
   private async fetchSubscriptionText(
     url: string,
     viaProxy: boolean,
-    httpPort: number | undefined,
     userAgent: string,
     signal?: AbortSignal
   ): Promise<{ text: string; userInfo?: SubscriptionConfig['userInfo'] }> {
@@ -525,8 +524,7 @@ export class SubscriptionService {
 
     // viaProxy=true → pin 到 update-in socks 入站（动态端口，proxyManager.getUpdateInPort）：与应用更新/资源链路
     // 统一经核 route 按 proxyMode 决策。端口不可用（核未起/未分配/未注入）→ 退直连（自举友好）。viaProxy=false → 直连。
-    // 注：httpPort 参数已废弃（订阅经代理改走 update-in 端口；保留签名待块1 合并后统一清理调用方），viaProxy 路径不再读它。
-    void httpPort;
+    // 订阅经代理唯一入口 = update-in 端口（旧 httpPort/mixedPort 参数已彻底移除，L1）。
     let fetchImpl: typeof net.fetch;
     // 实际是否走 proxied（经核 update-in socks，远程出口、本机内网不可达）——SSRF guard 的 FakeIP 豁免须键于此，
     // 而非 viaProxy 意图：viaProxy=true 但 update-in 端口不可用时回退 direct，那时不能豁免 FakeIP（防本机内网 SSRF）。
@@ -687,7 +685,6 @@ export class SubscriptionService {
     ctx: {
       allowProviders: boolean;
       viaProxy: boolean;
-      httpPort?: number;
       userAgent: string;
       // throwOnEmpty=false：provider 复用路径用（0 节点返回空集而非 throw，让 resolveProxyProviders
       // 按 permanent 0-node 处理；真正的 YAML/JSON 结构错误仍由 tryLoadClashDoc 上抛）。默认 true。
@@ -810,7 +807,6 @@ export class SubscriptionService {
     ctx: {
       allowProviders: boolean;
       viaProxy: boolean;
-      httpPort?: number;
       userAgent: string;
       throwOnEmpty?: boolean;
     }
@@ -840,7 +836,6 @@ export class SubscriptionService {
             const { text } = await this.fetchSubscriptionText(
               url,
               ctx.viaProxy,
-              ctx.httpPort,
               ctx.userAgent,
               signal
             );
@@ -853,7 +848,6 @@ export class SubscriptionService {
             const r = await this.parseSubscriptionContent(text, subscriptionId, {
               allowProviders: false,
               viaProxy: ctx.viaProxy,
-              httpPort: ctx.httpPort,
               userAgent: ctx.userAgent,
               throwOnEmpty: false,
             });
@@ -916,7 +910,6 @@ export class SubscriptionService {
     url: string,
     subscriptionId: string,
     viaProxy: boolean = false,
-    httpPort?: number,
     userAgent?: string
   ): Promise<{
     servers: ServerConfig[];
@@ -937,7 +930,6 @@ export class SubscriptionService {
       const { text, userInfo } = await this.fetchSubscriptionText(
         url,
         viaProxy,
-        httpPort,
         ua,
         AbortSignal.timeout(SubscriptionService.MAIN_FETCH_TIMEOUT_MS)
       );
@@ -952,7 +944,6 @@ export class SubscriptionService {
         {
           allowProviders: true,
           viaProxy,
-          httpPort,
           userAgent: ua,
         }
       );

--- a/src/main/services/UpdateNetwork.ts
+++ b/src/main/services/UpdateNetwork.ts
@@ -43,4 +43,18 @@ export class UpdateNetwork {
   async sessionFor(viaProxy: boolean, port: number): Promise<Session> {
     return viaProxy ? this.getProxiedSession(port) : this.getDirectSession();
   }
+
+  /**
+   * sessionFor 的兜底版（M1）：经代理会话构造（setProxy/partition 初始化）极罕见 reject 时，回落强制直连会话，
+   * **绝不让调用方拿到 undefined**——否则 net.request({session:undefined}) 会落到 Electron default session，
+   * 重新引入系统代理污染 / manual 模式挂死，违反「更新链路不消费 default session」。与 CoreDownloader.updateSession
+   * 的 direct 兜底同口径。direct 自身再 reject（几乎不可能：setProxy mode:direct）才由调用方最终兜底。
+   */
+  async sessionForOrDirect(viaProxy: boolean, port: number): Promise<Session> {
+    try {
+      return await this.sessionFor(viaProxy, port);
+    } catch {
+      return this.getDirectSession();
+    }
+  }
 }

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -103,8 +103,9 @@ export class UpdateService {
     }
     // viaProxy 但 update-in 端口不可用（核未起/未分配）→ 直连兜底，不 pin 到无效端口
     if (viaProxy && updateInPort <= 0) viaProxy = false;
-    // sessionFor 内部 setProxy 极罕见可能 reject；兜底 undefined（回落 default session）守住「绝不抛」契约。
-    return this.updateNetwork.sessionFor(viaProxy, updateInPort).catch(() => undefined);
+    // sessionFor 内部 setProxy 极罕见可能 reject → sessionForOrDirect 回落强制直连会话（绝不落 default session，
+    // M1：对齐 CoreDownloader）；连 direct 也 reject（几乎不可能）才最终兜底 undefined 守「绝不抛」契约。
+    return this.updateNetwork.sessionForOrDirect(viaProxy, updateInPort).catch(() => undefined);
   }
 
   /** 读用户配置的 GitHub 加速前缀（规范化）。未配置/读失败 → undefined（直连兜底，不抛）。 */

--- a/src/main/services/__tests__/SubscriptionScheduler.test.ts
+++ b/src/main/services/__tests__/SubscriptionScheduler.test.ts
@@ -46,7 +46,7 @@ describe('SubscriptionScheduler per-sub 经代理调度', () => {
     await run();
     // 仅直连订阅被拉取（viaProxy=false）；经代理订阅被跳过、未拉取
     expect(fetchSubscription).toHaveBeenCalledTimes(1);
-    expect(fetchSubscription).toHaveBeenCalledWith('http://direct', 'd', false, 7890, undefined);
+    expect(fetchSubscription).toHaveBeenCalledWith('http://direct', 'd', false, undefined);
     expect(pending()).toBe(true);
   });
 
@@ -54,8 +54,8 @@ describe('SubscriptionScheduler per-sub 经代理调度', () => {
     const { fetchSubscription, run, pending } = makeScheduler(makeConfig(), true);
     await run();
     expect(fetchSubscription).toHaveBeenCalledTimes(2);
-    expect(fetchSubscription).toHaveBeenCalledWith('http://direct', 'd', false, 7890, undefined);
-    expect(fetchSubscription).toHaveBeenCalledWith('http://proxy', 'p', true, 7890, undefined);
+    expect(fetchSubscription).toHaveBeenCalledWith('http://direct', 'd', false, undefined);
+    expect(fetchSubscription).toHaveBeenCalledWith('http://proxy', 'p', true, undefined);
     expect(pending()).toBe(false);
   });
 
@@ -67,7 +67,7 @@ describe('SubscriptionScheduler per-sub 经代理调度', () => {
     await run();
     // direct 覆盖 per-sub → 两订阅都直连拉取
     expect(fetchSubscription).toHaveBeenCalledTimes(2);
-    expect(fetchSubscription).toHaveBeenCalledWith('http://proxy', 'p', false, 7890, undefined);
+    expect(fetchSubscription).toHaveBeenCalledWith('http://proxy', 'p', false, undefined);
     expect(pending()).toBe(false);
   });
 
@@ -79,8 +79,8 @@ describe('SubscriptionScheduler per-sub 经代理调度', () => {
     await run();
     // proxy 覆盖 per-sub → 即便 'd' 未设 updateViaProxy 也经代理
     expect(fetchSubscription).toHaveBeenCalledTimes(2);
-    expect(fetchSubscription).toHaveBeenCalledWith('http://direct', 'd', true, 7890, undefined);
-    expect(fetchSubscription).toHaveBeenCalledWith('http://proxy', 'p', true, 7890, undefined);
+    expect(fetchSubscription).toHaveBeenCalledWith('http://direct', 'd', true, undefined);
+    expect(fetchSubscription).toHaveBeenCalledWith('http://proxy', 'p', true, undefined);
     expect(pending()).toBe(false);
   });
 

--- a/src/main/services/__tests__/update-network.test.ts
+++ b/src/main/services/__tests__/update-network.test.ts
@@ -1,0 +1,69 @@
+/**
+ * UpdateNetwork 单测（node env）：mock electron session（fromPartition + setProxy）。
+ * 覆盖 M1：sessionForOrDirect 在经代理会话 setProxy reject 时回落 direct（绝不返 undefined→default session）；
+ * + direct/proxied partition 选择、proxied 端口变化才重设。
+ */
+const mockFromPartition = jest.fn();
+jest.mock('electron', () => ({
+  session: { fromPartition: (...a: unknown[]) => mockFromPartition(...a) },
+}));
+
+import { UpdateNetwork } from '../UpdateNetwork';
+
+function makeSession() {
+  return { setProxy: jest.fn().mockResolvedValue(undefined), fetch: jest.fn() };
+}
+
+describe('UpdateNetwork', () => {
+  beforeEach(() => mockFromPartition.mockReset());
+
+  it('sessionFor(false) → flowz-update-direct partition + mode:direct', async () => {
+    const direct = makeSession();
+    mockFromPartition.mockReturnValue(direct);
+    const s = await new UpdateNetwork().sessionFor(false, 0);
+    expect(mockFromPartition).toHaveBeenCalledWith('flowz-update-direct');
+    expect(direct.setProxy).toHaveBeenCalledWith({ mode: 'direct' });
+    expect(s).toBe(direct);
+  });
+
+  it('sessionFor(true, port) → flowz-update-proxied partition + socks5 pin', async () => {
+    const proxied = makeSession();
+    mockFromPartition.mockReturnValue(proxied);
+    await new UpdateNetwork().sessionFor(true, 52330);
+    expect(mockFromPartition).toHaveBeenCalledWith('flowz-update-proxied');
+    expect(proxied.setProxy).toHaveBeenCalledWith({ proxyRules: 'socks5://127.0.0.1:52330' });
+  });
+
+  it('proxied 同端口复用、端口变化才重设 setProxy', async () => {
+    const proxied = makeSession();
+    mockFromPartition.mockReturnValue(proxied);
+    const un = new UpdateNetwork();
+    await un.sessionFor(true, 1111);
+    await un.sessionFor(true, 1111);
+    expect(proxied.setProxy).toHaveBeenCalledTimes(1); // 同端口复用，不重设
+    await un.sessionFor(true, 2222);
+    expect(proxied.setProxy).toHaveBeenCalledTimes(2); // 端口变 → 重设
+    expect(proxied.setProxy).toHaveBeenLastCalledWith({ proxyRules: 'socks5://127.0.0.1:2222' });
+  });
+
+  it('M1：sessionForOrDirect 在经代理会话 setProxy reject 时回落 direct（非抛、非 undefined）', async () => {
+    const proxied = {
+      setProxy: jest.fn().mockRejectedValue(new Error('setProxy boom')),
+      fetch: jest.fn(),
+    };
+    const direct = makeSession();
+    mockFromPartition.mockImplementation((name: string) =>
+      name === 'flowz-update-proxied' ? proxied : direct
+    );
+    const s = await new UpdateNetwork().sessionForOrDirect(true, 52330);
+    expect(s).toBe(direct); // 回落 direct，绝不 undefined
+    expect(direct.setProxy).toHaveBeenCalledWith({ mode: 'direct' });
+  });
+
+  it('sessionForOrDirect(false) 正常返回 direct', async () => {
+    const direct = makeSession();
+    mockFromPartition.mockReturnValue(direct);
+    const s = await new UpdateNetwork().sessionForOrDirect(false, 0);
+    expect(s).toBe(direct);
+  });
+});


### PR DESCRIPTION
针对 2026-06-28 全量 code review 报告的 4 项修复。

## M1 — updateSession 失败回落 default session
UpdateService/RuleResourceManager.updateSession 在 sessionFor reject 时返回 undefined → net.request 落 Electron default session（系统代理污染 / manual 模式挂死）。新增 `UpdateNetwork.sessionForOrDirect`（sessionFor reject → 回落明确 direct），两处 updateSession 改用，对齐已正确的 CoreDownloader。

## M2 — flowz-icon 仅校验首跳的 redirect SSRF
icon-protocol handler 原 ses.fetch 默认 follow redirect、30x 后 Location 不复检（direct 模式窄 SSRF）。改 `redirect:'manual'` 自管重定向链，每跳 Location 经 new URL(loc, base) + 协议检查 + assertHostAllowed 复检，最多 5 跳（复用 SubscriptionService H2 模式）。

## L1 — 订阅 httpPort 残留参数
删 update-in 迁移后残留的 httpPort/localProxyPort 参数链路（fetchSubscription/fetchSubscriptionText/parseSubscriptionContent/handleClashDoc + subscription-handlers/SubscriptionScheduler），收敛 update-in 为唯一订阅代理入口。

## L2 — 单测缺口
补 UpdateNetwork（sessionForOrDirect / partition / 端口重设）+ icon-protocol（URL 解码 / 协议限制 / SSRF 首跳+重定向 / 跨协议降级 / 超跳上限 / 相对 Location）直接单测。

gate 全绿（tsc main+renderer / eslint / jest 2074 passed）；独立 review 确认四项修复均正确、M2 SSRF 逐跳 guard 完整闭合。