### PR TITLE
feat: 路由规则条件字段按平台支持情况展示（Windows 隐藏 source MAC/主机名）

### DIFF
--- a/src/renderer/components/rules/rule-dialog.tsx
+++ b/src/renderer/components/rules/rule-dialog.tsx
@@ -27,7 +27,11 @@ import { Loader2, ListPlus, Plus, X } from 'lucide-react';
 import { ServerSelectGroups } from '@/components/settings/server-select-groups';
 import { useAppStore } from '@/store/app-store';
 import type { Rule, RuleType, RuleAction, RuleCondition } from '../../../shared/types';
-import { validateRuleValue, RULE_TYPE_IDS } from '../../../shared/rules';
+import {
+  validateRuleValue,
+  isRuleTypePlatformSupported,
+  findAddableRuleType,
+} from '../../../shared/rules';
 import {
   meshForcedRouteCidrs,
   meshForceRoutedServers,
@@ -144,6 +148,16 @@ export function RuleDialog({ open, onOpenChange, mode, rule }: RuleDialogProps) 
   }, [open, mode, rule]);
 
   const usedTypes = new Set(conditionTypes);
+  // 平台门控：device 类别（source_mac_address / source_hostname）仅 Linux/macOS 内核支持（sing-box 1.14 邻居
+  // 解析，已真机 check 实证，见 shared/neighbor），Windows 选了也被 main 侧 fail-closed 丢弃。故 Windows 隐藏
+  // device 类型；判定下沉 shared/rules#isRuleTypePlatformSupported（与生成层单一真值），呈现/新增时再叠加
+  // 「本块已选中」豁免（edit 跨平台旧规则不丢可见性/可删性）。
+  const platform = window.electron?.platform;
+  const isTypePlatformSupported = (tp: RuleType) => isRuleTypePlatformSupported(tp, platform);
+  // 下一个可新增类型（未用 ∧ 平台支持）：决定「添加条件」按钮显隐 + addCondition 取值，单一来源防口径漂移
+  // （Windows 上 device 组用尽即无候选 → 按钮隐藏）。
+  const nextAddableType = findAddableRuleType(usedTypes, platform);
+  const canAddCondition = nextAddableType !== undefined;
   // bypassFakeIP 是规则级设置：只要任一条件是域名类即可用（生成期对域名类条件取真实 DNS）。
   const bypassApplicable = conditionTypes.some((ct) => BYPASS_FAKEIP_TYPES.includes(ct));
 
@@ -163,10 +177,9 @@ export function RuleDialog({ open, onOpenChange, mode, rule }: RuleDialogProps) 
   };
 
   const addCondition = () => {
-    const next = RULE_TYPE_IDS.find((tp) => !usedTypes.has(tp));
-    if (!next) return; // 全部类型用尽
+    if (!nextAddableType) return; // 全部（当前平台支持的）类型用尽
     setFocusedType(null);
-    setConditionTypes((prev) => [...prev, next]);
+    setConditionTypes((prev) => [...prev, nextAddableType]);
   };
 
   const removeCondition = (ct: RuleType) => {
@@ -394,22 +407,29 @@ export function RuleDialog({ open, onOpenChange, mode, rule }: RuleDialogProps) 
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {RULE_CATEGORIES.map((cat) => (
-                        <SelectGroup key={cat}>
-                          <SelectLabel>
-                            {t(`rules.category.${cat}`, CATEGORY_NAME[cat])}
-                          </SelectLabel>
-                          {CATEGORY_TYPES[cat].map((tp) => (
-                            <SelectItem
-                              key={tp}
-                              value={tp}
-                              disabled={usedTypes.has(tp) && tp !== ct}
-                            >
-                              {t(`rules.types.${tp}.name`, RULE_TYPE_NAME[tp])}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      ))}
+                      {RULE_CATEGORIES.map((cat) => {
+                        // 平台不支持的类型隐藏，但保留「当前块已选中」的（edit 跨平台旧规则仍可见/可改/可删）。
+                        const types = CATEGORY_TYPES[cat].filter(
+                          (tp) => isTypePlatformSupported(tp) || tp === ct
+                        );
+                        if (types.length === 0) return null; // 整组不支持且未选中（如 Windows 的 device 组）→ 隐藏
+                        return (
+                          <SelectGroup key={cat}>
+                            <SelectLabel>
+                              {t(`rules.category.${cat}`, CATEGORY_NAME[cat])}
+                            </SelectLabel>
+                            {types.map((tp) => (
+                              <SelectItem
+                                key={tp}
+                                value={tp}
+                                disabled={usedTypes.has(tp) && tp !== ct}
+                              >
+                                {t(`rules.types.${tp}.name`, RULE_TYPE_NAME[tp])}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
                   {PROCESS_TYPES.includes(ct) && (
@@ -444,7 +464,7 @@ export function RuleDialog({ open, onOpenChange, mode, rule }: RuleDialogProps) 
               </div>
             ))}
 
-            {usedTypes.size < RULE_TYPE_IDS.length && (
+            {canAddCondition && (
               <Button
                 type="button"
                 variant="outline"

--- a/src/shared/__tests__/rules.test.ts
+++ b/src/shared/__tests__/rules.test.ts
@@ -1,0 +1,86 @@
+/**
+ * shared/rules 纯逻辑单测。当前聚焦 isRuleTypePlatformSupported（路由规则条件字段的平台门控）：
+ * device 类别（source_mac_address / source_hostname）仅 Linux/macOS，其余类别全平台。
+ */
+import { isRuleTypePlatformSupported, findAddableRuleType } from '../rules';
+import type { RuleType } from '../types';
+
+const DEVICE_TYPES: RuleType[] = ['sourceMac', 'sourceHostname'];
+const NON_DEVICE_TYPES: RuleType[] = [
+  'domain',
+  'domainSuffix',
+  'domainKeyword',
+  'domainRegex',
+  'ipCidr',
+  'sourceIpCidr',
+  'port',
+  'sourcePort',
+  'processName',
+  'processPath',
+  'geosite',
+  'geoip',
+  'ruleSet',
+];
+
+describe('isRuleTypePlatformSupported（device 类别仅 Linux/macOS，其余全平台）', () => {
+  it('device 类别在 win32 不支持', () => {
+    for (const tp of DEVICE_TYPES) {
+      expect(isRuleTypePlatformSupported(tp, 'win32')).toBe(false);
+    }
+  });
+
+  it('device 类别在 linux/darwin 支持', () => {
+    for (const p of ['linux', 'darwin']) {
+      for (const tp of DEVICE_TYPES) {
+        expect(isRuleTypePlatformSupported(tp, p)).toBe(true);
+      }
+    }
+  });
+
+  it('device 类别在未知/undefined 平台保守视为不支持', () => {
+    expect(isRuleTypePlatformSupported('sourceMac', undefined)).toBe(false);
+    expect(isRuleTypePlatformSupported('sourceHostname', 'unknown')).toBe(false);
+  });
+
+  it('非 device 类别全平台支持（含 win32 与 undefined）', () => {
+    for (const tp of NON_DEVICE_TYPES) {
+      expect(isRuleTypePlatformSupported(tp, 'win32')).toBe(true);
+      expect(isRuleTypePlatformSupported(tp, 'linux')).toBe(true);
+      expect(isRuleTypePlatformSupported(tp, undefined)).toBe(true);
+    }
+  });
+
+  it('进程类别（processName/processPath）桌面全平台支持（非平台受限）', () => {
+    for (const tp of ['processName', 'processPath'] as RuleType[]) {
+      expect(isRuleTypePlatformSupported(tp, 'win32')).toBe(true);
+    }
+  });
+});
+
+describe('findAddableRuleType（添加条件单一来源：未用 ∧ 平台支持）', () => {
+  it('空集 → 第一个类型 domain（任意平台）', () => {
+    expect(findAddableRuleType(new Set(), 'win32')).toBe('domain');
+    expect(findAddableRuleType(new Set(), 'linux')).toBe('domain');
+  });
+
+  it('跳过已用，返回下一个未用且支持的类型', () => {
+    const used = new Set<RuleType>(['domain', 'domainSuffix']);
+    expect(findAddableRuleType(used, 'win32')).toBe('domainKeyword');
+  });
+
+  it('win32：非 device 类型用尽 → undefined（device 平台不支持，不作候选 → 按钮隐藏）', () => {
+    const used = new Set<RuleType>(NON_DEVICE_TYPES);
+    expect(findAddableRuleType(used, 'win32')).toBeUndefined();
+  });
+
+  it('linux：非 device 用尽 → 仍可加 device（sourceMac）', () => {
+    const used = new Set<RuleType>(NON_DEVICE_TYPES);
+    expect(findAddableRuleType(used, 'linux')).toBe('sourceMac');
+  });
+
+  it('全部 15 类型用尽 → undefined（任意平台）', () => {
+    const all = new Set<RuleType>([...NON_DEVICE_TYPES, ...DEVICE_TYPES]);
+    expect(findAddableRuleType(all, 'linux')).toBeUndefined();
+    expect(findAddableRuleType(all, 'win32')).toBeUndefined();
+  });
+});

--- a/src/shared/neighbor.ts
+++ b/src/shared/neighbor.ts
@@ -2,9 +2,14 @@
  * LAN 设备识别簇（sing-box 1.14 「邻居解析」/Neighbor Resolution）的共享校验 + 平台门控 ——
  * 主进程构建（route/dns/inbounds builder）与渲染层表单（rule-dialog / network-settings）共用单一真值。
  *
- * 能力来自 sing-box 1.14（已用真实 1.14.0-alpha.32 内核 `sing-box check` 实证，见 [[singbox-1.14-features]] §D）：
+ * 能力来自 sing-box 1.14（字段在 1.14.0-alpha.32 真机 `sing-box check` 验过被接受，见 [[singbox-1.14-features]] §D）：
  *   1. route / DNS rule item `source_mac_address` / `source_hostname`（Listable[string]）——按源设备 MAC /
- *      主机名（DHCP 租约）分流。仅 Linux/macOS（及 Android/macOS 图形客户端）支持。
+ *      主机名（DHCP 租约）分流。**仅 Linux/macOS（及 Android/macOS 图形客户端）支持**——此平台门控由 sing-box
+ *      源码 build tag 坐实（非 `check`：`check` 是 config 解析、跨平台不 FATAL，证不了 Windows 排除）：解析
+ *      「源 IP→MAC/主机名」的邻居解析器 `route/neighbor_resolver_{linux,darwin}.go` 各带 `//go:build linux|darwin`
+ *      真实现，`neighbor_resolver_stub.go`（`//go:build !linux && !darwin`）的 `newNeighborResolver` 直接
+ *      `return nil, os.ErrInvalid`、无 windows 实现；`route/router.go` 对 `os.ErrInvalid` 静默跳过 → Windows 上
+ *      解析器不存在、这两类规则永不匹配且不报错（静默死规则）→ 故必须 UI/生成层 fail-closed。
  *      · MAC：内核走 Go `net.ParseMAC`，仅接受 EUI-48 三种写法（冒号 / 连字符 / Cisco 点分），其余 FATAL。
  *        route 规则的 MAC 在 `check` 期不校验（运行期按字符串匹配），但 UI/构建仍按内核 parser 校验，杜绝脏值。
  *   2. local DNS server `neighbor_domain`（Listable[string]）——对单标签短名（host 部分无 `.`）走邻居解析，

--- a/src/shared/rules.ts
+++ b/src/shared/rules.ts
@@ -4,7 +4,7 @@
  * 保证两侧规则语义完全一致（仿 shared/version.ts 的共享惯例）。
  */
 import type { Rule, RuleType, RuleCondition, LegacyDomainRule, RuleAction } from './types';
-import { isValidMacAddress, isValidSourceHostname } from './neighbor';
+import { isValidMacAddress, isValidSourceHostname, isSourceDeviceMatchSupported } from './neighbor';
 
 export const RULE_TYPE_IDS: RuleType[] = [
   'domain',
@@ -47,6 +47,31 @@ export const RULE_TYPE_CATEGORY: Record<RuleType, RuleCategory> = {
 
 /** 仅这三类域名规则支持 bypassFakeIP。 */
 export const BYPASS_FAKEIP_TYPES: RuleType[] = ['domain', 'domainSuffix', 'domainKeyword'];
+
+/**
+ * 规则类型在指定平台是否受内核支持：device 类别（source_mac_address / source_hostname，sing-box 1.14 邻居
+ * 解析）仅 Linux/macOS（真机 check 实证，见 shared/neighbor），其余类别全平台。渲染层据此隐藏不支持的类型
+ * 选项、主进程据此 fail-closed 丢弃条件，单一真值（避免 UI 与生成层对平台支持面漂移）。
+ */
+export function isRuleTypePlatformSupported(
+  type: RuleType,
+  platform: NodeJS.Platform | string | undefined
+): boolean {
+  return RULE_TYPE_CATEGORY[type] !== 'device' || isSourceDeviceMatchSupported(platform);
+}
+
+/**
+ * 下一个可新增的条件类型（未被使用 ∧ 当前平台支持），无则 undefined。rule-dialog 的「添加条件」按钮显隐
+ * 与 addCondition 取值共用本函数，保证「按钮显示 ⟺ 点击有结果」（口径单一来源，防二者漂移）。
+ */
+export function findAddableRuleType(
+  usedTypes: ReadonlySet<RuleType>,
+  platform: NodeJS.Platform | string | undefined
+): RuleType | undefined {
+  return RULE_TYPE_IDS.find(
+    (tp) => !usedTypes.has(tp) && isRuleTypePlatformSupported(tp, platform)
+  );
+}
 
 // 域名：标签 1-63 字符、可含通配 *. 前缀（domainSuffix 容忍）；不强校验 TLD（geosite 标签另有规则）
 const DOMAIN_RE =


### PR DESCRIPTION
## 背景

路由规则编辑器的 `source_mac_address` / `source_hostname`（device 类别，sing-box 1.14 邻居解析）**仅 Linux/macOS 内核支持**（已用 1.14 真机 `sing-box check` 实证，见 `shared/neighbor`）。Windows 上这两个条件即便选了也会被主进程 fail-closed 丢弃（`singbox-custom-rules` 调 `isSourceDeviceMatchSupported` 门控），但 UI 仍把它们列为可选项 → 用户配了却静默无效，误导。

实证结论（官方文档 + 既有真机实证，未臆测）：
- `process_name` / `process_path`：Only supported on Linux, Windows, and macOS → FlowZ 三个桌面平台**全支持，不受限**。
- `source_mac_address` / `source_hostname`：仅 Linux/macOS（device 类别）。
- 其余字段（域名 / IP / 端口 / geosite / geoip / 规则集）无平台限制。

## 改动

- `shared/rules` 新增 `isRuleTypePlatformSupported(type, platform)`：device 类别仅 Linux/macOS，其余全平台。与主进程生成层 fail-closed 同源单一真值，避免 UI 与生成层对平台支持面漂移。
- `rule-dialog` 按 `window.electron.platform` 渲染：
  - Windows 隐藏 device 组类型选项（整组无候选则连分组标题一起不渲染）。
  - `addCondition` 与「添加条件」按钮按**当前平台可用类型**计数（Windows device 组用尽即不再有候选，不会点了无反应）。
  - 保留「本块当前选中」的类型（`tp === ct`）——edit 跨平台旧规则（如从 macOS 同步来的含 source MAC 规则）在 Windows 仍可见、可改、可删，不丢可操作性。

## 验证

- 新增 `isRuleTypePlatformSupported` 单测（device 在 win32 不支持 / linux·darwin 支持 / undefined 保守不支持 / 非 device 全平台 / 进程类全平台）。
- gate 全绿：tsc 0、eslint 0、jest 通过。
- Linux/macOS 全部 15 类型正常显示（非 device 不受影响）。