### PR TITLE
perf: 缓解 Windows RDP 拖动卡顿——日志批处理 + 拖动门控 + StatsService 拆 utilityProcess (#225)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,7 +44,7 @@ import { CoreUpdateScheduler } from './services/CoreUpdateScheduler';
 import { SpeedTestService } from './services/SpeedTestService';
 import { AutoSwitchService } from './services/AutoSwitchService';
 import { SubscriptionScheduler } from './services/SubscriptionScheduler';
-import { StatsService } from './services/StatsService';
+import { StatsWorkerHost } from './services/StatsWorkerHost';
 import { PlatformPrivilegeService } from './services/PlatformPrivilegeService';
 import { IpInfoService } from './services/IpInfoService';
 import { RuleResourceManager } from './services/RuleResourceManager';
@@ -133,6 +133,20 @@ let trayManager: TrayManager | null = null;
 const isDevelopment = process.env.NODE_ENV === 'development';
 let idleCheckInterval: NodeJS.Timeout | null = null; // 自动空闲模式轮询（powerMonitor 真实系统输入空闲）
 
+// 窗口拖动态（T2，issue #225）：Windows 拖动 frameless 窗口走 move modal loop（跑主线程），拖动期间任何
+// 非关键 UI 推流（日志/流量/连接）都会逼整窗逐帧重绘 + RDP 全帧重编码 → 拖动卡顿。move 时置位、moved 去抖后清零。
+let isDragging = false;
+
+/**
+ * UI 广播活跃谓词（T1/T2/T4 统一门控，issue #225）：窗口可见 **且** 非拖动中 才推 UI 更新。
+ * - 日志批 flush（registerLogHandlers）按此门控：不活跃只暂存不推。
+ * - 流量/连接 relay（StatsWorkerHost）按此门控：不活跃只更新缓存不 sendToAll，活跃恢复时补推一帧最新。
+ * 隐藏（macOS hide / minimizeToTray / 轻量销毁）= 无 UI 消费者；拖动中 = 让主线程只处理窗口移动重绘。
+ */
+function isUiBroadcastActive(): boolean {
+  return !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible() && !isDragging;
+}
+
 // Privacy Mode State (Main Process)
 let isPrivacyMode = false;
 
@@ -219,7 +233,7 @@ let speedTestService: SpeedTestService;
 let autoSwitchService: AutoSwitchService;
 let subscriptionScheduler: SubscriptionScheduler;
 let coreUpdateScheduler: CoreUpdateScheduler | null = null;
-let statsService: StatsService | null = null;
+let statsService: StatsWorkerHost | null = null;
 let ipInfoService: IpInfoService | null = null;
 let ruleResourceManager: RuleResourceManager | null = null;
 let ruleResourceScheduler: RuleResourceScheduler | null = null;
@@ -658,6 +672,34 @@ async function createWindow(forceShow = false) {
   mainWindow.on('maximize', sendMaximizeState);
   mainWindow.on('unmaximize', sendMaximizeState);
 
+  // ── 窗口拖动门控（T2，issue #225）── 仅 Windows
+  // 拖动 frameless 窗口走 OS move modal loop（主线程），期间整窗逐帧重绘 + RDP 全帧重编码；若同时有日志/流量/连接
+  // 广播触发重渲，拖动即卡顿。拖动期间置 isDragging → isUiBroadcastActive 返 false → 日志批 flush 与 stats relay
+  // 全部挂起，让主线程只处理窗口移动重绘；拖动结束后去抖恢复并补推一帧最新缓存。
+  // 仅 win32 门控：macOS/Linux 拖动由合成器流畅处理、无主线程 modal 阻塞，挂起只会徒增「拖动时数字冻住」无收益。
+  // 拖动结束判定用「move 流停止」（最后一个 move 后 DRAG_SETTLE_MS 内无新 move）——比 'moved' 事件在各平台/RDP 更可靠。
+  isDragging = false; // 新窗口重置（防上个窗口拖动中被销毁致 isDragging 滞留 true）
+  let dragSettleTimer: NodeJS.Timeout | null = null;
+  if (process.platform === 'win32') {
+    const DRAG_SETTLE_MS = 120;
+    mainWindow.on('move', () => {
+      if (!isDragging) isDragging = true; // 仅拖动起始置位（move 高频，避免重复赋值）
+      if (dragSettleTimer) clearTimeout(dragSettleTimer);
+      dragSettleTimer = setTimeout(() => {
+        isDragging = false;
+        dragSettleTimer = null;
+        // 拖动结束补推一帧最新流量/连接（免等 worker 下一帧最多 ~1s 滞后）；日志由下一 flush tick 自动恢复。
+        statsService?.resume();
+      }, DRAG_SETTLE_MS);
+    });
+    // 拖动中窗口被销毁 → 清残留 settle timer（防对已销毁窗口的滞留回调）。
+    mainWindow.on('closed', () => {
+      if (dragSettleTimer) clearTimeout(dragSettleTimer);
+      dragSettleTimer = null;
+      isDragging = false;
+    });
+  }
+
   // 移除默认菜单栏（Windows/Linux）
   if (process.platform !== 'darwin') {
     mainWindow.setMenu(null);
@@ -855,6 +897,8 @@ async function runCleanup(): Promise<void> {
     coreUpdateScheduler?.stop();
     ruleResourceScheduler?.stop();
     autoSwitchService?.destroy();
+    // T4：终止 stats utilityProcess（停 respawn + kill worker），避免退出后遗留子进程。
+    statsService?.dispose();
 
     // 1. 拆除代理（去 status.running 门控：跨会话孤儿 / 隐藏会话残留也必须回收；退出语境零提权弹框）
     if (proxyManager) {
@@ -1195,16 +1239,19 @@ if (gotTheLock) {
     proxyManager.setPrivilegeService(privilegeService);
     coreUpdateService.setPrivilegeService(privilegeService);
 
-    // 流量统计：代理运行时经管理 API（gRPC）订阅 Status/Connections 流，经事件推渲染端展示。
-    // getApiClient 取 ProxyManager 运行期管理 API 客户端（核未起返回 null → 不开流）。
-    statsService = new StatsService(
-      (stats) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_STATS_UPDATED, stats),
-      () => proxyManager?.getApiClient() ?? null,
-      (snap) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, snap),
-      // P1/P2：窗口可见才广播——隐藏（macOS hide / minimizeToTray）/销毁（轻量模式）时无 UI 消费者，
-      // 跳过 broadcast（流仍维护快照）。读模块级 mainWindow 当前值（创建/销毁会变）。
-      () => !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
-    );
+    // 流量统计（T4，issue #225）：StatsService 已拆入 utilityProcess（见 services/StatsWorkerHost + workers/stats-worker）。
+    // 本宿主 fork/看护 worker、缓存最新快照、按 isUiBroadcastActive(可见 && !拖动) 门控后 sendToAll——把 Status/
+    // Connections 长流的 per-frame 解析+物化移出主线程，消除拖动期事件循环争用。worker 据 getStatsApiEndpoint 重建
+    // 自己的 gRPC client（端口随每次启动可能变 → 'api-client-ready' 时经 resubscribe 重发）。
+    statsService = new StatsWorkerHost({
+      workerPath: path.join(__dirname, 'workers', 'stats-worker.js'),
+      onStats: (stats) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_STATS_UPDATED, stats),
+      onConnections: (snap) =>
+        ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, snap),
+      isUiActive: isUiBroadcastActive,
+      getEndpoint: () => proxyManager?.getStatsApiEndpoint() ?? null,
+      log: (level, message) => logManager.addLog(level, message, 'StatsWorker'),
+    });
     // 杀核前静默 StatsService：停其到管理 API 的 Status/Connections gRPC 流（核将死，提前 cancel 避免 RST 噪音）。
     proxyManager.setQuiesceStats(() => {
       statsService?.stop();
@@ -1405,7 +1452,7 @@ if (gotTheLock) {
     registerConfigHandlers(configManager);
     registerPrivacyHandlers();
     registerServerHandlers(protocolParser, configManager, logManager);
-    registerLogHandlers(logManager, proxyManager);
+    registerLogHandlers(logManager, proxyManager, isUiBroadcastActive);
     registerProxyHandlers(proxyManager, statsService);
     registerIpInfoHandlers(ipInfoService);
     registerSystemHandlers();

--- a/src/main/ipc/handlers/__tests__/log-handlers-batch.test.ts
+++ b/src/main/ipc/handlers/__tests__/log-handlers-batch.test.ts
@@ -1,0 +1,103 @@
+/**
+ * 日志广播批处理 + UI 门控单测（T1，issue #225）。覆盖 registerLogHandlers 的 coalescer 行为：
+ *  1) 多条 'log' 在 ~150ms 窗口内合并为单次 EVENT_LOG_RECEIVED_BATCH（数组、顺序保持），非逐条广播。
+ *  2) isUiActive 门控：不活跃（拖动/隐藏）时只暂存不广播；活跃后下一 tick 一次性 flush 全部暂存。
+ *  3) 暂存上限 MAX_PENDING_LOG_BATCH=500：超限丢最旧、保最新（live tail 语义）。
+ * 经 mock registerIpcHandler（LOGS_GET/CLEAR 桩）+ broadcastEvent（捕获广播）+ fake timers 驱动 flush。
+ */
+import { EventEmitter } from 'events';
+import { IPC_CHANNELS } from '../../../../shared/ipc-channels';
+import type { LogEntry } from '../../../../shared/types';
+
+// LOGS_GET/LOGS_CLEAR 处理器注册桩（本测不关心，避免触达真实 IPC）。
+jest.mock('../../ipc-handler', () => ({
+  registerIpcHandler: jest.fn(),
+}));
+// 捕获广播：断言批次内容/次数。
+jest.mock('../../ipc-events', () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+import { registerLogHandlers } from '../log-handlers';
+import { broadcastEvent } from '../../ipc-events';
+
+const mockBroadcast = broadcastEvent as jest.MockedFunction<typeof broadcastEvent>;
+
+function entry(message: string): LogEntry {
+  return { timestamp: '2026-06-30T00:00:00.000Z', level: 'info', message, source: 'test' };
+}
+
+/** 最小 LogManager 桩：仅需 on('log')（EventEmitter）。getLogs/clearLogs 不触达（registerIpcHandler 已 mock）。 */
+function makeLogManager() {
+  return new EventEmitter() as unknown as Parameters<typeof registerLogHandlers>[0];
+}
+
+describe('registerLogHandlers 日志批处理 (T1)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockBroadcast.mockClear();
+  });
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('多条日志在一个 flush 窗口内合并为单次 BATCH 广播（顺序保持）', () => {
+    const lm = makeLogManager();
+    registerLogHandlers(lm, undefined, () => true);
+
+    (lm as unknown as EventEmitter).emit('log', entry('a'));
+    (lm as unknown as EventEmitter).emit('log', entry('b'));
+    (lm as unknown as EventEmitter).emit('log', entry('c'));
+    expect(mockBroadcast).not.toHaveBeenCalled(); // flush 前不广播
+
+    jest.advanceTimersByTime(150);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    const [channel, batch] = mockBroadcast.mock.calls[0];
+    expect(channel).toBe(IPC_CHANNELS.EVENT_LOG_RECEIVED_BATCH);
+    expect((batch as LogEntry[]).map((e) => e.message)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('空 pending 不广播', () => {
+    const lm = makeLogManager();
+    registerLogHandlers(lm, undefined, () => true);
+    jest.advanceTimersByTime(600);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('isUiActive=false（拖动/隐藏）时只暂存不广播；恢复后一次性 flush 全部', () => {
+    let active = false;
+    const lm = makeLogManager();
+    registerLogHandlers(lm, undefined, () => active);
+
+    (lm as unknown as EventEmitter).emit('log', entry('x'));
+    (lm as unknown as EventEmitter).emit('log', entry('y'));
+    jest.advanceTimersByTime(450); // 多个 tick 都不活跃
+    expect(mockBroadcast).not.toHaveBeenCalled();
+
+    active = true;
+    jest.advanceTimersByTime(150);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    expect((mockBroadcast.mock.calls[0][1] as LogEntry[]).map((e) => e.message)).toEqual([
+      'x',
+      'y',
+    ]);
+  });
+
+  it('暂存超上限丢最旧保最新（live tail），上限 500', () => {
+    let active = false;
+    const lm = makeLogManager();
+    registerLogHandlers(lm, undefined, () => active);
+    // 不活跃期间灌 600 条 → 暂存超 500 上限，丢最旧 100 条（m0..m99），保最新 500（m100..m599）。
+    for (let i = 0; i < 600; i++) {
+      (lm as unknown as EventEmitter).emit('log', entry(`m${i}`));
+    }
+    active = true;
+    jest.advanceTimersByTime(150);
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    const batch = mockBroadcast.mock.calls[0][1] as LogEntry[];
+    expect(batch).toHaveLength(500);
+    expect(batch[0].message).toBe('m100'); // 最旧保留项 = 第 101 条
+    expect(batch[batch.length - 1].message).toBe('m599'); // 最新
+  });
+});

--- a/src/main/ipc/handlers/log-handlers.ts
+++ b/src/main/ipc/handlers/log-handlers.ts
@@ -14,7 +14,20 @@ import { broadcastEvent } from '../ipc-events';
 /**
  * 注册日志管理相关的 IPC 处理器
  */
-export function registerLogHandlers(logManager: LogManager, proxyManager?: ProxyManager): void {
+/** 日志 UI 批 flush 间隔（ms）：~150ms 窗口合并多条日志为单次 IPC，渲染端单次 setState。体感无延迟。 */
+const LOG_FLUSH_INTERVAL_MS = 150;
+/** 不活跃（拖动/隐藏）期 pending 暂存上限：超出丢最旧并计数（落盘不受影响，仅 UI live tail 截断）。 */
+const MAX_PENDING_LOG_BATCH = 500;
+
+/**
+ * @param isUiActive 可选门控谓词：返回 false（窗口不可见 或 拖动中）时只暂存日志、不广播——拖动期不打断窗口
+ *   移动重绘（issue #225），隐藏期无 UI 消费者。活跃后下一 tick 一次性 flush。缺省（未注入，如旧调用）= 始终广播。
+ */
+export function registerLogHandlers(
+  logManager: LogManager,
+  proxyManager?: ProxyManager,
+  isUiActive?: () => boolean
+): void {
   // 获取日志
   registerIpcHandler<{ limit?: number }, LogEntry[]>(
     IPC_CHANNELS.LOGS_GET,
@@ -34,8 +47,33 @@ export function registerLogHandlers(logManager: LogManager, proxyManager?: Proxy
     }
   });
 
-  // 监听日志事件并广播到所有渲染进程
+  // 日志广播批处理（T1，issue #225）：原「每条 'log' 即一次 IPC broadcast」在 sing-box 启动期日志洪流下
+  // → N 行 = N 次 IPC 序列化+send，撞 Windows 拖动 move modal loop（跑主线程）致拖动冻顿。改为 ~150ms 窗口
+  // coalesce 成单次 EVENT_LOG_RECEIVED_BATCH（渲染端单次 setState），并按 isUiActive(可见 && !拖动) 门控。
+  let pending: LogEntry[] = [];
+  let droppedWhileInactive = 0;
+  const flushTimer = setInterval(() => {
+    if (pending.length === 0) return;
+    if (isUiActive && !isUiActive()) return; // 不活跃（拖动/隐藏）→ 保留 pending 等下次活跃 tick
+    const batch = pending;
+    pending = [];
+    if (droppedWhileInactive > 0) {
+      // 诚实记录暂存溢出丢弃（不进 logManager 避免再入 pending；落盘日志不受影响）。
+      console.warn(
+        `[log-batch] UI 暂存溢出丢弃 ${droppedWhileInactive} 条日志（仅 UI live tail 截断，已落盘）`
+      );
+      droppedWhileInactive = 0;
+    }
+    broadcastEvent(IPC_CHANNELS.EVENT_LOG_RECEIVED_BATCH, batch);
+  }, LOG_FLUSH_INTERVAL_MS);
+  // 后台定时器不应拖住进程退出（Electron 主进程常驻，这里仅防御性 unref）。
+  if (typeof flushTimer.unref === 'function') flushTimer.unref();
+
   logManager.on('log', (log: LogEntry) => {
-    broadcastEvent(IPC_CHANNELS.EVENT_LOG_RECEIVED, log);
+    pending.push(log);
+    if (pending.length > MAX_PENDING_LOG_BATCH) {
+      pending.shift(); // 丢最旧，保最新（live tail 语义）
+      droppedWhileInactive++;
+    }
   });
 }

--- a/src/main/ipc/handlers/proxy-handlers.ts
+++ b/src/main/ipc/handlers/proxy-handlers.ts
@@ -15,7 +15,8 @@ import type {
 import { registerIpcHandler } from '../ipc-handler';
 import { ProxyManager } from '../../services/ProxyManager';
 import { tailscaleStateExists } from '../../services/tailscale-state';
-import type { StatsService } from '../../services/StatsService';
+// 只需「读快照」最小面（getSnapshot/getConnectionsSnapshot）：StatsWorkerHost（T4 生产）与 StatsService（单测）皆满足。
+import type { StatsProvider } from '../../services/StatsWorkerHost';
 import type { TailscaleStatusSnapshot } from '../../../shared/tailscale-status';
 
 /**
@@ -37,7 +38,7 @@ export function setTrayStateCallback(callback: TrayStateUpdateCallback): void {
  */
 export function registerProxyHandlers(
   proxyManager: ProxyManager,
-  statsService?: StatsService | null
+  statsService?: StatsProvider | null
 ): void {
   // 注：系统代理 enable/clear 已收口于 ProxyManager（start reconcile + ensureSystemProxyCleared），
   // 本 handler 不再直接持有 systemProxyManager（拆双轨，修 C1/M4）。

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -203,6 +203,9 @@ export interface IProxyManager {
   getDashboardConnectionInfo(): { ok: boolean; url: string; apiUrl: string; secret: string };
   // 运行期管理 API 客户端（sing-box 1.14 gRPC）：供 StatsService 经此订阅 Status/Connections 流；未启动核时为 null。
   getApiClient(): SingBoxApiClient | null;
+  // stats worker（T4，issue #225）：运行期管理 API 端点（host/port/secret），供 StatsWorkerHost 让 worker 重建
+  // 自己的 gRPC client；核未起返回 null。
+  getStatsApiEndpoint(): { host: string; port: number; secret: string } | null;
   generateSingBoxConfig(config: UserConfig, resolvedIps?: Record<string, string>): SingBoxConfig;
   on(
     event:
@@ -1973,6 +1976,21 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       apiUrl: `http://127.0.0.1:${port}`,
       secret: this.currentConfig?.clashApiSecret || '',
     };
+  }
+
+  /**
+   * stats worker（T4，issue #225）运行期管理 API 端点。worker 进程据此重建自己的 SingBoxApiClient 订阅 Status/
+   * Connections 流（main 不再在主线程跑 stats 解析）。host 恒 127.0.0.1（本地核）；端口随每次启动可能重解析
+   * （见 resolveTailscaleApiPort）→ 'api-client-ready' 时由 StatsWorkerHost.resubscribe 重新下发。核未运行/无端口
+   * → null（worker 不开流，对齐 getApiClient 语义）。
+   * secret 取 currentConfig.clashApiSecret（与 live tailscaleApiClient 同源——二者均随 startInternal 同步刷新）。
+   * worker 重连仅由 'api-client-ready'(=核重启) 驱动，而重启必重跑 startInternal 同时更新 currentConfig 与端口，
+   * 故 endpoint 的 secret/port 与新核恒一致；不存在「secret 不重启被改写后 worker 拿旧值」的路径。
+   */
+  getStatsApiEndpoint(): { host: string; port: number; secret: string } | null {
+    const port = this.tailscaleApiPort;
+    if (!this.getStatus().running || !port) return null;
+    return { host: '127.0.0.1', port, secret: this.currentConfig?.clashApiSecret || '' };
   }
 
   /**

--- a/src/main/services/StatsWorkerHost.ts
+++ b/src/main/services/StatsWorkerHost.ts
@@ -1,0 +1,228 @@
+/**
+ * StatsWorkerHost —— main 侧 stats utilityProcess 宿主（T4，issue #225）。
+ *
+ * 背景：原 StatsService 在 main 进程订阅 sing-box 1.14 管理 API 的 Status/Connections gRPC 长流，每帧解析连接事件、
+ * 物化连接列表（trimConnection × N）。这部分 per-frame 工作与 Windows 拖动的 move modal loop（跑主线程）抢事件循环，
+ * 是「拖动卡顿 + 启动后迟缓」的结构性来源（perf doc P2-1 实测 main 事件循环 >100ms 高频）。
+ *
+ * 方案：把 StatsService **原样**搬进 utilityProcess（见 workers/stats-worker.ts，类逻辑不改，保 #210/#167/审计#3 全部
+ * 不变量），main 侧仅留本宿主：fork/看护 worker、转发控制、缓存最新快照、按 uiActive(可见 && !拖动) 门控后 sendToAll。
+ * 本宿主**镜像 StatsService 的对外公共接口**（resubscribe/stop/getSnapshot/getConnectionsSnapshot）做近 drop-in，
+ * index.ts 接线与 proxy-handlers 几乎不变。
+ *
+ * 进程拓扑：worker 持自己的 SingBoxApiClient（仅 stats，不订 Tailscale）；main 保留 tailscaleApiClient 管 Tailscale。
+ * 两 client 各连同一 127.0.0.1:apiPort 的不同 RPC 流，互不冲突。
+ */
+import { utilityProcess, type UtilityProcess } from 'electron';
+import type { TrafficStats, ConnectionsSnapshot } from '../../shared/types';
+
+/** worker 重建 SingBoxApiClient 所需的运行期管理 API 端点（本地恒无 tls）。 */
+export interface StatsApiEndpoint {
+  host: string;
+  port: number;
+  secret: string;
+  tls?: { ca?: string; skipVerify?: boolean };
+}
+
+/** proxy-handlers 只需「读快照」这一最小面；StatsWorkerHost 与（测试用的）StatsService 均满足。 */
+export interface StatsProvider {
+  getSnapshot(): TrafficStats;
+  getConnectionsSnapshot(): ConnectionsSnapshot;
+}
+
+/** main → worker 控制消息。 */
+export type HostToWorkerMessage =
+  | { type: 'connect'; endpoint: StatsApiEndpoint }
+  | { type: 'stop' }
+  // C（issue #225 review）：门控 worker 的 connections 跨进程 post——不活跃（隐藏/拖动）时 worker 跳过把连接表
+  // 克隆推给 main（隐藏挂托盘 + 上千连接时的主要浪费）。status 帧不门控、始终流动，故本标志靠 host 在每个 status
+  // 帧上惰性同步（见 syncConnActive），无需窗口事件接线、无 worker 卡死风险。
+  | { type: 'setConnActive'; active: boolean }
+  | { type: 'dispose' };
+
+/** worker → main 数据/握手消息。 */
+export type WorkerToHostMessage =
+  | { type: 'ready' }
+  | { type: 'stats'; payload: TrafficStats }
+  | { type: 'connections'; payload: ConnectionsSnapshot };
+
+const ZERO_STATS: TrafficStats = {
+  uploadSpeed: 0,
+  downloadSpeed: 0,
+  totalUpload: 0,
+  totalDownload: 0,
+  activeConnections: 0,
+};
+
+export interface StatsWorkerHostOptions {
+  /** 已编译 worker 入口绝对路径（dist 下 .js）。 */
+  workerPath: string;
+  /** 流量快照广播到渲染端（main 侧门控后调用）。 */
+  onStats: (s: TrafficStats) => void;
+  /** 连接快照广播到渲染端（main 侧门控后调用）。 */
+  onConnections: (snap: ConnectionsSnapshot) => void;
+  /** UI 广播活跃谓词：false（不可见/拖动中）时只缓存不广播。 */
+  isUiActive: () => boolean;
+  /** 取运行期管理 API 端点（核未起返回 null → worker 不开流）。 */
+  getEndpoint: () => StatsApiEndpoint | null;
+  /** 可选日志钩子（接 logManager）。 */
+  log?: (level: 'info' | 'warn' | 'error', message: string) => void;
+}
+
+export class StatsWorkerHost implements StatsProvider {
+  private worker: UtilityProcess | null = null;
+  private snapshot: TrafficStats = { ...ZERO_STATS };
+  private connections: ConnectionsSnapshot = { connections: [], at: 0 };
+  /** 是否应处于订阅态（代理运行）。崩溃 respawn 后据此自动重连，不丢流。 */
+  private started = false;
+  private disposed = false;
+  private respawnTimer: ReturnType<typeof setTimeout> | null = null;
+  private respawnDelayMs = 500;
+  /** 上次下发给 worker 的 connActive（C）。null=未发过（reconnect/respawn 后重置，强制下个 status 帧重新同步）。 */
+  private lastConnActiveSent: boolean | null = null;
+
+  constructor(private readonly opts: StatsWorkerHostOptions) {
+    this.spawn();
+  }
+
+  private spawn(): void {
+    if (this.disposed) return;
+    try {
+      const w = utilityProcess.fork(this.opts.workerPath, [], { serviceName: 'flowz-stats' });
+      this.worker = w;
+      w.on('message', (msg: WorkerToHostMessage) => this.onWorkerMessage(msg));
+      w.on('exit', (code: number) => this.onWorkerExit(code));
+      // 退避不在此重置：fork 成功 ≠ worker 健康。boot 即崩的 worker 收不到 'ready'，退避须持续增长（见 'ready' case）。
+    } catch (e) {
+      this.opts.log?.('error', `stats worker spawn 失败: ${(e as Error)?.message ?? e}`);
+      this.scheduleRespawn();
+    }
+  }
+
+  private onWorkerExit(code: number): void {
+    this.worker = null;
+    if (this.disposed) return;
+    // 非 dispose 的退出 = 崩溃 → 退避 respawn；spawn 后收到 'ready' 时若 started 自动重连（见 onWorkerMessage）。
+    this.opts.log?.('warn', `stats worker 退出(code=${code})，${this.respawnDelayMs}ms 后重启`);
+    this.scheduleRespawn();
+  }
+
+  private scheduleRespawn(): void {
+    if (this.respawnTimer || this.disposed) return;
+    const delay = this.respawnDelayMs;
+    this.respawnTimer = setTimeout(() => {
+      this.respawnTimer = null;
+      this.spawn();
+    }, delay);
+    this.respawnDelayMs = Math.min(this.respawnDelayMs * 2, 10_000); // 指数退避，上限 10s
+  }
+
+  private post(msg: HostToWorkerMessage): void {
+    // worker 重启窗口内 worker=null → 丢弃；respawn 后据 started 由 'ready' 握手重连，不需在此重试。
+    try {
+      this.worker?.postMessage(msg);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private postConnect(): void {
+    // reconnect/respawn 后强制下个 status 帧重新同步 connActive（worker 可能是新进程、默认 connActive=true）。
+    this.lastConnActiveSent = null;
+    const endpoint = this.opts.getEndpoint();
+    if (!endpoint) {
+      this.post({ type: 'stop' });
+      return;
+    }
+    this.post({ type: 'connect', endpoint });
+  }
+
+  /**
+   * 惰性同步 worker 的 connActive（C）：仅在 isUiActive 变化时下发，借「始终流动」的 status 帧驱动——故无需
+   * 监听窗口 show/hide/minimize 事件，且 status 不门控 → worker 不会卡死在 inactive。
+   * 自愈延迟分两档：**stats/连接计数 ≤1 个 status 间隔（~1s）**（status 恒流、转活跃下一帧即经 relay 广播）；
+   * **连接明细列表最坏 ~2 个流间隔**（先一个 status 帧触发本同步 setConnActive(true)，worker 收到后再等下一个
+   * connections 帧才 post）。功能正确、仅列表多 ~1s 滞后，隐藏期本无列表消费者，可接受。
+   */
+  private syncConnActive(): void {
+    const active = this.opts.isUiActive();
+    if (active !== this.lastConnActiveSent) {
+      this.lastConnActiveSent = active;
+      this.post({ type: 'setConnActive', active });
+    }
+  }
+
+  private onWorkerMessage(msg: WorkerToHostMessage): void {
+    switch (msg?.type) {
+      case 'ready':
+        // worker 监听器就绪握手：避免 fork 后立即 post 被「监听器未挂」竞态吞掉。worker 证明健康 → 重置退避
+        //（修 boot-即崩 worker 把退避永远卡在 500ms 的紧循环：退避只该被「健康过」的 worker 重置）。
+        this.respawnDelayMs = 500;
+        if (this.started) this.postConnect();
+        break;
+      case 'stats':
+        // started 门控：stop() 后 worker 在途旧帧（stop 消息送达前 worker 可能刚 post 一帧非零）必须丢弃，
+        // 否则缓存被旧值覆盖 + 广播残留非零速率/总量，直到下次 connect → 违反 stop「停止即清零」不变量。
+        if (!this.started) return;
+        this.syncConnActive(); // 借常流的 status 帧惰性同步 worker 的 connActive（C）
+        this.snapshot = msg.payload;
+        if (this.opts.isUiActive()) this.opts.onStats(this.snapshot);
+        break;
+      case 'connections':
+        if (!this.started) return; // 同上：停后在途连接帧丢弃，避免残留旧连接列表。
+        this.connections = msg.payload;
+        if (this.opts.isUiActive()) this.opts.onConnections(this.connections);
+        break;
+    }
+  }
+
+  // ── 镜像 StatsService 对外公共接口（近 drop-in） ──────────────────────────────
+
+  /** 代理就绪（api-client-ready）/ 切端口：让 worker 连最新端点并重订阅。worker 未 ready 时由 'ready' 握手补连。 */
+  resubscribe(): void {
+    this.started = true;
+    this.postConnect();
+  }
+
+  /** 停止订阅 + 清零广播（对齐 StatsService.stop：不门控、直接清 UI，避免停后残留旧值）。 */
+  stop(): void {
+    this.started = false;
+    this.post({ type: 'stop' });
+    this.snapshot = { ...ZERO_STATS };
+    this.connections = { connections: [], at: Date.now() };
+    this.opts.onStats({ ...this.snapshot });
+    this.opts.onConnections({ connections: [], at: Date.now() });
+  }
+
+  /** 拖动结束：立即补推一帧缓存最新（免等 worker 下一帧滞后）。窗口由隐藏转可见时不另补推——stats/计数走恒流的
+   *  status 帧 ≤1s 自然广播；连接列表经 connActive 重新激活后 ~2 个流间隔恢复（见 syncConnActive），与原行为大致一致。 */
+  resume(): void {
+    if (!this.opts.isUiActive()) return;
+    this.opts.onStats({ ...this.snapshot });
+    this.opts.onConnections({ connections: this.connections.connections, at: Date.now() });
+  }
+
+  getSnapshot(): TrafficStats {
+    return { ...this.snapshot };
+  }
+
+  getConnectionsSnapshot(): ConnectionsSnapshot {
+    return { connections: this.connections.connections, at: Date.now() };
+  }
+
+  /** app 退出：终止 worker，停止 respawn。 */
+  dispose(): void {
+    this.disposed = true;
+    if (this.respawnTimer) {
+      clearTimeout(this.respawnTimer);
+      this.respawnTimer = null;
+    }
+    this.post({ type: 'dispose' });
+    try {
+      this.worker?.kill();
+    } catch {
+      /* ignore */
+    }
+    this.worker = null;
+  }
+}

--- a/src/main/services/__tests__/stats-worker-host.test.ts
+++ b/src/main/services/__tests__/stats-worker-host.test.ts
@@ -1,0 +1,281 @@
+/**
+ * StatsWorkerHost 单测（T4，issue #225）。覆盖 main 侧宿主逻辑（worker 由 mock electron.utilityProcess 替身）：
+ *  1) 构造即 fork worker；resubscribe 下发最新端点 connect / 端点为 null 下发 stop。
+ *  2) worker 数据消息：缓存 + 按 isUiActive 门控广播（不活跃只缓存不 onStats/onConnections）。
+ *  3) resume 补推缓存最新（活跃才推）；stop 不门控清零广播。
+ *  4) getSnapshot/getConnectionsSnapshot 读缓存。
+ *  5) 'ready' 握手 / 崩溃 exit → 退避 respawn + 自动重连；dispose 终止不再 respawn。
+ */
+import type { TrafficStats, ConnectionsSnapshot } from '../../../shared/types';
+
+// mock electron：utilityProcess.fork 返回 EventEmitter 替身（postMessage/kill 为 jest.fn）。
+jest.mock('electron', () => {
+  const { EventEmitter } = require('events');
+  // 工厂内用 any 规避「值当类型」（EventEmitter 是 require 来的运行期值）；外部用 FakeWorker 类型断言。
+  const forkedWorkers: any[] = [];
+  const fork = jest.fn(() => {
+    const w: any = new EventEmitter();
+    w.postMessage = jest.fn();
+    w.kill = jest.fn();
+    forkedWorkers.push(w);
+    return w;
+  });
+  return {
+    utilityProcess: { fork },
+    __getForkedWorkers: () => forkedWorkers,
+    __reset: () => {
+      forkedWorkers.length = 0;
+      fork.mockClear();
+    },
+  };
+});
+
+import { StatsWorkerHost, type StatsApiEndpoint } from '../StatsWorkerHost';
+
+const electron = require('electron');
+type FakeWorker = import('events').EventEmitter & { postMessage: jest.Mock; kill: jest.Mock };
+const workers = (): FakeWorker[] => electron.__getForkedWorkers();
+const lastWorker = (): FakeWorker => workers()[workers().length - 1];
+
+const ENDPOINT: StatsApiEndpoint = { host: '127.0.0.1', port: 9090, secret: 'sec' };
+const SAMPLE_STATS: TrafficStats = {
+  uploadSpeed: 10,
+  downloadSpeed: 20,
+  totalUpload: 100,
+  totalDownload: 200,
+  activeConnections: 3,
+};
+const SAMPLE_CONNS: ConnectionsSnapshot = {
+  connections: [{ id: 'c1', chains: [], rule: '', rulePayload: '', metadata: {} }],
+  at: 123,
+};
+
+function makeHost() {
+  const onStats = jest.fn();
+  const onConnections = jest.fn();
+  const state = { active: true, endpoint: ENDPOINT as StatsApiEndpoint | null };
+  const host = new StatsWorkerHost({
+    workerPath: '/fake/stats-worker.js',
+    onStats,
+    onConnections,
+    isUiActive: () => state.active,
+    getEndpoint: () => state.endpoint,
+  });
+  return { host, onStats, onConnections, state };
+}
+
+beforeEach(() => electron.__reset());
+
+describe('StatsWorkerHost 控制面 (T4)', () => {
+  it('构造即 fork worker', () => {
+    makeHost();
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(1);
+    expect(workers()).toHaveLength(1);
+  });
+
+  it('resubscribe 下发最新端点 connect', () => {
+    const { host } = makeHost();
+    host.resubscribe();
+    expect(lastWorker().postMessage).toHaveBeenCalledWith({ type: 'connect', endpoint: ENDPOINT });
+  });
+
+  it('resubscribe 端点为 null（核未起）→ 下发 stop', () => {
+    const { host, state } = makeHost();
+    state.endpoint = null;
+    host.resubscribe();
+    expect(lastWorker().postMessage).toHaveBeenCalledWith({ type: 'stop' });
+  });
+});
+
+describe('StatsWorkerHost 数据面门控 (T4)', () => {
+  it('活跃时 stats 消息缓存 + 广播', () => {
+    const { onStats, host } = makeHost();
+    host.resubscribe(); // started=true（生产中帧只在 connect 后才来）
+    lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(onStats).toHaveBeenCalledWith(SAMPLE_STATS);
+    expect(host.getSnapshot()).toEqual(SAMPLE_STATS);
+  });
+
+  it('不活跃时 stats 消息只缓存不广播', () => {
+    const { onStats, host, state } = makeHost();
+    host.resubscribe(); // started=true
+    state.active = false;
+    lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(onStats).not.toHaveBeenCalled();
+    expect(host.getSnapshot()).toEqual(SAMPLE_STATS); // 缓存仍更新
+  });
+
+  it('connections 消息同样门控 + 缓存', () => {
+    const { onConnections, host, state } = makeHost();
+    host.resubscribe(); // started=true
+    state.active = false;
+    lastWorker().emit('message', { type: 'connections', payload: SAMPLE_CONNS });
+    expect(onConnections).not.toHaveBeenCalled();
+    expect(host.getConnectionsSnapshot().connections).toEqual(SAMPLE_CONNS.connections);
+  });
+
+  it('resume 活跃时补推缓存最新；不活跃不推', () => {
+    const { onStats, onConnections, host, state } = makeHost();
+    host.resubscribe(); // started=true
+    state.active = false;
+    lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    lastWorker().emit('message', { type: 'connections', payload: SAMPLE_CONNS });
+    onStats.mockClear();
+    onConnections.mockClear();
+
+    host.resume(); // 仍不活跃 → 不推
+    expect(onStats).not.toHaveBeenCalled();
+
+    state.active = true;
+    host.resume(); // 活跃 → 补推缓存
+    expect(onStats).toHaveBeenCalledWith(SAMPLE_STATS);
+    expect(onConnections).toHaveBeenCalledWith(
+      expect.objectContaining({ connections: SAMPLE_CONNS.connections })
+    );
+  });
+
+  it('stop 不门控、清零广播', () => {
+    const { onStats, onConnections, host, state } = makeHost();
+    host.resubscribe(); // started=true，下面的帧进缓存
+    lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(host.getSnapshot().activeConnections).toBe(3); // 缓存确为非零
+    onStats.mockClear();
+    onConnections.mockClear();
+    state.active = false; // 即便不活跃，stop 仍广播清零
+
+    host.stop();
+    expect(onStats).toHaveBeenCalledWith(
+      expect.objectContaining({ uploadSpeed: 0, downloadSpeed: 0, activeConnections: 0 })
+    );
+    expect(onConnections).toHaveBeenCalledWith(expect.objectContaining({ connections: [] }));
+    expect(host.getSnapshot().activeConnections).toBe(0);
+  });
+
+  // Medium-A 回归：stop 后 worker 在途旧帧（stop 消息送达前 post 的非零帧）必须被 started 门控丢弃，
+  // 否则缓存被旧值覆盖 + 广播残留非零，违反 stop「停止即清零」。
+  it('stop 后 worker 在途旧帧被丢弃（!started 门控，不广播不覆盖缓存）', () => {
+    const { onStats, host } = makeHost();
+    host.resubscribe(); // started=true
+    lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(host.getSnapshot()).toEqual(SAMPLE_STATS);
+
+    host.stop(); // started=false + 清零
+    onStats.mockClear();
+    lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS }); // 在途旧帧
+    lastWorker().emit('message', { type: 'connections', payload: SAMPLE_CONNS });
+    expect(onStats).not.toHaveBeenCalled();
+    expect(host.getSnapshot().activeConnections).toBe(0); // 缓存仍为 stop 的零值
+    expect(host.getConnectionsSnapshot().connections).toEqual([]);
+  });
+});
+
+describe('StatsWorkerHost connActive 惰性同步 (C)', () => {
+  it('isUiActive 变化时经 status 帧下发 setConnActive，未变化不重复下发', () => {
+    const { host, state } = makeHost();
+    host.resubscribe();
+    const w = lastWorker();
+    w.postMessage.mockClear();
+
+    // 首个 status 帧（active=true，lastSent=null）→ 下发 setConnActive(true)
+    w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(w.postMessage).toHaveBeenCalledWith({ type: 'setConnActive', active: true });
+    w.postMessage.mockClear();
+
+    // 再来 status 帧、active 未变 → 不重复下发
+    w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(w.postMessage).not.toHaveBeenCalledWith({ type: 'setConnActive', active: true });
+
+    // 转不活跃（隐藏/拖动）→ 下个 status 帧下发 setConnActive(false)
+    state.active = false;
+    w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(w.postMessage).toHaveBeenCalledWith({ type: 'setConnActive', active: false });
+  });
+
+  it('reconnect 后重置同步态，强制下个 status 帧重新下发 setConnActive', () => {
+    const { host } = makeHost();
+    host.resubscribe();
+    const w = lastWorker();
+    w.emit('message', { type: 'stats', payload: SAMPLE_STATS }); // 已下发 setConnActive(true)
+    w.postMessage.mockClear();
+
+    host.resubscribe(); // reconnect → postConnect 重置 lastConnActiveSent=null
+    w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(w.postMessage).toHaveBeenCalledWith({ type: 'setConnActive', active: true }); // 重新下发
+  });
+});
+
+describe('StatsWorkerHost 生命周期 (T4)', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("'ready' 握手在 started 后补连 connect", () => {
+    const { host } = makeHost();
+    host.resubscribe(); // started=true，已发一次 connect
+    lastWorker().postMessage.mockClear();
+    lastWorker().emit('message', { type: 'ready' });
+    expect(lastWorker().postMessage).toHaveBeenCalledWith({ type: 'connect', endpoint: ENDPOINT });
+  });
+
+  it('worker 崩溃 exit → 退避 respawn，新 worker ready 后自动重连', () => {
+    const { host } = makeHost();
+    host.resubscribe(); // started=true
+    expect(workers()).toHaveLength(1);
+
+    lastWorker().emit('exit', 1); // 崩溃
+    jest.advanceTimersByTime(500); // 首次退避 500ms
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(2); // 已 respawn
+    expect(workers()).toHaveLength(2);
+
+    lastWorker().emit('message', { type: 'ready' }); // 新 worker 就绪
+    expect(lastWorker().postMessage).toHaveBeenCalledWith({ type: 'connect', endpoint: ENDPOINT });
+  });
+
+  // Medium-B 回归：退避只该被「证明健康（发过 ready）」的 worker 重置；boot-即崩 worker 退避须持续增长。
+  it('boot-即崩 worker（从不 ready）退避指数增长，不卡在 500ms', () => {
+    makeHost();
+    lastWorker().emit('exit', 1); // 第 1 次崩（从未 ready）
+    jest.advanceTimersByTime(500);
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(2); // 首次退避 500ms
+
+    lastWorker().emit('exit', 1); // 第 2 次崩
+    jest.advanceTimersByTime(500); // 退避已升到 1000ms，500ms 不够
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(2); // 未 respawn
+    jest.advanceTimersByTime(500); // 累计 1000ms
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(3); // 现在才 respawn
+  });
+
+  // 强化版：先连续 boot-crash 把退避涨到 2000ms，再 ready 验回落 500ms——这样删掉 'ready' 里的重置即会 fail，
+  // 真正护住 B（旧版只崩一次、初始退避本就 500ms，删重置也通过、抓不到回归）。
+  it('worker 发过 ready（证明健康）后再崩，退避从涨高值重置回 500ms', () => {
+    const { host } = makeHost();
+    host.resubscribe();
+    // 连续 boot-crash：退避 500→1000→2000
+    lastWorker().emit('exit', 1);
+    jest.advanceTimersByTime(500); // fork #2，退避→1000
+    lastWorker().emit('exit', 1);
+    jest.advanceTimersByTime(1000); // fork #3，退避→2000
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(3);
+
+    // 健康握手 → 退避应重置 500；随后崩，500ms 即应 respawn（若未重置则退避=2000，500ms 不够 → fail）
+    lastWorker().emit('message', { type: 'ready' });
+    lastWorker().emit('exit', 1);
+    jest.advanceTimersByTime(500);
+    expect(electron.utilityProcess.fork).toHaveBeenCalledTimes(4);
+  });
+
+  it('dispose 终止 worker 且不再 respawn', () => {
+    const { host } = makeHost();
+    host.dispose();
+    expect(lastWorker().postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(lastWorker().kill).toHaveBeenCalled();
+
+    // dispose 后再 exit 不应 respawn。
+    const forkCountBefore = electron.utilityProcess.fork.mock.calls.length;
+    lastWorker().emit('exit', 0);
+    jest.advanceTimersByTime(10000);
+    expect(electron.utilityProcess.fork.mock.calls.length).toBe(forkCountBefore);
+  });
+});

--- a/src/main/workers/stats-worker.ts
+++ b/src/main/workers/stats-worker.ts
@@ -1,0 +1,71 @@
+/**
+ * stats-worker —— Electron utilityProcess 入口（T4，issue #225）。
+ *
+ * 把 StatsService 的 Status/Connections gRPC 长流订阅 + 连接事件解析 + per-frame 物化从 main 进程移出，消除主线程
+ * 事件循环争用（Windows 拖动 move modal loop 跑主线程，与 stats 处理抢线程 → 拖动卡顿 / 启动后迟缓）。
+ *
+ * 设计要点：
+ * - StatsService 类**原样复用**（import 现有实现，逻辑不改 → 保 #210 长流重建 / #167 LRU eviction / 审计#3 OOM 上限
+ *   / resubscribe 切端口 等全部不变量；存量单测继续护）。
+ * - worker 持自己的 SingBoxApiClient（仅 stats，不传 onUpdate → 不订 Tailscale）；端点参数由 main 经 'connect' 下发。
+ * - isWindowVisible **恒缺省**（undefined）→ worker 永远物化 + post；可见性/拖动门控统一在 main 侧 relay 完成
+ *   （StatsWorkerHost.onWorkerMessage 按 uiActive 门控），worker 不感知窗口态。
+ */
+import { StatsService } from '../services/StatsService';
+import { SingBoxApiClient } from '../services/singbox-api-client';
+import type { HostToWorkerMessage, WorkerToHostMessage } from '../services/StatsWorkerHost';
+
+// utilityProcess 子进程的父端口（Electron 在子进程 process 上注入）。
+const parentPort = process.parentPort;
+
+let apiClient: SingBoxApiClient | null = null;
+// connActive（C，issue #225 review）：main 经 'setConnActive' 下发。false（UI 隐藏/拖动）时跳过把连接表克隆推给
+// main（隐藏挂托盘 + 上千连接的主要浪费）。status 帧不门控、始终流动 → main 借其惰性同步本标志，无卡死风险。
+// 默认 true：连上即推，待 main 首个 status 帧校正（最坏多推 ~1s 连接帧，无害）。
+let connActive = true;
+
+function post(msg: WorkerToHostMessage): void {
+  parentPort.postMessage(msg);
+}
+
+// StatsService 实例常驻：'connect' 切 client + resubscribe，'stop' 停流。getApiClient 返回 worker 当前 client。
+const stats = new StatsService(
+  (s) => post({ type: 'stats', payload: s }), // status 不门控：始终流动，驱动 main 惰性同步 connActive
+  () => apiClient,
+  (snap) => {
+    if (connActive) post({ type: 'connections', payload: snap }); // C：不活跃跳过连接表跨进程克隆
+  }
+  // 第 4 参 isWindowVisible 故意不传 → status 始终广播；connections 由 connActive 门控（上方）。
+);
+
+parentPort.on('message', (e: Electron.MessageEvent) => {
+  const msg = e.data as HostToWorkerMessage;
+  switch (msg?.type) {
+    case 'connect':
+      // 切到最新端点（apiPort 每次启动可能重解析变化）：重建 client 后 resubscribe（停旧流句柄 → 按新 client 重订阅）。
+      // connActive 复位 true：新订阅默认活跃推连接，避免持久 worker 重连时残留的 stale-false 抑制连接帧；
+      // host 的 postConnect 已重置同步态，会在首个 status 帧（≤1s）按真实可见性校正。
+      connActive = true;
+      apiClient = new SingBoxApiClient(
+        { host: msg.endpoint.host, port: msg.endpoint.port, tls: msg.endpoint.tls },
+        msg.endpoint.secret
+      );
+      stats.resubscribe();
+      break;
+    case 'setConnActive':
+      connActive = msg.active; // C：门控 connections 跨进程 post（status 不受影响）
+      break;
+    case 'stop':
+      stats.stop();
+      apiClient = null;
+      break;
+    case 'dispose':
+      stats.stop();
+      apiClient = null;
+      process.exit(0);
+      break;
+  }
+});
+
+// 监听器已挂 → 握手通知 main 可安全下发 'connect'（避免 fork 后立即 post 被竞态吞掉）。
+post({ type: 'ready' });

--- a/src/renderer/bridge/api-wrapper.ts
+++ b/src/renderer/bridge/api-wrapper.ts
@@ -247,8 +247,8 @@ export function addEventListener(event: string, listener: (...args: any[]) => vo
       return api.proxy.onError(listener);
     case 'configChanged':
       return api.config.onChanged(listener);
-    case 'logReceived':
-      return api.logs.onReceived(listener);
+    case 'logReceivedBatch':
+      return api.logs.onReceivedBatch(listener);
     case 'statsUpdated':
       return api.stats.onUpdated(listener);
     default:

--- a/src/renderer/components/logs/real-time-logs.tsx
+++ b/src/renderer/components/logs/real-time-logs.tsx
@@ -40,13 +40,18 @@ export function RealTimeLogs({
   const connectionStatus = useAppStore((state) => state.connectionStatus);
 
   // Effect ①：实时日志订阅 —— 仅挂载时订阅一次；容量经 maxBufferRef 读取，props 变化不重订阅。
+  // T1（issue #225）：改订阅批量通道 'logReceivedBatch'（主进程 ~150ms coalesce），一批日志单次 setState 追加，
+  // 取代逐条 setState（启动期洪流下逐条 = 高频重渲 + RDP 逐帧流式，拖动卡顿主因之一）。
   useEffect(() => {
-    const handleLogReceived = (logEntry: LogEntry) => {
-      setLogs((prev) =>
-        [...prev, { ...logEntry, _id: nextIdRef.current++ }].slice(-maxBufferRef.current)
-      );
+    const handleLogBatch = (entries: LogEntry[]) => {
+      if (!entries || entries.length === 0) return;
+      setLogs((prev) => {
+        const next = prev.slice();
+        for (const e of entries) next.push({ ...e, _id: nextIdRef.current++ });
+        return next.slice(-maxBufferRef.current);
+      });
     };
-    const unsubscribe = addEventListener('logReceived', handleLogReceived);
+    const unsubscribe = addEventListener('logReceivedBatch', handleLogBatch);
     return unsubscribe;
   }, []);
 

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -469,10 +469,11 @@ export const logsApi = {
   },
 
   /**
-   * 监听日志接收事件
+   * 监听批量日志接收事件（T1，issue #225）：主进程 ~150ms coalesce 多条日志为一次数组推送，
+   * 渲染端单次 setState 批量追加。取代旧逐条 EVENT_LOG_RECEIVED（已删，削渲染端高频重渲与 RDP 逐帧流式开销）。
    */
-  onReceived(listener: (log: LogEntry) => void): () => void {
-    return ipcClient.on(IPC_CHANNELS.EVENT_LOG_RECEIVED, listener);
+  onReceivedBatch(listener: (logs: LogEntry[]) => void): () => void {
+    return ipcClient.on(IPC_CHANNELS.EVENT_LOG_RECEIVED_BATCH, listener);
   },
 };
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -135,7 +135,9 @@ export const IPC_CHANNELS = {
   EVENT_PROXY_STOPPED: 'event:proxyStopped',
   EVENT_PROXY_ERROR: 'event:proxyError',
   EVENT_CONFIG_CHANGED: 'event:configChanged',
-  EVENT_LOG_RECEIVED: 'event:logReceived',
+  // 日志批处理广播（T1，issue #225）：~150ms 窗口 coalesce 多条日志为单次数组 IPC（取代旧逐条 event:logReceived，
+  // 已删），削平 sing-box 启动期日志洪流对主线程的 IPC 冲击（每条一次 send → 撞 Windows 拖动 move 循环致拖动卡顿）。
+  EVENT_LOG_RECEIVED_BATCH: 'event:logReceivedBatch',
   EVENT_STATS_UPDATED: 'event:statsUpdated',
   EVENT_CONNECTIONS_UPDATED: 'event:connectionsUpdated',
   EVENT_ENTER_PRIVACY_MODE: 'event:enterPrivacyMode',


### PR DESCRIPTION
## 背景

issue #225：Windows RDP 远程会话下拖动窗口卡顿。根因分层：

- **L0 物理底座**：RDP 会话无 GPU → Chromium 退化为软件合成；集成标题栏是 frameless 自绘拖动，拖动时整窗逐帧重绘，每帧像素都要编码后推过 RDP 网络线（本机有 GPU + 无帧流式 → 不卡；RDP → 卡）。
- **L2 启动期（极卡）**：起核 spawn + Windows 路由表注入（helper child_process）+ DNS/系统代理接管，叠加 sing-box 启动期日志洪流——日志逐条无批处理广播，N 行 = N 次 IPC 序列化+send，撞 Windows 拖动 move modal loop（跑主进程 UI 线程）。
- **L3 启动后（迟缓）**：status/connections 流 + 日志持续推流，渲染端永不空闲。

（Mica / CSS 非主因：RDP 下 Mica 回落实色，CSS 侧无 backdrop-filter；已禁硬件加速仅 Linux，Windows 保留 GPU。）

## 改动（三档）

- **日志广播批处理**：逐条 `EVENT_LOG_RECEIVED` → ~150ms 窗口 coalesce 成单次 `EVENT_LOG_RECEIVED_BATCH`，渲染端单次 setState 批量追加；按「可见 && !拖动」门控，暂存上限 500 丢最旧。削平启动期日志洪流对主线程的 IPC 冲击。
- **拖动期挂起非关键推流（仅 Windows）**：拖动期间挂起日志/流量/连接广播，让主线程只处理窗口移动重绘，拖动结束去抖（move 流停止判定）后恢复并补推一帧。macOS/Linux 拖动由合成器流畅处理、不门控。
- **StatsService 拆 Electron utilityProcess**：把 status/connections gRPC 长流订阅 + 连接事件解析 + 物化移出主线程，消除事件循环争用。`StatsService` 逻辑**原样复用**（保 issue #210 长流重建 / #167 LRU eviction / OOM 上限 / resubscribe 切端口等不变量），main 侧新增 `StatsWorkerHost` 做近 drop-in（缓存快照 / 可见性门控 relay / 崩溃退避 respawn / ready 握手 / dispose）；worker 持自己的 `SingBoxApiClient` 仅订 stats，端点经 `ProxyManager.getStatsApiEndpoint()` 下发。`connActive` 惰性同步（借恒流的 status 帧驱动）使隐藏/拖动期跳过连接表跨进程克隆，且 worker 不会卡死在 inactive。

## 测试

- 新增 20 单测：日志批处理（coalesce / 门控 / 暂存 cap）；`StatsWorkerHost`（控制面 / 数据面门控 / stop 清零 / 崩溃退避 respawn 自愈 / connActive 惰性同步）。
- `tsc`(main+renderer) + `eslint` + `jest`（2235 测）全绿。
- 两轮独立多视角 review（正确性·生命周期 + 集成·回归）+ 一轮修复后复审，均判可合，无 High/Medium/Low 功能缺陷。

## 待验证（runtime 语义，需 Windows RDP 真机）

- 启动期 / 启动后拖动是否改善；开/关日志页拖动对比。
- 流量/连接面板实时性不退；worker 崩溃自愈。
- 打包（asar）后 `utilityProcess` 能 fork + worker 内 `@grpc/grpc-js` 连得上管理 API（双 client 连同一 localhost 端口）。

Closes #225
