### PR TITLE
chore: 清理零引用死代码

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -13,7 +13,6 @@
  *   且 `MainMessageKey = keyof typeof MESSAGES` 自动派生 key 联合类型（新增键无需手维护 union）。
  */
 import {
-  SUPPORTED_LANGUAGES,
   DEFAULT_LANGUAGE,
   resolveEffectiveLanguage,
   type SupportedLanguage,
@@ -456,9 +455,6 @@ export function mt(key: MainMessageKey): string {
   const row = MESSAGES[key];
   return row[currentLang] ?? row[DEFAULT_LANGUAGE];
 }
-
-/** 受支持语言数（供测试校验 parity）。 */
-export const MAIN_I18N_LANG_COUNT = SUPPORTED_LANGUAGES.length;
 
 /** 全部文案键（供测试遍历校验）。 */
 export const MAIN_MESSAGE_KEYS = Object.keys(MESSAGES) as MainMessageKey[];

--- a/src/main/ipc/ipc-events.ts
+++ b/src/main/ipc/ipc-events.ts
@@ -85,10 +85,3 @@ export const ipcEventEmitter = new IpcEventEmitter();
 export function broadcastEvent<T = any>(channel: string, data: T): void {
   ipcEventEmitter.sendToAll(channel, data);
 }
-
-/**
- * 便捷函数：向特定窗口发送事件
- */
-export function sendEventToWindow<T = any>(window: BrowserWindow, channel: string, data: T): void {
-  ipcEventEmitter.sendToWindow(window, channel, data);
-}

--- a/src/main/ipc/ipc-handler.ts
+++ b/src/main/ipc/ipc-handler.ts
@@ -145,10 +145,3 @@ export function registerIpcHandler<TArgs = any, TResult = any>(
 ): void {
   ipcHandlerRegistry.register(channel, handler);
 }
-
-/**
- * 便捷函数：注销 IPC 处理器
- */
-export function unregisterIpcHandler(channel: IpcChannel): void {
-  ipcHandlerRegistry.unregister(channel);
-}

--- a/src/main/services/WarpDeregisterQueue.ts
+++ b/src/main/services/WarpDeregisterQueue.ts
@@ -273,8 +273,3 @@ export function getWarpDeregisterQueue(logManager?: LogManager): WarpDeregisterQ
   }
   return singleton;
 }
-
-/** 仅供测试：重置单例（隔离用例间状态）。 */
-export function __resetWarpDeregisterQueueSingleton(): void {
-  singleton = null;
-}


### PR DESCRIPTION
## 背景
6 路并行架构 review（B 死代码视角）发现 4 个零引用 export（grep + codegraph 双重确认）。

## 清理
| 文件 | 符号 | 证据 |
|------|------|------|
| i18n.ts | MAIN_I18N_LANG_COUNT | 仅定义行，全仓库零引用（连带移除 unused import） |
| ipc-events.ts | sendEventToWindow | 姊妹函数 broadcastEvent 才是实际广播路径 |
| ipc-handler.ts | unregisterIpcHandler | IPC handler 生命周期内不注销（设计取舍），registerIpcHandler 在用 |
| WarpDeregisterQueue.ts | __resetWarpDeregisterQueueSingleton | 注释自称"仅供测试"但无测试调用，孤儿 helper |

## 范围说明
T16 提权三件套 fallback + shq 三副本属安全敏感重构（Linux TUN 提权路径），需更深入运行时验证，留后续独立 PR。本 PR 只清理确定的零风险死代码。

全量 **2126 tests passed** + tsc + eslint 0 warnings。

来源：6 路并行架构 review（B 死代码视角）。