### PR TITLE
refactor: 抽统一「带逐跳 SSRF 复检的安全重定向 fetch」helper

### DIFF
--- a/src/main/__tests__/safe-redirect-fetch.test.ts
+++ b/src/main/__tests__/safe-redirect-fetch.test.ts
@@ -1,0 +1,237 @@
+/**
+ * safeRedirectFetch 单测（node env）：真实 assertHostAllowed + 注入 lookup/fetchImpl。
+ * 覆盖：首跳 + 逐跳 redirect SSRF 复检、重定向上限、协议非法、drainBody、signal 透传、
+ * FakeIP 豁免（仅经代理）、fetchImpl 网络错误原样冒泡（非 SafeFetchError）。
+ */
+import { safeRedirectFetch, SafeFetchError } from '../safe-redirect-fetch';
+
+interface FakeResp {
+  status: number;
+  headers: { get(n: string): string | null };
+  body?: { cancel: jest.Mock };
+}
+
+function makeResp(status: number, location?: string): FakeResp {
+  const h = new Map<string, string>();
+  if (location) h.set('location', location);
+  return {
+    status,
+    headers: { get: (k: string) => h.get(k.toLowerCase()) ?? null },
+    body: { cancel: jest.fn().mockResolvedValue(undefined) },
+  };
+}
+
+const PUBLIC = [{ address: '93.184.216.34' }];
+const INTERNAL = [{ address: '10.0.0.5' }];
+const META = [{ address: '169.254.169.254' }];
+const FAKEIP6 = [{ address: 'fc00::57' }]; // FlowZ FakeIP（IPv6 fc00::/18）：isPrivateIp 判 ULA、isFlowzFakeIp 豁免
+
+const base = {
+  userAgent: 'TestUA',
+  exemptFakeIp: false,
+};
+
+async function expectReason(p: Promise<unknown>, reason: SafeFetchError['reason']): Promise<void> {
+  let caught: unknown;
+  try {
+    await p;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(SafeFetchError);
+  expect((caught as SafeFetchError).reason).toBe(reason);
+}
+
+describe('safeRedirectFetch', () => {
+  it('首跳公网 → 返回终态响应，下发 redirect:manual + UA', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(makeResp(200));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    const r = await safeRedirectFetch<FakeResp>({
+      ...base,
+      fetchImpl,
+      url: 'https://cdn.example.com/x',
+      lookup,
+    });
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://cdn.example.com/x',
+      expect.objectContaining({ redirect: 'manual', headers: { 'User-Agent': 'TestUA' } })
+    );
+  });
+
+  it('首跳解析到内网 → SafeFetchError(ssrf)，不发起 fetch', async () => {
+    const fetchImpl = jest.fn();
+    const lookup = jest.fn().mockResolvedValue(INTERNAL);
+    await expectReason(
+      safeRedirectFetch<FakeResp>({
+        ...base,
+        fetchImpl,
+        url: 'https://evil.example.com/x',
+        lookup,
+      }),
+      'ssrf'
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('首跳 SSRF 消息透传 assertHostAllowed 原文（含「本机/内网」）', async () => {
+    const fetchImpl = jest.fn();
+    const lookup = jest.fn().mockResolvedValue(META); // 云元数据
+    await expect(
+      safeRedirectFetch<FakeResp>({ ...base, fetchImpl, url: 'https://meta.example.com/x', lookup })
+    ).rejects.toThrow(/本机\/内网/);
+  });
+
+  it('30x 跳到内网 → SafeFetchError(ssrf)（逐跳复检 Location）', async () => {
+    const fetchImpl = jest.fn().mockResolvedValueOnce(makeResp(302, 'https://inner.example.com/y'));
+    const lookup = jest
+      .fn()
+      .mockResolvedValueOnce(PUBLIC) // 首跳：公网
+      .mockResolvedValueOnce(INTERNAL); // 重定向目标：内网
+    await expectReason(
+      safeRedirectFetch<FakeResp>({ ...base, fetchImpl, url: 'https://cdn.example.com/x', lookup }),
+      'ssrf'
+    );
+  });
+
+  it('30x 跳到公网 → 续跳返回终态，drain 上一跳 body', async () => {
+    const first = makeResp(301, 'https://cdn2.example.com/z');
+    const fetchImpl = jest.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(makeResp(200));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    const r = await safeRedirectFetch<FakeResp>({
+      ...base,
+      fetchImpl,
+      url: 'https://cdn.example.com/x',
+      lookup,
+    });
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(first.body!.cancel).toHaveBeenCalled(); // 上一跳 body 已 drain
+  });
+
+  it('30x 跳到内网（抛错路径）→ 仍 drain 当前跳 body（防 socket 泄漏）', async () => {
+    const first = makeResp(302, 'https://inner.example.com/y');
+    const fetchImpl = jest.fn().mockResolvedValueOnce(first);
+    const lookup = jest
+      .fn()
+      .mockResolvedValueOnce(PUBLIC) // 首跳：公网
+      .mockResolvedValueOnce(INTERNAL); // 重定向目标：内网 → 抛 ssrf
+    await expectReason(
+      safeRedirectFetch<FakeResp>({ ...base, fetchImpl, url: 'https://cdn.example.com/x', lookup }),
+      'ssrf'
+    );
+    expect(first.body!.cancel).toHaveBeenCalled(); // 被拒的那一跳 body 也已释放
+  });
+
+  it('相对 Location 以当前 URL 为基准解析', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeResp(302, '/sub/path'))
+      .mockResolvedValueOnce(makeResp(200));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    await safeRedirectFetch<FakeResp>({
+      ...base,
+      fetchImpl,
+      url: 'https://cdn.example.com/a/b',
+      lookup,
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://cdn.example.com/sub/path',
+      expect.anything()
+    );
+  });
+
+  it('重定向超过上限 → SafeFetchError(too-many-redirects)，消息含「重定向次数超过上限」', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(makeResp(302, 'https://loop.example.com/next'));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    await expectReason(
+      safeRedirectFetch<FakeResp>({
+        ...base,
+        fetchImpl,
+        url: 'https://loop.example.com/x',
+        lookup,
+        maxRedirects: 2,
+      }),
+      'too-many-redirects'
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // hop 0,1,2；hop=2 时 hop>=max 抛
+    await expect(
+      safeRedirectFetch<FakeResp>({
+        ...base,
+        fetchImpl: jest.fn().mockResolvedValue(makeResp(302, 'https://loop.example.com/next')),
+        url: 'https://loop.example.com/x',
+        lookup,
+      })
+    ).rejects.toThrow(/重定向次数超过上限/);
+  });
+
+  it('重定向目标非 http(s) → SafeFetchError(redirect-protocol)', async () => {
+    const fetchImpl = jest.fn().mockResolvedValueOnce(makeResp(302, 'ftp://x/y'));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    await expectReason(
+      safeRedirectFetch<FakeResp>({ ...base, fetchImpl, url: 'https://cdn.example.com/x', lookup }),
+      'redirect-protocol'
+    );
+  });
+
+  it('exemptFakeIp=true → 豁免 FlowZ FakeIP（IPv6 fc00::/18，经代理出口）', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(makeResp(200));
+    const lookup = jest.fn().mockResolvedValue(FAKEIP6);
+    const r = await safeRedirectFetch<FakeResp>({
+      ...base,
+      exemptFakeIp: true,
+      fetchImpl,
+      url: 'https://sub.example.com/x',
+      lookup,
+    });
+    expect(r.status).toBe(200); // FakeIP 豁免，不拒
+  });
+
+  it('exemptFakeIp=false → FakeIP(fc00::) 视作内网拒（直连不豁免）', async () => {
+    const fetchImpl = jest.fn();
+    const lookup = jest.fn().mockResolvedValue(FAKEIP6);
+    await expectReason(
+      safeRedirectFetch<FakeResp>({ ...base, fetchImpl, url: 'https://sub.example.com/x', lookup }),
+      'ssrf'
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('signal 透传到 fetchImpl', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(makeResp(200));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    const ctrl = new AbortController();
+    await safeRedirectFetch<FakeResp>({
+      ...base,
+      fetchImpl,
+      url: 'https://cdn.example.com/x',
+      lookup,
+      signal: ctrl.signal,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://cdn.example.com/x',
+      expect.objectContaining({ signal: ctrl.signal })
+    );
+  });
+
+  it('fetchImpl 网络错误 → 原样冒泡（非 SafeFetchError）', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const lookup = jest.fn().mockResolvedValue(PUBLIC);
+    let caught: unknown;
+    try {
+      await safeRedirectFetch<FakeResp>({
+        ...base,
+        fetchImpl,
+        url: 'https://cdn.example.com/x',
+        lookup,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(SafeFetchError);
+    expect((caught as Error).message).toBe('ECONNREFUSED');
+  });
+});

--- a/src/main/icon-protocol.ts
+++ b/src/main/icon-protocol.ts
@@ -5,10 +5,9 @@
  * 用户手动输入（add-custom-app），故复用 ssrf-guard 拦内网（仅实际经代理时豁免 FlowZ FakeIP，同订阅链路）。
  */
 import { protocol } from 'electron';
-import { promises as dnsPromises } from 'dns';
 import { ICON_PROXY_SCHEME } from '../shared/icon-proxy';
-import { assertHostAllowed } from '../shared/ssrf-guard';
 import { resolveUpdateProxyTarget } from '../shared/update-proxy';
+import { safeRedirectFetch, SafeFetchError } from './safe-redirect-fetch';
 import { APP_USER_AGENT } from '../shared/constants';
 import type { UpdateNetwork } from './services/UpdateNetwork';
 import type { UserConfig } from '../shared/types';
@@ -37,18 +36,6 @@ export interface IconProtocolDeps {
 // 远低于渲染，1s TTL 足够新鲜；proxyRunning / update-in 端口走 thunk（内存、廉价）每次取最新、不缓存。
 let cfgMsvpCache: { value: boolean | undefined; expiry: number } | null = null;
 const CFG_CACHE_TTL_MS = 1000;
-
-// 图标代理重定向上限（M2）：与订阅链路同口径，redirect:'manual' 自管链、逐跳过 SSRF guard。
-const MAX_ICON_REDIRECTS = 5;
-
-/** 释放响应体，避免重定向丢弃上一跳 body 时 socket/内存泄漏。 */
-async function drainBody(r: Response): Promise<void> {
-  try {
-    await r.body?.cancel();
-  } catch {
-    /* ignore */
-  }
-}
 
 /** app ready 后注册 flowz-icon:// handler（经 update-in 统一会话拉取图标，回退 direct）。 */
 export function registerIconProtocol(deps: IconProtocolDeps): void {
@@ -89,50 +76,22 @@ export function registerIconProtocol(deps: IconProtocolDeps): void {
       viaProxy = false; // 读 config 失败 → 直连兜底
     }
 
-    const lookupFn = (h: string) => dnsPromises.lookup(h, { all: true });
-    // SSRF：图标 URL 部分来自用户手动输入 → 拦内网/回环/link-local；仅实际经代理（socks）时豁免 FlowZ
-    // FakeIP（系统 DNS 把公网域名解析成假 IP，核按域名 socks5h 重解析、本机内网不可达），直连不豁免。
-    try {
-      await assertHostAllowed(target, lookupFn, viaProxy); // 首跳 guard
-    } catch {
-      return new Response(null, { status: 403 });
-    }
-
-    // M2：redirect:'manual' 自管重定向链——每跳 Location 重跑 SSRF guard（含 DNS 解析）通过才续跳，最多
-    // MAX_ICON_REDIRECTS 跳。默认 follow 会让首跳过 guard 后 30x 到内网不复检（direct 模式下用户自输入 URL
-    // 借此 SSRF）。首跳 target 已在上方 guard 过；循环内复检后续每一跳。
+    // SSRF + 逐跳 redirect 复检收口到 safeRedirectFetch（首跳 + 每跳 Location 过 assertHostAllowed）：图标 URL
+    // 部分来自用户手动输入，仅实际经代理（socks，本机内网不可达）时豁免 FlowZ FakeIP。安全拒绝按 reason 映射
+    // 状态码（协议非法→400 / SSRF→403 / 超上限→502）；fetchImpl 网络错误冒泡到末端 catch→502。
     try {
       const ses = await deps.updateNetwork.sessionFor(viaProxy, port);
-      let currentUrl = target.toString();
-      let response: Response | null = null;
-      for (let hop = 0; hop <= MAX_ICON_REDIRECTS; hop++) {
-        response = await ses.fetch(currentUrl, {
-          headers: { 'User-Agent': APP_USER_AGENT },
-          redirect: 'manual',
-        });
-        const loc =
-          response.status >= 300 && response.status < 400 ? response.headers.get('location') : null;
-        if (!loc) break; // 非 30x（或无 Location）→ 终态响应
-        await drainBody(response); // 释放上一跳 body
-        if (hop >= MAX_ICON_REDIRECTS) return new Response(null, { status: 502 }); // 超重定向上限
-        let nextObj: URL;
-        try {
-          nextObj = new URL(loc, currentUrl); // 相对 Location 以当前 URL 为基准解析
-        } catch {
-          return new Response(null, { status: 400 });
-        }
-        if (nextObj.protocol !== 'https:' && nextObj.protocol !== 'http:') {
-          return new Response(null, { status: 400 });
-        }
-        try {
-          await assertHostAllowed(nextObj, lookupFn, viaProxy); // 重定向目标过同一 guard（含 DNS 解析）
-        } catch {
-          return new Response(null, { status: 403 });
-        }
-        currentUrl = nextObj.toString();
-      }
-      return response ?? new Response(null, { status: 502 });
+      return await safeRedirectFetch<Response>({
+        fetchImpl: (u, init) => ses.fetch(u, init),
+        url: target.toString(),
+        userAgent: APP_USER_AGENT,
+        exemptFakeIp: viaProxy,
+      });
     } catch (e) {
+      if (e instanceof SafeFetchError) {
+        const status = e.reason === 'redirect-protocol' ? 400 : e.reason === 'ssrf' ? 403 : 502;
+        return new Response(null, { status });
+      }
       deps.logManager.addLog('warn', `图标代理拉取失败: ${e}`, 'IconProtocol');
       return new Response(null, { status: 502 });
     }

--- a/src/main/safe-redirect-fetch.ts
+++ b/src/main/safe-redirect-fetch.ts
@@ -1,0 +1,127 @@
+/**
+ * 带逐跳 SSRF 复检的安全重定向 fetch（订阅 / flowz-icon:// 统一安全拉取入口）。
+ *
+ * 抽出动机（审计类3）：订阅、图标协议各自内联同一段「redirect:'manual' 自管链 + 每跳 Location 过
+ * assertHostAllowed + drainBody 上一跳 + 重定向上限」。默认 redirect:'follow' 会让首 URL 过 guard 后被
+ * 30x 跳到内网而不复检，构成 SSRF 绕过；逐跳复检是安全关键，分散在多处易漏。收口到本 helper：新入口直接
+ * 复用，不会再出现「首 URL 校验了、redirect 没逐跳校验」。
+ *
+ * 错误以结构化 SafeFetchError(reason) 抛出，调用方按 reason 映射各自语义（icon → HTTP 状态码；订阅 → 中文
+ * 错误文案冒泡给 UI）。fetchImpl 自身的网络错误（非 SafeFetchError）原样冒泡，由调用方兜底。
+ */
+import { promises as dnsPromises } from 'dns';
+import { assertHostAllowed, type DnsLookupAll } from '../shared/ssrf-guard';
+
+/** 安全 fetch 拒绝原因：调用方据此映射 HTTP 状态码（icon）或区分错误类别。 */
+export type SafeFetchRejectReason = 'redirect-protocol' | 'ssrf' | 'too-many-redirects';
+
+/** redirect 链中的安全拒绝（区别于 fetchImpl 网络错误）。reason 供调用方映射状态码/文案。 */
+export class SafeFetchError extends Error {
+  constructor(
+    readonly reason: SafeFetchRejectReason,
+    message: string
+  ) {
+    super(message);
+    this.name = 'SafeFetchError';
+  }
+}
+
+/** helper 容忍的最小 Response 形状（Electron Response 与 net.fetch GlobalResponse 的同构子集）。 */
+interface MinimalResponse {
+  status: number;
+  headers: { get(name: string): string | null };
+  body?: { cancel(): Promise<unknown> } | null;
+}
+
+export interface SafeRedirectFetchOptions<R extends MinimalResponse> {
+  /** 绑定好会话的 fetch（Session.fetch.bind / net.fetch）；helper 固定下发 redirect:'manual'。 */
+  fetchImpl: (
+    url: string,
+    init: { headers: Record<string, string>; redirect: 'manual'; signal?: AbortSignal }
+  ) => Promise<R>;
+  /** 起始 URL，调用方已保证为 http(s)。 */
+  url: string;
+  userAgent: string;
+  /** 仅实际经代理（proxied socks 出口、本机内网不可达）时豁免 FlowZ FakeIP；直连/端口回退传 false。 */
+  exemptFakeIp: boolean;
+  /** 重定向上限（含首跳之外的跳数），默认 5。 */
+  maxRedirects?: number;
+  signal?: AbortSignal;
+  /** 注入 DNS 解析（默认 dnsPromises.lookup all），便于测试。 */
+  lookup?: DnsLookupAll;
+}
+
+const DEFAULT_MAX_REDIRECTS = 5;
+
+/** 释放响应体，避免丢弃上一跳 body 时 socket/内存泄漏。 */
+async function drainBody(r: MinimalResponse): Promise<void> {
+  try {
+    await r.body?.cancel();
+  } catch {
+    /* ignore */
+  }
+}
+
+/** SSRF guard：assertHostAllowed 抛错统一归类为 SafeFetchError('ssrf')，保留原始消息（含 hostname/解析结果）。 */
+async function guard(urlObj: URL, lookup: DnsLookupAll, exemptFakeIp: boolean): Promise<void> {
+  try {
+    await assertHostAllowed(urlObj, lookup, exemptFakeIp);
+  } catch (e) {
+    throw new SafeFetchError('ssrf', e instanceof Error ? e.message : String(e));
+  }
+}
+
+/**
+ * 首跳 + 每一跳 Location 都过 SSRF guard（含 DNS 逐 IP 判定），通过才续跳，最多 maxRedirects 跳。
+ * 返回终态（非 30x）response，其 body 未消费、交调用方处理；中途 30x 的 body 由本 helper drain。
+ */
+export async function safeRedirectFetch<R extends MinimalResponse>(
+  opts: SafeRedirectFetchOptions<R>
+): Promise<R> {
+  const maxRedirects = Math.max(0, opts.maxRedirects ?? DEFAULT_MAX_REDIRECTS);
+  const lookup: DnsLookupAll = opts.lookup ?? ((h) => dnsPromises.lookup(h, { all: true }));
+  let currentUrl = opts.url;
+
+  // 首跳 guard（起始 URL 协议由调用方保证为 http(s)）。
+  await guard(new URL(currentUrl), lookup, opts.exemptFakeIp);
+
+  let response: R | null = null;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    response = await opts.fetchImpl(currentUrl, {
+      headers: { 'User-Agent': opts.userAgent },
+      redirect: 'manual',
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    });
+
+    const loc =
+      response.status >= 300 && response.status < 400 ? response.headers.get('location') : null;
+    if (!loc) break; // 非 30x（或无 Location）→ 终态响应（body 交调用方消费）
+
+    // 确认是 30x 重定向：后续无论续跳还是抛错（超上限/协议非法/SSRF）都已离开本跳响应，先释放其 body
+    // 防 socket 泄漏（须在抛错分支之前 drain，否则被拒的那一跳 body 不被 cancel）。
+    await drainBody(response);
+    if (hop >= maxRedirects) {
+      throw new SafeFetchError(
+        'too-many-redirects',
+        `重定向次数超过上限（${maxRedirects}），已拒绝`
+      );
+    }
+    let nextObj: URL;
+    try {
+      nextObj = new URL(loc, currentUrl); // 相对 Location 以当前 URL 为基准解析
+    } catch {
+      throw new SafeFetchError('redirect-protocol', '重定向目标非法，已拒绝');
+    }
+    if (nextObj.protocol !== 'http:' && nextObj.protocol !== 'https:') {
+      throw new SafeFetchError(
+        'redirect-protocol',
+        '重定向目标协议不支持（仅允许 http/https），已拒绝'
+      );
+    }
+    await guard(nextObj, lookup, opts.exemptFakeIp); // 重定向目标过同一 guard（含 DNS 解析）
+    currentUrl = nextObj.toString();
+  }
+
+  // 循环 hop=0 必执行一次 fetchImpl，response 必非 null（maxRedirects 已 clamp ≥0）。
+  return response as R;
+}

--- a/src/main/services/SubscriptionService.ts
+++ b/src/main/services/SubscriptionService.ts
@@ -3,8 +3,7 @@ import { app, net, session, type Session } from 'electron';
 import type { ServerConfig, SubscriptionConfig } from '../../shared/types';
 import { ProtocolParser } from './ProtocolParser';
 import { LogManager } from './LogManager';
-import { promises as dnsPromises } from 'dns';
-import { assertHostAllowed } from '../../shared/ssrf-guard';
+import { safeRedirectFetch } from '../safe-redirect-fetch';
 import {
   CLASH_PROBE_RE,
   tryLoadClashDoc,
@@ -99,8 +98,6 @@ type SingboxOutbound = {
 export class SubscriptionService {
   // 响应体积上限：超大响应直接 OOM（兼缓解 YAML 锚点炸弹的输入面）。content-length 预检 + 读取后字节校验双闸。
   private static readonly MAX_BODY_BYTES = 10 * 1024 * 1024; // 10MB
-  // 重定向链最大跳数：每跳 Location 重跑 SSRF guard（含 DNS 解析），超过即拒（防无限跳/绕 guard）。
-  private static readonly MAX_REDIRECTS = 5;
   // 主订阅 fetch 超时（比 provider 15s 宽）：防 slow-loris 挂死、scheduler isRunning 永真卡死后续更新。
   private static readonly MAIN_FETCH_TIMEOUT_MS = 30_000;
 
@@ -544,62 +541,19 @@ export class SubscriptionService {
       fetchImpl = ds.fetch.bind(ds);
     }
 
-    // H2：redirect:'manual' 自管重定向链——每跳 Location 重跑 SSRF guard（含 H1 DNS 解析），
-    // 通过才续跳，最多 MAX_REDIRECTS 跳。默认 follow 会让首跳过 guard 后跳到内网不复检。
-    let currentUrl = url;
-    // 仅实际走 proxied（viaProxiedSession）才豁免 FlowZ FakeIP（TUN+FakeIP 下系统 DNS 把公网域名解析成假 IP，
-    // 经核反查真实；直连/端口不可用回退直连不豁免，防域名真实解析到本机内网的 SSRF）。
-    await assertHostAllowed(
-      parse(currentUrl),
-      (h) => dnsPromises.lookup(h, { all: true }),
-      viaProxiedSession
-    ); // H1：初始 URL 解析后逐 IP 校验
-
-    let response: GlobalResponse | null = null;
-    for (let hop = 0; hop <= SubscriptionService.MAX_REDIRECTS; hop++) {
-      response = await fetchImpl(currentUrl, {
-        headers: { 'User-Agent': userAgent },
-        redirect: 'manual',
-        ...(signal ? { signal } : {}),
-      });
-
-      // 30x：取 Location，重跑 guard 后续跳。
-      if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
-        if (hop >= SubscriptionService.MAX_REDIRECTS) {
-          throw new Error(`订阅重定向次数超过上限（${SubscriptionService.MAX_REDIRECTS}），已拒绝`);
-        }
-        const loc = response.headers.get('location')!;
-        // 相对 Location 以当前 URL 为基准解析；再校验协议 + 解析后 IP。
-        let nextObj: URL;
-        try {
-          nextObj = new URL(loc, currentUrl);
-        } catch {
-          throw new Error('订阅重定向目标非法，已拒绝');
-        }
-        if (nextObj.protocol !== 'http:' && nextObj.protocol !== 'https:') {
-          throw new Error('订阅重定向目标协议不支持（仅允许 http/https），已拒绝');
-        }
-        await assertHostAllowed(
-          nextObj,
-          (h) => dnsPromises.lookup(h, { all: true }),
-          viaProxiedSession
-        ); // 重定向目标过同一 guard（含 DNS 解析）
-        // 释放上一跳响应体，避免泄漏。
-        try {
-          await response.body?.cancel();
-        } catch {
-          // ignore
-        }
-        currentUrl = nextObj.toString();
-        continue;
-      }
-
-      break; // 非 30x（或无 Location）→ 终态响应
-    }
-
-    if (!response) {
-      throw new Error('订阅拉取未获得响应');
-    }
+    // H1+H2：初始 URL + 每跳 Location 都过 SSRF guard，收口到 safeRedirectFetch（首跳 + 逐跳复检防 redirect
+    // 跳到内网的 SSRF 绕过）。先 parse 校验协议（保留订阅特有「订阅地址协议不支持」文案 + 脱敏），再交 helper。
+    // 仅实际走 proxied（viaProxiedSession）才豁免 FlowZ FakeIP（系统 DNS 把公网域名解析成假 IP、经核反查真实、
+    // 本机内网不可达）；直连/端口回退不豁免，防域名真实解析到本机内网的 SSRF。helper 的安全拒绝（含「重定向
+    // 次数超过上限」「本机/内网」）按原文案冒泡给 UI。
+    parse(url); // 初始 URL 协议校验（http/https）
+    const response = await safeRedirectFetch<GlobalResponse>({
+      fetchImpl: (u, init) => fetchImpl(u, init),
+      url,
+      userAgent,
+      exemptFakeIp: viaProxiedSession,
+      ...(signal ? { signal } : {}),
+    });
     if (!response.ok) {
       throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
     }


### PR DESCRIPTION
## 背景

订阅拉取 `SubscriptionService.fetchSubscriptionText`（H1+H2）与图标协议 `flowz-icon://`（M2）此前各自内联同一段安全关键逻辑：

```
redirect:'manual' 自管重定向链
  → 首跳 + 每跳 Location 都过 assertHostAllowed（含 DNS 逐 IP 判定）
  → drainBody 上一跳
  → 重定向上限
```

默认 `redirect:'follow'` 会让首 URL 过 guard 后被 30x 跳到内网而**不复检**，构成 SSRF 绕过。逐跳复检是安全关键，分散在多处易在新入口漏写。

## 改动

- 新增 `src/main/safe-redirect-fetch.ts`：`safeRedirectFetch<R>(opts)` 收口「逐跳 SSRF 复检 + drainBody + 重定向上限」。安全拒绝抛结构化 `SafeFetchError(reason)`（`redirect-protocol` / `ssrf` / `too-many-redirects`），`assertHostAllowed` 抛错包成 `ssrf` 并透传原消息；`fetchImpl` 自身网络错误原样冒泡，由调用方兜底。
- 订阅 / 图标两处改调 helper，各自保留语义：
  - icon：按 `reason` 映射 HTTP 状态码（协议非法→400 / SSRF→403 / 其余→502），网络错误→log+502。
  - 订阅：错误文案冒泡给 UI，保留「订阅地址协议不支持」（`parse` 首跳协议校验）、「重定向次数超过上限」、「本机/内网」（assertHostAllowed 透传）。
- 30x 重定向确认后**即** drain 当前跳 body（含续跳与抛错路径），修复 redirect 抛错路径下 socket/body 不释放的泄漏面。

## 行为等价

- 首跳 + 每一跳 Location 都过 guard，无校验点丢失（对比抽取前两处旧逻辑逐分支核对）。
- `exemptFakeIp` 键于「实际经 proxied socks 出口」（icon=viaProxy 且 resolveUpdateProxyTarget 保证 viaProxy⟹port>0；订阅=viaProxiedSession，端口回退 direct 时不豁免）——防本机内网 SSRF。
- 终态 response body 不被 helper 消费，交调用方（icon 返 renderer / 订阅交 readBodyCapped + content-length/userInfo）。

## 验证

- 新增 `safe-redirect-fetch` 单测：首跳/逐跳 redirect SSRF 复检、重定向上限、协议非法、drainBody（含抛错路径）、signal 透传、FakeIP 豁免（仅经代理）、fetchImpl 网络错误原样冒泡。
- 订阅 / 图标既有单测全过（行为等价）。
- gate 全绿：tsc(main) 0、eslint 0、jest 2100 passed。