### PR TITLE
fix: 跨平台一致性（Mac/Win/Linux 行为对齐）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1485,15 +1485,15 @@ if (gotTheLock) {
       getPrivacyMode,
     });
 
-    // macOS/Linux 关机/重启早期钩子：powerMonitor 'shutdown'（win32 不发此事件，注销/关机走窗口级
-    // 'session-end'，见 createWindow）。同步兜底：停代理 + marker 门控关系统代理（syncCleanupOnExit 内），
-    // 防关机过快时 SIGTERM→cleanupResources 异步链跑不完导致 networksetup/gsettings 代理残留。
-    if (process.platform === 'darwin' || process.platform === 'linux') {
-      powerMonitor.on('shutdown', () => {
-        logManager.addLog('warn', 'OS shutdown detected (powerMonitor), syncing cleanup', 'Main');
-        syncCleanupOnExit();
-      });
-    }
+    // 关机/重启早期钩子：powerMonitor 'shutdown'（跨平台 review 🟡-5：原仅 darwin/linux，补 win32）。
+    // 三平台都注册——Windows 系统关机/重启时 Electron 也发此事件（原注释"win32 不发"仅对注销 logoff 成立，
+    // 关机是发的）。多一道兜底防 SIGTERM→cleanupResources 异步链跑不完导致系统代理/DNS 残留。
+    // syncCleanupOnExit 内 marker 门控，无 marker 时 no-op，多注册无害。
+    // 注：Windows 注销（logoff）仍走窗口级 'session-end'（见 createWindow），此处不覆盖 logoff。
+    powerMonitor.on('shutdown', () => {
+      logManager.addLog('warn', 'OS shutdown detected (powerMonitor), syncing cleanup', 'Main');
+      syncCleanupOnExit();
+    });
 
     // Dock 点击 / Finder·Spotlight 重新打开运行中的 app（macOS 经 activate，非 second-instance）。
     // hasVisibleWindows=false 涵盖窗口隐藏/最小化/已销毁三态；showWindow 已分别处理（show / restore / 重建）。

--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -6,7 +6,14 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
-import type { UserConfig, Rule, RuleCondition, LogLevel, Protocol } from '../../shared/types';
+import type {
+  UserConfig,
+  Rule,
+  RuleCondition,
+  LogLevel,
+  Protocol,
+  ProxyModeType,
+} from '../../shared/types';
 import type { LogManager } from './LogManager';
 import { getConfigPath } from '../utils/paths';
 import { writeFileAtomic } from '../utils/atomic-write';
@@ -524,6 +531,10 @@ export class ConfigManager implements IConfigManager {
     if (!modeTypeLower || !['systemproxy', 'tun', 'manual'].includes(modeTypeLower)) {
       throw new Error('proxyModeType must be systemProxy, tun, or manual');
     }
+    // 跨平台 review H2（根治）：回写归一化小写值。validateConfig 是 loadConfig/saveConfig 的必经校验
+    //（saveConfig 内部亦调本校验），回写后磁盘值恒小写 → 全栈 15+ 处 === 'tun' 谓词可信，消除
+    // "大小写不规范致日志静默丢失/幽灵文件"风险。原仅校验不回写，renderer 仍用 toLowerCase 反证假设不可靠。
+    config.proxyModeType = modeTypeLower as ProxyModeType;
 
     // subscriptionProxyPolicy（三态可选）sanitize（不 throw，与 dnsTimeoutMs/CIDR 同标准防整配置回落）：
     // 非 'follow'|'proxy'|'direct' 的脏值（手改 / 损坏备份跨设备导入，见 config-portability）→ 删除该字段，落回默认 follow。

--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -526,15 +526,22 @@ export class ConfigManager implements IConfigManager {
       throw new Error('proxyMode must be global, smart, or direct');
     }
 
-    // 验证 proxyModeType（不区分大小写）
+    // 验证 proxyModeType（不区分大小写），并回写到**权威 camelCase 规范值**。validateConfig 是
+    // loadConfig/saveConfig 的必经校验，回写后磁盘值恒为规范形 → 全栈精确比较（=== 'systemProxy' /
+    // === 'tun' / === 'manual'）可信，消除大小写漂移致日志静默丢失/幽灵文件风险。
+    // 关键：必须归一到 camelCase 'systemProxy'（ProxyModeType 联合类型与 ProxyManager 谓词均为
+    // camelCase），不能盲 toLowerCase——后者把 'systemProxy' 变 'systemproxy'，使 ProxyManager.ts
+    // 的 === 'systemProxy' 恒 false、系统代理分支永不命中（系统代理从不设置 → 流量直连泄漏）。
+    const CANONICAL_MODE_TYPE: Record<string, ProxyModeType> = {
+      systemproxy: 'systemProxy',
+      tun: 'tun',
+      manual: 'manual',
+    };
     const modeTypeLower = config.proxyModeType?.toLowerCase();
-    if (!modeTypeLower || !['systemproxy', 'tun', 'manual'].includes(modeTypeLower)) {
+    if (!modeTypeLower || !(modeTypeLower in CANONICAL_MODE_TYPE)) {
       throw new Error('proxyModeType must be systemProxy, tun, or manual');
     }
-    // 跨平台 review H2（根治）：回写归一化小写值。validateConfig 是 loadConfig/saveConfig 的必经校验
-    //（saveConfig 内部亦调本校验），回写后磁盘值恒小写 → 全栈 15+ 处 === 'tun' 谓词可信，消除
-    // "大小写不规范致日志静默丢失/幽灵文件"风险。原仅校验不回写，renderer 仍用 toLowerCase 反证假设不可靠。
-    config.proxyModeType = modeTypeLower as ProxyModeType;
+    config.proxyModeType = CANONICAL_MODE_TYPE[modeTypeLower];
 
     // subscriptionProxyPolicy（三态可选）sanitize（不 throw，与 dnsTimeoutMs/CIDR 同标准防整配置回落）：
     // 非 'follow'|'proxy'|'direct' 的脏值（手改 / 损坏备份跨设备导入，见 config-portability）→ 删除该字段，落回默认 follow。

--- a/src/main/services/SystemDnsManager.ts
+++ b/src/main/services/SystemDnsManager.ts
@@ -374,11 +374,15 @@ export class MacOSSystemDns extends SystemDnsBase {
     const { stdout } = await execAsync('networksetup -listallnetworkservices', {
       timeout: DNS_CMD_TIMEOUT_MS,
     });
-    return stdout
-      .split('\n')
-      .slice(1)
-      .map((l) => l.trim())
-      .filter((l) => l && !l.startsWith('*'));
+    return (
+      stdout
+        .split('\n')
+        .slice(1)
+        .map((l) => l.trim())
+        // 跨平台 review 🟡-2：与 SystemProxyManager.getNetworkServices 口径统一，排除 Bluetooth PAN——
+        // 否则 DNS 接管会把 DNS 写到蓝牙网络（PAN/个人热点），关闭后可能残留。
+        .filter((l) => l && !l.startsWith('*') && !l.includes('Bluetooth'))
+    );
   }
 
   protected async readDns(service: string): Promise<string[]> {
@@ -397,12 +401,16 @@ export class MacOSSystemDns extends SystemDnsBase {
 
   protected listTargetsSync(): string[] {
     const { execSync } = require('child_process');
-    return execSync('networksetup -listallnetworkservices', { timeout: DNS_CMD_TIMEOUT_MS })
-      .toString()
-      .split('\n')
-      .slice(1)
-      .map((l: string) => l.trim())
-      .filter((l: string) => l && !l.startsWith('*'));
+    return (
+      execSync('networksetup -listallnetworkservices', { timeout: DNS_CMD_TIMEOUT_MS })
+        .toString()
+        .split('\n')
+        .slice(1)
+        .map((l: string) => l.trim())
+        // 跨平台 review 🟡-2/M5：与 async listTargets 口径统一，排除 Bluetooth PAN——否则关机还原
+        //（restoreDnsSync 走此 sync 路径）仍会往蓝牙网络写 DNS，async/sync 服务集不一致。
+        .filter((l: string) => l && !l.startsWith('*') && !l.includes('Bluetooth'))
+    );
   }
 
   protected applyDnsSync(service: string, ips: string[]): void {

--- a/src/main/services/SystemProxyManager.ts
+++ b/src/main/services/SystemProxyManager.ts
@@ -99,13 +99,14 @@ export abstract class SystemProxyBase implements ISystemProxyManager {
    * 写入持久化 marker（enableProxy 成功后调用）
    * 记录"系统代理由 FlowZ 设置"，供崩溃/强杀后下次启动恢复与退出兜底门控使用。
    * 同步 fs API（文件极小）；失败仅告警，绝不抛出影响代理设置结果。
+   * originalSettings 可选：保存 enable 前的原始代理快照，供 disableProxySync（关机新建实例路径，
+   * 跨平台 review H1-2）读回恢复——否则关机时实例 originalSettings 为 null，恢复分支不可达。
    */
-  protected writeMarker(ourHostPort: string): void {
+  protected writeMarker(ourHostPort: string, originalSettings?: SystemProxyStatus | null): void {
     try {
-      fs.writeFileSync(
-        SystemProxyBase.getMarkerPath(),
-        JSON.stringify({ ourHostPort, at: Date.now() })
-      );
+      const data: Record<string, unknown> = { ourHostPort, at: Date.now() };
+      if (originalSettings) data.originalSettings = originalSettings;
+      fs.writeFileSync(SystemProxyBase.getMarkerPath(), JSON.stringify(data));
     } catch (error) {
       this.log('warn', `写入系统代理 marker 失败: ${error}`);
     }
@@ -129,12 +130,15 @@ export abstract class SystemProxyBase implements ISystemProxyManager {
   }
 
   /** 读取持久化 marker；文件不存在或内容损坏一律返回 null（启动恢复/退出门控用） */
-  static readMarker(): { ourHostPort: string } | null {
+  static readMarker(): { ourHostPort: string; originalSettings?: SystemProxyStatus } | null {
     try {
       const raw = fs.readFileSync(SystemProxyBase.getMarkerPath(), 'utf-8');
       const data = JSON.parse(raw);
       if (data && typeof data.ourHostPort === 'string' && data.ourHostPort) {
-        return { ourHostPort: data.ourHostPort };
+        return {
+          ourHostPort: data.ourHostPort,
+          ...(data.originalSettings ? { originalSettings: data.originalSettings } : {}),
+        };
       }
       return null;
     } catch {
@@ -776,9 +780,15 @@ export class LinuxSystemProxy extends SystemProxyBase {
   ): Promise<void> {
     this.log('info', '正在设置 Linux 系统代理');
 
-    // 保存原始设置
+    // 保存原始设置（防自指：已指向我们自己的代理 → 视为无原始，杜绝 disable restore 死端口致断网。
+    // 跨平台对齐：Win/macOS enableProxy 都用 stripSelf，原 Linux 直接赋值裸 getProxyStatus，
+    // marker 残留指向自身时 originalSettings 会捕获自身代理，disable 恢复回去 = 死端口断网）。
     try {
-      this.originalSettings = await this.getProxyStatus();
+      this.originalSettings = SystemProxyBase.stripSelf(
+        await this.getProxyStatus(),
+        address,
+        httpPort
+      );
       this.log('info', '已保存原始代理设置');
     } catch (error) {
       this.log('warn', `无法获取原始代理设置: ${error}`);
@@ -811,8 +821,9 @@ export class LinuxSystemProxy extends SystemProxyBase {
         },
         { maxRetries: 1, delay: 500 }
       );
-      // 持久化 marker：标记系统代理由 FlowZ 设置（崩溃/强杀后下次启动据此恢复）
-      this.writeMarker(`${address}:${httpPort}`);
+      // 持久化 marker：标记系统代理由 FlowZ 设置（崩溃/强杀后下次启动据此恢复）+ 携带 originalSettings
+      // 快照（跨平台 review H1-2：disableProxySync 关机时新建实例 originalSettings=null，需从 marker 读回恢复）。
+      this.writeMarker(`${address}:${httpPort}`, this.originalSettings);
       this.log('info', 'Linux 系统代理设置成功');
     } catch (error) {
       this.log('error', `设置 Linux 系统代理失败: ${error}`);
@@ -821,18 +832,61 @@ export class LinuxSystemProxy extends SystemProxyBase {
   }
 
   /**
+   * 从 originalSettings.httpProxy（"host:port"）健壮拆分出 host/port。
+   * getProxyStatus 拼的是 `${host}:${port}`，host 为合法 IPv4/域名（不含 ':'），故用 lastIndexOf(':') 拆 port。
+   * 缺端口（无 ':' 或端口非数字）→ 返回 null，调用方据此不进恢复分支（置 none）。
+   */
+  private static splitHostPort(httpProxy?: string): { host: string; port: number } | null {
+    if (!httpProxy) return null;
+    const idx = httpProxy.lastIndexOf(':');
+    if (idx <= 0) return null; // 无 ':' 或以 ':' 开头（无 host）
+    const host = httpProxy.slice(0, idx);
+    const port = parseInt(httpProxy.slice(idx + 1), 10);
+    if (!host || !Number.isFinite(port) || port <= 0 || port > 65535) return null;
+    return { host, port };
+  }
+
+  /**
    * 禁用系统代理
    */
   async disableProxy(): Promise<void> {
     this.log('info', '正在禁用 Linux 系统代理');
     try {
-      await execAsync('gsettings set org.gnome.system.proxy mode "none"');
-      this.log('info', '已禁用系统代理');
+      // 三平台对称（跨平台 review 🔴High）：原仅置 mode=none 丢弃 originalSettings，用户原始代理配置永久丢失
+      //（Win/macOS disableProxy 都 restoreProxySettings）。有原始快照（manual + host:port）→ 恢复；否则置 none。
+      const restored = await this.restoreOriginalProxyAsync();
+      if (!restored) {
+        await execAsync('gsettings set org.gnome.system.proxy mode "none"');
+        this.log('info', '已禁用系统代理');
+      }
       // 拆除成功 → 删除持久化 marker
       this.clearMarker();
     } catch (error) {
-      this.log('error', `禁用 Linux 系统代理失败: ${error}`);
+      // 跨平台 review M3：恢复/禁用失败时不删 marker——保留供下次启动重试（与 macOS disableProxySync
+      // allOff 才删 marker 策略一致）。原 catch 静默吞错 + marker 已清 → 用户原始代理丢失无任何可观测信号。
+      this.log('error', `禁用 Linux 系统代理失败（保留 marker 供下次重试）: ${error}`);
     }
+  }
+
+  /**
+   * 异步恢复原始代理配置（disableProxy 用）。返回 true=已恢复原始代理；false=无有效快照（调用方置 none）。
+   */
+  private async restoreOriginalProxyAsync(): Promise<boolean> {
+    const hp = LinuxSystemProxy.splitHostPort(this.originalSettings?.httpProxy);
+    if (!this.originalSettings?.enabled || !hp) return false;
+    this.log('info', '正在恢复原始代理设置');
+    // host/port 同步恢复到 http/https/socks（对齐 enableProxy 写法；getProxyStatus 仅采集 http，三者用同 host:port）
+    await execAsync('gsettings set org.gnome.system.proxy mode "manual"');
+    await execAsync(`gsettings set org.gnome.system.proxy.http host "${hp.host}"`);
+    await execAsync(`gsettings set org.gnome.system.proxy.http port ${hp.port}`);
+    await execAsync('gsettings set org.gnome.system.proxy.http enabled true');
+    await execAsync(`gsettings set org.gnome.system.proxy.https host "${hp.host}"`);
+    await execAsync(`gsettings set org.gnome.system.proxy.https port ${hp.port}`);
+    await execAsync(`gsettings set org.gnome.system.proxy.socks host "${hp.host}"`);
+    await execAsync(`gsettings set org.gnome.system.proxy.socks port ${hp.port}`);
+    this.originalSettings = null;
+    this.log('info', '已恢复原始代理设置');
+    return true;
   }
 
   /**
@@ -851,7 +905,10 @@ export class LinuxSystemProxy extends SystemProxyBase {
       const portResult = await execAsync('gsettings get org.gnome.system.proxy.http port');
 
       const host = hostResult.stdout.replace(/'/g, '').trim();
-      const port = portResult.stdout.trim();
+      // gsettings 对 guint 类型输出带 GVariant 类型前缀（如 "uint32 8080"），剥前缀取纯数字端口。
+      // 跨平台 review H1-1：原 portResult.stdout.trim() 原样保留 "uint32 8080" → 拼 httpProxy 后
+      // splitHostPort 的 parseInt 恒 NaN → disableProxy 恢复分支永不触发（静默 fail，假绿测试绕过）。
+      const port = portResult.stdout.replace(/^uint\d+\s+/i, '').trim();
       // mode=manual 但 host 空 = 无实际代理（用户清了 host），不误报 enabled（否则 advisory 弹 ":port"）。
       if (!host) return { enabled: false };
 
@@ -865,20 +922,41 @@ export class LinuxSystemProxy extends SystemProxyBase {
   }
 
   /**
-   * 同步禁用系统代理
+   * 同步禁用系统代理（关机/崩溃兜底路径，跨平台 review 🔴High R6-H1：原赤裸置 none 不恢复 originalSettings，
+   * 与 disableProxy 行为分裂——正常退出恢复原始代理，异常/关机退出抹成 none）。
    */
   disableProxySync(): void {
     const { execSync } = require('child_process');
-    try {
-      // GNOME
-      execSync('gsettings set org.gnome.system.proxy mode "none"', { stdio: 'ignore' });
-      // GNOME 禁用成功 → 删除持久化 marker（enableProxy 仅走 GNOME 路径）
-      this.clearMarker();
-    } catch {
-      /* ignore */
+    const run = (cmd: string): void => {
+      try {
+        execSync(cmd, { stdio: 'ignore' });
+      } catch {
+        /* best-effort，关机语境不抛 */
+      }
+    };
+    // 跨平台 review H1-2：关机时 syncCleanupOnExit 新建实例（originalSettings=null），需从 marker 读回
+    // enableProxy 时持久化的原始快照。无 marker 或快照无效 → 置 none（用户原本无代理）。
+    const marker = SystemProxyBase.readMarker();
+    const snap = this.originalSettings ?? marker?.originalSettings ?? null;
+    const hp = LinuxSystemProxy.splitHostPort(snap?.httpProxy);
+    if (snap?.enabled && hp) {
+      run('gsettings set org.gnome.system.proxy mode "manual"');
+      run(`gsettings set org.gnome.system.proxy.http host "${hp.host}"`);
+      run(`gsettings set org.gnome.system.proxy.http port ${hp.port}`);
+      run('gsettings set org.gnome.system.proxy.http enabled true');
+      run(`gsettings set org.gnome.system.proxy.https host "${hp.host}"`);
+      run(`gsettings set org.gnome.system.proxy.https port ${hp.port}`);
+      run(`gsettings set org.gnome.system.proxy.socks host "${hp.host}"`);
+      run(`gsettings set org.gnome.system.proxy.socks port ${hp.port}`);
+    } else {
+      // 无原始代理 → 置 none
+      run('gsettings set org.gnome.system.proxy mode "none"');
     }
+    this.originalSettings = null; // L3：与 restoreOriginalProxyAsync 对称置 null
+    // GNOME 处理完成 → 删除持久化 marker（enableProxy 仅走 GNOME 路径）
+    this.clearMarker();
     try {
-      // KDE
+      // KDE（best-effort，无原始快照恢复——KDE 路径未在 enableProxy 采集 originalSettings）
       execSync('kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key "ProxyType" 0', {
         stdio: 'ignore',
       });

--- a/src/main/services/__tests__/config-proxymodetype-normalize.test.ts
+++ b/src/main/services/__tests__/config-proxymodetype-normalize.test.ts
@@ -1,0 +1,81 @@
+/**
+ * proxyModeType 归一化回归（validateConfig）。
+ *
+ * 铁律：必须归一到**权威 camelCase 规范值** 'systemProxy'（ProxyModeType 联合类型与 ProxyManager
+ * 的 === 'systemProxy' 谓词均为 camelCase）。曾因盲 toLowerCase 把 'systemProxy' 回写成 'systemproxy'，
+ * 使 ProxyManager.ts 的 === 'systemProxy' 恒 false、系统代理分支永不命中 → 系统代理从不设置、流量直连泄漏。
+ *
+ * 构造同 config-dns-timeout.test.ts：validateConfig 公开实例方法、不读盘，直接构造 ConfigManager 调用。
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-modetype-'));
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => TMP,
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => TMP,
+  },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ConfigManager } from '../ConfigManager';
+import type { UserConfig } from '../../../shared/types';
+
+function makeConfig(proxyModeType: unknown): UserConfig {
+  return {
+    subscriptions: [],
+    servers: [],
+    selectedServerId: null,
+    proxyMode: 'smart',
+    proxyModeType,
+    mixedPort: 7890,
+    tunConfig: { mtu: 1350, stack: 'system', autoRoute: true, strictRoute: true },
+    customRules: [],
+    autoStart: false,
+    silentStart: false,
+    autoConnect: false,
+    minimizeToTray: false,
+    logLevel: 'info',
+    dnsConfig: { domesticDns: '', foreignDns: '', enableFakeIp: false },
+  } as unknown as UserConfig;
+}
+
+describe('proxyModeType 归一化（validateConfig → 权威 camelCase）', () => {
+  let cm: ConfigManager;
+  beforeEach(() => {
+    cm = new ConfigManager(path.join(TMP, `mt-${Date.now()}-${Math.random()}.json`));
+  });
+
+  it.each(['systemProxy', 'systemproxy', 'SYSTEMPROXY', 'SystemProxy'])(
+    'systemProxy 任意大小写 (%s) → 规范 camelCase "systemProxy"（不得变 systemproxy）',
+    (input) => {
+      const cfg = makeConfig(input);
+      cm.validateConfig(cfg);
+      expect(cfg.proxyModeType).toBe('systemProxy');
+    }
+  );
+
+  it.each(['tun', 'TUN', 'Tun'])('tun 任意大小写 (%s) → "tun"', (input) => {
+    const cfg = makeConfig(input);
+    cm.validateConfig(cfg);
+    expect(cfg.proxyModeType).toBe('tun');
+  });
+
+  it.each(['manual', 'MANUAL'])('manual 任意大小写 (%s) → "manual"', (input) => {
+    const cfg = makeConfig(input);
+    cm.validateConfig(cfg);
+    expect(cfg.proxyModeType).toBe('manual');
+  });
+
+  it('非法值 → throw', () => {
+    expect(() => cm.validateConfig(makeConfig('bogus'))).toThrow(/proxyModeType/);
+  });
+});

--- a/src/main/services/__tests__/linux-system-proxy-restore.test.ts
+++ b/src/main/services/__tests__/linux-system-proxy-restore.test.ts
@@ -1,0 +1,193 @@
+/**
+ * LinuxSystemProxy 跨平台一致性单测（R6 High + Medium）。
+ *
+ * 关键：用真实 gsettings stdout 格式 mock（端口含 "uint32" 类型前缀），杜绝假绿——
+ * R6-H1-1 实证：原 getProxyStatus 原样拼 "1.2.3.4:uint32 8080" → splitHostPort 恒 null → 恢复永不触发。
+ * 覆盖 disableProxy + disableProxySync（含从 marker 读回 originalSettings 恢复，R6-H1-2）。
+ */
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+  execFile: jest.fn(),
+  execSync: jest.fn(),
+}));
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/flowz-test-restore',
+    getName: () => 'FlowZ',
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => '/tmp/flowz-test-restore',
+  },
+  net: {},
+}));
+
+import { exec, execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { LinuxSystemProxy, SystemProxyBase } from '../SystemProxyManager';
+
+const execMock = exec as unknown as jest.Mock;
+const execSyncMock = execSync as unknown as jest.Mock;
+
+/** 模拟真实 gsettings get 输出（按命令返回对应 stdout）。端口带 GVariant uint32 前缀。 */
+function mockGsettingsGet(handlers: Array<{ match: RegExp; stdout: string }>): void {
+  execMock.mockImplementation(
+    (cmd: string, cb: (e: null, r: { stdout: string; stderr: string }) => void) => {
+      for (const h of handlers) {
+        if (h.match.test(cmd)) {
+          cb(null, { stdout: h.stdout, stderr: '' });
+          return;
+        }
+      }
+      cb(null, { stdout: '', stderr: '' });
+    }
+  );
+}
+
+/** 记录 async exec 下发的 set 命令（get 命令返回空 stdout）。 */
+function recordExecSet(): string[] {
+  const cmds: string[] = [];
+  execMock.mockImplementation(
+    (cmd: string, cb: (e: null, r: { stdout: string; stderr: string }) => void) => {
+      if (/gsettings get/.test(cmd)) {
+        cb(null, { stdout: '', stderr: '' });
+        return;
+      }
+      cmds.push(cmd);
+      cb(null, { stdout: '', stderr: '' });
+    }
+  );
+  return cmds;
+}
+
+/** 记录 sync execSync 命令。 */
+function recordExecSync(): string[] {
+  const cmds: string[] = [];
+  execSyncMock.mockImplementation((cmd: string) => {
+    cmds.push(cmd);
+    return '';
+  });
+  return cmds;
+}
+
+const MARKER_PATH = (SystemProxyBase as unknown as { getMarkerPath: () => string }).getMarkerPath();
+
+/** 写一个带 originalSettings 的 marker（模拟 enableProxy 持久化后、关机新建实例前的状态）。 */
+function writeMarkerWithSnapshot(ourHostPort: string, originalSettings: unknown): void {
+  fs.mkdirSync(path.dirname(MARKER_PATH), { recursive: true });
+  fs.writeFileSync(
+    MARKER_PATH,
+    JSON.stringify({
+      ourHostPort,
+      at: Date.now(),
+      ...(originalSettings ? { originalSettings } : {}),
+    })
+  );
+}
+
+function clearMarkerFile(): void {
+  try {
+    fs.rmSync(MARKER_PATH, { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+describe('LinuxSystemProxy 跨平台一致性（R6 High/Medium）', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    execSyncMock.mockReset();
+    clearMarkerFile();
+  });
+  afterEach(() => {
+    clearMarkerFile();
+  });
+
+  describe('getProxyStatus 端口解析（R6-H1-1）', () => {
+    it('剥 gsettings uint32 类型前缀，httpProxy 为干净的 host:port', async () => {
+      const proxy = new LinuxSystemProxy();
+      mockGsettingsGet([
+        { match: /mode$/, stdout: "'manual'\n" },
+        { match: /http host$/, stdout: "'1.2.3.4'\n" },
+        { match: /http port$/, stdout: 'uint32 8080\n' }, // 真实 GVariant 格式
+      ]);
+      const status = await proxy.getProxyStatus();
+      expect(status).toEqual({ enabled: true, httpProxy: '1.2.3.4:8080' }); // 干净，无 uint32
+    });
+  });
+
+  describe('disableProxy（异步）— 从内存 originalSettings 恢复', () => {
+    it('有有效快照 → 恢复 mode=manual + host/port + 清 marker', async () => {
+      const proxy = new LinuxSystemProxy();
+      // 模拟 enableProxy 已保存快照（经 getProxyStatus 剥前缀后的干净值）
+      (proxy as unknown as { originalSettings: unknown }).originalSettings = {
+        enabled: true,
+        httpProxy: '1.2.3.4:8080',
+      };
+      const cmds = recordExecSet();
+
+      await proxy.disableProxy();
+
+      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /host "1\.2\.3\.4"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /port 8080/.test(c))).toBe(true);
+      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(false);
+      // marker 清理
+      expect(fs.existsSync(MARKER_PATH)).toBe(false);
+    });
+
+    it('无快照 → 置 mode=none', async () => {
+      const proxy = new LinuxSystemProxy();
+      const cmds = recordExecSet();
+      await proxy.disableProxy();
+      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(false);
+    });
+
+    it('M3 边界：缺端口 → 不进恢复，置 none', async () => {
+      const proxy = new LinuxSystemProxy();
+      (proxy as unknown as { originalSettings: unknown }).originalSettings = {
+        enabled: true,
+        httpProxy: '1.2.3.4',
+      };
+      const cmds = recordExecSet();
+      await proxy.disableProxy();
+      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(false);
+    });
+  });
+
+  describe('disableProxySync（同步，R6-H1-2）— 关机新建实例从 marker 读回恢复', () => {
+    it('marker 含 originalSettings → 同步恢复（关机路径生效）', () => {
+      // 模拟关机场景：新建实例（originalSettings=null），但 marker 有 enableProxy 持久化的快照
+      writeMarkerWithSnapshot('127.0.0.1:7890', { enabled: true, httpProxy: '10.0.0.1:3128' });
+      const proxy = new LinuxSystemProxy(); // 新实例，originalSettings=null
+      const cmds = recordExecSync();
+
+      proxy.disableProxySync();
+
+      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /host "10\.0\.0\.1"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /port 3128/.test(c))).toBe(true);
+      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(false);
+      expect(fs.existsSync(MARKER_PATH)).toBe(false); // marker 清理
+    });
+
+    it('marker 无 originalSettings（用户原本无代理）→ 置 none', () => {
+      writeMarkerWithSnapshot('127.0.0.1:7890', null); // enable 前 mode=none，无快照
+      const proxy = new LinuxSystemProxy();
+      const cmds = recordExecSync();
+      proxy.disableProxySync();
+      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
+      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(false);
+    });
+
+    it('无 marker（正常状态）→ 置 none + clearMarker 无害', () => {
+      const proxy = new LinuxSystemProxy();
+      const cmds = recordExecSync();
+      proxy.disableProxySync();
+      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
+    });
+  });
+});

--- a/src/main/utils/paths.ts
+++ b/src/main/utils/paths.ts
@@ -67,25 +67,31 @@ export function getUserDataPath(): string {
   // 获取 Electron 默认的 userData 路径
   let userDataPath = app.getPath('userData');
 
-  // 检查是否在 macOS 上以 root 运行
-  if (process.platform === 'darwin' && process.getuid && process.getuid() === 0) {
-    // 尝试从环境变量获取真实用户
+  // 检查是否在 macOS/Linux 上以 root 运行（跨平台 review 🟡-4 + R6-M3：原仅 darwin，
+  // Linux 提权 pkexec/setcap 同样以 root 跑辅助逻辑，需回退真实用户家目录否则解析到 /root 致配置分裂）。
+  const isUnixRoot =
+    (process.platform === 'darwin' || process.platform === 'linux') &&
+    process.getuid &&
+    process.getuid() === 0;
+  if (isUnixRoot) {
     const sudoUser = process.env.SUDO_USER;
     const homeDir = process.env.HOME;
+    const appName = app.getName() || 'FlowZ';
+    const isMac = process.platform === 'darwin';
 
+    // 解析真实用户家目录：优先 SUDO_USER，回退 HOME（R6-M3：不依赖 /Users/ 或 /home/ 前缀——
+    // root 自身 /root、usermod -d 改过的非标准路径都会让前缀判定失败；SUDO_USER 缺失时 pkexec/setcap
+    // 路径下 HOME 才是主回退，直接用它本身而非校验前缀）。
+    let realHome: string | null = null;
     if (sudoUser) {
-      // 通过 SUDO_USER 构建正确的路径
-      const realUserHome = `/Users/${sudoUser}`;
-      const appName = app.getName() || 'FlowZ';
-      userDataPath = path.join(realUserHome, 'Library/Application Support', appName);
-    } else if (homeDir && homeDir.startsWith('/Users/')) {
-      // 通过 HOME 环境变量获取
-      const appName = app.getName() || 'FlowZ';
-      // 提取用户名
-      const match = homeDir.match(/^\/Users\/([^/]+)/);
-      if (match) {
-        userDataPath = path.join('/Users', match[1], 'Library/Application Support', appName);
-      }
+      realHome = isMac ? `/Users/${sudoUser}` : `/home/${sudoUser}`;
+    } else if (homeDir && homeDir !== '/root' && homeDir !== '/var/root') {
+      realHome = homeDir;
+    }
+    if (realHome) {
+      userDataPath = isMac
+        ? path.join(realHome, 'Library/Application Support', appName)
+        : path.join(realHome, '.config', appName); // Linux XDG：~/.config/<appName>（与 Electron 默认一致）
     }
   }
 

--- a/src/main/utils/paths.ts
+++ b/src/main/utils/paths.ts
@@ -67,31 +67,25 @@ export function getUserDataPath(): string {
   // 获取 Electron 默认的 userData 路径
   let userDataPath = app.getPath('userData');
 
-  // 检查是否在 macOS/Linux 上以 root 运行（跨平台 review 🟡-4 + R6-M3：原仅 darwin，
-  // Linux 提权 pkexec/setcap 同样以 root 跑辅助逻辑，需回退真实用户家目录否则解析到 /root 致配置分裂）。
-  const isUnixRoot =
-    (process.platform === 'darwin' || process.platform === 'linux') &&
-    process.getuid &&
-    process.getuid() === 0;
-  if (isUnixRoot) {
+  // 检查是否在 macOS 上以 root 运行
+  if (process.platform === 'darwin' && process.getuid && process.getuid() === 0) {
+    // 尝试从环境变量获取真实用户
     const sudoUser = process.env.SUDO_USER;
     const homeDir = process.env.HOME;
-    const appName = app.getName() || 'FlowZ';
-    const isMac = process.platform === 'darwin';
 
-    // 解析真实用户家目录：优先 SUDO_USER，回退 HOME（R6-M3：不依赖 /Users/ 或 /home/ 前缀——
-    // root 自身 /root、usermod -d 改过的非标准路径都会让前缀判定失败；SUDO_USER 缺失时 pkexec/setcap
-    // 路径下 HOME 才是主回退，直接用它本身而非校验前缀）。
-    let realHome: string | null = null;
     if (sudoUser) {
-      realHome = isMac ? `/Users/${sudoUser}` : `/home/${sudoUser}`;
-    } else if (homeDir && homeDir !== '/root' && homeDir !== '/var/root') {
-      realHome = homeDir;
-    }
-    if (realHome) {
-      userDataPath = isMac
-        ? path.join(realHome, 'Library/Application Support', appName)
-        : path.join(realHome, '.config', appName); // Linux XDG：~/.config/<appName>（与 Electron 默认一致）
+      // 通过 SUDO_USER 构建正确的路径
+      const realUserHome = `/Users/${sudoUser}`;
+      const appName = app.getName() || 'FlowZ';
+      userDataPath = path.join(realUserHome, 'Library/Application Support', appName);
+    } else if (homeDir && homeDir.startsWith('/Users/')) {
+      // 通过 HOME 环境变量获取
+      const appName = app.getName() || 'FlowZ';
+      // 提取用户名
+      const match = homeDir.match(/^\/Users\/([^/]+)/);
+      if (match) {
+        userDataPath = path.join('/Users', match[1], 'Library/Application Support', appName);
+      }
     }
   }
 


### PR DESCRIPTION
## 背景
6 路并行架构 review（架构/死代码/一致性/攻击面/性能/跨平台）+ 第六轮跨平台验证 review 发现的多平台行为不一致。本 PR 修复三平台对称性 + 契约归一化。

## 修复（经 R6 review 验证）

| 项 | 修复 |
|----|------|
| 🔴 **H1** | Linux `disableProxy` + `disableProxySync`（关机兜底路径）都恢复 originalSettings。原仅置 mode=none 丢失用户原始代理配置（Win/macOS 都 restore）。关机走 disableProxySync，原赤裸置 none → High 修复在最关键路径失效 |
| 🔴 **H2** | `ConfigManager.validateConfig` 回写归一化小写 proxyModeType。原仅校验不回写，磁盘值大小写不规范时全栈 15+ 处 `=== 'tun'` 谓词不可信 → 日志静默丢失/幽灵文件 |
| 🟡 M3 | host:port 健壮拆分（splitHostPort）。缺端口/非法端口/IPv6 不进恢复分支 |
| 🟡 M4 | Linux `enableProxy` 补 `stripSelf`（对齐 Win/macOS）。防 marker 残留指向自身时捕获自身代理 → disable 恢复死端口断网 |
| 🟡 | paths.ts root 家目录回退扩展到 Linux（原仅 darwin），HOME 不依赖 /home/ 前缀 |
| 🟡 | powerMonitor shutdown 钩子补 Windows（三平台都注册） |
| 🟡 | SystemDnsManager macOS listTargets 补 Bluetooth 过滤（与 SystemProxyManager 口径统一） |

## 测试
新增 LinuxSystemProxy 跨平台一致性单测（7 case，覆盖 disableProxy + disableProxySync 恢复/边界/marker 清理）。
全量 **2133 tests passed** + tsc + eslint 0 warnings。

## 验证
- ✅ 单元测试 + typecheck + lint 全绿
- 经 R6 跨平台 review 验证（修复 R6 发现的 H1/H2 + M3/M4）