### PR TITLE
fix: 根治连接风暴下首页/界面卡死（issue #227）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1246,8 +1246,8 @@ if (gotTheLock) {
     statsService = new StatsWorkerHost({
       workerPath: path.join(__dirname, 'workers', 'stats-worker.js'),
       onStats: (stats) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_STATS_UPDATED, stats),
-      onConnections: (snap) =>
-        ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, snap),
+      onAggregate: (agg) =>
+        ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_AGGREGATE, agg),
       isUiActive: isUiBroadcastActive,
       getEndpoint: () => proxyManager?.getStatsApiEndpoint() ?? null,
       log: (level, message) => logManager.addLog(level, message, 'StatsWorker'),

--- a/src/main/ipc/handlers/proxy-handlers.ts
+++ b/src/main/ipc/handlers/proxy-handlers.ts
@@ -11,6 +11,7 @@ import type {
   ProxyStatus,
   TrafficStats,
   ConnectionsSnapshot,
+  ConnectionsAggregate,
 } from '../../../shared/types';
 import { registerIpcHandler } from '../ipc-handler';
 import { ProxyManager } from '../../services/ProxyManager';
@@ -58,9 +59,18 @@ export function registerProxyHandlers(
     proxyManager.probeOutbound(args?.outbound, args?.isEndpoint)
   );
 
-  // 连接快照（topology 统一供数；窗口重建/挂载回填）
+  // 连接明细 pull（连接信息页打开时按 interval 拉；窗口重建/挂载回填）。非每秒全量 push（issue #227）。
   registerIpcHandler<void, ConnectionsSnapshot>(IPC_CHANNELS.CONNECTIONS_GET, async () =>
     statsService ? statsService.getConnectionsSnapshot() : { connections: [], at: Date.now() }
+  );
+
+  // 首页拓扑聚合回填（挂载初值；后续增量走 EVENT_CONNECTIONS_AGGREGATE 广播）。载荷 ~Top-N host + 出口数。
+  registerIpcHandler<void, ConnectionsAggregate>(
+    IPC_CHANNELS.CONNECTIONS_AGGREGATE_GET,
+    async () =>
+      statsService
+        ? statsService.getAggregateSnapshot()
+        : { total: 0, hosts: [], outbounds: [], at: Date.now() }
   );
 
   // 关单条连接：经 ProxyManager（9090 keep-alive agent + Bearer secret 内部封装）发 DELETE /connections/{id}，

--- a/src/main/services/StatsService.ts
+++ b/src/main/services/StatsService.ts
@@ -1,6 +1,8 @@
 /**
- * 流量统计服务：代理运行时经 sing-box 1.14 管理 API（gRPC）订阅 Status / Connections 流，算累计/速率/连接数，
- * 经 EVENT_STATS_UPDATED / EVENT_CONNECTIONS_UPDATED 推给渲染端展示。仅读取、不影响代理；流断开静默（客户端内部 2s 重连）。
+ * 流量统计服务：代理运行时经 sing-box 1.14 管理 API（gRPC）订阅 Status / Connections 流，算累计/速率/连接数。
+ * 本类现运行于 stats utilityProcess（#225），经 onStats/onConnections 回调把帧 post 给 StatsWorkerHost；后者
+ * relay EVENT_STATS_UPDATED（流量）/ EVENT_CONNECTIONS_AGGREGATE（host 侧聚合后的拓扑数据，#227）给渲染端。
+ * 仅读取、不影响代理；流断开静默（客户端内部 2s 重连）。
  *
  * §3-B：取代旧 clash_api `/connections` 每秒轮询。速率（uplink/downlink）由 server 直接给出（无需本地 delta/dt 自算）；
  * 连接以事件流（NEW/UPDATE/CLOSED 增量 + reset 全量重置）维护一份 map，避免每秒拉全量连接列表。

--- a/src/main/services/StatsWorkerHost.ts
+++ b/src/main/services/StatsWorkerHost.ts
@@ -14,7 +14,8 @@
  * 两 client 各连同一 127.0.0.1:apiPort 的不同 RPC 流，互不冲突。
  */
 import { utilityProcess, type UtilityProcess } from 'electron';
-import type { TrafficStats, ConnectionsSnapshot } from '../../shared/types';
+import type { TrafficStats, ConnectionsSnapshot, ConnectionsAggregate } from '../../shared/types';
+import { aggregateConnections } from './connections-aggregate';
 
 /** worker 重建 SingBoxApiClient 所需的运行期管理 API 端点（本地恒无 tls）。 */
 export interface StatsApiEndpoint {
@@ -28,6 +29,7 @@ export interface StatsApiEndpoint {
 export interface StatsProvider {
   getSnapshot(): TrafficStats;
   getConnectionsSnapshot(): ConnectionsSnapshot;
+  getAggregateSnapshot(): ConnectionsAggregate;
 }
 
 /** main → worker 控制消息。 */
@@ -54,13 +56,18 @@ const ZERO_STATS: TrafficStats = {
   activeConnections: 0,
 };
 
+/** 空聚合（stop/初始化用）。 */
+function emptyAggregate(at: number): ConnectionsAggregate {
+  return { total: 0, hosts: [], outbounds: [], at };
+}
+
 export interface StatsWorkerHostOptions {
   /** 已编译 worker 入口绝对路径（dist 下 .js）。 */
   workerPath: string;
   /** 流量快照广播到渲染端（main 侧门控后调用）。 */
   onStats: (s: TrafficStats) => void;
-  /** 连接快照广播到渲染端（main 侧门控后调用）。 */
-  onConnections: (snap: ConnectionsSnapshot) => void;
+  /** 连接聚合广播到渲染端（首页拓扑，main 侧门控后调用，issue #227）。 */
+  onAggregate: (agg: ConnectionsAggregate) => void;
   /** UI 广播活跃谓词：false（不可见/拖动中）时只缓存不广播。 */
   isUiActive: () => boolean;
   /** 取运行期管理 API 端点（核未起返回 null → worker 不开流）。 */
@@ -72,7 +79,10 @@ export interface StatsWorkerHostOptions {
 export class StatsWorkerHost implements StatsProvider {
   private worker: UtilityProcess | null = null;
   private snapshot: TrafficStats = { ...ZERO_STATS };
+  // worker post 来的最近连接明细快照：仅供连接信息页 CONNECTIONS_GET 按需 pull，不再 relay 给渲染端（旧放大器）。
   private connections: ConnectionsSnapshot = { connections: [], at: 0 };
+  // 由 connections 每帧 host 侧 O(N) 聚合而来（首页拓扑供数）：relay EVENT_CONNECTIONS_AGGREGATE + CONNECTIONS_AGGREGATE_GET 回填。
+  private aggregate: ConnectionsAggregate = emptyAggregate(0);
   /** 是否应处于订阅态（代理运行）。崩溃 respawn 后据此自动重连，不丢流。 */
   private started = false;
   private disposed = false;
@@ -170,8 +180,12 @@ export class StatsWorkerHost implements StatsProvider {
         break;
       case 'connections':
         if (!this.started) return; // 同上：停后在途连接帧丢弃，避免残留旧连接列表。
+        // issue #227：worker 仍 post 全量明细（供连接页 pull 缓存），但 host 不再把它 relay 给渲染端（旧每秒全量
+        // EVENT_CONNECTIONS_UPDATED 放大器）。host 侧 O(N) 聚合一次 → 只 relay 小载荷聚合（拓扑），渲染端零 O(N)
+        // 重算。隐藏/拖动期 worker 经 connActive 门控本就不 post connections，故此聚合也随之停。
         this.connections = msg.payload;
-        if (this.opts.isUiActive()) this.opts.onConnections(this.connections);
+        this.aggregate = aggregateConnections(msg.payload.connections, msg.payload.at);
+        if (this.opts.isUiActive()) this.opts.onAggregate(this.aggregate);
         break;
     }
   }
@@ -190,8 +204,9 @@ export class StatsWorkerHost implements StatsProvider {
     this.post({ type: 'stop' });
     this.snapshot = { ...ZERO_STATS };
     this.connections = { connections: [], at: Date.now() };
+    this.aggregate = emptyAggregate(Date.now());
     this.opts.onStats({ ...this.snapshot });
-    this.opts.onConnections({ connections: [], at: Date.now() });
+    this.opts.onAggregate(this.aggregate);
   }
 
   /** 拖动结束：立即补推一帧缓存最新（免等 worker 下一帧滞后）。窗口由隐藏转可见时不另补推——stats/计数走恒流的
@@ -199,7 +214,7 @@ export class StatsWorkerHost implements StatsProvider {
   resume(): void {
     if (!this.opts.isUiActive()) return;
     this.opts.onStats({ ...this.snapshot });
-    this.opts.onConnections({ connections: this.connections.connections, at: Date.now() });
+    this.opts.onAggregate(this.aggregate);
   }
 
   getSnapshot(): TrafficStats {
@@ -207,7 +222,14 @@ export class StatsWorkerHost implements StatsProvider {
   }
 
   getConnectionsSnapshot(): ConnectionsSnapshot {
-    return { connections: this.connections.connections, at: Date.now() };
+    // at 用 worker 真实采样时刻（this.connections.at），非拉取时刻：连接页速率差分以采样间隔为分母，避免 pull
+    // 节奏与 worker 帧节奏漂移时同一缓存被拉两次 → Δbytes=0 报速率 0、下次翻倍的抖动（review Low-2）。
+    return { connections: this.connections.connections, at: this.connections.at };
+  }
+
+  /** 首页拓扑挂载回填（CONNECTIONS_AGGREGATE_GET）：缓存的最近聚合（后续增量走 EVENT_CONNECTIONS_AGGREGATE）。 */
+  getAggregateSnapshot(): ConnectionsAggregate {
+    return this.aggregate;
   }
 
   /** app 退出：终止 worker，停止 respawn。 */

--- a/src/main/services/__tests__/connections-aggregate.test.ts
+++ b/src/main/services/__tests__/connections-aggregate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * aggregateConnections 单测（issue #227：首页拓扑聚合下沉 main）。锁：host 名优先级 / outbound 取链首 /
+ * 同 host 累加 count+flows / Top-N + Others 合并到 sentinel / 无名连接计入 total+outbound 但不建 host /
+ * outbounds 降序。原 topology-layout 的聚合语义逐字移此（layout 单测只剩坐标）。
+ */
+import { aggregateConnections, TOPOLOGY_TOP_N } from '../connections-aggregate';
+import {
+  TOPOLOGY_OTHERS_KEY,
+  type ConnectionEntry,
+  type ConnectionsAggregate,
+} from '../../../shared/types';
+
+let idc = 0;
+function conn(o: {
+  host?: string;
+  destinationIP?: string;
+  rule?: string;
+  rulePayload?: string;
+  chain?: string;
+}): ConnectionEntry {
+  return {
+    id: `c${idc++}`,
+    chains: o.chain ? [o.chain] : [],
+    rule: o.rule ?? 'final',
+    rulePayload: o.rulePayload ?? '',
+    metadata:
+      o.host || o.destinationIP ? { host: o.host, destinationIP: o.destinationIP } : undefined,
+  } as ConnectionEntry;
+}
+
+const hostByName = (agg: ConnectionsAggregate, name: string) =>
+  agg.hosts.find((h) => h.name === name);
+const outByName = (agg: ConnectionsAggregate, name: string) =>
+  agg.outbounds.find((o) => o.name === name);
+
+describe('aggregateConnections', () => {
+  it('total = 连接总数；同 host+outbound 累加 count + flows', () => {
+    const agg = aggregateConnections(
+      [conn({ host: 'a.com', chain: 'P' }), conn({ host: 'a.com', chain: 'P' })],
+      0
+    );
+    expect(agg.total).toBe(2);
+    expect(hostByName(agg, 'a.com')?.count).toBe(2);
+    expect(hostByName(agg, 'a.com')?.flows).toEqual([{ outbound: 'P', count: 2 }]);
+    expect(outByName(agg, 'P')?.count).toBe(2);
+  });
+
+  it('host 名优先级 host > destinationIP > rule:payload > rule', () => {
+    expect(
+      hostByName(
+        aggregateConnections([conn({ host: 'h.com', destinationIP: '1.1.1.1', rule: 'r' })], 0),
+        'h.com'
+      )
+    ).toBeTruthy();
+    expect(
+      hostByName(
+        aggregateConnections([conn({ destinationIP: '1.2.3.4', rule: 'r' })], 0),
+        '1.2.3.4'
+      )
+    ).toBeTruthy();
+    expect(
+      hostByName(aggregateConnections([conn({ rule: 'GEOIP', rulePayload: 'CN' })], 0), 'GEOIP: CN')
+    ).toBeTruthy();
+    expect(hostByName(aggregateConnections([conn({ rule: 'final' })], 0), 'final')).toBeTruthy();
+  });
+
+  it('outbound 取 chains[0]，无链 → Direct', () => {
+    expect(outByName(aggregateConnections([conn({ host: 'a.com' })], 0), 'Direct')).toBeTruthy();
+    expect(
+      outByName(aggregateConnections([conn({ host: 'a.com', chain: 'hk' })], 0), 'hk')
+    ).toBeTruthy();
+  });
+
+  it('>TOP_N distinct host → Top-N + Others（最小者按 count 合并到 sentinel）', () => {
+    // host_k 有 k 条连接（k=1..TOP_N+1）→ 排序后 host1(最小=1 条) 落入 Others。
+    const conns: ConnectionEntry[] = [];
+    for (let k = 1; k <= TOPOLOGY_TOP_N + 1; k++) {
+      for (let n = 0; n < k; n++) conns.push(conn({ host: `host${k}.com`, chain: 'P' }));
+    }
+    const agg = aggregateConnections(conns, 0);
+    expect(agg.hosts).toHaveLength(TOPOLOGY_TOP_N + 1); // Top-N + Others
+    const others = hostByName(agg, TOPOLOGY_OTHERS_KEY);
+    expect(others?.count).toBe(1); // 仅 host1(1 条) 被收敛
+    expect(others?.flows).toEqual([{ outbound: 'P', count: 1 }]);
+  });
+
+  it('无名连接（metadata 空 + rule 空）计入 total + outbound，但不建 host 节点', () => {
+    const agg = aggregateConnections(
+      [conn({ rule: '', chain: 'P' }), conn({ host: 'a.com', chain: 'P' })],
+      0
+    );
+    expect(agg.total).toBe(2);
+    expect(agg.hosts).toHaveLength(1); // 仅 a.com
+    expect(hostByName(agg, 'a.com')?.count).toBe(1);
+    expect(outByName(agg, 'P')?.count).toBe(2); // 两条都计入 outbound
+  });
+
+  it('outbounds 按 count 降序', () => {
+    const agg = aggregateConnections(
+      [
+        conn({ host: 'a.com', chain: 'P1' }),
+        conn({ host: 'b.com', chain: 'P2' }),
+        conn({ host: 'c.com', chain: 'P2' }),
+      ],
+      0
+    );
+    expect(agg.outbounds.map((o) => o.name)).toEqual(['P2', 'P1']); // P2(2) > P1(1)
+  });
+
+  it('空输入 → 空聚合（保留 at）', () => {
+    expect(aggregateConnections([], 123)).toEqual({
+      total: 0,
+      hosts: [],
+      outbounds: [],
+      at: 123,
+    });
+  });
+});

--- a/src/main/services/__tests__/custom-protocol-probe.test.ts
+++ b/src/main/services/__tests__/custom-protocol-probe.test.ts
@@ -178,7 +178,11 @@ describe('probeCache LRU 上限（性能 review M1）', () => {
     expect(await pm.probeOutbound({ ...SNELL, server_port: 10000 + total }, false)).toMatchObject({
       ok: true,
     });
-  }, 30000); // MAX=2048 次真实 probe 需更宽松超时（每次含 sha1+tmp 写，~1ms×2068≈2-3s）
+    // 超时根治（CI flaky）：MAX≈2048 → MAX+20 次真实 probe，每次含 sha1 + tmp config 写。本机 ~2-3s，但 CI
+    // 慢文件 IO（windows/macos runner）实测可达 ~30s，撞原 30000ms 硬超时 → jest 中断该用例 → 已在飞的 probe
+    // promise 泄漏，回调时污染下一用例「命中缓存」的 mockExecFile 计数（Received 2）→ 连锁 2 fail + worker 不优雅退出。
+    // 给 ~3x 余量使该用例在慢 CI 也必跑完（无中断、无 in-flight 泄漏），根除该 flaky。
+  }, 90000);
 
   it('probeOutbound 实际命中缓存（不重复 spawn check）', async () => {
     mockExecFile.mockReset(); // 隔离前一个 case 的 mock 状态

--- a/src/main/services/__tests__/stats-worker-host.test.ts
+++ b/src/main/services/__tests__/stats-worker-host.test.ts
@@ -1,9 +1,10 @@
 /**
  * StatsWorkerHost 单测（T4，issue #225）。覆盖 main 侧宿主逻辑（worker 由 mock electron.utilityProcess 替身）：
  *  1) 构造即 fork worker；resubscribe 下发最新端点 connect / 端点为 null 下发 stop。
- *  2) worker 数据消息：缓存 + 按 isUiActive 门控广播（不活跃只缓存不 onStats/onConnections）。
+ *  2) worker 数据消息：缓存 + 按 isUiActive 门控广播（不活跃只缓存不 onStats/onAggregate；connections 经 host
+ *     侧聚合后 relay 聚合给拓扑，明细只缓存供 pull，issue #227）。
  *  3) resume 补推缓存最新（活跃才推）；stop 不门控清零广播。
- *  4) getSnapshot/getConnectionsSnapshot 读缓存。
+ *  4) getSnapshot/getConnectionsSnapshot/getAggregateSnapshot 读缓存。
  *  5) 'ready' 握手 / 崩溃 exit → 退避 respawn + 自动重连；dispose 终止不再 respawn。
  */
 import type { TrafficStats, ConnectionsSnapshot } from '../../../shared/types';
@@ -46,22 +47,25 @@ const SAMPLE_STATS: TrafficStats = {
   activeConnections: 3,
 };
 const SAMPLE_CONNS: ConnectionsSnapshot = {
-  connections: [{ id: 'c1', chains: [], rule: '', rulePayload: '', metadata: {} }],
+  // 带 host + chain：使 host 侧聚合产出非空 hosts（覆盖 getAggregateSnapshot 实路径，issue #227 review Nit）。
+  connections: [
+    { id: 'c1', chains: ['proxy'], rule: '', rulePayload: '', metadata: { host: 'a.com' } },
+  ],
   at: 123,
 };
 
 function makeHost() {
   const onStats = jest.fn();
-  const onConnections = jest.fn();
+  const onAggregate = jest.fn();
   const state = { active: true, endpoint: ENDPOINT as StatsApiEndpoint | null };
   const host = new StatsWorkerHost({
     workerPath: '/fake/stats-worker.js',
     onStats,
-    onConnections,
+    onAggregate,
     isUiActive: () => state.active,
     getEndpoint: () => state.endpoint,
   });
-  return { host, onStats, onConnections, state };
+  return { host, onStats, onAggregate, state };
 }
 
 beforeEach(() => electron.__reset());
@@ -105,49 +109,50 @@ describe('StatsWorkerHost 数据面门控 (T4)', () => {
     expect(host.getSnapshot()).toEqual(SAMPLE_STATS); // 缓存仍更新
   });
 
-  it('connections 消息同样门控 + 缓存', () => {
-    const { onConnections, host, state } = makeHost();
+  it('connections 消息门控 + host 聚合（明细缓存供 pull、聚合供拓扑，issue #227）', () => {
+    const { onAggregate, host, state } = makeHost();
     host.resubscribe(); // started=true
     state.active = false;
     lastWorker().emit('message', { type: 'connections', payload: SAMPLE_CONNS });
-    expect(onConnections).not.toHaveBeenCalled();
+    expect(onAggregate).not.toHaveBeenCalled(); // 不活跃不广播
+    // 明细缓存（连接页 CONNECTIONS_GET pull）+ host 已 O(N) 聚合（拓扑 CONNECTIONS_AGGREGATE_GET 回填）
     expect(host.getConnectionsSnapshot().connections).toEqual(SAMPLE_CONNS.connections);
+    expect(host.getAggregateSnapshot().total).toBe(1);
+    expect(host.getAggregateSnapshot().hosts.map((h) => h.name)).toEqual(['a.com']); // 聚合产出 host 节点
   });
 
   it('resume 活跃时补推缓存最新；不活跃不推', () => {
-    const { onStats, onConnections, host, state } = makeHost();
+    const { onStats, onAggregate, host, state } = makeHost();
     host.resubscribe(); // started=true
     state.active = false;
     lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
     lastWorker().emit('message', { type: 'connections', payload: SAMPLE_CONNS });
     onStats.mockClear();
-    onConnections.mockClear();
+    onAggregate.mockClear();
 
     host.resume(); // 仍不活跃 → 不推
     expect(onStats).not.toHaveBeenCalled();
 
     state.active = true;
-    host.resume(); // 活跃 → 补推缓存
+    host.resume(); // 活跃 → 补推缓存（stats + 聚合）
     expect(onStats).toHaveBeenCalledWith(SAMPLE_STATS);
-    expect(onConnections).toHaveBeenCalledWith(
-      expect.objectContaining({ connections: SAMPLE_CONNS.connections })
-    );
+    expect(onAggregate).toHaveBeenCalledWith(expect.objectContaining({ total: 1 }));
   });
 
   it('stop 不门控、清零广播', () => {
-    const { onStats, onConnections, host, state } = makeHost();
+    const { onStats, onAggregate, host, state } = makeHost();
     host.resubscribe(); // started=true，下面的帧进缓存
     lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
     expect(host.getSnapshot().activeConnections).toBe(3); // 缓存确为非零
     onStats.mockClear();
-    onConnections.mockClear();
+    onAggregate.mockClear();
     state.active = false; // 即便不活跃，stop 仍广播清零
 
     host.stop();
     expect(onStats).toHaveBeenCalledWith(
       expect.objectContaining({ uploadSpeed: 0, downloadSpeed: 0, activeConnections: 0 })
     );
-    expect(onConnections).toHaveBeenCalledWith(expect.objectContaining({ connections: [] }));
+    expect(onAggregate).toHaveBeenCalledWith(expect.objectContaining({ total: 0, hosts: [] }));
     expect(host.getSnapshot().activeConnections).toBe(0);
   });
 

--- a/src/main/services/connections-aggregate.ts
+++ b/src/main/services/connections-aggregate.ts
@@ -1,0 +1,87 @@
+/**
+ * 连接聚合（首页拓扑数据下沉 main，issue #227）——纯函数：从连接明细聚合出 ConnectionsAggregate
+ * （Top-N host + 各出口分布 + 出口总数）。取代渲染端 topology-layout 内对全量 ConnectionEntry[] 的每秒
+ * O(N) 聚合 + 全量明细经 IPC 广播：main 算一次、广播小载荷（~Top-N host + 出口数），渲染端只做坐标布局。
+ *
+ * host 显示名优先级与原 topology-layout 严格一致：metadata.host(域名) > metadata.destinationIP(目标 IP)
+ * > `rule: payload` > rule。outbound 取 chains[0]（连接首跳出站 tag），无链则 'Direct'。无名连接（上述全空）
+ * 计入 total/outbound 但不建 host 节点（对齐原 layout 的 filter(n && n.trim())）。纯函数、无副作用，供单测。
+ */
+import {
+  TOPOLOGY_OTHERS_KEY,
+  type ConnectionEntry,
+  type ConnectionsAggregate,
+  type ConnectionAggHost,
+} from '../../shared/types';
+
+/** 拓扑中列 host 节点上限（与渲染端原 MAX_NODES 对齐）；超出按 count 降序取 Top-N，其余并入 TOPOLOGY_OTHERS_KEY。 */
+export const TOPOLOGY_TOP_N = 15;
+
+/** host 显示名（与原 topology-layout 同优先级）。trimConnection 恒置 rulePayload='' 故 `rule: payload` 分支
+ *  当前不触发，保留以对齐原逻辑（未来若上游回填 rulePayload 自动生效）。 */
+function hostNameOf(c: ConnectionEntry): string {
+  const m = c.metadata || {};
+  if (m.host) return m.host;
+  if (m.destinationIP) return m.destinationIP;
+  if (c.rulePayload) return `${c.rule}: ${c.rulePayload}`;
+  return c.rule || '';
+}
+
+// outbound = chains[0]（首跳出站 tag），无链则 'Direct'。与原 topology-layout 实质等价：原 `if (chains.length>0)
+// outbound=chains[0]` 在 chains[0] 为空串时会产出空串出口名，本实现回落 'Direct'——空 tag 实际不会发生（sing-box
+// 链节点恒有 tag），此差异仅是更稳健的兜底，不改变真实数据下的结果。
+function outboundOf(c: ConnectionEntry): string {
+  return (Array.isArray(c.chains) && c.chains[0]) || 'Direct';
+}
+
+function flowsToArr(flows: Map<string, number>): ConnectionAggHost['flows'] {
+  return Array.from(flows.entries()).map(([outbound, count]) => ({ outbound, count }));
+}
+
+export function aggregateConnections(
+  conns: ConnectionEntry[],
+  at: number,
+  topN: number = TOPOLOGY_TOP_N
+): ConnectionsAggregate {
+  const hostMap = new Map<string, { count: number; flows: Map<string, number> }>();
+  const outboundTotals = new Map<string, number>();
+
+  for (const c of conns) {
+    const ob = outboundOf(c);
+    // outbound 计入所有连接（含无名，与原 layout 的 outboundTotals 同口径——右列节点高度按全部连接算）。
+    outboundTotals.set(ob, (outboundTotals.get(ob) || 0) + 1);
+    const name = hostNameOf(c);
+    if (!name.trim()) continue; // 无名连接：计 total/outbound、不建 host 节点（对齐原 layout 过滤）
+    let h = hostMap.get(name);
+    if (!h) {
+      h = { count: 0, flows: new Map() };
+      hostMap.set(name, h);
+    }
+    h.count++;
+    h.flows.set(ob, (h.flows.get(ob) || 0) + 1);
+  }
+
+  const sorted = Array.from(hostMap.entries()).sort((a, b) => b[1].count - a[1].count);
+  let hosts: ConnectionAggHost[];
+  if (sorted.length > topN) {
+    const top = sorted.slice(0, topN);
+    const othersFlows = new Map<string, number>();
+    let othersCount = 0;
+    for (const [, d] of sorted.slice(topN)) {
+      othersCount += d.count;
+      for (const [k, v] of d.flows) othersFlows.set(k, (othersFlows.get(k) || 0) + v);
+    }
+    hosts = [
+      ...top.map(([name, d]) => ({ name, count: d.count, flows: flowsToArr(d.flows) })),
+      { name: TOPOLOGY_OTHERS_KEY, count: othersCount, flows: flowsToArr(othersFlows) },
+    ];
+  } else {
+    hosts = sorted.map(([name, d]) => ({ name, count: d.count, flows: flowsToArr(d.flows) }));
+  }
+
+  const outbounds = Array.from(outboundTotals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => ({ name, count }));
+
+  return { total: conns.length, hosts, outbounds, at };
+}

--- a/src/renderer/components/connections/connections-table.tsx
+++ b/src/renderer/components/connections/connections-table.tsx
@@ -72,6 +72,11 @@ function ruleActionVariant(action: string): 'secondary' | 'destructive' | 'defau
 /** 稳定的零速率引用：speeds 无此 id 时传入，使 ConnectionRow memo 的 speed 比较恒定（不每帧新建对象）。 */
 const ZERO_SPEED: ConnSpeed = { up: 0, down: 0 };
 
+/** 连接明细 pull 间隔（issue #227）：本页打开期间每隔此时长拉一次 CONNECTIONS_GET，取代旧「每秒全量 push 给
+ *  所有窗口」订阅——连接明细成本仅在用户主动查看本页时产生，且页面关闭即停。对齐旧 push 的 1s 节奏（连接页仅
+ *  打开时拉，1s 无额外负担），关连接另有乐观更新即时反馈，不依赖本间隔。 */
+const PULL_INTERVAL_MS = 1000;
+
 /**
  * 全表共享秒级 tick（P3）：时长列每秒刷新原本随父组件 setNow 触发整表 reconcile（重跑 visible.map + diff ≤500 行）。
  * 改为模块级外部 store + useSyncExternalStore：1s tick 只重渲订阅它的各 DurationCell（纯文本），不穿透
@@ -210,31 +215,44 @@ export function ConnectionsTable() {
   pausedRef.current = paused;
   // per-conn 速率差分的上一帧缓存（不入 state，避免无谓重渲染）。
   const rateRef = useRef<RateState>(new Map());
+  // pull in-flight 守卫（review Low-B）：慢主进程/Windows 拖动期 setInterval 仍每秒派发，防 CONNECTIONS_GET
+  // 叠加排队、drag-end 一并 flush 的瞬时尖峰。
+  const inFlightRef = useRef(false);
 
-  // 数据：挂载 CONNECTIONS_GET 回填 + 订阅 EVENT_CONNECTIONS_UPDATED。暂停时冻结（不更新表 + 不推进速率基准）。
+  // 数据（issue #227）：连接明细改【按需 pull】——本页打开期间每 PULL_INTERVAL_MS 拉一次 CONNECTIONS_GET，
+  // 不再订阅每秒全量 push。暂停 / 窗口隐藏时停拉（冻结当前帧 + 不推进速率基准）；页面卸载清 interval，无残留。
   useEffect(() => {
     let mounted = true;
     const apply = (snap: ConnectionsSnapshot) => {
-      if (pausedRef.current) return; // 本地冻结：保留当前帧
       const { speeds: s, next } = computeConnSpeeds(snap.connections, rateRef.current, snap.at);
       rateRef.current = next;
       setSpeeds(s);
       setConnections(snap.connections);
     };
-    api.connections
-      .get()
-      .then((snap) => {
-        if (mounted) apply(snap);
-      })
-      .catch(() => {
-        /* 静默：核未运行 / 鉴权未就绪，空态由 proxyRunning gate 兜底 */
-      });
-    const unsub = api.connections.onUpdated((snap) => {
-      if (mounted) apply(snap);
-    });
+    const pull = () => {
+      // 暂停 / 窗口隐藏：跳过拉取（无 UI 消费者；对齐 main 侧 isUiBroadcastActive 可见性门控，省隐藏期每秒
+      // CONNECTIONS_GET 的主线程 IPC + 序列化开销，review Med）。拖动期对齐需 main 推拖动态 → 记真机监控项。
+      // in-flight 守卫（Low-B）：上一次未 resolve 不叠加，防慢主进程/拖动期排队积压。
+      if (pausedRef.current || document.hidden || inFlightRef.current) return;
+      inFlightRef.current = true;
+      api.connections
+        .get()
+        .then((snap) => {
+          // 在途结果若期间已暂停则丢弃（gate 上移到 pull 后，apply 不再自查 paused，Low-A）。
+          if (mounted && !pausedRef.current) apply(snap);
+        })
+        .catch(() => {
+          /* 静默：核未运行 / 鉴权未就绪，空态由 proxyRunning gate 兜底 */
+        })
+        .finally(() => {
+          inFlightRef.current = false;
+        });
+    };
+    pull(); // 挂载即拉一次（回填初值）
+    const timer = setInterval(pull, PULL_INTERVAL_MS);
     return () => {
       mounted = false;
-      unsub();
+      clearInterval(timer);
     };
   }, []);
 

--- a/src/renderer/components/home/__tests__/topology-layout.test.ts
+++ b/src/renderer/components/home/__tests__/topology-layout.test.ts
@@ -1,39 +1,39 @@
 /**
  * topology-layout 纯函数单测（Tier-2：connection-topology 抽出布局计算后的离线安全网）。
- * 锁逐字移出的 computeTopologyLayout 坐标/聚合/Top-N/配色/缎带路径，使「每 2s 全量重算」的布局可回归。
+ * issue #227 后 layout 只做坐标布局——聚合（host 累加 / 名称优先级 / Top-N / Others）已下沉 main 的
+ * aggregateConnections（见 connections-aggregate.test）。本测试锁坐标/配色/缎带路径 + OTHERS sentinel→i18n 替换。
  */
 import { computeTopologyLayout, getSankeyPath, FIXED_HEIGHT } from '../topology-layout';
-import type { ConnectionEntry } from '../../../../shared/types';
+import { TOPOLOGY_OTHERS_KEY, type ConnectionsAggregate } from '../../../../shared/types';
 
 const t = (k: string) => k; // 恒等 i18n：home.others→'home.others'、home.myDevice→'home.myDevice'
 
-let idc = 0;
-function conn(o: {
-  host?: string;
-  destinationIP?: string;
-  rule?: string;
-  rulePayload?: string;
-  chain?: string;
-}): ConnectionEntry {
+/** 构造聚合输入：hosts=[name, count, flows([outbound,count])]，outbounds=[name, count]。 */
+function agg(
+  hosts: Array<[string, number, Array<[string, number]>]>,
+  outbounds: Array<[string, number]>
+): ConnectionsAggregate {
   return {
-    id: `c${idc++}`,
-    chains: o.chain ? [o.chain] : [],
-    rule: o.rule ?? 'final',
-    rulePayload: o.rulePayload ?? '',
-    metadata:
-      o.host || o.destinationIP ? { host: o.host, destinationIP: o.destinationIP } : undefined,
-  } as ConnectionEntry;
+    total: hosts.reduce((a, [, c]) => a + c, 0),
+    hosts: hosts.map(([name, count, flows]) => ({
+      name,
+      count,
+      flows: flows.map(([outbound, c]) => ({ outbound, count: c })),
+    })),
+    outbounds: outbounds.map(([name, count]) => ({ name, count })),
+    at: 0,
+  };
 }
 
 const byId = <T extends { id: string }>(nodes: T[], id: string): T =>
   nodes.find((n) => n.id === id)!;
 
 describe('computeTopologyLayout — 空态', () => {
-  it('无连接 → 空', () => {
-    expect(computeTopologyLayout([], 800, t)).toEqual({ nodes: [], links: [] });
+  it('无 host → 空', () => {
+    expect(computeTopologyLayout(agg([], []), 800, t)).toEqual({ nodes: [], links: [] });
   });
   it('width=0 → 空', () => {
-    expect(computeTopologyLayout([conn({ host: 'a.com', chain: 'P' })], 0, t)).toEqual({
+    expect(computeTopologyLayout(agg([['a.com', 1, [['P', 1]]]], [['P', 1]]), 0, t)).toEqual({
       nodes: [],
       links: [],
     });
@@ -42,7 +42,7 @@ describe('computeTopologyLayout — 空态', () => {
 
 describe('computeTopologyLayout — 单连接精确坐标（width=800）', () => {
   const { nodes, links } = computeTopologyLayout(
-    [conn({ host: 'example.com', chain: 'Proxy' })],
+    agg([['example.com', 1, [['Proxy', 1]]]], [['Proxy', 1]]),
     800,
     t
   );
@@ -105,53 +105,45 @@ describe('computeTopologyLayout — 单连接精确坐标（width=800）', () =>
   });
 });
 
-describe('computeTopologyLayout — 聚合', () => {
-  it('同 host+outbound 多连接 → 单节点累加 value', () => {
+describe('computeTopologyLayout — 多 host 比例缩放', () => {
+  it('source.value = 各 host count 之和；同 outbound 累加 outbound 节点高度', () => {
     const { nodes } = computeTopologyLayout(
-      [conn({ host: 'a.com', chain: 'P' }), conn({ host: 'a.com', chain: 'P' })],
+      agg(
+        [
+          ['a.com', 2, [['P', 2]]],
+          ['b.com', 1, [['P', 1]]],
+        ],
+        [['P', 3]]
+      ),
       800,
       t
     );
-    expect(byId(nodes, 'source').value).toBe(2);
+    expect(byId(nodes, 'source').value).toBe(3);
     expect(byId(nodes, 'mid-a.com').value).toBe(2);
-    expect(byId(nodes, 'out-P').value).toBe(2);
-  });
-
-  it('名称优先级 host > destinationIP > rule:payload', () => {
-    const r1 = computeTopologyLayout(
-      [conn({ host: 'h.com', destinationIP: '1.1.1.1', rule: 'r' })],
-      800,
-      t
-    );
-    expect(byId(r1.nodes, 'mid-h.com')).toBeTruthy();
-
-    const r2 = computeTopologyLayout([conn({ destinationIP: '1.2.3.4', rule: 'r' })], 800, t);
-    expect(byId(r2.nodes, 'mid-1.2.3.4')).toBeTruthy();
-
-    const r3 = computeTopologyLayout([conn({ rule: 'GEOIP', rulePayload: 'CN' })], 800, t);
-    expect(byId(r3.nodes, 'mid-GEOIP: CN')).toBeTruthy();
-  });
-
-  it('outbound 取 chains[0]，无链 → Direct', () => {
-    const { nodes } = computeTopologyLayout([conn({ host: 'a.com' })], 800, t);
-    expect(byId(nodes, 'out-Direct')).toBeTruthy();
+    expect(byId(nodes, 'mid-b.com').value).toBe(1);
+    expect(byId(nodes, 'out-P').value).toBe(3);
   });
 });
 
-describe('computeTopologyLayout — Top-N + Others 收敛', () => {
-  it('>15 distinct host → 15 + Others（聚合余量）', () => {
-    // host_k 有 k 条连接（k=1..16）→ 排序后 host1(最小) 落入 Others
-    const conns: ConnectionEntry[] = [];
-    for (let k = 1; k <= 16; k++) {
-      for (let n = 0; n < k; n++) conns.push(conn({ host: `host${k}.com`, chain: 'P' }));
-    }
-    const { nodes } = computeTopologyLayout(conns, 800, t);
-    const mids = nodes.filter((n) => n.type === 'rule');
-    expect(mids).toHaveLength(16); // 15 top + Others
+describe('computeTopologyLayout — OTHERS sentinel → i18n 替换', () => {
+  it('main 下发的 TOPOLOGY_OTHERS_KEY 合并组 → 显示 t(home.others) + slate 配色', () => {
+    const { nodes } = computeTopologyLayout(
+      agg(
+        [
+          ['top.com', 5, [['P', 5]]],
+          [TOPOLOGY_OTHERS_KEY, 3, [['P', 3]]],
+        ],
+        [['P', 8]]
+      ),
+      800,
+      t
+    );
     const others = byId(nodes, 'mid-home.others');
-    expect(others.name).toBe('home.others');
-    expect(others.value).toBe(1); // 仅 host1(1 条) 被收敛
+    expect(others.name).toBe('home.others'); // sentinel 被替换为本地化文案
+    expect(others.value).toBe(3);
     expect(others.color).toBe('fill-muted-foreground'); // Others 用 slate(token)
+    // 非 others 节点保持真实 host 名（不被替换）
+    expect(byId(nodes, 'mid-top.com').color).toBe('fill-success');
   });
 });
 

--- a/src/renderer/components/home/connection-topology.tsx
+++ b/src/renderer/components/home/connection-topology.tsx
@@ -5,12 +5,14 @@ import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/store/app-store';
 import { api } from '@/ipc';
 import { toast } from 'sonner';
-import type { Rule, RuleAction, ConnectionEntry } from '../../../shared/types';
+import type { Rule, RuleAction, ConnectionsAggregate } from '../../../shared/types';
 import { getRuleActionStyle } from '@/lib/rule-action-style';
 import { computeTopologyLayout, FIXED_HEIGHT, NODE_WIDTH, type Node } from './topology-layout';
 
+const EMPTY_AGGREGATE: ConnectionsAggregate = { total: 0, hosts: [], outbounds: [], at: 0 };
+
 export function ConnectionTopology() {
-  const [connections, setConnections] = useState<ConnectionEntry[]>([]);
+  const [aggregate, setAggregate] = useState<ConnectionsAggregate>(EMPTY_AGGREGATE);
   const [loading, setLoading] = useState(true);
   const [hovered, setHovered] = useState<{ type: 'node' | 'link'; id: string } | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
@@ -44,24 +46,24 @@ export function ConnectionTopology() {
     return () => resizeObserver.disconnect();
   }, []);
 
-  // F22：连接数据统一由 main 单一 poller 供给。挂载即用 CONNECTIONS_GET 回填初值，再订阅 EVENT_CONNECTIONS_UPDATED
-  // 收广播。渲染端不再直连 :9090、不再持有 clash secret；停止代理时 main 广播空快照 → 自然落入空态。
-  // main 连接流订阅跟随 started（代理运行即推送），无需渲染端注册——拓扑只 get 回填 + onUpdated 即可。
+  // issue #227：拓扑改消费 main 侧【连接聚合】（小载荷，与连接总数解耦），取代旧「每秒全量 ConnectionEntry[] 广播」。
+  // 挂载即用 CONNECTIONS_AGGREGATE_GET 回填初值，再订阅 EVENT_CONNECTIONS_AGGREGATE 收增量。main 连接流订阅跟随
+  // started（代理运行即推送），停止代理时 main 广播空聚合 → 自然落入空态。渲染端不再直连 :9090、不持 secret。
   useEffect(() => {
     let mounted = true;
-    api.connections
+    api.connections.aggregate
       .get()
-      .then((snap) => {
+      .then((agg) => {
         if (mounted) {
-          setConnections(snap.connections);
+          setAggregate(agg);
           setLoading(false);
         }
       })
       .catch(() => {
         if (mounted) setLoading(false);
       });
-    const unsub = api.connections.onUpdated((snap) => {
-      setConnections(snap.connections);
+    const unsub = api.connections.aggregate.onUpdated((agg) => {
+      setAggregate(agg);
       setLoading(false);
     });
     return () => {
@@ -71,8 +73,8 @@ export function ConnectionTopology() {
   }, []);
 
   const { nodes, links } = useMemo(
-    () => computeTopologyLayout(connections, width, t),
-    [connections, width, t]
+    () => computeTopologyLayout(aggregate, width, t),
+    [aggregate, width, t]
   );
 
   // --- Interaction Logic ---
@@ -314,13 +316,13 @@ export function ConnectionTopology() {
           onMouseMove={handleMouseMove}
           onMouseLeave={handleMouseLeave}
         >
-          {loading && connections.length === 0 && (
+          {loading && nodes.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center text-muted-foreground h-full">
               {t('home.loading')}
             </div>
           )}
 
-          {!loading && connections.length === 0 && (
+          {!loading && nodes.length === 0 && (
             <div className="absolute inset-0 text-muted-foreground text-sm flex flex-col items-center justify-center gap-2 h-full">
               <Network className="h-8 w-8 opacity-50" />
               <span>{proxyRunning ? t('home.noActiveConnections') : t('home.plsStartProxy')}</span>

--- a/src/renderer/components/home/topology-layout.ts
+++ b/src/renderer/components/home/topology-layout.ts
@@ -1,9 +1,9 @@
 /**
  * 连接拓扑（首页 Sankey 图）布局计算 —— 纯函数，从 connection-topology.tsx 抽出（审计 §2/§6 Tier-2：布局计算不可测）。
- * 输入连接快照 + 容器宽度 + i18n 取值器，输出三列 Sankey 的 {nodes, links} 坐标与缎带路径；
- * 无 react/electron/@别名依赖，可被 .test.ts 直接 import 单测。原 useMemo 体逐字保留，t 由参数注入。
+ * 输入【main 已聚合好的连接快照（ConnectionsAggregate，issue #227）】+ 容器宽度 + i18n 取值器，输出三列 Sankey 的
+ * {nodes, links} 坐标与缎带路径；无 react/electron/@别名依赖，可被 .test.ts 直接 import 单测。
  */
-import type { ConnectionEntry } from '../../../shared/types';
+import { TOPOLOGY_OTHERS_KEY, type ConnectionsAggregate } from '../../../shared/types';
 
 export interface Node {
   id: string;
@@ -53,85 +53,43 @@ export function getSankeyPath(
 }
 
 /**
- * 聚合连接 → 三列 Sankey（source / rule[按 host 细分] / outbound）节点与缎带。
- * Top-15 + Others 收敛；高度按连接数比例缩放（MAX_SCALE 封顶）；各列垂直居中。
+ * 把【main 已聚合好的】连接快照摆成三列 Sankey（source / host / outbound）节点与缎带坐标。
+ * 聚合（Top-15 host + others 合并 + 出口分布）已下沉 main 的 aggregateConnections（issue #227）——本函数不再
+ * 遍历全量连接明细，只做坐标布局。高度按连接数比例缩放（MAX_SCALE 封顶）；各列垂直居中。
  */
 export function computeTopologyLayout(
-  connections: ConnectionEntry[],
+  aggregate: ConnectionsAggregate,
   width: number,
   t: (key: string) => string
 ): { nodes: Node[]; links: Link[] } {
-  // Only recalc if we have width and connections
-  if (connections.length === 0 || width === 0) return { nodes: [], links: [] };
+  if (aggregate.hosts.length === 0 || width === 0) return { nodes: [], links: [] };
 
-  // --- 1. Data Aggregation ---
-  // We want to breakdown generic rules (final) by Host to give more detail
+  // host 显示名：main 用 TOPOLOGY_OTHERS_KEY sentinel 标记「其它」合并组（main 不知 i18n）→ 此处替换为本地化文案。
+  const displayName = (name: string): string =>
+    name === TOPOLOGY_OTHERS_KEY ? t('home.others') : name;
 
-  // Better Aggregation Structure
-  const middleNodes = new Map<string, { value: number; flows: Map<string, number> }>();
-  const outboundTotals = new Map<string, number>();
+  // 摆成原布局代码消费的形态。main 已按 count 降序 + Top-N + others 合并，保持其次序（不再渲染端聚合/排序）。
+  // isOthers 由 main 下发的 sentinel 判定（非显示名比较），杜绝真实 host 恰为本地化「其它」文案时被误染/撞 id。
+  const sortedMiddle: Array<
+    [string, { value: number; flows: Map<string, number>; isOthers: boolean }]
+  > = aggregate.hosts.map((h) => [
+    displayName(h.name),
+    {
+      value: h.count,
+      flows: new Map(h.flows.map((f) => [f.outbound, f.count])),
+      isOthers: h.name === TOPOLOGY_OTHERS_KEY,
+    },
+  ]);
+  const sortedOutbounds: Array<[string, number]> = aggregate.outbounds.map((o) => [
+    o.name,
+    o.count,
+  ]);
 
-  connections.forEach((conn) => {
-    let name = conn.rule;
-    const metadata = conn.metadata || {};
-
-    // Prioritize Host/IP for display to show actual websites, falling back to Rule
-    if (metadata.host) {
-      name = metadata.host;
-    } else if (metadata.destinationIP) {
-      name = metadata.destinationIP;
-    } else if (conn.rulePayload) {
-      name = `${conn.rule}: ${conn.rulePayload}`;
-    }
-
-    let outbound = 'Direct';
-    if (conn.chains && conn.chains.length > 0) {
-      outbound = conn.chains[0];
-    }
-
-    // Update Middle Node
-    if (!middleNodes.has(name)) {
-      middleNodes.set(name, { value: 0, flows: new Map() });
-    }
-    const node = middleNodes.get(name)!;
-    node.value += 1;
-    node.flows.set(outbound, (node.flows.get(outbound) || 0) + 1);
-
-    // Update Outbound Totals
-    outboundTotals.set(outbound, (outboundTotals.get(outbound) || 0) + 1);
-  });
-
-  // --- 2. Node Selection (Top N) ---
-  const MAX_NODES = 15;
-  let sortedMiddle = Array.from(middleNodes.entries()).sort((a, b) => b[1].value - a[1].value);
-
-  // Filter out potential noise or empty names if any
-  sortedMiddle = sortedMiddle.filter(([n]) => n && n.trim() !== '');
-
-  if (sortedMiddle.length > MAX_NODES) {
-    const top = sortedMiddle.slice(0, MAX_NODES);
-    const others = sortedMiddle.slice(MAX_NODES);
-
-    const startValue = { value: 0, flows: new Map<string, number>() };
-    const othersNode = others.reduce((acc, [_, data]) => {
-      acc.value += data.value;
-      data.flows.forEach((v, k) => {
-        acc.flows.set(k, (acc.flows.get(k) || 0) + v);
-      });
-      return acc;
-    }, startValue);
-
-    sortedMiddle = [...top, [t('home.others'), othersNode]];
-  }
-
-  // --- 3. Layout Calculation (Responsive) ---
+  // --- Layout Calculation (Responsive) ---
   const nodeList: Node[] = [];
   const availableHeight = FIXED_HEIGHT - 2 * PADDING_Y;
 
-  // Prepare Outbounds
-  const sortedOutbounds = Array.from(outboundTotals.entries()).sort((a, b) => b[1] - a[1]);
-
-  // Determine total connections (for source node)
+  // Determine total connections (for source node)：有名 host 连接数之和（与原 layout 同口径，不含无名连接）。
   const totalConnections = sortedMiddle.reduce((acc, [_, d]) => acc + d.value, 0);
 
   const middleCount = sortedMiddle.length;
@@ -182,7 +140,7 @@ export function computeTopologyLayout(
       x: middleX,
       y: currentY,
       height: h,
-      color: name === t('home.others') ? 'fill-muted-foreground' : 'fill-success', // token: Others slate / 域名 live 绿
+      color: data.isOthers ? 'fill-muted-foreground' : 'fill-success', // token: Others slate / 域名 live 绿（按 sentinel 判定）
     };
     nodeList.push(node);
     midNodeParams.set(name, node);

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -11,6 +11,7 @@ import type {
   ProxyStatus,
   ProxyErrorCode,
   ConnectionsSnapshot,
+  ConnectionsAggregate,
   LogEntry,
   TrafficStats,
   Rule,
@@ -515,13 +516,24 @@ export const statsApi = {
   },
 };
 
-/** 连接快照 API：topology 经此消费 main 单一 poller 的数据，渲染端不再直连 :9090、不持 secret。 */
+/**
+ * 连接数据 API：渲染端不再直连 :9090、不持 secret。两条独立通道（issue #227 治本）：
+ *  - aggregate：首页拓扑用。StatsWorkerHost 每帧 O(N) 聚合后推小载荷（~Top-N host + 出口数），与连接总数解耦。
+ *  - get：连接信息页明细 pull。仅页面打开时按 interval 拉，不再「每秒全量 push 给所有窗口」。
+ */
 export const connectionsApi = {
+  /** 连接明细 pull（连接信息页打开时定时拉；非每秒 push）。 */
   async get(): Promise<ConnectionsSnapshot> {
     return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_GET);
   },
-  onUpdated(listener: (snap: ConnectionsSnapshot) => void): () => void {
-    return ipcClient.on(IPC_CHANNELS.EVENT_CONNECTIONS_UPDATED, listener);
+  /** 首页拓扑聚合（挂载回填 + 订阅增量广播）。 */
+  aggregate: {
+    async get(): Promise<ConnectionsAggregate> {
+      return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_AGGREGATE_GET);
+    },
+    onUpdated(listener: (agg: ConnectionsAggregate) => void): () => void {
+      return ipcClient.on(IPC_CHANNELS.EVENT_CONNECTIONS_AGGREGATE, listener);
+    },
   },
   /** 关单条连接（main 经 9090 DELETE /connections/{id}；渲染端无 secret）。 */
   async close(id: string): Promise<{ ok: boolean }> {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -78,7 +78,8 @@ export const IPC_CHANNELS = {
 
   // 统计信息
   STATS_GET: 'stats:get',
-  CONNECTIONS_GET: 'connections:get',
+  CONNECTIONS_GET: 'connections:get', // 连接信息页明细 pull（仅页面打开时定时拉，非每秒全量 push）
+  CONNECTIONS_AGGREGATE_GET: 'connections:aggregateGet', // 首页拓扑聚合回填（挂载初值；后续走 EVENT_CONNECTIONS_AGGREGATE）
   CONNECTIONS_CLOSE: 'connections:close', // 关单条连接（main 经 9090 DELETE /connections/{id}）
   CONNECTIONS_CLOSE_ALL: 'connections:closeAll', // 关全部连接（main 经 9090 DELETE /connections，触发 ResetNetwork）
 
@@ -139,7 +140,9 @@ export const IPC_CHANNELS = {
   // 已删），削平 sing-box 启动期日志洪流对主线程的 IPC 冲击（每条一次 send → 撞 Windows 拖动 move 循环致拖动卡顿）。
   EVENT_LOG_RECEIVED_BATCH: 'event:logReceivedBatch',
   EVENT_STATS_UPDATED: 'event:statsUpdated',
-  EVENT_CONNECTIONS_UPDATED: 'event:connectionsUpdated',
+  // 首页拓扑连接聚合（StatsWorkerHost 每帧 O(N) 聚合后广播，载荷 ~Top-N host + 出口数，与连接总数解耦）。
+  // 取代旧 EVENT_CONNECTIONS_UPDATED（每秒全量 ConnectionEntry[] relay）——连接风暴下渲染端被全量明细拖死（issue #227）。
+  EVENT_CONNECTIONS_AGGREGATE: 'event:connectionsAggregate',
   EVENT_ENTER_PRIVACY_MODE: 'event:enterPrivacyMode',
   EVENT_EXIT_PRIVACY_MODE: 'event:exitPrivacyMode', // 退出隐私模式（解锁/idle 计时复位）
   EVENT_NAVIGATE: 'navigate', // 托盘菜单 -> 渲染端路由跳转

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -87,6 +87,10 @@ export type {
   InvalidNodeInfo,
   ConnectionEntry,
   ConnectionsSnapshot,
+  ConnectionsAggregate,
+  ConnectionAggHost,
+  ConnectionAggOutbound,
+  ConnectionAggFlow,
   HelperStatus,
   SystemProxyStatus,
   LogEntry,
@@ -98,7 +102,7 @@ export type {
   PlatformInfo,
 } from './types/runtime';
 
-export { ProxyErrorCode, isProxyErrorCode } from './types/runtime';
+export { ProxyErrorCode, isProxyErrorCode, TOPOLOGY_OTHERS_KEY } from './types/runtime';
 
 // ============================================================================
 // 基础类型

--- a/src/shared/types/runtime.ts
+++ b/src/shared/types/runtime.ts
@@ -111,9 +111,44 @@ export interface ConnectionEntry {
   start?: string; // 连接建立时刻（RFC3339）
 }
 
-/** 连接快照：经 EVENT_CONNECTIONS_UPDATED 推送 / CONNECTIONS_GET 回填。 */
+/** 连接快照：连接信息页经 CONNECTIONS_GET 按需 pull（仅页面打开时定时拉，非每秒全量 push 广播）。 */
 export interface ConnectionsSnapshot {
   connections: ConnectionEntry[];
+  at: number; // 采样时刻 epoch ms
+}
+
+/** 拓扑「其它」分组的 sentinel host 名（聚合 Top-N 截断后剩余的合并条目）。渲染端 topology-layout 见此值 →
+ *  替换为 i18n 文案 t('home.others')。用控制字符前缀确保绝不与真实 host/IP/rule 名冲突。 */
+export const TOPOLOGY_OTHERS_KEY = '\u0000others';
+
+/** 某目标（host）→ 单个出口的连接数分布项。 */
+export interface ConnectionAggFlow {
+  outbound: string;
+  count: number;
+}
+
+/** 按目标聚合的一组连接：host/destIP/rule 显示名 → 连接数 + 各出口分布（topology 中列节点）。 */
+export interface ConnectionAggHost {
+  name: string;
+  count: number;
+  flows: ConnectionAggFlow[];
+}
+
+/** 按出口聚合的连接数（topology 右列节点）。 */
+export interface ConnectionAggOutbound {
+  name: string;
+  count: number;
+}
+
+/**
+ * 连接聚合快照（首页拓扑专用）：StatsWorkerHost 每帧 O(N) 聚合后经 EVENT_CONNECTIONS_AGGREGATE 广播，载荷与连接
+ * 总数解耦（恒 ~Top-N host + 出口数）。取代「每秒全量 ConnectionEntry[] relay」——连接风暴下渲染端不再被全量明细
+ * 序列化 + 每秒 O(N) 重算拖死（issue #227）。hosts 已按 count 降序、截断 Top-N（剩余并入 TOPOLOGY_OTHERS_KEY）。
+ */
+export interface ConnectionsAggregate {
+  total: number; // 活跃连接总数
+  hosts: ConnectionAggHost[];
+  outbounds: ConnectionAggOutbound[];
   at: number; // 采样时刻 epoch ms
 }
 


### PR DESCRIPTION
## 问题（#227）
Linux Fedora TUN 模式，本机容器（pasta / rootless podman）以 ~40 连接/秒持续猛连同一地址制造连接风暴时，首页界面卡死（托盘「进入轻量模式」销毁窗口后可恢复 → 渲染进程被拖死）。

## 根因
旧 `EVENT_CONNECTIONS_UPDATED` 每秒把**全量 `ConnectionEntry[]`** 无条件 `sendToAll` 广播给所有窗口。连接风暴下 connMap 因漏发 CLOSED 累积到数千上万，每秒「序列化大数组过 IPC + 首页拓扑 O(N) 重算 + setState 重渲染」压垮渲染主线程。

## 方案：连接数据管线对连接量解耦，拆两条独立通道
- **拓扑（聚合 push）**：main 侧每帧 O(N) 聚合一次（`aggregateConnections`：Top-N host + 各出口分布），经 `EVENT_CONNECTIONS_AGGREGATE` 推小载荷（~Top-N host + 出口数，载荷与连接总数解耦）。`topology-layout` 只做坐标，聚合 / Top-N / Others 下沉 main。渲染端 O(N) 重算消失。
- **明细（按需 pull）**：连接信息页改 `CONNECTIONS_GET` 每 1s 拉（仅页面打开时），取消每秒全量 push 给所有窗口。关连接有乐观更新即时反馈。
- 取消旧 `EVENT_CONNECTIONS_UPDATED` 全量广播（无 live 残留消费点）。

## 测试
- tsc(main+renderer) + lint + 全量 jest 全绿。
- 新增 `connections-aggregate` 纯函数单测（聚合语义）；`topology-layout`（坐标 + Others sentinel→i18n）、`stats-service-gating`（聚合广播 + 明细 pull 物化）测试同步。

## 待验证
- 真机（Linux TUN）造连接风暴复现验证未做（提交环境本机无法复现）。

## 说明
issue 的「CPU 占满一核」是 sing-box 内核处理 40 conn/s 的固有成本（FakeIP + route 链匹配 + socks 出站 + 日志），客户端侧不可控；曾评估「TUN 模式抬内核日志级别」方案，因会让所有 TUN 用户丢失路由决策 / 生命周期日志 + Tailscale 自动登录提示而放弃。缓解措施见 issue 回复（停风暴源 / 给目标加直连规则 / 日志调 warn）。

Close #227
