### PR TITLE
refactor: 架构收敛（atomicWrite 归一 + IPC handler 统一）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,7 +36,7 @@ import {
   registerSystemHandlers,
   registerRuleResourceHandlers,
 } from './ipc/handlers';
-import { setIpcLogger } from './ipc/ipc-handler';
+import { setIpcLogger, registerIpcHandler } from './ipc/ipc-handler';
 import { createAutoStartManager } from './services/AutoStartManager';
 import { UpdateService } from './services/UpdateService';
 import { CoreUpdateService } from './services/CoreUpdateService';
@@ -1429,9 +1429,9 @@ if (gotTheLock) {
       updateTrayMenuState(isRunning, hasError);
     });
 
-    // 监听渲染进程语言同步
-    const { ipcMain } = require('electron');
-    ipcMain.handle(IPC_CHANNELS.APP_SET_LANGUAGE, (_: any, lang: string) => {
+    // 监听渲染进程语言同步（架构 review：改走 registerIpcHandler 统一 ApiResponse 契约 + 进注册表，
+    // 原裸 ipcMain.handle 是 19 个 handler 中唯一例外，绕过 wrapper 且无返回值）
+    registerIpcHandler<string, void>(IPC_CHANNELS.APP_SET_LANGUAGE, (_event, lang: string) => {
       currentLanguage = lang || currentLanguage;
       setMainLanguage(currentLanguage); // 主进程 i18n（桌面通知等）同步语言
       if (trayManager) {

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -76,6 +76,7 @@ import {
   classifyReseedResult,
 } from '../../shared/core-build';
 import { retry } from '../utils/retry';
+import { writeFileAtomic } from '../utils/atomic-write';
 import { coreVersionAtLeast } from '../../shared/version';
 import { parseTailscaleAuthLine } from '../../shared/tailscale';
 import { safeHttpUrl } from '../../shared/url';
@@ -1422,7 +1423,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     this.customRuleFilesDegraded = false;
     try {
       await fs.mkdir(dir, { recursive: true });
-      // 孤儿清扫（含 atomicWrite 可能残留的 .tmp）
+      // 孤儿清扫（含 atomicWrite 可能残留的 .tmp）。writeFileAtomic 用唯一后缀 .<pid>.<rand6hex>.tmp
+      //（架构 review：原固定 .tmp 正则不匹配新后缀，硬崩溃残留文件无法被清扫）——放宽正则匹配任意中间段。
       let existing: string[] = [];
       try {
         existing = await fs.readdir(dir);
@@ -1430,7 +1432,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         /* 目录刚建/读失败：无孤儿可清 */
       }
       for (const name of existing) {
-        if (/^custom-rule-.+\.json(\.tmp)?$/.test(name) && !expected.has(name)) {
+        // 匹配 custom-rule-*.json 及其任意后缀的 .tmp 残留（.<pid>.<rand>.tmp 或裸 .tmp）
+        if (/^custom-rule-.+\.json(?:\.[^.]+)*\.tmp$/.test(name) && !expected.has(name)) {
           await fs.unlink(path.join(dir, name)).catch(() => {});
         }
       }
@@ -1485,9 +1488,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
   /** 原子写：临时文件 + rename（与 RuleResourceManager 同形；rename-over 触发 sing-box fswatch 热重载）。 */
   private async atomicWrite(filePath: string, content: string): Promise<void> {
-    const tmp = `${filePath}.tmp`;
-    await fs.writeFile(tmp, content, 'utf-8');
-    await fs.rename(tmp, filePath);
+    // 架构 review：改用 utils/writeFileAtomic（唯一后缀 .tmp 防多 writer 撞车），消除本处复刻的固定
+    // `${filePath}.tmp`——正是 util 已修掉的形态（多 writer 写同一 .tmp 致字节交错损坏正本）。
+    await writeFileAtomic(filePath, content);
   }
 
   /**

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -152,6 +152,16 @@ export function parseCheckEndpointIndex(stderr: string): number | null {
 }
 
 /**
+ * 外化自定义规则的孤儿文件判定（单一真值，便于单测）。匹配：
+ *  - 裸 custom-rule-<id>.json（孤儿主目标：删规则/禁用/转 inline/改 id/direct 切换的遗留）；
+ *  - .json 后跟任意中间段的 .tmp 残留（writeFileAtomic 唯一后缀 .<pid>.<rand>.tmp 或裸 .tmp）。
+ * .tmp 段整体可选——勿丢裸 .json（曾因强制 .tmp$ 致裸 .json 孤儿永久残留）。
+ */
+export function isCustomRuleOrphanFile(name: string): boolean {
+  return /^custom-rule-.+\.json(?:(?:\.[^.]+)*\.tmp)?$/.test(name);
+}
+
+/**
  * 进程优雅终止升级（SIGTERM → 宽限期 → SIGKILL），注入式纯逻辑（便于单测）：
  *  1. 立即发 SIGTERM（优雅退出窗口）；
  *  2. graceMs 后若进程仍存活（未触发 exit 收尾）→ 发 SIGKILL 强杀。
@@ -1423,8 +1433,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     this.customRuleFilesDegraded = false;
     try {
       await fs.mkdir(dir, { recursive: true });
-      // 孤儿清扫（含 atomicWrite 可能残留的 .tmp）。writeFileAtomic 用唯一后缀 .<pid>.<rand6hex>.tmp
-      //（架构 review：原固定 .tmp 正则不匹配新后缀，硬崩溃残留文件无法被清扫）——放宽正则匹配任意中间段。
+      // 孤儿清扫：裸 custom-rule-*.json（主目标：删规则/禁用/转 inline/改 id/direct 切换的遗留）
+      // + atomicWrite 残留的 .tmp。writeFileAtomic 用唯一后缀 .<pid>.<rand6hex>.tmp（架构 review：
+      // 原固定 .tmp 正则不匹配新后缀）——正则放宽匹配任意中间段的 .tmp，且把 .tmp 段整体设为**可选**
+      // 以保留裸 .json 清扫（否则强制 .tmp$ 会让删规则后的 .json 孤儿永久残留）。
       let existing: string[] = [];
       try {
         existing = await fs.readdir(dir);
@@ -1432,8 +1444,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         /* 目录刚建/读失败：无孤儿可清 */
       }
       for (const name of existing) {
-        // 匹配 custom-rule-*.json 及其任意后缀的 .tmp 残留（.<pid>.<rand>.tmp 或裸 .tmp）
-        if (/^custom-rule-.+\.json(?:\.[^.]+)*\.tmp$/.test(name) && !expected.has(name)) {
+        // 孤儿判定抽到 isCustomRuleOrphanFile（单一真值，含裸 .json + .tmp 变体，见其说明）。
+        if (isCustomRuleOrphanFile(name) && !expected.has(name)) {
           await fs.unlink(path.join(dir, name)).catch(() => {});
         }
       }

--- a/src/main/services/__tests__/custom-rule-orphan-match.test.ts
+++ b/src/main/services/__tests__/custom-rule-orphan-match.test.ts
@@ -1,0 +1,39 @@
+/**
+ * isCustomRuleOrphanFile（外化规则孤儿文件判定）单测。
+ * 回归：曾因正则强制 .tmp$ 丢了裸 custom-rule-*.json（孤儿主目标），致删规则/改 id/转 inline 后
+ * .json 孤儿文件永久残留磁盘。本测试钉死「裸 .json + 任意 .tmp 变体」都命中、非目标不误删。
+ */
+import * as os from 'os';
+import * as fsSync from 'fs';
+import * as path from 'path';
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-orphan-'));
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { isCustomRuleOrphanFile } from '../ProxyManager';
+
+describe('isCustomRuleOrphanFile（裸 .json + .tmp 变体）', () => {
+  it.each([
+    'custom-rule-abc.json', // 裸 .json —— 孤儿主目标（回归点）
+    'custom-rule-x_y.z@1.json', // id 含特殊字符
+    'custom-rule-abc.json.tmp', // 裸 .tmp 残留
+    'custom-rule-abc.json.4321.abcdef.tmp', // writeFileAtomic 唯一后缀 .<pid>.<rand>.tmp
+  ])('命中孤儿: %s', (name) => {
+    expect(isCustomRuleOrphanFile(name)).toBe(true);
+  });
+
+  it.each([
+    'custom-rule-abc.txt', // 非 .json
+    'other.json', // 非 custom-rule- 前缀
+    'app.log',
+    'custom-rule-abc.json.bak', // .json 后非 .tmp 结尾
+  ])('不误删: %s', (name) => {
+    expect(isCustomRuleOrphanFile(name)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景
6 路并行架构 review（A 架构视角）发现的横切关注点未完全收敛。

## 修复
| 项 | 修复 |
|----|------|
| 🟡 | `ProxyManager.atomicWrite` 复刻固定 `.tmp` 后缀（util writeFileAtomic 已修掉的多 writer 撞车 bug）。改调 util（唯一后缀）|
| 🟡 | `APP_SET_LANGUAGE` 原裸 `ipcMain.handle`，19 个 handler 中唯一绕过 `registerIpcHandler` 封装的例外。改走统一契约 |

## 范围说明
路径分裂（getUserDataPath 被 app.getPath 绕过）+ atomicWrite 4 套散落全量归一属更大重构，留后续独立 PR（依赖跨平台一致性 PR 的 paths 修正）。本 PR 聚焦原子写撞车 bug + IPC 契约统一。

全量 **2126 tests passed** + tsc + eslint 0 warnings。

来源：6 路并行架构 review（A 架构视角）。