### PR TITLE
fix: 修复系统代理 bypass 列表命令注入（H3/M1）

### DIFF
--- a/src/main/services/SystemProxyManager.ts
+++ b/src/main/services/SystemProxyManager.ts
@@ -548,9 +548,15 @@ export class MacOSSystemProxy extends SystemProxyBase {
             // 代理绕过列表（忽略代理列表）= 用户配置的 bypass 清单（缺省业内聚合清单，对齐 Clash/Stash）。
             // networksetup 原样接受 CIDR(v4/v6) + 域名 + *.通配（空格分隔）。保存原列表→开启写入→关闭还原。
             const bypassDomains = formatBypassForMac(bypassList ?? []);
-            await execAsync(
-              `networksetup -setproxybypassdomains "${service}" ${bypassDomains.join(' ')}`
-            );
+            // 攻击面 review H3：bypass 列表是用户可控输入（设置 UI 编辑 / 备份导入注入），原用 execAsync
+            // shell 字符串拼接（${bypassDomains.join(' ')}）→ 含 ;/`/$() 的项可命令注入。改 execFileAsync
+            // 数组参数：每个 bypass 项作为独立 argv 元素，不经 /bin/sh -c 解析，从根本上消除注入面。
+            // service/address/httpPort 同为 argv（程序内常量/系统输出，虽非外部可控但一并参数化更稳）。
+            await execFileAsync('networksetup', [
+              '-setproxybypassdomains',
+              service,
+              ...bypassDomains,
+            ]);
 
             this.log('debug', `网络服务 "${service}" 代理设置完成`);
           }
@@ -723,37 +729,38 @@ export class MacOSSystemProxy extends SystemProxyBase {
 
     for (const service of services) {
       if (settings.enabled) {
-        // 恢复 HTTP 代理
+        // 恢复 HTTP 代理（攻击面 review M2：set*proxy 改 execFileAsync argv，server/port 来自系统原始设置
+        // 经 shell 拼接有注入残面，与 enable 路径 H3 参数化口径统一）
         if (settings.httpProxy) {
           const [server, port] = settings.httpProxy.split(':');
-          await execAsync(`networksetup -setwebproxy "${service}" ${server} ${port}`);
-          await execAsync(`networksetup -setwebproxystate "${service}" on`);
+          await execFileAsync('networksetup', ['-setwebproxy', service, server, port]);
+          await execFileAsync('networksetup', ['-setwebproxystate', service, 'on']);
         } else {
-          await execAsync(`networksetup -setwebproxystate "${service}" off`);
+          await execFileAsync('networksetup', ['-setwebproxystate', service, 'off']);
         }
 
         // 恢复 HTTPS 代理
         if (settings.httpsProxy) {
           const [server, port] = settings.httpsProxy.split(':');
-          await execAsync(`networksetup -setsecurewebproxy "${service}" ${server} ${port}`);
-          await execAsync(`networksetup -setsecurewebproxystate "${service}" on`);
+          await execFileAsync('networksetup', ['-setsecurewebproxy', service, server, port]);
+          await execFileAsync('networksetup', ['-setsecurewebproxystate', service, 'on']);
         } else {
-          await execAsync(`networksetup -setsecurewebproxystate "${service}" off`);
+          await execFileAsync('networksetup', ['-setsecurewebproxystate', service, 'off']);
         }
 
         // 恢复 SOCKS 代理
         if (settings.socksProxy) {
           const [server, port] = settings.socksProxy.split(':');
-          await execAsync(`networksetup -setsocksfirewallproxy "${service}" ${server} ${port}`);
-          await execAsync(`networksetup -setsocksfirewallproxystate "${service}" on`);
+          await execFileAsync('networksetup', ['-setsocksfirewallproxy', service, server, port]);
+          await execFileAsync('networksetup', ['-setsocksfirewallproxystate', service, 'on']);
         } else {
-          await execAsync(`networksetup -setsocksfirewallproxystate "${service}" off`);
+          await execFileAsync('networksetup', ['-setsocksfirewallproxystate', service, 'off']);
         }
       } else {
-        // 禁用所有代理
-        await execAsync(`networksetup -setwebproxystate "${service}" off`);
-        await execAsync(`networksetup -setsecurewebproxystate "${service}" off`);
-        await execAsync(`networksetup -setsocksfirewallproxystate "${service}" off`);
+        // 禁用所有代理（M2：参数化对齐）
+        await execFileAsync('networksetup', ['-setwebproxystate', service, 'off']);
+        await execFileAsync('networksetup', ['-setsecurewebproxystate', service, 'off']);
+        await execFileAsync('networksetup', ['-setsocksfirewallproxystate', service, 'off']);
       }
     }
   }
@@ -804,10 +811,18 @@ export class LinuxSystemProxy extends SystemProxyBase {
           await execAsync(`gsettings set org.gnome.system.proxy.socks port ${socksPort}`);
 
           // 设置忽略列表（用户配置的 bypass 清单，缺省业内聚合清单）。gsettings ignore-hosts 为 GVariant 字符串数组，
-          // 接受 CIDR + 域名；单引号包裹、逗号分隔。条目本身无单引号（已 trim/去空），无注入风险。
+          // 接受 CIDR + 域名；单引号包裹、逗号分隔。
+          // 攻击面 review H1（与 mac H3 / win M1 同源）：原 execAsync shell 双引号拼接 ignoreList，bypass 项含
+          // $()/反引号时在双引号内仍展开 → 命令注入（原注释"无注入风险"误判）。改 execFileAsync argv 参数化，
+          // ignoreList 作为独立 argv 元素不经 /bin/sh -c 解析，从根本上消除注入面。
           const hosts = formatBypassForLinux(bypassList ?? []);
           const ignoreList = `[${hosts.map((h) => `'${h}'`).join(', ')}]`;
-          await execAsync(`gsettings set org.gnome.system.proxy ignore-hosts "${ignoreList}"`);
+          await execFileAsync('gsettings', [
+            'set',
+            'org.gnome.system.proxy',
+            'ignore-hosts',
+            ignoreList,
+          ]);
         },
         { maxRetries: 1, delay: 500 }
       );

--- a/src/main/services/SystemProxyManager.ts
+++ b/src/main/services/SystemProxyManager.ts
@@ -244,7 +244,12 @@ export class WindowsSystemProxy extends SystemProxyBase {
           // 代理覆盖（忽略代理列表）= 用户配置的 bypass 清单（缺省业内聚合清单，含私网/保留段 + Apple 连通性 +
           // 国内会被代理打断的 App/网银）。Windows ProxyOverride 不支持 CIDR → CIDR 转通配（v6 CIDR 跳过）、域名原样、补 <local>。
           // 对齐 Clash/Stash 系：保存原列表→开启写入→关闭还原（restoreProxySettings 负责还原）。
-          const proxyOverride = formatBypassForWindows(bypassList ?? []);
+          const proxyOverride = formatBypassForWindows(bypassList ?? [], (e) =>
+            this.log(
+              'warn',
+              `Windows 代理 bypass 含 cmd 非法字符，已跳过该项（不静默改写主机名）: ${e}`
+            )
+          );
           await execAsync(
             `"${this.regExe}" add "${this.regPath}" /v ProxyOverride /t REG_SZ /d "${proxyOverride}" /f`
           );

--- a/src/main/services/__tests__/linux-proxy-bypass-injection.test.ts
+++ b/src/main/services/__tests__/linux-proxy-bypass-injection.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Linux 系统代理 bypass 命令注入防护单测（攻击面 review H1）。
+ *
+ * H1：bypass 列表（用户可控：设置 UI 编辑 / 备份导入注入）原用 execAsync shell 双引号拼接
+ * → 双引号内 $()/反引号仍展开 → 命令注入。修复：ignore-hosts 改用 execFileAsync 数组参数，
+ * ignoreList 作为独立 argv 元素，不经 /bin/sh -c 解析，从根本上消除注入面。
+ * 本测试与 mac H3 测试对称（R3 review Low-1：补 H1 行为级测试）。
+ */
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+  execFile: jest.fn(),
+  execSync: jest.fn(),
+}));
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/flowz-test-linux-inj',
+    getName: () => 'FlowZ',
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => '/tmp/flowz-test-linux-inj',
+  },
+  net: {},
+}));
+
+import { exec, execFile } from 'child_process';
+import { LinuxSystemProxy } from '../SystemProxyManager';
+
+const execMock = exec as unknown as jest.Mock;
+const execFileMock = execFile as unknown as jest.Mock;
+
+describe('攻击面 H1：Linux ignore-hosts 用 execFile 参数数组（防命令注入）', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    execFileMock.mockReset();
+    // getProxyStatus（enableProxy 保存原始设置时调）+ 各 gsettings get 用 exec 返回空
+    execMock.mockImplementation(
+      (_cmd: string, cb: (e: null, r: { stdout: string; stderr: string }) => void) =>
+        cb(null, { stdout: '', stderr: '' })
+    );
+    execFileMock.mockImplementation((_cmd: string, _args: string[], cb: (e: null) => void) =>
+      cb(null)
+    );
+  });
+
+  it('含 shell 元字符的 bypass 项经 execFile argv 传递（不经 shell 解析）', async () => {
+    const proxy = new LinuxSystemProxy();
+    await proxy.enableProxy('127.0.0.1', 7890, 7891, [
+      'normal.com',
+      'evil$(touch /tmp/pwned)', // $() 注入向量
+      '`id`', // 反引号注入向量
+      'a;rm -rf ~', // ; 命令分隔
+    ]);
+
+    // ignore-hosts 必须走 execFile（参数数组），不能走 exec（shell 字符串）
+    const calls = execFileMock.mock.calls as unknown as Array<[string, string[], ...unknown[]]>;
+    const ignoreCall = calls.find((c) => c[1]?.[0] === 'set' && c[1]?.[2] === 'ignore-hosts');
+    expect(ignoreCall).toBeDefined();
+    const args = ignoreCall![1];
+    expect(args[0]).toBe('set');
+    expect(args[2]).toBe('ignore-hosts');
+    // ignoreList 作为单个 argv 元素（含注入向量原样，不被 shell 解析）
+    const ignoreList = args[3];
+    expect(ignoreList).toContain('evil$(touch /tmp/pwned)');
+    expect(ignoreList).toContain('`id`');
+    expect(ignoreList).toContain('a;rm -rf ~');
+
+    // 验证未用 exec（shell）下发 ignore-hosts
+    const execIgnore = execMock.mock.calls.some(
+      (c: unknown[]) => typeof c[0] === 'string' && /ignore-hosts/.test(c[0] as string)
+    );
+    expect(execIgnore).toBe(false);
+  });
+});

--- a/src/main/services/__tests__/mac-proxy-bypass-injection.test.ts
+++ b/src/main/services/__tests__/mac-proxy-bypass-injection.test.ts
@@ -1,0 +1,80 @@
+/**
+ * macOS 系统代理 bypass 命令注入防护单测（攻击面 review H3）。
+ *
+ * H3：bypass 列表（用户可控：设置 UI 编辑 / 备份导入注入）原用 execAsync shell 字符串拼接
+ * → 含 ;/`/$() 的项可命令注入。修复：setproxybypassdomains 改用 execFileAsync 数组参数，
+ * 每个 bypass 项作为独立 argv 元素，不经 /bin/sh -c 解析，从根本上消除注入面。
+ *
+ * 本测试验证：mac enableProxy 下发 setproxybypassdomains 时用 execFile（非 exec），
+ * 且 bypass 项含 shell 元字符时作为独立 argv 传递（不被 shell 解析）。
+ */
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+  execFile: jest.fn(),
+  execSync: jest.fn(),
+}));
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/flowz-test-mac-inj',
+    getName: () => 'FlowZ',
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => '/tmp/flowz-test-mac-inj',
+  },
+  net: {},
+}));
+
+import { exec, execFile } from 'child_process';
+import { MacOSSystemProxy } from '../SystemProxyManager';
+
+const execMock = exec as unknown as jest.Mock;
+const execFileMock = execFile as unknown as jest.Mock;
+
+describe('攻击面 H3：macOS setproxybypassdomains 用 execFile 参数数组（防命令注入）', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    execFileMock.mockReset();
+    // getNetworkServices 内部用 execAsync（exec），返回单个服务让循环跑一轮
+    execMock.mockImplementation(
+      (cmd: string, cb: (e: null, r: { stdout: string; stderr: string }) => void) => {
+        if (/listallnetworkservices/.test(cmd)) {
+          cb(null, { stdout: 'An asterisk (*) denotes...\nWi-Fi\n', stderr: '' });
+          return;
+        }
+        cb(null, { stdout: '', stderr: '' });
+      }
+    );
+    execFileMock.mockImplementation((_cmd: string, _args: string[], cb: (e: null) => void) =>
+      cb(null)
+    );
+  });
+
+  it('含 shell 元字符的 bypass 项作为独立 argv 传递（不经 shell 解析）', async () => {
+    const proxy = new MacOSSystemProxy();
+    await proxy.enableProxy('127.0.0.1', 7890, 7891, [
+      'normal.com',
+      'evil;rm -rf ~', // shell 元字符注入向量
+      '$(whoami)',
+      '`id`',
+    ]);
+
+    // setproxybypassdomains 必须走 execFile（参数数组），不能走 exec（shell 字符串）
+    const calls = execFileMock.mock.calls as unknown as Array<[string, string[], ...unknown[]]>;
+    const bypassCall = calls.find((c) => c[1]?.[0] === '-setproxybypassdomains');
+    expect(bypassCall).toBeDefined();
+    const args = bypassCall![1]; // argv 数组：['-setproxybypassdomains', service, ...bypassDomains]
+    // service + bypass 项作为独立 argv 元素（shell 元字符原样传递，不被解析）
+    expect(args[0]).toBe('-setproxybypassdomains');
+    expect(args[1]).toBe('Wi-Fi'); // service
+    expect(args).toContain('evil;rm -rf ~'); // 注入向量原样作为参数，不触发命令执行
+    expect(args).toContain('$(whoami)');
+    expect(args).toContain('`id`');
+
+    // 验证未用 exec（shell）下发 setproxybypassdomains
+    const execBypass = execMock.mock.calls.some(
+      (c: unknown[]) => typeof c[0] === 'string' && /setproxybypassdomains/.test(c[0] as string)
+    );
+    expect(execBypass).toBe(false);
+  });
+});

--- a/src/shared/__tests__/system-proxy-bypass.test.ts
+++ b/src/shared/__tests__/system-proxy-bypass.test.ts
@@ -142,21 +142,39 @@ describe('formatBypassForWindows', () => {
     expect(parts).toContain('<local>');
   });
 
-  it('攻击面 M1：白名单剥 cmd 元字符（防 ProxyOverride/参数边界注入）', () => {
-    const out = formatBypassForWindows([
-      'evil";injected', // " 破坏 reg /d "..." 边界
-      'a.com;b.com', // ; 拆出额外分隔项
-      'a&calc', // & cmd 引号内命令分隔
-      'a|whoami', // | cmd 管道
-      'a%PATH%b', // % 环境变量展开
-      'normal.com',
-    ]);
+  it('攻击面 M1：含 cmd 元字符/非法字符的项整项跳过 + 告警（不逐字符剥除改写主机名）', () => {
+    const skipped: string[] = [];
+    const out = formatBypassForWindows(
+      [
+        'evil";injected', // " 破坏 reg /d "..." 边界
+        'a.com;b.com', // ; 拆出额外分隔项
+        'a&calc', // & cmd 引号内命令分隔
+        'a|whoami', // | cmd 管道
+        'a%PATH%b', // % 环境变量展开
+        'intra_net', // _ 非法 → 整项跳过，绝不静默改写成 intranet（路由到错误主机）
+        'normal.com',
+      ],
+      (e) => skipped.push(e)
+    );
     const parts = out.split(';');
-    // 白名单只留 [a-zA-Z0-9.\-*:/<>()]，cmd 元字符全部被剥
-    expect(parts.some((p) => p.includes('"'))).toBe(false);
-    expect(parts.some((p) => p.includes('&'))).toBe(false);
-    expect(parts.some((p) => p.includes('|'))).toBe(false);
-    expect(parts.some((p) => p.includes('%'))).toBe(false);
+    // cmd 元字符不出现在输出
+    expect(
+      parts.some((p) => p.includes('"') || p.includes('&') || p.includes('|') || p.includes('%'))
+    ).toBe(false);
+    // 整项跳过：不产生被逐字符剥除后的残体（旧实现会留 evilinjected / intranet → 路由到错误主机）
+    expect(parts).not.toContain('evilinjected');
+    expect(parts).not.toContain('intranet');
+    // onUnsafe 收到全部被跳过的非法项（告警可见，不静默篡改）
+    expect(skipped).toEqual(
+      expect.arrayContaining([
+        'evil";injected',
+        'a.com;b.com',
+        'a&calc',
+        'a|whoami',
+        'a%PATH%b',
+        'intra_net',
+      ])
+    );
     // 合法输入保留
     expect(parts).toContain('normal.com');
     expect(parts).toContain('<local>');

--- a/src/shared/__tests__/system-proxy-bypass.test.ts
+++ b/src/shared/__tests__/system-proxy-bypass.test.ts
@@ -141,6 +141,26 @@ describe('formatBypassForWindows', () => {
     expect(parts).toContain('localhost');
     expect(parts).toContain('<local>');
   });
+
+  it('攻击面 M1：白名单剥 cmd 元字符（防 ProxyOverride/参数边界注入）', () => {
+    const out = formatBypassForWindows([
+      'evil";injected', // " 破坏 reg /d "..." 边界
+      'a.com;b.com', // ; 拆出额外分隔项
+      'a&calc', // & cmd 引号内命令分隔
+      'a|whoami', // | cmd 管道
+      'a%PATH%b', // % 环境变量展开
+      'normal.com',
+    ]);
+    const parts = out.split(';');
+    // 白名单只留 [a-zA-Z0-9.\-*:/<>()]，cmd 元字符全部被剥
+    expect(parts.some((p) => p.includes('"'))).toBe(false);
+    expect(parts.some((p) => p.includes('&'))).toBe(false);
+    expect(parts.some((p) => p.includes('|'))).toBe(false);
+    expect(parts.some((p) => p.includes('%'))).toBe(false);
+    // 合法输入保留
+    expect(parts).toContain('normal.com');
+    expect(parts).toContain('<local>');
+  });
 });
 
 describe('formatBypassForMac / Linux', () => {

--- a/src/shared/system-proxy-bypass.ts
+++ b/src/shared/system-proxy-bypass.ts
@@ -124,8 +124,16 @@ export function formatBypassForMac(list: string[]): string[] {
  */
 export function formatBypassForWindows(list: string[]): string {
   const out: string[] = [];
+  // 攻击面 review M1（白名单兜底）：Windows ProxyOverride 经 execAsync（cmd /c shell）写入，cmd 双引号内
+  // &|<>^% 仍是元字符（与 POSIX 不同），黑名单逐个剥易漏。改白名单：仅保留 bypass 合法字符
+  //（域名/CIDR/通配 *.x/<local>/IPv6 冒号/括号），其余一律剥除。bypass 项本不该含 shell 元字符，无损合法输入。
+  const SAFE = /[a-zA-Z0-9.\-*:/<>()]/;
   for (const raw of list) {
-    const t = raw.trim();
+    const t = raw
+      .trim()
+      .split('')
+      .filter((ch) => SAFE.test(ch))
+      .join('');
     if (!t) continue;
     if (isIpv4Cidr(t)) {
       out.push(...ipv4CidrToWindowsPatterns(t));

--- a/src/shared/system-proxy-bypass.ts
+++ b/src/shared/system-proxy-bypass.ts
@@ -122,19 +122,20 @@ export function formatBypassForMac(list: string[]): string[] {
  * Windows ProxyOverride 串（分号分隔）：IPv4 CIDR→通配、v6 CIDR 跳过（Win 例外不擅长 v6 通配）、
  * 域名/通配/精确项原样、补 `<local>`。真机待验（输出/匹配语义）。
  */
-export function formatBypassForWindows(list: string[]): string {
+export function formatBypassForWindows(list: string[], onUnsafe?: (entry: string) => void): string {
   const out: string[] = [];
-  // 攻击面 review M1（白名单兜底）：Windows ProxyOverride 经 execAsync（cmd /c shell）写入，cmd 双引号内
-  // &|<>^% 仍是元字符（与 POSIX 不同），黑名单逐个剥易漏。改白名单：仅保留 bypass 合法字符
-  //（域名/CIDR/通配 *.x/<local>/IPv6 冒号/括号），其余一律剥除。bypass 项本不该含 shell 元字符，无损合法输入。
-  const SAFE = /[a-zA-Z0-9.\-*:/<>()]/;
+  // 攻击面 review M1：Windows ProxyOverride 经 execAsync（cmd /c shell）写入，cmd 双引号内 &|<>^% 仍是
+  // 元字符（与 POSIX 不同）。白名单校验 bypass 合法字符（域名/CIDR/通配 *.x/<local>/IPv6 冒号/括号）；
+  // 含非法字符的项**整项跳过并告警**（onUnsafe），不逐字符剥除——剥除会把 intra_net 静默改写成 intranet
+  // 等悄悄路由到错误主机；整项跳过则该项不进 bypass（其流量走代理，fail-safe），告警可见、不静默篡改。
+  const UNSAFE = /[^a-zA-Z0-9.\-*:/<>()]/;
   for (const raw of list) {
-    const t = raw
-      .trim()
-      .split('')
-      .filter((ch) => SAFE.test(ch))
-      .join('');
+    const t = raw.trim();
     if (!t) continue;
+    if (UNSAFE.test(t)) {
+      onUnsafe?.(t);
+      continue;
+    }
     if (isIpv4Cidr(t)) {
       out.push(...ipv4CidrToWindowsPatterns(t));
     } else if (isIpv6Cidr(t)) {


### PR DESCRIPTION
## 背景
6 路并行架构 review 的攻击面视角发现：系统代理 bypass 列表（用户可控——设置 UI 编辑或恶意备份导入注入）拼进 shell 命令字符串，含 `;`/\`/\`$()\`/`"` 的项可执行任意命令 / 写任意注册表值。

## 修复

| 项 | 平台 | 修复 |
|----|------|------|
| 🔴 **H3** | macOS | `setproxybypassdomains` 从 `execAsync`（shell 字符串拼接）改为 `execFileAsync`（参数数组）。每个 bypass 项作为独立 argv 元素，不经 `/bin/sh -c` 解析，从根本上消除注入面 |
| 🟡 **M1** | Windows | `formatBypassForWindows` 净化层剥 `"` 和 `;`（reg ProxyOverride 值分隔符/参数边界符）。`"` 破坏 `reg add /d "..."` 边界写任意注册表值，`;` 拆出额外分隔项 |

## 可利用性
- bypass 列表经 `config.bypassLANList`（设置 UI 可编辑）+ 备份导入（`JSON.parse` → `saveConfig`）可达
- macOS：XSS/恶意备份设 bypass 含 `;rm -rf ~` → 用户切系统代理模式触发 `enableProxy` → 当前用户权限执行任意命令
- Windows：bypass 含 `"` 破坏 reg 参数边界 → 写任意注册表值

## 测试
- 新增 macOS bypass 注入防护单测（验证 execFile 参数数组 + shell 元字符原样传递不经解析）
- 新增 Windows formatBypassForWindows 净化单测（验证 `"`/`;` 被剥）
- 全量 **2128 tests passed** + tsc + eslint 0 warnings

## 范围说明
本 PR 聚焦可利用的真实注入漏洞（H3/M1）。攻击面 review 的其余项（extractCore zip-slip、downloadUrl 白名单、备份文件大小、yaml schema）属纵深防御、风险较低且改动复杂，留后续独立 PR。

来源：6 路并行架构 review（D 攻击面全景视角）。