### PR TITLE
Linux 系统代理 restore/disable 改 execFile argv 收口注入面（复审 Low-2）

### DIFF
--- a/src/main/services/SystemProxyManager.ts
+++ b/src/main/services/SystemProxyManager.ts
@@ -876,7 +876,7 @@ export class LinuxSystemProxy extends SystemProxyBase {
       //（Win/macOS disableProxy 都 restoreProxySettings）。有原始快照（manual + host:port）→ 恢复；否则置 none。
       const restored = await this.restoreOriginalProxyAsync();
       if (!restored) {
-        await execAsync('gsettings set org.gnome.system.proxy mode "none"');
+        await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy', 'mode', 'none']);
         this.log('info', '已禁用系统代理');
       }
       // 拆除成功 → 删除持久化 marker
@@ -895,15 +895,19 @@ export class LinuxSystemProxy extends SystemProxyBase {
     const hp = LinuxSystemProxy.splitHostPort(this.originalSettings?.httpProxy);
     if (!this.originalSettings?.enabled || !hp) return false;
     this.log('info', '正在恢复原始代理设置');
-    // host/port 同步恢复到 http/https/socks（对齐 enableProxy 写法；getProxyStatus 仅采集 http，三者用同 host:port）
-    await execAsync('gsettings set org.gnome.system.proxy mode "manual"');
-    await execAsync(`gsettings set org.gnome.system.proxy.http host "${hp.host}"`);
-    await execAsync(`gsettings set org.gnome.system.proxy.http port ${hp.port}`);
-    await execAsync('gsettings set org.gnome.system.proxy.http enabled true');
-    await execAsync(`gsettings set org.gnome.system.proxy.https host "${hp.host}"`);
-    await execAsync(`gsettings set org.gnome.system.proxy.https port ${hp.port}`);
-    await execAsync(`gsettings set org.gnome.system.proxy.socks host "${hp.host}"`);
-    await execAsync(`gsettings set org.gnome.system.proxy.socks port ${hp.port}`);
+    // host/port 同步恢复到 http/https/socks（getProxyStatus 仅采集 http，三者用同 host:port）。
+    // 攻击面收口（Low-2，与 #213 enable 路径硬化口径统一）：hp.host 来自系统既有 gsettings（可被
+    // dconf 投毒含 $()/反引号/分号等），改 execFileAsync argv——host 作独立参数下发，不经 /bin/sh -c
+    // 插值，杜绝命令注入（原 execAsync 字符串拼接是注入面）。
+    const port = String(hp.port);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy', 'mode', 'manual']);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.http', 'host', hp.host]);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.http', 'port', port]);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.http', 'enabled', 'true']);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.https', 'host', hp.host]);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.https', 'port', port]);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.socks', 'host', hp.host]);
+    await execFileAsync('gsettings', ['set', 'org.gnome.system.proxy.socks', 'port', port]);
     this.originalSettings = null;
     this.log('info', '已恢复原始代理设置');
     return true;
@@ -946,10 +950,12 @@ export class LinuxSystemProxy extends SystemProxyBase {
    * 与 disableProxy 行为分裂——正常退出恢复原始代理，异常/关机退出抹成 none）。
    */
   disableProxySync(): void {
-    const { execSync } = require('child_process');
-    const run = (cmd: string): void => {
+    const { execSync, execFileSync } = require('child_process');
+    // 攻击面收口（Low-2）：gsettings 经 execFileSync argv 下发——host 来自系统 gsettings 可投毒，
+    // argv 形式不经 /bin/sh -c 插值。best-effort，关机语境不抛。
+    const gset = (args: string[]): void => {
       try {
-        execSync(cmd, { stdio: 'ignore' });
+        execFileSync('gsettings', args, { stdio: 'ignore' });
       } catch {
         /* best-effort，关机语境不抛 */
       }
@@ -960,17 +966,18 @@ export class LinuxSystemProxy extends SystemProxyBase {
     const snap = this.originalSettings ?? marker?.originalSettings ?? null;
     const hp = LinuxSystemProxy.splitHostPort(snap?.httpProxy);
     if (snap?.enabled && hp) {
-      run('gsettings set org.gnome.system.proxy mode "manual"');
-      run(`gsettings set org.gnome.system.proxy.http host "${hp.host}"`);
-      run(`gsettings set org.gnome.system.proxy.http port ${hp.port}`);
-      run('gsettings set org.gnome.system.proxy.http enabled true');
-      run(`gsettings set org.gnome.system.proxy.https host "${hp.host}"`);
-      run(`gsettings set org.gnome.system.proxy.https port ${hp.port}`);
-      run(`gsettings set org.gnome.system.proxy.socks host "${hp.host}"`);
-      run(`gsettings set org.gnome.system.proxy.socks port ${hp.port}`);
+      const port = String(hp.port);
+      gset(['set', 'org.gnome.system.proxy', 'mode', 'manual']);
+      gset(['set', 'org.gnome.system.proxy.http', 'host', hp.host]);
+      gset(['set', 'org.gnome.system.proxy.http', 'port', port]);
+      gset(['set', 'org.gnome.system.proxy.http', 'enabled', 'true']);
+      gset(['set', 'org.gnome.system.proxy.https', 'host', hp.host]);
+      gset(['set', 'org.gnome.system.proxy.https', 'port', port]);
+      gset(['set', 'org.gnome.system.proxy.socks', 'host', hp.host]);
+      gset(['set', 'org.gnome.system.proxy.socks', 'port', port]);
     } else {
       // 无原始代理 → 置 none
-      run('gsettings set org.gnome.system.proxy mode "none"');
+      gset(['set', 'org.gnome.system.proxy', 'mode', 'none']);
     }
     this.originalSettings = null; // L3：与 restoreOriginalProxyAsync 对称置 null
     // GNOME 处理完成 → 删除持久化 marker（enableProxy 仅走 GNOME 路径）

--- a/src/main/services/__tests__/linux-system-proxy-restore.test.ts
+++ b/src/main/services/__tests__/linux-system-proxy-restore.test.ts
@@ -1,14 +1,19 @@
 /**
- * LinuxSystemProxy 跨平台一致性单测（R6 High + Medium）。
+ * LinuxSystemProxy 跨平台一致性单测（R6 High + Medium）+ 攻击面收口（Low-2）。
  *
  * 关键：用真实 gsettings stdout 格式 mock（端口含 "uint32" 类型前缀），杜绝假绿——
  * R6-H1-1 实证：原 getProxyStatus 原样拼 "1.2.3.4:uint32 8080" → splitHostPort 恒 null → 恢复永不触发。
  * 覆盖 disableProxy + disableProxySync（含从 marker 读回 originalSettings 恢复，R6-H1-2）。
+ *
+ * Low-2：restore/disableProxySync 的 gsettings 改 execFileAsync/execFileSync argv（host 来自系统
+ * gsettings 可被 dconf 投毒），故本测试以 argv 数组断言，并验证恶意 host 作为字面参数下发、不经 shell 插值。
+ * 注：getProxyStatus 的 gsettings GET 仍走 execAsync（只读、无注入面），保留 exec mock。
  */
 jest.mock('child_process', () => ({
   exec: jest.fn(),
   execFile: jest.fn(),
   execSync: jest.fn(),
+  execFileSync: jest.fn(),
 }));
 
 jest.mock('electron', () => ({
@@ -22,13 +27,14 @@ jest.mock('electron', () => ({
   net: {},
 }));
 
-import { exec, execSync } from 'child_process';
+import { exec, execFile, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { LinuxSystemProxy, SystemProxyBase } from '../SystemProxyManager';
 
 const execMock = exec as unknown as jest.Mock;
-const execSyncMock = execSync as unknown as jest.Mock;
+const execFileMock = execFile as unknown as jest.Mock;
+const execFileSyncMock = execFileSync as unknown as jest.Mock;
 
 /** 模拟真实 gsettings get 输出（按命令返回对应 stdout）。端口带 GVariant uint32 前缀。 */
 function mockGsettingsGet(handlers: Array<{ match: RegExp; stdout: string }>): void {
@@ -45,30 +51,33 @@ function mockGsettingsGet(handlers: Array<{ match: RegExp; stdout: string }>): v
   );
 }
 
-/** 记录 async exec 下发的 set 命令（get 命令返回空 stdout）。 */
-function recordExecSet(): string[] {
-  const cmds: string[] = [];
-  execMock.mockImplementation(
-    (cmd: string, cb: (e: null, r: { stdout: string; stderr: string }) => void) => {
-      if (/gsettings get/.test(cmd)) {
-        cb(null, { stdout: '', stderr: '' });
-        return;
-      }
-      cmds.push(cmd);
-      cb(null, { stdout: '', stderr: '' });
-    }
-  );
-  return cmds;
+/** 记录 async execFile 下发的 gsettings set 调用（argv 扁平为 [file, ...args]）。 */
+function recordExecFileSet(): string[][] {
+  const calls: string[][] = [];
+  execFileMock.mockImplementation((file: string, args: string[], a3: unknown, a4?: unknown) => {
+    const cb = (typeof a3 === 'function' ? a3 : a4) as (
+      e: null,
+      r: { stdout: string; stderr: string }
+    ) => void;
+    calls.push([file, ...args]);
+    cb(null, { stdout: '', stderr: '' });
+  });
+  return calls;
 }
 
-/** 记录 sync execSync 命令。 */
-function recordExecSync(): string[] {
-  const cmds: string[] = [];
-  execSyncMock.mockImplementation((cmd: string) => {
-    cmds.push(cmd);
+/** 记录 sync execFileSync 下发的 gsettings 调用（argv 扁平为 [file, ...args]）。 */
+function recordExecFileSync(): string[][] {
+  const calls: string[][] = [];
+  execFileSyncMock.mockImplementation((file: string, args: string[]) => {
+    calls.push([file, ...args]);
     return '';
   });
-  return cmds;
+  return calls;
+}
+
+/** argv 调用集合里是否存在「同时含全部给定 token」的一条。 */
+function hasCall(calls: string[][], ...tokens: string[]): boolean {
+  return calls.some((c) => tokens.every((t) => c.includes(t)));
 }
 
 const MARKER_PATH = (SystemProxyBase as unknown as { getMarkerPath: () => string }).getMarkerPath();
@@ -94,10 +103,11 @@ function clearMarkerFile(): void {
   }
 }
 
-describe('LinuxSystemProxy 跨平台一致性（R6 High/Medium）', () => {
+describe('LinuxSystemProxy 跨平台一致性（R6 High/Medium）+ 注入收口（Low-2）', () => {
   beforeEach(() => {
     execMock.mockReset();
-    execSyncMock.mockReset();
+    execFileMock.mockReset();
+    execFileSyncMock.mockReset();
     clearMarkerFile();
   });
   afterEach(() => {
@@ -117,32 +127,35 @@ describe('LinuxSystemProxy 跨平台一致性（R6 High/Medium）', () => {
     });
   });
 
-  describe('disableProxy（异步）— 从内存 originalSettings 恢复', () => {
+  describe('disableProxy（异步）— 从内存 originalSettings 恢复（execFileAsync argv）', () => {
     it('有有效快照 → 恢复 mode=manual + host/port + 清 marker', async () => {
       const proxy = new LinuxSystemProxy();
-      // 模拟 enableProxy 已保存快照（经 getProxyStatus 剥前缀后的干净值）
       (proxy as unknown as { originalSettings: unknown }).originalSettings = {
         enabled: true,
         httpProxy: '1.2.3.4:8080',
       };
-      const cmds = recordExecSet();
+      const calls = recordExecFileSet();
 
       await proxy.disableProxy();
 
-      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /host "1\.2\.3\.4"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /port 8080/.test(c))).toBe(true);
-      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(false);
-      // marker 清理
+      expect(hasCall(calls, 'mode', 'manual')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.http', 'host', '1.2.3.4')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.http', 'port', '8080')).toBe(true);
+      // https/socks 同 host:port 一并恢复（三 schema 全覆盖）
+      expect(hasCall(calls, 'org.gnome.system.proxy.https', 'host', '1.2.3.4')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.https', 'port', '8080')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.socks', 'host', '1.2.3.4')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.socks', 'port', '8080')).toBe(true);
+      expect(hasCall(calls, 'mode', 'none')).toBe(false);
       expect(fs.existsSync(MARKER_PATH)).toBe(false);
     });
 
     it('无快照 → 置 mode=none', async () => {
       const proxy = new LinuxSystemProxy();
-      const cmds = recordExecSet();
+      const calls = recordExecFileSet();
       await proxy.disableProxy();
-      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(false);
+      expect(hasCall(calls, 'mode', 'none')).toBe(true);
+      expect(hasCall(calls, 'mode', 'manual')).toBe(false);
     });
 
     it('M3 边界：缺端口 → 不进恢复，置 none', async () => {
@@ -151,43 +164,59 @@ describe('LinuxSystemProxy 跨平台一致性（R6 High/Medium）', () => {
         enabled: true,
         httpProxy: '1.2.3.4',
       };
-      const cmds = recordExecSet();
+      const calls = recordExecFileSet();
       await proxy.disableProxy();
-      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(false);
+      expect(hasCall(calls, 'mode', 'none')).toBe(true);
+      expect(hasCall(calls, 'mode', 'manual')).toBe(false);
+    });
+
+    it('Low-2：恶意 host 作为字面 argv 参数下发，不经 shell 插值', async () => {
+      const proxy = new LinuxSystemProxy();
+      const evil = '$(touch /tmp/pwned)';
+      (proxy as unknown as { originalSettings: unknown }).originalSettings = {
+        enabled: true,
+        httpProxy: `${evil}:8080`,
+      };
+      const calls = recordExecFileSet();
+      await proxy.disableProxy();
+      // 恶意串作为独立 host 参数原样出现在 argv（execFile 不过 shell → 无命令替换执行）
+      expect(hasCall(calls, 'org.gnome.system.proxy.http', 'host', evil)).toBe(true);
+      // 每条调用都是 file='gsettings' + argv，绝无把 host 拼进单一命令串
+      expect(calls.every((c) => c[0] === 'gsettings')).toBe(true);
+      // 负向护栏：完全不走 exec（字符串 /bin/sh -c）路径——恶意串绝无机会被 shell 解释
+      expect(execMock).not.toHaveBeenCalled();
     });
   });
 
-  describe('disableProxySync（同步，R6-H1-2）— 关机新建实例从 marker 读回恢复', () => {
+  describe('disableProxySync（同步，R6-H1-2）— 关机新建实例从 marker 读回恢复（execFileSync argv）', () => {
     it('marker 含 originalSettings → 同步恢复（关机路径生效）', () => {
-      // 模拟关机场景：新建实例（originalSettings=null），但 marker 有 enableProxy 持久化的快照
       writeMarkerWithSnapshot('127.0.0.1:7890', { enabled: true, httpProxy: '10.0.0.1:3128' });
-      const proxy = new LinuxSystemProxy(); // 新实例，originalSettings=null
-      const cmds = recordExecSync();
+      const proxy = new LinuxSystemProxy();
+      const calls = recordExecFileSync();
 
       proxy.disableProxySync();
 
-      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /host "10\.0\.0\.1"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /port 3128/.test(c))).toBe(true);
-      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(false);
-      expect(fs.existsSync(MARKER_PATH)).toBe(false); // marker 清理
+      expect(hasCall(calls, 'mode', 'manual')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.http', 'host', '10.0.0.1')).toBe(true);
+      expect(hasCall(calls, 'org.gnome.system.proxy.http', 'port', '3128')).toBe(true);
+      expect(hasCall(calls, 'mode', 'none')).toBe(false);
+      expect(fs.existsSync(MARKER_PATH)).toBe(false);
     });
 
     it('marker 无 originalSettings（用户原本无代理）→ 置 none', () => {
-      writeMarkerWithSnapshot('127.0.0.1:7890', null); // enable 前 mode=none，无快照
+      writeMarkerWithSnapshot('127.0.0.1:7890', null);
       const proxy = new LinuxSystemProxy();
-      const cmds = recordExecSync();
+      const calls = recordExecFileSync();
       proxy.disableProxySync();
-      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
-      expect(cmds.some((c) => /mode "manual"/.test(c))).toBe(false);
+      expect(hasCall(calls, 'mode', 'none')).toBe(true);
+      expect(hasCall(calls, 'mode', 'manual')).toBe(false);
     });
 
-    it('无 marker（正常状态）→ 置 none + clearMarker 无害', () => {
+    it('无 marker（正常状态）→ 置 none', () => {
       const proxy = new LinuxSystemProxy();
-      const cmds = recordExecSync();
+      const calls = recordExecFileSync();
       proxy.disableProxySync();
-      expect(cmds.some((c) => /mode "none"/.test(c))).toBe(true);
+      expect(hasCall(calls, 'mode', 'none')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## 背景
整体复审（#211→最新）的 Low-2：#212 在 `restoreOriginalProxyAsync` / `disableProxySync` 新增以 `execAsync`/`execSync` **字符串插值**下发 gsettings，其中 `hp.host` 来自系统既有 gsettings（可被 dconf/admin 投毒含 `$()`/反引号/分号），经 `/bin/sh -c` 会命令注入；且与 #213 把 enable 路径迁 `execFileAsync` 的硬化方向背离——同一文件混存「硬化/未硬化」两种口径。

## 改动
- `restoreOriginalProxyAsync` / `disableProxySync` 的 gsettings 全部迁 `execFileAsync`/`execFileSync` **argv** 形式：host/port 作独立参数下发，不经 shell 插值，杜绝注入。
- `disableProxy` 的 `mode=none` 一并迁（gsettings SET 口径统一）。
- **不动**：enable 路径的 host 是 FlowZ 自身可信 `address`（非注入面）；`getProxyStatus` 的 gsettings **GET** 只读、保留 `execAsync`。

## 测试
`linux-system-proxy-restore` 改为 argv 数组断言；新增**注入抵抗**用例——恶意 host `$(touch /tmp/pwned)` 作字面 argv 参数下发、绝不拼进单一命令串。

## 验证
tsc 0；eslint 0；jest 全量 162 套（2192）通过。真机层（GNOME 代理在 argv 形式下恢复行为一致）建议真机实测后合入。