### PR TITLE
chore: 内核升级 1.14.0-alpha.35 → alpha.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowz",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "FlowZ - 简洁现代的跨平台代理客户端",
   "main": "dist/main/main/index.js",
   "scripts": {

--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,11 +1,11 @@
 {
-  "bundledCoreVersion": "1.14.0-alpha.35",
+  "bundledCoreVersion": "1.14.0-alpha.36",
   "cronetVersion": "v148.0.7778.96-1",
   "coreArchiveSha256": {
-    "linux": "b5ed3e0c4af654099812dfa0dd0740ceaa3abf0b02dddf4060c40c3006461e97",
-    "win": "358a2de32c2b94f728233ded0499fb4a25ab23603c3619cb50e9520b23c75595",
-    "mac-x64": "f05aa7a8613578687f338571c1123cc42b9662c200b0bd3de99e80689ffc1a23",
-    "mac-arm64": "59379726b4a3f171cec819a6263645e131b1975a7f4f72c967612d0c3f498422"
+    "linux": "8bbe5a10170d906c14e439ad495de290a9f755d8de76ffc08e61e290a0fe691f",
+    "win": "1f7532376b9b8fcf080f524201eb406d672841b543d7337a6ad0d2cde10ef43d",
+    "mac-x64": "57c7c2fc6e9dd1f6f00537d34861d00b354874865a648489d0d5f9bc6aabf128",
+    "mac-arm64": "6dc18eb29b6d25c894ec31e554bf7aec8f8178fcb793339768a63b0c23fa2ad9"
   },
   "cronetArchiveSha256": {
     "linux": "dc7293a929dffa695aae1a89555e7366158fa0a3f40bbe3012d445bc05c99672",


### PR DESCRIPTION
## 改动

- `core-manifest.json`：`bundledCoreVersion` 1.14.0-alpha.35 → **alpha.36**，并同步 4 平台 `coreArchiveSha256`（值 = 官方 sing-box release REST API 的 asset digest，`gh api repos/SagerNet/sing-box/releases/tags/v1.14.0-alpha.36 --jq '.assets[]|{name,digest}'`）。
- `cronetVersion` 保持 `v148.0.7778.96-1`：alpha 小版本不动 cronet-go（Chromium 稳定 C ABI），按既有耦合策略仅当 naive 报符号错才升。

## 验证（本地二进制已同步）

- `node scripts/fetch-core.mjs --force`：4 平台 archive 下载 + 新 pin 逐字节校验 **4 ready / 0 failed**。
- 本地 linux 二进制实测：`sing-box version` → **1.14.0-alpha.36**。
- gate：tsc 0、jest 2130 passed / 37 snapshots（`version-handlers-t10` 等动态读 manifest，无硬编版本断言回归）。

> 随包二进制走 fetch（不入库，PR #177 模式）；本 PR 只改 manifest，CI fresh checkout 会按新版本+pin 重新拉取校验。