### PR TITLE
fix: 修复协议清单契约假对齐（H4）

### DIFF
--- a/src/main/services/__tests__/config-protocol-t5.test.ts
+++ b/src/main/services/__tests__/config-protocol-t5.test.ts
@@ -36,21 +36,11 @@ jest.mock('electron', () => ({
 
 import { ConfigManager } from '../ConfigManager';
 import type { Protocol, UserConfig } from '../../../shared/types';
+import { ALL_PROTOCOLS } from '../../../shared/server-completeness';
 
-/** Protocol 联合的全部成员——与 src/shared/types.ts 定义逐字对齐，作为白名单对齐的真值基准。 */
-const ALL_PROTOCOLS: Protocol[] = [
-  'vless',
-  'trojan',
-  'hysteria2',
-  'shadowsocks',
-  'anytls',
-  'tuic',
-  'vmess',
-  'naive',
-  'socks',
-  'http',
-  'ssh',
-];
+// 攻击面/一致性 review H4：原此处自建 ALL_PROTOCOLS（11 项，漏 wireguard/tailscale/custom），
+// 注释声称"与 types.ts 逐字对齐"实为假——白名单回归测试对漏列协议零覆盖。改 import 权威真值
+//（server-completeness.ts 的 ALL_PROTOCOLS，14 项全），让"新增协议同步"的契约真正可验证。
 
 /** 最小可校验 UserConfig（够过 validateConfig 的非 protocol 分支），按需覆盖 servers。
  *  mixed-only 后 validateConfig 尾部强制校验 mixedPort（http/socksPort 仅存在时宽松校验，且迁移会以 httpPort
@@ -89,6 +79,18 @@ function makeServerConfig(protocol: Protocol): UserConfig['servers'][number] {
   base.password = 'pass';
   base.username = 'user';
   base.shadowsocksSettings = { method: 'aes-256-gcm', password: 'pass' };
+  // 一致性 review H4：补齐原漏列协议的必填（wireguard/custom）。原 makeServerConfig 未覆盖，
+  // 导致 wireguard/custom 的「缺必填」校验从没被测到（测试本身漏列这俩协议）。
+  if (protocol === 'wireguard') {
+    base.wireguardSettings = {
+      privateKey: 'priv-key',
+      peerPublicKey: 'peer-key',
+      localAddress: ['10.0.0.2/32'],
+    };
+  }
+  if (protocol === 'custom') {
+    base.customSettings = { outbound: { type: 'trojan', server: '1.2.3.4', server_port: 443 } };
+  }
   return base;
 }
 

--- a/src/renderer/bridge/types.ts
+++ b/src/renderer/bridge/types.ts
@@ -30,18 +30,7 @@ export type {
   RuleResourceRef,
 } from '../../shared/types';
 
-export type ProtocolType =
-  | 'vless'
-  | 'trojan'
-  | 'hysteria2'
-  | 'shadowsocks'
-  | 'anytls'
-  | 'tuic'
-  | 'vmess'
-  | 'naive'
-  | 'socks'
-  | 'http'
-  | 'ssh'
-  | 'wireguard'
-  | 'tailscale'
-  | 'custom';
+// 一致性 review H4：原手抄 Protocol 联合 14 项（新增协议易漏同步）。改为从 Protocol alias，
+// 自动跟随 shared/types.ts 真值，消除"协议清单假对齐"漂移源。
+import type { Protocol as ProtocolT } from '../../shared/types';
+export type ProtocolType = ProtocolT;

--- a/src/renderer/components/settings/shared/__tests__/protocol-options.test.ts
+++ b/src/renderer/components/settings/shared/__tests__/protocol-options.test.ts
@@ -1,0 +1,25 @@
+/**
+ * 协议下拉选项 drift 护栏（一致性 review H4 follow-up / R1 Nit）。
+ *
+ * PROTOCOL_OPTIONS 是手抄数组（13 项，tailscale 抽到组网 tab），新增协议时需人肉记得来加一行。
+ * 补护栏：断言 PROTOCOL_OPTIONS 的 value 集合 ⊆ ALL_PROTOCOLS（TS 不强校验数组完备性，运行时断言兜底），
+ * 防止未来 Protocol 新增成员后 PROTOCOL_OPTIONS 漏更新（UI 缺新协议入口）。
+ */
+import { PROTOCOL_OPTIONS } from '../protocol-options';
+import { ALL_PROTOCOLS } from '../../../../../shared/server-completeness';
+
+describe('PROTOCOL_OPTIONS drift 护栏（R1 Nit）', () => {
+  it('PROTOCOL_OPTIONS 的 value 全部是合法 Protocol 成员（TS 运行时兜底）', () => {
+    for (const opt of PROTOCOL_OPTIONS) {
+      expect(ALL_PROTOCOLS).toContain(opt.value);
+    }
+  });
+
+  it('UI 代理协议下拉覆盖了所有非组网协议（tailscale 抽到组网 tab，故排除）', () => {
+    const values = PROTOCOL_OPTIONS.map((o) => o.value);
+    const expectedProxyProtocols = ALL_PROTOCOLS.filter((p) => p !== 'tailscale');
+    for (const p of expectedProxyProtocols) {
+      expect(values).toContain(p);
+    }
+  });
+});


### PR DESCRIPTION
## 背景
6 路并行架构 review 的一致性视角发现协议清单存在"假对齐"——多处各自枚举 Protocol，新增协议极易漏列，白名单回归测试有盲区。

## 修复

| 项 | 修复 |
|----|------|
| 🔴 **H4** | `config-protocol-t5.test.ts` 的 ALL_PROTOCOLS 原自建 11 项（漏 wireguard/tailscale/custom），注释声称"与 types.ts 逐字对齐"实为假。改 import 权威真值（`shared/server-completeness.ts` 的 ALL_PROTOCOLS，14 项全），让契约真正可验证。同时补 makeServerConfig 对 wireguard/custom 的必填字段 |
| 🟡 | `bridge/types.ts` ProtocolType 原手抄 Protocol 联合（漂移源），改为 `export type ProtocolType = Protocol` alias，自动跟随真值 |

## 修复后暴露的盲区
H4 修复后测试真覆盖 14 项，暴露了原测试漏列 wireguard/custom 导致的"缺必填校验从未被测"——makeServerConfig 没给这俩补必填字段。本 PR 一并补齐。

## 测试
config-protocol-t5 现真覆盖 14 项协议。全量 **2129 tests passed** + tsc + eslint 0 warnings。

来源：6 路并行架构 review（C 一致性漂移视角）。