### PR TITLE
refactor: 收口更新链路 viaProxy/port 决策到单点（消除四处端口闸重复）

### DIFF
--- a/src/main/icon-protocol.ts
+++ b/src/main/icon-protocol.ts
@@ -8,7 +8,7 @@ import { protocol } from 'electron';
 import { promises as dnsPromises } from 'dns';
 import { ICON_PROXY_SCHEME } from '../shared/icon-proxy';
 import { assertHostAllowed } from '../shared/ssrf-guard';
-import { resolveMainSessionViaProxy } from '../shared/update-proxy';
+import { resolveUpdateProxyTarget } from '../shared/update-proxy';
 import { APP_USER_AGENT } from '../shared/constants';
 import type { UpdateNetwork } from './services/UpdateNetwork';
 import type { UserConfig } from '../shared/types';
@@ -66,8 +66,9 @@ export function registerIconProtocol(deps: IconProtocolDeps): void {
       return new Response(null, { status: 400 });
     }
 
-    // viaProxy × update-in 端口（同四链路口径）：代理运行 ∧ mainSessionViaProxy 未关 ∧ 端口可用 → 经 update-in。
-    // config 经 TTL 缓存避免网格批量渲染逐请求读盘；端口/运行态走廉价 thunk 每次取最新。
+    // viaProxy × update-in 端口（同四链路口径，端口闸共用 resolveUpdateProxyTarget）：代理运行 ∧
+    // mainSessionViaProxy 未关 ∧ 端口可用 → 经 update-in。config 经 TTL 缓存避免网格批量渲染逐请求读盘；
+    // 端口/运行态走廉价 thunk 每次取最新。
     let viaProxy = false;
     let port = 0;
     try {
@@ -79,12 +80,14 @@ export function registerIconProtocol(deps: IconProtocolDeps): void {
         msvp = (await deps.configProvider()).mainSessionViaProxy;
         cfgMsvpCache = { value: msvp, expiry: now + CFG_CACHE_TTL_MS };
       }
-      viaProxy = resolveMainSessionViaProxy(deps.proxyRunningProvider(), msvp);
-      port = deps.updateInPortProvider() ?? 0;
+      ({ viaProxy, port } = resolveUpdateProxyTarget(
+        deps.proxyRunningProvider(),
+        msvp,
+        deps.updateInPortProvider()
+      ));
     } catch {
       viaProxy = false; // 读 config 失败 → 直连兜底
     }
-    if (viaProxy && port <= 0) viaProxy = false;
 
     const lookupFn = (h: string) => dnsPromises.lookup(h, { all: true });
     // SSRF：图标 URL 部分来自用户手动输入 → 拦内网/回环/link-local；仅实际经代理（socks）时豁免 FlowZ

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1034,11 +1034,14 @@ if (gotTheLock) {
     // Phase 1（更新网络统一层）：更新链路（检查/资源/应用）统一会话层——独立 partition 会话按 mainSessionViaProxy
     // ×proxyRunning 选经代理(socks 入站)/直连，取代裸 net.request 走 default session。proxyManager 已就绪。
     const updateNetwork = new UpdateNetwork();
-    updateService.setUpdateNetwork(
-      updateNetwork,
-      () => proxyManager?.getStatus().running ?? false,
-      () => proxyManager?.getUpdateInPort() ?? null
-    );
+    // 类2：主更新链路 viaProxy/port 决策 providers 一次注入 UpdateNetwork（共享 configManager/proxyManager）；
+    // UpdateService/RuleResourceManager/CoreDownloader 三处只调 resolveSessionForMainUpdate，不再各自重复决策（防漂移）。
+    updateNetwork.setMainUpdateProviders({
+      configProvider: () => configManager.loadConfig(),
+      proxyRunningProvider: () => proxyManager?.getStatus().running ?? false,
+      updateInPortProvider: () => proxyManager?.getUpdateInPort() ?? null,
+    });
+    updateService.setUpdateNetwork(updateNetwork);
     // §8 四链路收口：订阅经代理也 pin 到 update-in（socks），与应用更新/资源链路统一经核 route 按 proxyMode 决策。
     subscriptionService.setUpdateInPortProvider(() => proxyManager?.getUpdateInPort() ?? null);
     // §8 四链路收口：核更新链路（CoreDownloader）也接入 update-in；viaProxy 时经 update-in，否则 direct 兜底（自举）。
@@ -1184,11 +1187,7 @@ if (gotTheLock) {
       (cfg) => ipcEventEmitter.sendToAll('event:configChanged', { newValue: cfg }),
       (cfg) => mainEventEmitter.emit(MAIN_EVENTS.CONFIG_CHANGED, cfg)
     );
-    ruleResourceManager.setUpdateNetwork(
-      updateNetwork,
-      () => proxyManager?.getStatus().running ?? false,
-      () => proxyManager?.getUpdateInPort() ?? null
-    );
+    ruleResourceManager.setUpdateNetwork(updateNetwork);
     // 启动即把内置 geo 规则集补种到运行时目录：缺失/损坏补种 + 出厂态下 app 升级带来的新出厂数据刷新
     // （不回滚网络更新版）。使「规则资源」页在首次启动代理前也能反映真实文件、可更新/重置；幂等、不阻塞启动。
     void configManager

--- a/src/main/services/CoreUpdateService.ts
+++ b/src/main/services/CoreUpdateService.ts
@@ -112,11 +112,7 @@ export class CoreUpdateService {
 
   /** §8：把更新链路统一会话层转发给 CoreDownloader（核更新链路接入 update-in）；proxyRunning/update-in 端口惰性读 this.proxyManager。 */
   setUpdateNetwork(updateNetwork: UpdateNetwork): void {
-    this.coreDownloader.setUpdateNetwork(
-      updateNetwork,
-      () => this.proxyManager?.getStatus().running ?? false,
-      () => this.proxyManager?.getUpdateInPort() ?? null
-    );
+    this.coreDownloader.setUpdateNetwork(updateNetwork);
   }
 
   /** B 块：注入 helper（macOS 持久化内核更新经 helper v5 install-core 写受保护目录）。 */

--- a/src/main/services/RuleResourceManager.ts
+++ b/src/main/services/RuleResourceManager.ts
@@ -38,7 +38,6 @@ import {
 } from './builtin-geo-rulesets';
 import { enumerateResourceRefs, isResourceReferenced } from '../../shared/rule-resource-refs';
 import { UpdateNetwork } from './UpdateNetwork';
-import { resolveMainSessionViaProxy } from '../../shared/update-proxy';
 
 const IDLE_TIMEOUT_MS = 15_000;
 const OVERALL_TIMEOUT_MS = 120_000;
@@ -61,46 +60,25 @@ export class RuleResourceManager {
     private readonly notifyCoreReload: (config: UserConfig) => void
   ) {}
 
-  // Phase 1（更新网络统一层 §8）：更新链路统一会话层 + 代理运行态读取器，构造后由 index.ts 注入。
+  // 更新链路统一会话层（类2：viaProxy/port 决策已收口到 UpdateNetwork.resolveSessionForMainUpdate，providers
+  // 由 index.ts 一次注入 updateNetwork.setMainUpdateProviders；本服务只持 updateNetwork 引用）。
   // 未注入 → updateSession 返回 undefined（net.request 回落 default session，旧行为兜底）。
   private updateNetwork: UpdateNetwork | null = null;
-  private proxyRunningProvider: (() => boolean) | null = null;
-  // Phase 2：update-in inbound 动态端口读取器（proxyManager.getUpdateInPort）。viaProxy 时 pin 此口（非 mixedPort）。
-  private updateInPortProvider: (() => number | null) | null = null;
 
-  /** Phase 1/2：注入更新链路统一会话层 + 代理运行态读取器 + update-in 端口读取器（index.ts 装配）。 */
-  setUpdateNetwork(
-    updateNetwork: UpdateNetwork,
-    proxyRunningProvider: () => boolean,
-    updateInPortProvider: () => number | null
-  ): void {
+  /** 注入更新链路统一会话层（类2：决策 providers 改由 index.ts 注入 updateNetwork.setMainUpdateProviders）。 */
+  setUpdateNetwork(updateNetwork: UpdateNetwork): void {
     this.updateNetwork = updateNetwork;
-    this.proxyRunningProvider = proxyRunningProvider;
-    this.updateInPortProvider = updateInPortProvider;
   }
 
   /**
-   * Phase 1：资源下载统一会话。读 config(mainSessionViaProxy/mixedPort) + proxyRunning，经
-   * resolveMainSessionViaProxy 决定经代理（socks 入站）还是直连；未注入 → undefined（net.request 回落
-   * default session，旧行为兜底）。读 config 失败 → 直连兜底（绝不抛）。
+   * 资源下载统一会话。viaProxy/port 决策收口到 UpdateNetwork.resolveSessionForMainUpdate（类2 三链路单点防漂移）：
+   * mainSessionViaProxy×proxyRunning×updateInPort 求值、端口不可用/读 config 失败回落直连、经 sessionForOrDirect
+   * 绝不消费 default session（M1）。未注入 → undefined（旧行为兜底）；极罕见 direct 也 reject → undefined 守
+   * fetchBuffer/fetchJson「永不 reject」契约。
    */
   private async updateSession(): Promise<Session | undefined> {
     if (!this.updateNetwork) return undefined;
-    let viaProxy = false;
-    let updateInPort = 0;
-    try {
-      const cfg = await this.configManager.loadConfig();
-      const running = this.proxyRunningProvider ? this.proxyRunningProvider() : false;
-      viaProxy = resolveMainSessionViaProxy(running, cfg.mainSessionViaProxy);
-      updateInPort = this.updateInPortProvider?.() ?? 0;
-    } catch {
-      viaProxy = false; // 读 config 失败 → 直连兜底
-    }
-    // viaProxy 但 update-in 端口不可用（核未起/未分配）→ 直连兜底，不 pin 到无效端口
-    if (viaProxy && updateInPort <= 0) viaProxy = false;
-    // sessionFor 内部 setProxy 极罕见可能 reject → sessionForOrDirect 回落强制直连会话（绝不落 default session，
-    // M1：对齐 CoreDownloader）；连 direct 也 reject（几乎不可能）才最终兜底 undefined 守 fetchBuffer/fetchJson 「永不 reject」契约。
-    return this.updateNetwork.sessionForOrDirect(viaProxy, updateInPort).catch(() => undefined);
+    return this.updateNetwork.resolveSessionForMainUpdate().catch(() => undefined);
   }
 
   // 串行化所有 load-modify-save，防并发批次/删除/setGhProxy 在 load→save 窗口内交错丢写（review P2-1）

--- a/src/main/services/UpdateNetwork.ts
+++ b/src/main/services/UpdateNetwork.ts
@@ -1,4 +1,6 @@
 import { session, type Session } from 'electron';
+import { resolveUpdateProxyTarget } from '../../shared/update-proxy';
+import type { UserConfig } from '../../shared/types';
 
 /**
  * 更新链路统一网络层：资源/应用更新等 main 进程 `net.request` 的会话来源。
@@ -56,5 +58,45 @@ export class UpdateNetwork {
     } catch {
       return this.getDirectSession();
     }
+  }
+
+  // 类2 收口：主更新链路（应用/资源/核心）viaProxy/port 决策 providers，index.ts 一次注入（共享 proxyManager/
+  // configManager）。原 UpdateService/RuleResourceManager/CoreDownloader 三处各自重复「读 config→proxyRunning→
+  // updateInPort→viaProxy 求值→端口闸→sessionForOrDirect」易漂移；收口到 resolveSessionForMainUpdate 单点。
+  private configProvider: (() => Promise<UserConfig | null>) | null = null;
+  private proxyRunningProvider: (() => boolean) | null = null;
+  private updateInPortProvider: (() => number | null) | null = null;
+
+  /** index.ts 一次注入主更新链路决策 providers（configManager.loadConfig / proxyManager.running / getUpdateInPort）。 */
+  setMainUpdateProviders(deps: {
+    configProvider: () => Promise<UserConfig | null>;
+    proxyRunningProvider: () => boolean;
+    updateInPortProvider: () => number | null;
+  }): void {
+    this.configProvider = deps.configProvider;
+    this.proxyRunningProvider = deps.proxyRunningProvider;
+    this.updateInPortProvider = deps.updateInPortProvider;
+  }
+
+  /**
+   * 主更新链路统一会话决策（类2 收口单点）：读 config(mainSessionViaProxy)+proxyRunning+updateInPort，经
+   * resolveUpdateProxyTarget 决定 viaProxy/有效端口（端口闸单一真值，与 icon-protocol 共用）；读 config 失败
+   * → 直连兜底；返回 sessionForOrDirect（绝不消费 default session，M1）。UpdateService/RuleResourceManager/
+   * CoreDownloader 三处统一调用，防漂移。未注入 providers（理论：index 总注入）→ 读不到则 viaProxy=false。
+   */
+  async resolveSessionForMainUpdate(): Promise<Session> {
+    let target = { viaProxy: false, port: 0 };
+    try {
+      const cfg = this.configProvider ? await this.configProvider() : null;
+      const running = this.proxyRunningProvider ? this.proxyRunningProvider() : false;
+      target = resolveUpdateProxyTarget(
+        running,
+        cfg?.mainSessionViaProxy,
+        this.updateInPortProvider?.()
+      );
+    } catch {
+      target = { viaProxy: false, port: 0 }; // 读 config 失败 → 直连兜底
+    }
+    return this.sessionForOrDirect(target.viaProxy, target.port);
   }
 }

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -19,7 +19,6 @@ import { IPC_CHANNELS } from '../../shared/ipc-channels';
 import { createIdleTimeout, parseExpectedBytes } from './download-hardening';
 import { findSuitableUpdateAsset } from './update-asset';
 import { UpdateNetwork } from './UpdateNetwork';
-import { resolveMainSessionViaProxy } from '../../shared/update-proxy';
 import {
   buildWindowsUpdateVbs,
   buildLinuxAppImageScript,
@@ -48,12 +47,10 @@ export class UpdateService {
   // #60：注入配置读取器（仅用于读 ghProxyPrefix 下载镜像前缀），构造后注入。未配置→null（直连，旧行为）。
   // 与 CoreUpdateService.configProvider / CoreDownloader 同口径——App 自更新与内核/资源下载共用同一 gh 加速前缀。
   private configProvider: (() => Promise<UserConfig | null>) | null = null;
-  // Phase 1（更新网络统一层 §8）：更新链路统一会话层 + 代理运行态读取器，构造后由 index.ts 注入。
+  // 更新链路统一会话层（类2：viaProxy/port 决策已收口到 UpdateNetwork.resolveSessionForMainUpdate，providers
+  // 由 index.ts 一次注入 updateNetwork.setMainUpdateProviders；本服务只持 updateNetwork 引用）。
   // 未注入 → updateSession 返回 undefined（net.request 回落 default session，旧行为兜底）。
   private updateNetwork: UpdateNetwork | null = null;
-  private proxyRunningProvider: (() => boolean) | null = null;
-  // Phase 2：update-in inbound 动态端口读取器（proxyManager.getUpdateInPort）。viaProxy 时 pin 此口（非 mixedPort）。
-  private updateInPortProvider: (() => number | null) | null = null;
 
   constructor(logManager: LogManager) {
     this.logManager = logManager;
@@ -73,39 +70,20 @@ export class UpdateService {
     this.configProvider = provider;
   }
 
-  /** Phase 1/2：注入更新链路统一会话层 + 代理运行态读取器 + update-in 端口读取器（index.ts 装配）。 */
-  setUpdateNetwork(
-    updateNetwork: UpdateNetwork,
-    proxyRunningProvider: () => boolean,
-    updateInPortProvider: () => number | null
-  ): void {
+  /** 注入更新链路统一会话层（类2：决策 providers 改由 index.ts 注入 updateNetwork.setMainUpdateProviders）。 */
+  setUpdateNetwork(updateNetwork: UpdateNetwork): void {
     this.updateNetwork = updateNetwork;
-    this.proxyRunningProvider = proxyRunningProvider;
-    this.updateInPortProvider = updateInPortProvider;
   }
 
   /**
-   * Phase 1/2：更新链路（检查/下载）统一会话。读 mainSessionViaProxy + proxyRunning 经 resolveMainSessionViaProxy
-   * 决定经代理还是直连；经代理时 pin 到 update-in inbound 动态端口（Phase 2，非 mixedPort）。未注入 updateNetwork
-   * → undefined（net.request 回落 default session）。读 config 失败 / update-in 端口不可用 → 直连兜底（绝不抛）。
+   * 更新链路（检查/下载）统一会话。viaProxy/port 决策收口到 UpdateNetwork.resolveSessionForMainUpdate（类2，
+   * 三链路单点防漂移）：mainSessionViaProxy×proxyRunning×updateInPort 求值、端口不可用/读 config 失败回落直连、
+   * 经 sessionForOrDirect 绝不消费 default session（M1）。未注入 updateNetwork → undefined（旧行为兜底）；
+   * 极罕见 direct 也 reject → undefined 守 net.request「绝不抛」契约。
    */
   private async updateSession(): Promise<Session | undefined> {
     if (!this.updateNetwork) return undefined;
-    let viaProxy = false;
-    let updateInPort = 0;
-    try {
-      const cfg = this.configProvider ? await this.configProvider() : null;
-      const running = this.proxyRunningProvider ? this.proxyRunningProvider() : false;
-      viaProxy = resolveMainSessionViaProxy(running, cfg?.mainSessionViaProxy);
-      updateInPort = this.updateInPortProvider?.() ?? 0;
-    } catch {
-      viaProxy = false; // 读 config 失败 → 直连兜底
-    }
-    // viaProxy 但 update-in 端口不可用（核未起/未分配）→ 直连兜底，不 pin 到无效端口
-    if (viaProxy && updateInPort <= 0) viaProxy = false;
-    // sessionFor 内部 setProxy 极罕见可能 reject → sessionForOrDirect 回落强制直连会话（绝不落 default session，
-    // M1：对齐 CoreDownloader）；连 direct 也 reject（几乎不可能）才最终兜底 undefined 守「绝不抛」契约。
-    return this.updateNetwork.sessionForOrDirect(viaProxy, updateInPort).catch(() => undefined);
+    return this.updateNetwork.resolveSessionForMainUpdate().catch(() => undefined);
   }
 
   /** 读用户配置的 GitHub 加速前缀（规范化）。未配置/读失败 → undefined（直连兜底，不抛）。 */

--- a/src/main/services/__tests__/update-network.test.ts
+++ b/src/main/services/__tests__/update-network.test.ts
@@ -67,3 +67,60 @@ describe('UpdateNetwork', () => {
     expect(s).toBe(direct);
   });
 });
+
+describe('UpdateNetwork.resolveSessionForMainUpdate（类2 viaProxy/port 决策收口）', () => {
+  beforeEach(() => mockFromPartition.mockReset());
+
+  function setup(
+    cfg: { mainSessionViaProxy?: boolean } | null,
+    running: boolean,
+    port: number | null,
+    cfgReject = false
+  ) {
+    const proxied = makeSession();
+    const direct = makeSession();
+    mockFromPartition.mockImplementation((name: string) =>
+      name === 'flowz-update-proxied' ? proxied : direct
+    );
+    const un = new UpdateNetwork();
+    un.setMainUpdateProviders({
+      configProvider: () =>
+        cfgReject ? Promise.reject(new Error('config boom')) : Promise.resolve(cfg as never),
+      proxyRunningProvider: () => running,
+      updateInPortProvider: () => port,
+    });
+    return { un, proxied, direct };
+  }
+
+  it('running ∧ mainSessionViaProxy 未关 ∧ 端口可用 → proxied(socks)', async () => {
+    const { un, proxied } = setup({ mainSessionViaProxy: true }, true, 52330);
+    expect(await un.resolveSessionForMainUpdate()).toBe(proxied);
+    expect(proxied.setProxy).toHaveBeenCalledWith({ proxyRules: 'socks5://127.0.0.1:52330' });
+  });
+
+  it('代理未运行 → direct', async () => {
+    const { un, direct } = setup({ mainSessionViaProxy: true }, false, 52330);
+    expect(await un.resolveSessionForMainUpdate()).toBe(direct);
+  });
+
+  it('mainSessionViaProxy=false → direct', async () => {
+    const { un, direct } = setup({ mainSessionViaProxy: false }, true, 52330);
+    expect(await un.resolveSessionForMainUpdate()).toBe(direct);
+  });
+
+  it('端口不可用(<=0) → direct（不 pin 无效口）', async () => {
+    const { un, direct } = setup({ mainSessionViaProxy: true }, true, 0);
+    expect(await un.resolveSessionForMainUpdate()).toBe(direct);
+  });
+
+  it('读 config 失败 → direct 兜底', async () => {
+    const { un, direct } = setup(null, true, 52330, true);
+    expect(await un.resolveSessionForMainUpdate()).toBe(direct);
+  });
+
+  it('未注入 providers → viaProxy=false → direct', async () => {
+    const direct = makeSession();
+    mockFromPartition.mockReturnValue(direct);
+    expect(await new UpdateNetwork().resolveSessionForMainUpdate()).toBe(direct);
+  });
+});

--- a/src/main/services/core-downloader.ts
+++ b/src/main/services/core-downloader.ts
@@ -20,34 +20,25 @@ import { powershellPath } from '../utils/win-system32';
 import { MAX_GITHUB_JSON_BYTES } from '../utils/http-limits';
 import { findSuitableSingboxAsset } from './singbox-asset';
 import { UpdateNetwork } from './UpdateNetwork';
-import { resolveMainSessionViaProxy } from '../../shared/update-proxy';
 
 export class CoreDownloader {
   // direct 自举兜底会话（强制 mode:direct）：核下载是自举链路，UpdateNetwork 未注入 / update-in 端口不可用 /
   // sessionFor 失败时回落此口——绝不回落 default session（核更新链路统一经本类专用会话，default session 已
   // 回归系统代理且 bootstrap 期不可控）；TUN 模式 direct 由 OS 层透明捕获，系统代理模式直连 GitHub（实测均可达）。
   private updateDirectSession: Session | null = null;
-  // §8 四链路收口：核更新链路也接入 update-in（socks）。viaProxy（resolveMainSessionViaProxy）时经 update-in→route→
-  // proxy；否则走 direct 兜底（自举）。构造后由 CoreUpdateService 转发、index 装配。
+  // §8 四链路收口：核更新链路也接入 update-in（socks）。viaProxy/port 决策已收口到 UpdateNetwork.
+  // resolveSessionForMainUpdate（类2，providers 由 index.ts 一次注入）；本类只持 updateNetwork 引用 + 自举兜底。
   private updateNetwork: UpdateNetwork | null = null;
-  private proxyRunningProvider: (() => boolean) | null = null;
-  private updateInPortProvider: (() => number | null) | null = null;
 
   constructor(
     private readonly logManager: LogManager,
-    // 注入配置读取器（读 ghProxyPrefix 镜像前缀 + mainSessionViaProxy）；未配置时解析为 null。
+    // 注入配置读取器（读 ghProxyPrefix 镜像前缀）；未配置时解析为 null。
     private readonly configProvider: () => Promise<UserConfig | null>
   ) {}
 
-  /** §8：注入更新链路统一会话层 + 代理运行态/update-in 端口读取器（CoreUpdateService 转发，index 装配）。 */
-  setUpdateNetwork(
-    updateNetwork: UpdateNetwork,
-    proxyRunningProvider: () => boolean,
-    updateInPortProvider: () => number | null
-  ): void {
+  /** §8：注入更新链路统一会话层（类2：决策 providers 改由 index.ts 注入 updateNetwork.setMainUpdateProviders）。 */
+  setUpdateNetwork(updateNetwork: UpdateNetwork): void {
     this.updateNetwork = updateNetwork;
-    this.proxyRunningProvider = proxyRunningProvider;
-    this.updateInPortProvider = updateInPortProvider;
   }
 
   /** direct 自举兜底会话（强制 mode:direct，绕 default session http 入站挂死）。 */
@@ -60,28 +51,13 @@ export class CoreDownloader {
   }
 
   /**
-   * 核更新链路（检查/下载）统一会话。viaProxy（resolveMainSessionViaProxy = running && mainSessionViaProxy!==false）
-   * 且 update-in 端口可用 → 经 update-in（socks→route→proxy）；否则 direct 兜底（自举：核下载恒可达 direct+mirror）。
-   * 恒返回 Session（非 undefined）——核自举绝不回落 default session（http 入站挂死）；sessionFor 失败亦回 direct。
+   * 核更新链路（检查/下载）统一会话。viaProxy/port 决策收口到 UpdateNetwork.resolveSessionForMainUpdate（类2
+   * 三链路单点防漂移）。恒返回 Session（非 undefined）——核自举绝不回落 default session（http 入站挂死）：
+   * 未注入 updateNetwork / resolveSessionForMainUpdate 极罕见 reject → 回本类 direct 自举兜底。
    */
   private async updateSession(): Promise<Session> {
     if (!this.updateNetwork) return this.getDirectSession();
-    let viaProxy = false;
-    let updateInPort = 0;
-    try {
-      const cfg = await this.configProvider();
-      const running = this.proxyRunningProvider ? this.proxyRunningProvider() : false;
-      viaProxy = resolveMainSessionViaProxy(running, cfg?.mainSessionViaProxy);
-      updateInPort = this.updateInPortProvider?.() ?? 0;
-    } catch {
-      viaProxy = false;
-    }
-    if (viaProxy && updateInPort <= 0) viaProxy = false;
-    try {
-      return await this.updateNetwork.sessionFor(viaProxy, updateInPort);
-    } catch {
-      return this.getDirectSession(); // sessionFor/setProxy 失败 → direct 兜底（自举绝不回 default session）
-    }
+    return this.updateNetwork.resolveSessionForMainUpdate().catch(() => this.getDirectSession());
   }
 
   async fetchReleases(): Promise<any[]> {

--- a/src/shared/__tests__/update-proxy.test.ts
+++ b/src/shared/__tests__/update-proxy.test.ts
@@ -1,4 +1,4 @@
-import { resolveMainSessionViaProxy } from '../update-proxy';
+import { resolveMainSessionViaProxy, resolveUpdateProxyTarget } from '../update-proxy';
 
 describe('resolveMainSessionViaProxy（代理运行 AND mainSessionViaProxy 未关）', () => {
   it.each([
@@ -10,5 +10,36 @@ describe('resolveMainSessionViaProxy（代理运行 AND mainSessionViaProxy 未�
     [false, false, false],
   ])('running=%s gate=%s → %s', (running, gate, expected) => {
     expect(resolveMainSessionViaProxy(running, gate)).toBe(expected);
+  });
+});
+
+describe('resolveUpdateProxyTarget（viaProxy + 端口闸单一真值）', () => {
+  it.each([
+    // running, gate, port, expectedViaProxy, expectedPort
+    [true, undefined, 52330, true, 52330], // 默认开 + 端口可用 → 经代理
+    [true, true, 52330, true, 52330], // 显式开 + 端口可用 → 经代理
+    [true, false, 52330, false, 52330], // 显式关 → 直连（端口仍透传）
+    [false, true, 52330, false, 52330], // 代理未运行 → 直连
+    [true, true, 0, false, 0], // 端口闸：端口=0 → 强制直连（不 pin 无效口）
+    [true, true, -1, false, -1], // 端口闸：负端口 → 直连
+    [true, true, null, false, 0], // 端口未就绪(null) → 0 → 直连
+    [true, true, undefined, false, 0], // 端口 undefined → 0 → 直连
+    [false, true, 0, false, 0], // 未运行 + 无端口 → 直连
+  ])(
+    'running=%s gate=%s port=%s → viaProxy=%s port=%s',
+    (running, gate, port, expViaProxy, expPort) => {
+      expect(resolveUpdateProxyTarget(running, gate, port)).toEqual({
+        viaProxy: expViaProxy,
+        port: expPort,
+      });
+    }
+  );
+
+  it('viaProxy=true ⟹ port>0（自洽不变量）', () => {
+    for (const port of [1, 1080, 52330, 65535]) {
+      const t = resolveUpdateProxyTarget(true, true, port);
+      expect(t.viaProxy).toBe(true);
+      expect(t.port).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/shared/update-proxy.ts
+++ b/src/shared/update-proxy.ts
@@ -10,3 +10,20 @@ export function resolveMainSessionViaProxy(
 ): boolean {
   return proxyRunning && mainSessionViaProxy !== false;
 }
+
+/**
+ * 更新链路会话目标求值（viaProxy + 有效 update-in 端口），单一真值。把易漂移的「端口闸」收口到一处：
+ * = `resolveMainSessionViaProxy` 决定经代理；端口不可用(<=0) → 强制直连（不 pin 无效口）。返回的 viaProxy
+ * 与 port 自洽（viaProxy=true ⟹ port>0）。UpdateNetwork.resolveSessionForMainUpdate（返回 Session 的四链路）
+ * 与 icon-protocol（需裸 {viaProxy,port} 喂 SSRF guard）共用，避免端口闸规则在两处分叉。
+ */
+export function resolveUpdateProxyTarget(
+  proxyRunning: boolean,
+  mainSessionViaProxy: boolean | undefined,
+  updateInPort: number | null | undefined
+): { viaProxy: boolean; port: number } {
+  let viaProxy = resolveMainSessionViaProxy(proxyRunning, mainSessionViaProxy);
+  const port = updateInPort ?? 0;
+  if (viaProxy && port <= 0) viaProxy = false;
+  return { viaProxy, port };
+}


### PR DESCRIPTION
## 背景

更新链路四处入口（应用更新 `UpdateService`、规则资源 `RuleResourceManager`、内核下载 `CoreDownloader`、图标协议 `flowz-icon://`）此前各自内联同一段会话决策：

```
读 config(mainSessionViaProxy) → proxyRunning → updateInPort
  → resolveMainSessionViaProxy 求 viaProxy
  → 端口闸 if (viaProxy && port<=0) viaProxy=false
  → sessionForOrDirect / sessionFor
```

四份副本，端口闸规则一旦改动易在某处漏改 → 同一 config 下不同链路对「经代理/直连」做出分叉决策。

## 改动

- 新增 `UpdateNetwork.resolveSessionForMainUpdate()` 作为返回 `Session` 的三链路（应用/资源/核心）单点决策；`setMainUpdateProviders` 由 index 一次注入共享 `configManager.loadConfig` / `proxyManager.running` / `getUpdateInPort`。
- 端口闸纯决策（`resolveMainSessionViaProxy` + `port<=0→直连`）抽为 `shared/update-proxy#resolveUpdateProxyTarget`，返回自洽的 `{viaProxy, port}`（viaProxy=true ⟹ port>0）。`flowz-icon://` 需要裸 `{viaProxy,port}` 喂 SSRF guard、且自带 config TTL 缓存，无法收进返回 Session 的单点，故共用该纯函数——四处端口闸归一到一处。
- 三服务 `setUpdateNetwork` 签名从 `(updateNetwork, proxyRunningProvider, updateInPortProvider)` 简化为 `(updateNetwork)`，删各自重复的 provider 字段。

## 行为不变

- `UpdateService`/`RuleResourceManager` 末端 `catch→undefined` 守 net.request/fetchBuffer 契约；`CoreDownloader` `catch→getDirectSession` 自举兜底，绝不消费 default session（M1 不变量保持）。
- 端口闸、读 config 失败兜底、未注入 providers 兜底逐条等价。

## 验证

- `resolveSessionForMainUpdate` 决策单测（proxied / 代理未运行 / 显式关 / 端口不可用 / 读 config 失败 / 未注入）。
- `resolveUpdateProxyTarget` 端口闸单测（含 port=0/负/null/undefined + viaProxy⟹port>0 不变量）。
- gate 全绿：tsc(main) 0、eslint 0、jest 2087 passed。