### PR TITLE
fix: release notes 单一来源，消除重复的 ## What's Changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,30 +136,13 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Generate Release Notes
-        id: release_notes
-        run: |
-          if [ -f CHANGELOG.md ]; then
-            VERSION=${{ steps.version.outputs.VERSION }}
-            NOTES=$(sed -n "/## \[*${VERSION}\]*/,/## \[*/p" CHANGELOG.md | sed '$d')
-            if [ -z "$NOTES" ]; then
-              NOTES="Release $VERSION"
-            fi
-          else
-            NOTES=$(git log $(git describe --tags --abbrev=0 HEAD^)..HEAD --pretty=format:"- %s" || git log --pretty=format:"- %s")
-            NOTES="## What's Changed
-
-          $NOTES"
-          fi
-          echo "NOTES<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Create GitHub Release
+        # Release notes 单一来源：generate_release_notes 由 GitHub 自动从 PR 列表生成「## What's Changed」+
+        # Full Changelog。不再额外注入 body（曾与 generate_release_notes 叠加导致两个 ## What's Changed 且
+        # 与 PR 标题重复）；无需维护 CHANGELOG.md。
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ steps.version.outputs.VERSION }}
-          body: ${{ steps.release_notes.outputs.NOTES }}
           draft: true
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## 问题
每个 release 的描述出现**两个 `## What's Changed`** 且内容重复，且每次 push tag / re-run 会覆盖手动编辑。

## 根因
`.github/workflows/release.yml` 的 Create GitHub Release step 同时启用两套 notes 来源：
- 自定义 `body`（无 CHANGELOG.md 时走 git log 生成 `## What's Changed` + commit subjects）
- `generate_release_notes: true`（GitHub 自动生成 `## What's Changed` + PR by-line + Full Changelog）

softprops 把两段拼接 → 两个 `## What's Changed`；squash merge 后 commit subject = PR 标题，故内容重复。

## 方案
删 `Generate Release Notes` step + `body`，单一走 `generate_release_notes: true` 由 GitHub 自动从 PR 列表生成，无需维护 CHANGELOG.md。yaml 校验通过；files/env/draft 等不变。仅影响后续版本（已发布版本描述需手动清一次）。