### PR TITLE
root 提权下 userData 路径全局统一（setPath 下沉根治 shadow + 不硬编码家目录）

### DIFF
--- a/src/main/utils/__tests__/paths-userdata-unification.test.ts
+++ b/src/main/utils/__tests__/paths-userdata-unification.test.ts
@@ -1,0 +1,149 @@
+/**
+ * 回归：root 提权下 userData 路径全局统一。
+ *
+ * 1) shadow 已修复——root 修正移入 initUserDataPath() 并 setPath 下沉，getUserDataPath() 不再被
+ *    initUserDataPath 的早缓存屏蔽（原 bug：修正写在 getUserDataPath，但 init 先缓存默认路径致其从不执行）。
+ * 2) #12 已修——真实家目录解析不硬编码 /home 或 /Users 前缀：HOME 自定义路径直接采信；
+ *    /etc/passwd 反查由纯函数 parsePasswdHome 承担，单测直接钉死其解析（含 usermod -d 非标准家目录）。
+ *
+ * root 场景套件用 typeof process.getuid 守卫：getuid 仅 POSIX 存在，Windows 上 undefined，
+ * 直接 spyOn 会抛（gate 绿 / Windows CI 红）——与仓库既有 POSIX-only 测试同规约。
+ */
+
+const mockApp = {
+  getPath: jest.fn((k: string): string => (k === 'userData' ? '/root/.config/FlowZ' : '/root')),
+  getName: jest.fn((): string => 'FlowZ'),
+  setPath: jest.fn(),
+  isPackaged: false,
+};
+jest.mock('electron', () => ({ app: mockApp }));
+
+const describeRoot = typeof process.getuid === 'function' ? describe : describe.skip;
+
+describeRoot('userData root 提权统一（initUserDataPath setPath 根治 shadow）', () => {
+  let origPlatform: PropertyDescriptor | undefined;
+  let getuidSpy: jest.SpyInstance | undefined;
+  const ENV = ['SUDO_USER', 'HOME', 'PORTABLE_EXECUTABLE_DIR'];
+  const saved: Record<string, string | undefined> = {};
+
+  const setPlatform = (p: string): void => {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  };
+  const asRoot = (uid = 0): void => {
+    getuidSpy = jest
+      .spyOn(process as unknown as { getuid: () => number }, 'getuid')
+      .mockReturnValue(uid);
+  };
+  const setUserDataDefault = (def: string): void => {
+    mockApp.getPath.mockImplementation((k: string) => (k === 'userData' ? def : '/root'));
+  };
+
+  beforeEach(() => {
+    origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    for (const k of ENV) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    mockApp.setPath.mockClear();
+    mockApp.getPath.mockClear();
+  });
+
+  afterEach(() => {
+    if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+    if (getuidSpy) getuidSpy.mockRestore();
+    getuidSpy = undefined;
+    for (const k of ENV) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k] as string;
+    }
+    jest.restoreAllMocks();
+  });
+
+  // darwin 用例用哨兵用户名（宿主 /etc/passwd 必无）→ passwd 反查 miss → 走 /Users 兜底，避免依赖测试机用户。
+  it('darwin+root：initUserDataPath 修正到真实用户家并 setPath；getUserDataPath 不再被 shadow', () => {
+    setPlatform('darwin');
+    asRoot(0);
+    process.env.SUDO_USER = 'zzflowztestuser';
+    process.env.HOME = '/var/root';
+    setUserDataDefault('/var/root/Library/Application Support/FlowZ');
+    jest.isolateModules(() => {
+      const paths = require('../paths');
+      paths.initUserDataPath();
+      const expected = '/Users/zzflowztestuser/Library/Application Support/FlowZ';
+      expect(mockApp.setPath).toHaveBeenCalledWith('userData', expected);
+      expect(paths.getUserDataPath()).toBe(expected);
+    });
+  });
+
+  it('linux+root：HOME 指向自定义家目录（非 /home）→ 直接采信，不硬编码（#12）', () => {
+    setPlatform('linux');
+    asRoot(0);
+    process.env.HOME = '/data/custom-user';
+    setUserDataDefault('/root/.config/FlowZ');
+    jest.isolateModules(() => {
+      const paths = require('../paths');
+      paths.initUserDataPath();
+      const expected = '/data/custom-user/.config/FlowZ';
+      expect(mockApp.setPath).toHaveBeenCalledWith('userData', expected);
+      expect(paths.getUserDataPath()).toBe(expected);
+    });
+  });
+
+  it('普通用户（非 root）：不修正、不 setPath，用 Electron 默认', () => {
+    setPlatform('linux');
+    asRoot(1000);
+    process.env.HOME = '/home/normal';
+    setUserDataDefault('/home/normal/.config/FlowZ');
+    jest.isolateModules(() => {
+      const paths = require('../paths');
+      paths.initUserDataPath();
+      expect(mockApp.setPath).not.toHaveBeenCalled();
+      expect(paths.getUserDataPath()).toBe('/home/normal/.config/FlowZ');
+    });
+  });
+
+  it('getUserDataPath 独立调用（未先 init）：委托 init，root 下仍走修正', () => {
+    setPlatform('darwin');
+    asRoot(0);
+    process.env.HOME = '/var/root';
+    process.env.SUDO_USER = 'zzflowztestcarol';
+    setUserDataDefault('/var/root/Library/Application Support/FlowZ');
+    jest.isolateModules(() => {
+      const paths = require('../paths');
+      expect(paths.getUserDataPath()).toBe(
+        '/Users/zzflowztestcarol/Library/Application Support/FlowZ'
+      );
+    });
+  });
+});
+
+describe('parsePasswdHome（/etc/passwd 解析，#12 核心，纯函数）', () => {
+  // lazy require：避免顶层 import 在 mockApp 初始化前触发 electron mock 工厂
+  const { parsePasswdHome } = require('../paths');
+  const PASSWD = [
+    '# comment line',
+    '',
+    'root:x:0:0:root:/root:/bin/bash',
+    'alice:x:1000:1000:Alice:/home/alice:/bin/bash',
+    'bob:x:1001:1001::/data/bob:/bin/zsh', // usermod -d 非标准家目录
+    'short:x:1002', // 字段不足
+  ].join('\n');
+
+  it('命中 → 取第 6 字段家目录', () => {
+    expect(parsePasswdHome(PASSWD, 'alice')).toBe('/home/alice');
+  });
+
+  it('usermod -d 非标准家目录（不硬编码 /home）', () => {
+    expect(parsePasswdHome(PASSWD, 'bob')).toBe('/data/bob');
+  });
+
+  it('查不到用户 → null', () => {
+    expect(parsePasswdHome(PASSWD, 'nobody')).toBeNull();
+  });
+
+  it('注释行 / 空行 / 字段不足 / 空内容 均跳过', () => {
+    expect(parsePasswdHome(PASSWD, '# comment line')).toBeNull();
+    expect(parsePasswdHome(PASSWD, 'short')).toBeNull();
+    expect(parsePasswdHome('', 'alice')).toBeNull();
+  });
+});

--- a/src/main/utils/paths.ts
+++ b/src/main/utils/paths.ts
@@ -47,87 +47,136 @@ function getPortableDataPath(): string | null {
 }
 
 /**
- * 获取正确的用户数据路径
- * 解决以 root 权限运行时 app.getPath('userData') 返回 /var/root/... 的问题
+ * 提权（root）运行时解析「真实登录用户」的家目录；普通用户 / 解析失败返回 null（用 Electron 默认）。
+ * 不硬编码 /home 或 /Users 前缀——兼容 usermod -d 改过的非标准家目录（架构 review #12）。
  *
- * 在 macOS 上，当应用以 root 权限运行时：
- * - app.getPath('userData') 返回 /var/root/Library/Application Support/FlowZ
- * - 但我们需要的是 /Users/<actual_user>/Library/Application Support/FlowZ
+ * 优先级：
+ *  1) HOME 指向真实用户家（多数 sudoers 保留 HOME；取决于 env_reset/always_set_home）→ 直接采信，兼容自定义路径；
+ *  2) HOME 是 root 家（env_reset / sudo -i）→ 用 SUDO_USER 经 /etc/passwd 反查（Linux，兼容 usermod -d）；
+ *     macOS 常规用户不在 /etc/passwd（走 Open Directory），退回 /Users/<user> 系统约定。
  *
- * 策略：
- * 1. 如果已缓存路径，直接返回
- * 2. 检查是否以 root 运行，如果是则尝试获取真实用户的路径
- * 3. 否则使用 Electron 的默认路径
+ * 覆盖范围：sudo 系提权（HOME 保留 或 SUDO_USER 存在）。pkexec 整 app 提权不在范围——其设 HOME=/root、
+ * 不设 SUDO_USER（仅 PKEXEC_UID），两条均 miss → 回落默认；FlowZ 的 pkexec 仅用于 helper 脚本而非整 app
+ * 提权，故现实影响小（与改动前行为一致，非回归）。
  */
-export function getUserDataPath(): string {
-  if (cachedUserDataPath) {
-    return cachedUserDataPath;
+function resolveElevatedRealHome(): string | null {
+  const isUnixRoot =
+    (process.platform === 'darwin' || process.platform === 'linux') &&
+    typeof process.getuid === 'function' &&
+    process.getuid() === 0;
+  if (!isUnixRoot) return null;
+
+  const home = process.env.HOME;
+  if (home && home !== '/root' && home !== '/var/root') return home;
+
+  const sudoUser = process.env.SUDO_USER;
+  if (sudoUser && sudoUser !== 'root') {
+    const fromPasswd = lookupHomeFromPasswd(sudoUser);
+    if (fromPasswd) return fromPasswd;
+    if (process.platform === 'darwin') return `/Users/${sudoUser}`;
   }
-
-  // 获取 Electron 默认的 userData 路径
-  let userDataPath = app.getPath('userData');
-
-  // 检查是否在 macOS 上以 root 运行
-  if (process.platform === 'darwin' && process.getuid && process.getuid() === 0) {
-    // 尝试从环境变量获取真实用户
-    const sudoUser = process.env.SUDO_USER;
-    const homeDir = process.env.HOME;
-
-    if (sudoUser) {
-      // 通过 SUDO_USER 构建正确的路径
-      const realUserHome = `/Users/${sudoUser}`;
-      const appName = app.getName() || 'FlowZ';
-      userDataPath = path.join(realUserHome, 'Library/Application Support', appName);
-    } else if (homeDir && homeDir.startsWith('/Users/')) {
-      // 通过 HOME 环境变量获取
-      const appName = app.getName() || 'FlowZ';
-      // 提取用户名
-      const match = homeDir.match(/^\/Users\/([^/]+)/);
-      if (match) {
-        userDataPath = path.join('/Users', match[1], 'Library/Application Support', appName);
-      }
-    }
-  }
-
-  // 缓存路径
-  cachedUserDataPath = userDataPath;
-
-  return userDataPath;
+  return null;
 }
 
 /**
- * 设置用户数据路径（应在应用启动时尽早调用）
- * 这确保即使后来以 root 运行部分代码，也能使用正确的路径，
- * 并且在便携模式下，Electron 的内部数据也能正确重定向。
+ * 解析 /etc/passwd 文本，取 username 的家目录（第 6 字段 home）。纯函数（IO 分离，便于单测）。
+ * 跳过注释行 / 空行 / 字段不足；精确匹配用户名；兼容 usermod -d 的非标准家目录。
+ */
+export function parsePasswdHome(content: string, username: string): string | null {
+  for (const line of content.split('\n')) {
+    if (!line || line.startsWith('#')) continue;
+    const f = line.split(':'); // name:passwd:uid:gid:gecos:home:shell
+    if (f[0] === username && f[5]) return f[5];
+  }
+  return null;
+}
+
+/** 从 /etc/passwd 取用户名对应家目录（同步、零依赖）；无文件 / 读失败 / 查不到返回 null。 */
+function lookupHomeFromPasswd(username: string): string | null {
+  try {
+    return parsePasswdHome(fs.readFileSync('/etc/passwd', 'utf8'), username);
+  } catch {
+    return null; // 无 /etc/passwd（如 macOS 常规用户）或读取失败 → 由调用方回退
+  }
+}
+
+/**
+ * root 提权修正后的 userData 路径；非提权 / 解析失败返回 null。
+ * 与 Electron 默认布局一致：macOS=~/Library/Application Support/<app>，Linux=~/.config/<app>（XDG）。
+ */
+function resolveElevatedUserDataPath(): string | null {
+  const realHome = resolveElevatedRealHome();
+  if (!realHome) return null;
+  const appName = app.getName() || 'FlowZ';
+  return process.platform === 'darwin'
+    ? path.join(realHome, 'Library/Application Support', appName)
+    : path.join(realHome, '.config', appName);
+}
+
+/**
+ * 获取正确的用户数据路径。
+ *
+ * 以 root 运行时 app.getPath('userData') 解析到 /var/root（mac）或 /root（Linux），需回退真实用户家目录，
+ * 否则内核 / 配置 / marker 等跨用户目录分裂。修正与缓存由 initUserDataPath() 统一完成（便携 / root / 默认
+ * 三态，见其说明）；此处缓存未命中即委托它（而非另写一套优先级），保证两入口单一真值、不漏便携分支。
+ */
+export function getUserDataPath(): string {
+  if (!cachedUserDataPath) {
+    initUserDataPath();
+  }
+  return cachedUserDataPath ?? app.getPath('userData');
+}
+
+/** 把路径下沉给 Electron（必须在 app.requestSingleInstanceLock() 之前调用）。 */
+function applyUserDataPath(p: string): void {
+  try {
+    app.setPath('userData', p);
+  } catch (e) {
+    console.error('[Paths] Failed to set userData path:', e);
+  }
+}
+
+/**
+ * 设置用户数据路径（应在应用启动时尽早调用：index.ts 模块加载即调用，早于任何 service 构造）。
+ *
+ * 三态，命中便携 / root 修正时均 setPath 下沉给 Electron，使后续所有 app.getPath('userData')（含 paths
+ * 之外 ~13 处直接调用的消费点）自动统一到正确路径：
+ *  - 便携模式：重定向到可执行文件同级 data 目录；
+ *  - root 提权：回退真实用户家目录。根治：原 root 修正在 getUserDataPath 内，但本函数在模块加载即把
+ *    app.getPath('userData') 缓存死，getUserDataPath 的修正被 cache 屏蔽、从不执行——已用单测坐实；
+ *  - 普通用户：用 Electron 默认。
  */
 export function initUserDataPath(): void {
-  if (!cachedUserDataPath) {
-    // 优先尝试便携模式路径
-    const portablePath = getPortableDataPath();
-    if (portablePath) {
-      cachedUserDataPath = portablePath;
-
-      // 确保便携版数据目录存在
-      if (!fs.existsSync(cachedUserDataPath)) {
-        try {
-          fs.mkdirSync(cachedUserDataPath, { recursive: true });
-        } catch (e) {
-          console.error('[Paths] Failed to create portable data directory:', e);
-        }
-      }
-
-      // 核心：将 Electron 的 userData 路径重定向到便携目录
-      // 注意：这必须在 app.requestSingleInstanceLock() 之前调用
-      try {
-        app.setPath('userData', cachedUserDataPath);
-      } catch (e) {
-        console.error('[Paths] Failed to set userData path:', e);
-      }
-    } else {
-      // 在应用启动时（普通用户身份）缓存路径
-      cachedUserDataPath = app.getPath('userData');
-    }
+  if (cachedUserDataPath) {
+    return;
   }
+
+  // 1) 便携模式优先
+  const portablePath = getPortableDataPath();
+  if (portablePath) {
+    cachedUserDataPath = portablePath;
+    // 确保便携版数据目录存在
+    if (!fs.existsSync(cachedUserDataPath)) {
+      try {
+        fs.mkdirSync(cachedUserDataPath, { recursive: true });
+      } catch (e) {
+        console.error('[Paths] Failed to create portable data directory:', e);
+      }
+    }
+    applyUserDataPath(cachedUserDataPath);
+    return;
+  }
+
+  // 2) root 提权修正：下沉 setPath 统一全栈消费点（消除 ~13 处 app.getPath('userData') 绕过）
+  const elevated = resolveElevatedUserDataPath();
+  if (elevated) {
+    cachedUserDataPath = elevated;
+    applyUserDataPath(cachedUserDataPath);
+    return;
+  }
+
+  // 3) 普通用户：缓存 Electron 默认
+  cachedUserDataPath = app.getPath('userData');
 }
 
 /**


### PR DESCRIPTION
## 依赖：Stacked on #212

本 PR 基于 #212（`fix/cross-platform-consistency`，未合并 main），故当前 diff 含 #212 的提交。**#212 合并入 main 后，本 PR diff 自动收敛为仅 `paths.ts` + 其测试。** 本 PR 的 `paths.ts` 改动**取代** #212 在 `getUserDataPath()` 内的 root 修正（移至 `initUserDataPath()`）。建议 #212 先合，或两者一并 review。

## 根因

root 提权运行时 `app.getPath('userData')` 解析到 `/root`（Linux）/ `/var/root`（mac），需回退真实用户家目录，否则内核 / 配置 / marker 等跨用户目录分裂。两处问题：

1. **修正被 shadow**：#212 把 root 修正写在 `getUserDataPath()`，但 `initUserDataPath()`（`index.ts:93` 模块加载即无条件调用）会先把默认 `/root` 缓存死，`getUserDataPath()` 开头 `if (cachedUserDataPath) return` 使修正**从不执行**。已用单测坐实（darwin+root 下，单独 `getUserDataPath` 返回修正路径，但先 `init` 再调则返回未修正的 `/root`）。
2. **硬编码家目录（#12）**：原 `SUDO_USER` 分支硬编码 `/home/<user>` / `/Users/<user>`，与同段「兼容 usermod -d」的注释自相矛盾。

## 改动

1. root 修正 + `app.setPath('userData', 修正路径)` 移入 `initUserDataPath()`，发生在所有 service 构造之前 → 后续全栈 `app.getPath('userData')`（含 ResourceManager / CoreUpdateService / privacy-lock / helper-handlers 等约 13 处直接绕过点）自动统一，无需逐点改造。`getUserDataPath()` 缓存未命中即委托 `initUserDataPath()`，两入口单一真值（不漏便携分支）。
2. #12：`resolveElevatedRealHome` 不再硬编码前缀——HOME 指向真实用户家则直接采信（兼容自定义路径）；HOME 为 root 家时经 `SUDO_USER` + `/etc/passwd` 反查（解析抽纯函数 `parsePasswdHome`，兼容 usermod -d）；macOS 常规用户退回 `/Users/<user>` 约定。docstring 标明覆盖范围（sudo 系；pkexec 整 app 提权不在范围，非回归）。

## 测试

- root 场景套件用 `typeof process.getuid` 守卫（POSIX-only，Windows CI 跳过，与仓库既有规约一致）。
- `parsePasswdHome` 纯函数单测钉死解析：命中取第 6 字段 / usermod -d 非标准家 `/data/bob` / 查不到→null / 注释行+空行+字段不足+空内容跳过。
- 4 条回归：shadow 已修复 / 自定义家目录不硬编码 / 普通用户不修正 / getter 委托 init。

## 验证

- `tsc --noEmit`：0 错误
- `eslint`（`--max-warnings 0`）：0 warning
- `jest`：全量通过（root 套件本机 Linux 实跑未 skip）
- 真机层（各提权器下 HOME/SUDO_USER 实际值、root 属主目录后续非 root 读取）需真机实测，列为人工验证项。
