### PR TITLE
fix(tray/ui): 托盘打开主窗口回首页 + 折叠侧栏消除窗口复焦 focus 高亮

### DIFF
--- a/src/main/__tests__/tray-actions.test.ts
+++ b/src/main/__tests__/tray-actions.test.ts
@@ -1,0 +1,69 @@
+/**
+ * tray-actions 导航单测：托盘「打开主窗口」回首页(/home)、「打开设置」切设置(/settings)、「管理服务器」切 /server。
+ * mock electron（仅 app/BrowserWindow 占位）；验 showWindow + webContents.send(EVENT_NAVIGATE) 行为。
+ */
+jest.mock('electron', () => ({ app: { quit: jest.fn() }, BrowserWindow: class {} }));
+
+import { buildTrayCallbacks } from '../tray-actions';
+import { IPC_CHANNELS } from '../../shared/ipc-channels';
+
+function makeDeps() {
+  const send = jest.fn();
+  const showWindow = jest.fn();
+  const mainWindow = { isDestroyed: () => false, webContents: { send } };
+  const deps = {
+    getMainWindow: () => mainWindow,
+    getTrayManager: () => null,
+    getProxyManager: () => null,
+    logManager: { addLog: jest.fn() },
+    configManager: {} as never,
+    updateService: {} as never,
+    speedTestService: {} as never,
+    showWindow,
+    updateTrayMenuState: jest.fn(),
+    setPrivacyMode: jest.fn(),
+  };
+  return { deps, send, showWindow };
+}
+
+describe('tray-actions 导航', () => {
+  it('onShowWindow → showWindow + 导航首页 /home（与「打开设置」对称，不再停留上次页）', () => {
+    const { deps, send, showWindow } = makeDeps();
+    buildTrayCallbacks(deps as never).onShowWindow();
+    expect(showWindow).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith(IPC_CHANNELS.EVENT_NAVIGATE, '/home');
+  });
+
+  it('onOpenSettings → showWindow + 导航 /settings', () => {
+    const { deps, send } = makeDeps();
+    buildTrayCallbacks(deps as never).onOpenSettings();
+    expect(send).toHaveBeenCalledWith(IPC_CHANNELS.EVENT_NAVIGATE, '/settings');
+  });
+
+  it('onManageServers → 导航 /server', () => {
+    const { deps, send } = makeDeps();
+    buildTrayCallbacks(deps as never).onManageServers();
+    expect(send).toHaveBeenCalledWith(IPC_CHANNELS.EVENT_NAVIGATE, '/server');
+  });
+
+  it('窗口已销毁 → 不发送导航（不抛）', () => {
+    const send = jest.fn();
+    const showWindow = jest.fn();
+    const mainWindow = { isDestroyed: () => true, webContents: { send } };
+    const deps = {
+      getMainWindow: () => mainWindow,
+      getTrayManager: () => null,
+      getProxyManager: () => null,
+      logManager: { addLog: jest.fn() },
+      configManager: {} as never,
+      updateService: {} as never,
+      speedTestService: {} as never,
+      showWindow,
+      updateTrayMenuState: jest.fn(),
+      setPrivacyMode: jest.fn(),
+    };
+    buildTrayCallbacks(deps as never).onShowWindow();
+    expect(showWindow).toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/tray-actions.ts
+++ b/src/main/tray-actions.ts
@@ -88,6 +88,12 @@ export function buildTrayCallbacks(deps: TrayActionDeps) {
     },
     onShowWindow: () => {
       showWindow();
+      // 「打开主窗口」回首页（与「打开设置」恒切 /settings 对称）：原仅 show 保持上次路由 → 停设置页则仍显示设置页。
+      // getMainWindow 在 showWindow 后取（窗口可能刚重建），导航到首页。
+      const mainWindow = getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(IPC_CHANNELS.EVENT_NAVIGATE, '/home');
+      }
     },
     onQuit: () => {
       // 收敛到单一退出管线：app.quit() → before-quit(置 isQuitting) → close 放行 → will-quit → cleanupResources → exit

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -156,7 +156,7 @@ export function Sidebar({
         <button
           onClick={toggleCollapsed}
           title={collapsed ? t('sidebar.expand', '展开侧栏') : t('sidebar.collapse', '收起侧栏')}
-          className={`flex items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground ${
+          className={`sidebar-toggle flex items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground ${
             collapsed ? (isMac ? 'h-[52px] w-[52px]' : 'h-[44px] w-[44px]') : 'h-7 w-7'
           }`}
         >

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -287,12 +287,15 @@
     color: hsl(var(--foreground));
   }
 
-  /* 消除窗口重建/复焦后 Chromium 默认 :focus-visible 的橙黄 outline 钉在首个 nav 上；保留键盘可达性。 */
-  .nav-item:focus {
+  /* 消除窗口重建/复焦后 Chromium 默认 :focus-visible 的橙黄 outline 钉在首个 tabbable（折叠 toggle 是 icon-rail
+     首个 tabbable，托盘打开窗口后焦点落它）/ nav 上；保留键盘可达性（:focus-visible 才描 FlowZ ring）。 */
+  .nav-item:focus,
+  .sidebar-toggle:focus {
     outline: none;
   }
 
-  .nav-item:focus-visible {
+  .nav-item:focus-visible,
+  .sidebar-toggle:focus-visible {
     outline: 2px solid hsl(var(--ring));
     outline-offset: -2px;
   }


### PR DESCRIPTION
托盘 UI 两修复（用户反馈 + 截图）。

## 打开主窗口回首页
「打开主窗口」原 onShowWindow 仅 show、保持 renderer 上次路由 → 停设置页时打开主窗口仍显示设置页。改为 show + 导航 `/home`（与「打开设置」恒切 `/settings` 对称）；窗口重建时 currentView 初始即 home 双重兜底。

## 折叠侧栏按钮消除窗口复焦 focus 高亮
折叠 toggle 是 icon-rail 首个 tabbable，托盘打开窗口后焦点落它 → Chromium 默认橙黄 focus outline；它非 .nav-item、未被既有窗口复焦 focus 处理覆盖。加 `.sidebar-toggle` class 套同款（`:focus` 消 outline / `:focus-visible` 描 FlowZ ring，保键盘可达）。

单测：tray-actions 导航（onShowWindow→/home、onOpenSettings→/settings、onManageServers→/server、窗口已销毁不发送）。gate 全绿（tsc main+renderer / eslint / jest 2075）。**focus 视觉待真机验**。