### PR TITLE
提权逻辑收敛：删 ProxyManager 不可达 fallback 副本 + shq 单一真值

### DIFF
--- a/src/main/services/HelperManager.ts
+++ b/src/main/services/HelperManager.ts
@@ -20,6 +20,7 @@ import type { IPrivilegedHelper, HelperStartResult } from './IPrivilegedHelper';
 import type { ILogManager } from './LogManager';
 import { resourceManager } from './ResourceManager';
 import { getUserDataPath } from '../utils/paths';
+import { shq } from '../utils/shell-quote';
 import { sha256File } from '../../shared/file-hash';
 
 // .btm(NSKeyedArchiver) 结构化解析：plist 原为 electron-builder 间接依赖，已提升为直接 dependency 确保打包入 asar。
@@ -725,11 +726,6 @@ export class HelperManager implements IPrivilegedHelper {
   }
 
   // ── 脚本生成 ─────────────────────────────────────────────────────────────
-  /** 单引号包裹并转义，安全嵌入 bash。FlowZ 路径一般不含单引号，仍防御性处理。 */
-  private shq(s: string): string {
-    return `'${s.replace(/'/g, `'\\''`)}'`;
-  }
-
   private xmlEscape(s: string): string {
     return s
       .replace(/&/g, '&amp;')
@@ -787,24 +783,24 @@ export class HelperManager implements IPrivilegedHelper {
     return `#!/bin/bash
 set -e
 umask 077
-SRC=${this.shq(srcBinary)}
-DEST=${this.shq(HELPER_DEST)}
-SUPPORT=${this.shq(SYSTEM_SUPPORT)}
-PLIST=${this.shq(PLIST_PATH)}
+SRC=${shq(srcBinary)}
+DEST=${shq(HELPER_DEST)}
+SUPPORT=${shq(SYSTEM_SUPPORT)}
+PLIST=${shq(PLIST_PATH)}
 mkdir -p /Library/PrivilegedHelperTools "$SUPPORT"
 # 关键：umask 077 会把新建目录设成 700 → 普通用户 app 无法穿越该目录连接 socket(EACCES)。
 # 目录必须 755 可穿越（socket 内部仍靠 token 鉴权 + token 文件 600 保护）。
 chmod 755 /Library/PrivilegedHelperTools "$SUPPORT"
 cp "$SRC" "$DEST"
 chown root:wheel "$DEST"; chmod 755 "$DEST"
-printf '%s' ${this.shq(token)} > "$SUPPORT/helper.token"
+printf '%s' ${shq(token)} > "$SUPPORT/helper.token"
 chown root:wheel "$SUPPORT/helper.token"; chmod 600 "$SUPPORT/helper.token"
 # B 块 seed：把内置内核播种进受保护目录，作为 macOS 现役核「单一稳定真相」（root owner、755 → all 读/exec，
 # 仅 root 可写）。plist 的 --singbox 锁定 $COREDIR/sing-box，故 seed 后「写/读/执行」三处路径恒一致。
 # 守卫「仅当受保护目录尚无可执行 sing-box」→ 重装/修复 helper 不覆盖用户已更新的核；v4→v5 升级时目录为空、
 # 从 bundle 播种当前核。macOS cronet 静态编入 sing-box，无需额外 libcronet 文件。
-COREDIR=${this.shq(coreDir)}
-BUNDLED_SB=${this.shq(bundledSingbox)}
+COREDIR=${shq(coreDir)}
+BUNDLED_SB=${shq(bundledSingbox)}
 mkdir -p "$COREDIR"
 chown root:wheel "$COREDIR"; chmod 755 "$COREDIR"
 if [ ! -x "$COREDIR/sing-box" ]; then
@@ -832,10 +828,10 @@ echo installed-ok
 
   private buildUninstallScript(): string {
     return `#!/bin/bash
-PLIST=${this.shq(PLIST_PATH)}
+PLIST=${shq(PLIST_PATH)}
 launchctl bootout system "$PLIST" 2>/dev/null || true
-rm -f "$PLIST" ${this.shq(HELPER_DEST)}
-rm -rf ${this.shq(SYSTEM_SUPPORT)}
+rm -f "$PLIST" ${shq(HELPER_DEST)}
+rm -rf ${shq(SYSTEM_SUPPORT)}
 echo uninstalled-ok
 `;
   }

--- a/src/main/services/PlatformPrivilegeService.ts
+++ b/src/main/services/PlatformPrivilegeService.ts
@@ -38,6 +38,7 @@ import {
   getSingBoxPidPath,
 } from '../utils/paths';
 import { system32, powershellPath } from '../utils/win-system32';
+import { shq } from '../utils/shell-quote';
 
 /**
  * 提权服务依赖注入上下文。所有成员为只读回调——避免本服务直接访问 ProxyManager 内部状态。
@@ -126,21 +127,13 @@ export class PlatformPrivilegeService {
     private readonly helperManager: HelperManager | null
   ) {}
 
-  // ─── 工具方法（迁自 ProxyManager，原 private，本服务公开供 delegate）──────────────────────────
-
-  /**
-   * shell 单引号转义（防注入），与 HelperManager.shq 同形。
-   * 迁自 ProxyManager.shq。
-   */
-  shq(s: string): string {
-    return `'${s.replace(/'/g, `'\\''`)}'`;
-  }
+  // ─── 工具方法（迁自 ProxyManager；曾公开供 ProxyManager delegate，现仅 ensureCapabilities 内部用 → 收回 private）──
 
   /**
    * 运行命令并捕获 stdout（出错 reject）。用于 getcap 探测。
    * 迁自 ProxyManager.execCapture。
    */
-  execCapture(bin: string, args: string[]): Promise<string> {
+  private execCapture(bin: string, args: string[]): Promise<string> {
     return new Promise((resolve, reject) => {
       const proc = spawn(bin, args);
       let stdout = '';
@@ -163,7 +156,7 @@ export class PlatformPrivilegeService {
    * 以 pkexec(root) 跑 bash 脚本（弹一次密码框）。区分取消(126)/无认证代理(127)。
    * 迁自 ProxyManager.runPkexecScript。
    */
-  runPkexecScript(scriptPath: string): Promise<{ success: boolean; error?: string }> {
+  private runPkexecScript(scriptPath: string): Promise<{ success: boolean; error?: string }> {
     return new Promise((resolve) => {
       const proc = spawn('/usr/bin/pkexec', ['/bin/bash', scriptPath]);
       let stderr = '';
@@ -186,12 +179,12 @@ export class PlatformPrivilegeService {
    * 生成 Linux TUN 提权脚本：setcap 赋权 + 安装限定用户的 resolve1 polkit 规则（含 0.105 .pkla 回退）。
    * 迁自 ProxyManager.buildLinuxTunSetupScript。
    */
-  buildLinuxTunSetupScript(corePath: string, user: string, rulesFile: string): string {
+  private buildLinuxTunSetupScript(corePath: string, user: string, rulesFile: string): string {
     // user 已经白名单校验（[a-z0-9_.@-]），可安全嵌入 heredoc 字面量
     return `#!/bin/bash
 set -e
-CORE=${this.shq(corePath)}
-RULES=${this.shq(rulesFile)}
+CORE=${shq(corePath)}
+RULES=${shq(rulesFile)}
 SETCAP="$(command -v setcap || echo /usr/sbin/setcap)"
 # setcap 缺失（精简 Debian 无 libcap2-bin）→ 用退出码 3 区分于 pkexec 的 126/127（P3-1）
 [ -x "$SETCAP" ] || { echo "setcap 未安装(libcap)" >&2; exit 3; }

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -3267,100 +3267,6 @@ done
     return process.platform === 'win32' && this.needsRootPrivilege();
   }
 
-  /** shell 单引号转义（防注入），与 HelperManager.shq 同形。delegate → PlatformPrivilegeService（T16 子 commit 1）。 */
-  private shq(s: string): string {
-    return this.privilegeService?.shq(s) ?? `'${s.replace(/'/g, `'\\''`)}'`;
-  }
-
-  /**
-   * 运行命令并捕获 stdout（出错 reject）。用于 getcap 探测。
-   * delegate → PlatformPrivilegeService（T16 子 commit 1）；未注入时保留原实现兜底（防 index.ts 装配前调用）。
-   */
-  private execCapture(bin: string, args: string[]): Promise<string> {
-    if (this.privilegeService) return this.privilegeService.execCapture(bin, args);
-    return new Promise((resolve, reject) => {
-      const proc = spawn(bin, args);
-      let stdout = '';
-      let stderr = '';
-      proc.stdout?.on('data', (d) => {
-        stdout += d.toString();
-      });
-      proc.stderr?.on('data', (d) => {
-        stderr += d.toString();
-      });
-      proc.on('exit', (code) => {
-        if (code === 0) resolve(stdout);
-        else reject(new Error(stderr.trim() || `exit ${code}`));
-      });
-      proc.on('error', reject);
-    });
-  }
-
-  /**
-   * 以 pkexec(root) 跑 bash 脚本（弹一次密码框）。区分取消(126)/无认证代理(127)。
-   * delegate → PlatformPrivilegeService（T16 子 commit 1）；未注入时保留原实现兜底。
-   */
-  private runPkexecScript(scriptPath: string): Promise<{ success: boolean; error?: string }> {
-    if (this.privilegeService) return this.privilegeService.runPkexecScript(scriptPath);
-    return new Promise((resolve) => {
-      const proc = spawn('/usr/bin/pkexec', ['/bin/bash', scriptPath]);
-      let stderr = '';
-      proc.stderr?.on('data', (d) => {
-        stderr += d.toString();
-      });
-      proc.on('exit', (code) => {
-        if (code === 0) resolve({ success: true });
-        else if (code === 126) resolve({ success: false, error: '授权被取消' });
-        else if (code === 127)
-          resolve({ success: false, error: '授权失败或系统缺少 polkit 认证代理' });
-        else if (code === 3) resolve({ success: false, error: '系统缺少 setcap（libcap2-bin）' });
-        else resolve({ success: false, error: stderr.trim() || `pkexec 退出码 ${code}` });
-      });
-      proc.on('error', (err) => resolve({ success: false, error: err.message }));
-    });
-  }
-
-  /**
-   * 生成 Linux TUN 提权脚本：setcap 赋权 + 安装限定用户的 resolve1 polkit 规则（含 0.105 .pkla 回退）。
-   * delegate → PlatformPrivilegeService（T16 子 commit 1）；未注入时保留原实现兜底。
-   */
-  private buildLinuxTunSetupScript(corePath: string, user: string, rulesFile: string): string {
-    if (this.privilegeService)
-      return this.privilegeService.buildLinuxTunSetupScript(corePath, user, rulesFile);
-    // user 已经白名单校验（[a-z0-9_.@-]），可安全嵌入 heredoc 字面量
-    return `#!/bin/bash
-set -e
-CORE=${this.shq(corePath)}
-RULES=${this.shq(rulesFile)}
-SETCAP="$(command -v setcap || echo /usr/sbin/setcap)"
-# setcap 缺失（精简 Debian 无 libcap2-bin）→ 用退出码 3 区分于 pkexec 的 126/127（P3-1）
-[ -x "$SETCAP" ] || { echo "setcap 未安装(libcap)" >&2; exit 3; }
-"$SETCAP" 'cap_net_admin,cap_net_bind_service,cap_net_raw=+ep' "$CORE"
-mkdir -p /etc/polkit-1/rules.d
-cat > "$RULES" <<'EOF'
-// FlowZ: 允许指定用户改 systemd-resolved 链路 DNS（TUN auto_route 免逐条密码框）。手动删除本文件即恢复默认。
-polkit.addRule(function(action, subject) {
-  if (action.id.indexOf("org.freedesktop.resolve1.") === 0 &&
-      subject.user === "${user}" && subject.local && subject.active) {
-    return polkit.Result.YES;
-  }
-});
-EOF
-# 0.105 .pkla 回退：只要 polkit localauthority 父目录在就建 50-local.d 并写（P3-2，放宽过严条件）
-PKLA_DIR=/etc/polkit-1/localauthority/50-local.d
-if [ -d /etc/polkit-1/localauthority ]; then
-  mkdir -p "$PKLA_DIR"
-  cat > "$PKLA_DIR/49-flowz-resolved.pkla" <<'EOF2'
-[FlowZ resolved DNS]
-Identity=unix-user:${user}
-Action=org.freedesktop.resolve1.*
-ResultActive=yes
-EOF2
-fi
-echo flowz-linux-tun-setup-ok
-`;
-  }
-
   /**
    * Linux TUN：确保打包核心具备 TUN 所需 capabilities，并安装一条「仅当前用户改 systemd-resolved
    * 链路 DNS」的 polkit 规则——否则 sing-box(auto_route) 经 resolve1 D-Bus 设 DNS 时，polkit 按 uid
@@ -3369,100 +3275,13 @@ echo flowz-linux-tun-setup-ok
    * 仅 Linux TUN 生效；root 运行整 app 时跳过。
    *
    * T16 子 commit 4：实现迁入 PlatformPrivilegeService.ensureCapabilities，此处 delegate；
-   * 未注入时保留原实现兜底（防 index.ts 装配前调用）。
+   * 未注入抛错（装配链路恒先注入，理由同 execCapture）。删原内联兜底实现——它整体复刻
+   * ensureCapabilities（getcap 探测 / 用户名白名单 / 写脚本 / pkexec / 复检），属同类死副本。
    */
   private async ensureLinuxTunCapabilities(): Promise<void> {
-    if (this.privilegeService) return this.privilegeService.ensureCapabilities();
-    if (process.platform !== 'linux' || !this.needsRootPrivilege()) return;
-    // 以 root 跑整个 app → 已有全部权限，无需 pkexec
-    if (typeof process.getuid === 'function' && process.getuid() === 0) return;
-
-    const fs = require('fs');
-    const corePath = this.singboxPath;
-    const rulesFile = '/etc/polkit-1/rules.d/49-flowz-resolved.rules';
-
-    // 核心不存在 → 直接报「找不到」（命中 nonRetryableErrors），不白弹密码框（P2-3）
-    if (!fs.existsSync(corePath)) {
-      throw new Error(`找不到 sing-box 可执行文件: ${corePath}`);
-    }
-
-    // 定位 getcap（普通用户 PATH 常不含 /usr/sbin）；绝对路径都不在则退回裸名走 PATH（P2-1）
-    const getcapBin =
-      ['/usr/sbin/getcap', '/sbin/getcap', '/usr/bin/getcap'].find((p) => {
-        try {
-          return fs.existsSync(p);
-        } catch {
-          return false;
-        }
-      }) || 'getcap';
-
-    // true=有 caps，false=无 caps，null=getcap 不可用（无法判定，复检时以脚本退出码为准）
-    const probeCaps = async (): Promise<boolean | null> => {
-      try {
-        return /cap_net_admin/.test(await this.execCapture(getcapBin, [corePath]));
-      } catch {
-        return null;
-      }
-    };
-
-    let rulesExist = false;
-    try {
-      rulesExist = fs.existsSync(rulesFile);
-    } catch {
-      /* ignore */
-    }
-
-    // 已具备 caps 且规则文件已存在 → 零弹窗
-    if ((await probeCaps()) === true && rulesExist) return;
-
-    // 当前用户名（白名单校验，杜绝注入）。允许企业目录用户名常见的 . 与 @（SSSD/AD），
-    // 三处嵌入上下文（quoted-heredoc / JS 双引号串 / .pkla 值）对 . @ 均安全。
-    let user = '';
-    try {
-      user = require('os').userInfo().username;
-    } catch {
-      /* fallthrough */
-    }
-    if (!user) {
-      throw new Error('TUN 模式需要管理员权限：无法确定当前用户名，请手动配置 setcap');
-    }
-    if (!/^[a-z_][a-z0-9_.@-]*$/i.test(user)) {
-      throw new Error(`TUN 模式需要管理员权限：用户名 "${user}" 含不支持的字符，请手动配置 setcap`);
-    }
-
-    this.logToManager(
-      'info',
-      'Linux TUN 首次配置：请求一次管理员授权（赋核心网络权限 + 安装 DNS polkit 规则）...'
-    );
-
-    const scriptPath = path.join(getUserDataPath(), 'flowz-linux-tun-setup.sh');
-    try {
-      fs.writeFileSync(scriptPath, this.buildLinuxTunSetupScript(corePath, user, rulesFile), {
-        mode: 0o755,
-      });
-    } catch (e) {
-      throw new Error(
-        `TUN 模式需要管理员权限：无法写入提权脚本 (${e instanceof Error ? e.message : String(e)})`
-      );
-    }
-
-    const result = await this.runPkexecScript(scriptPath);
-    try {
-      fs.unlinkSync(scriptPath);
-    } catch {
-      /* 忽略 */
-    }
-
-    // 复检 caps。getcap 不可用（null）时无法验证 → 信任脚本退出码（set -e + 末行 echo 保证 setcap
-    // 成功才退 0）。仅当「getcap 明确说无 caps」或「getcap 不可用且脚本失败」才判失败（P2-1）。
-    const post = await probeCaps();
-    if (post === false || (post === null && !result.success)) {
-      throw new Error(
-        `TUN 模式需要管理员权限：${result.error || '授权被取消或系统缺少 polkit 认证代理'}。` +
-          `可手动执行: sudo setcap 'cap_net_admin,cap_net_bind_service,cap_net_raw=+ep' "${corePath}"`
-      );
-    }
-    this.logToManager('info', 'Linux TUN 提权配置完成（核心已赋权，DNS polkit 规则已安装）');
+    if (!this.privilegeService)
+      throw new Error('privilegeService 未注入：ensureLinuxTunCapabilities 不可用');
+    return this.privilegeService.ensureCapabilities();
   }
 
   /**

--- a/src/main/services/update-install-script.ts
+++ b/src/main/services/update-install-script.ts
@@ -16,11 +16,10 @@
  *   installed 形态（NSIS / dpkg）由安装器自身原位升级，亦不动各自 data 目录。
  */
 
+import { shq } from '../utils/shell-quote';
+
 /** VBS 字符串字面量里的反斜杠按既有约定双写（与旧 installUpdate 一致，Windows 容忍双反斜杠路径）。 */
 const vbsPath = (p: string): string => p.replace(/\\/g, '\\\\');
-
-/** bash 单引号安全转义。 */
-const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
 
 /**
  * Windows 更新 VBS。portableTarget 非空=便携态（覆盖回原 exe 再启动）；否则=NSIS（运行下载的 setup，原行为逐字保留）。

--- a/src/main/utils/__tests__/shell-quote.test.ts
+++ b/src/main/utils/__tests__/shell-quote.test.ts
@@ -1,0 +1,25 @@
+import { shq } from '../shell-quote';
+
+describe('shq（shell 单引号转义）', () => {
+  it('普通字符串：整体单引号包裹', () => {
+    expect(shq('/usr/bin/sing-box')).toBe(`'/usr/bin/sing-box'`);
+  });
+
+  it("含单引号：闭合-转义-重开（'\\''）", () => {
+    expect(shq(`a'b`)).toBe(`'a'\\''b'`);
+  });
+
+  it('shell 元字符（$ ` ; & | 空格）单引号内全部失活', () => {
+    const raw = `$(touch /tmp/x)\`id\`; rm -rf / & echo hi`;
+    // 仅被单引号包裹，内部不含未转义单引号 → POSIX sh 视为纯字面量，无命令替换/分隔
+    expect(shq(raw)).toBe(`'${raw}'`);
+  });
+
+  it('空字符串：一对空单引号', () => {
+    expect(shq('')).toBe(`''`);
+  });
+
+  it('多个单引号：逐个转义', () => {
+    expect(shq(`''`)).toBe(`''\\'''\\'''`);
+  });
+});

--- a/src/main/utils/shell-quote.ts
+++ b/src/main/utils/shell-quote.ts
@@ -1,0 +1,10 @@
+/**
+ * shell 单引号转义（防注入）：把字符串包进单引号，内部单引号用 '\'' 序列闭合-转义-重开。
+ * POSIX sh / bash 通用。
+ *
+ * shell 脚本生成的单一真值——原先 ProxyManager / PlatformPrivilegeService / HelperManager /
+ * update-install-script 各持一份字节级同形副本，收敛至此，杜绝「改一处忘同步另一处」的转义漂移。
+ */
+export function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}


### PR DESCRIPTION
## 背景 / 根因

架构 review（死代码视角）发现 ProxyManager 内多处与 `PlatformPrivilegeService` **字节级一致**的 fallback 副本。装配链路 `setPrivilegeService`（`index.ts:1156`）恒先于任何 `proxyManager.start`（startup-tasks / tray-actions / proxy-handlers / 重启路径均晚于注入），这些 fallback **永不执行**——但它们是真实漂移源：双份 Linux TUN 提权 bash 脚本，改一处忘另一处即提权行为分叉。

## 改动

1. 删 4 处不可达 fallback：`execCapture` / `runPkexecScript` / `buildLinuxTunSetupScript` / `ensureLinuxTunCapabilities`。`ensureLinuxTunCapabilities` 收为薄 delegate（缺注入即抛错，fail-loud 取代静默用漂移副本）；前三个 helper 的唯一调用方就是该 fallback，随之零调用方 → 整体删除（净删约 191 行）。
2. `shq`（shell 单引号转义）原有 **4 份**字节级同形副本（ProxyManager / PlatformPrivilegeService / HelperManager / update-install-script）→ 新建 `src/main/utils/shell-quote.ts` 作单一真值，四处统一 import。
3. `PlatformPrivilegeService` 三个原「公开供 delegate」的 helper 现仅 `ensureCapabilities` 内部使用 → 收回 `private`。
4. 补 `shell-quote` 单测。

## 范围说明

原计划列「3 件套」，`ensureLinuxTunCapabilities` 是同款第 4 处——删其 fallback 会孤立前三者，故一并收敛。其余兄弟 delegate（`needsRootPrivilege` 等 7 处）同属可收敛的死代码，但为控制本批范围保留，留后续分阶段处理。

## 正确性

独立 review 已坐实：`new ProxyManager`@1027 → `setPrivilegeService`@1156 之间无顶层事件循环让渡；所有 `start()` 触发器均晚于 1156；`ensureLinuxTunCapabilities` 仅经 start 到达，删的 fallback 在生产恒不可达。live 路径（`PlatformPrivilegeService.ensureCapabilities`）与被删 fallback 逐句同构，行为零变化；全仓 grep 确认无残留调用方，`shell-quote.ts` 的 `shq` 与原副本逐字一致、转义语义不变。

## 验证

- `tsc --noEmit`：0 错误
- `eslint`（改动文件，`--max-warnings 0`）：0 warning
- `jest`：全量 152 套通过（含新增 shell-quote 单测）
- 真机层（Linux TUN pkexec 提权行为）需 Linux 真机实测，列为人工验证项。
