### PR TITLE
fix: Linux deb 升级改 pkexec apt-get install 原位升级（取代 openPath 踩 App Center）

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -197,5 +197,8 @@
       }
     ]
   },
+  "deb": {
+    "recommends": ["policykit-1"]
+  },
   "publish": null
 }

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -22,6 +22,7 @@ import { UpdateNetwork } from './UpdateNetwork';
 import {
   buildWindowsUpdateVbs,
   buildLinuxAppImageScript,
+  buildLinuxDebScript,
   buildMacUpdateScript,
   macAppBundleFromExe,
 } from './update-install-script';
@@ -333,19 +334,39 @@ export class UpdateService {
         }, 1000);
       } else {
         // Linux: AppImage(loose, $APPIMAGE) → 覆盖原 AppImage 原位更新 + 重启（只换文件、不碰 ~/.config）；
-        // deb(installed) → 交 dpkg/GUI 安装器原位升级（openPath，原行为）。
+        // deb(installed) → pkexec apt-get install 原位升级 + 重启（取代旧 shell.openPath(.deb)：Ubuntu 24.04+
+        // 默认 .deb 处理器 App Center 对本地 deb 不做版本升级、只显示 Installed，见 buildLinuxDebScript）。
+        // 两路统一走 spawn detached bash 脚本（不再依赖系统默认 .deb 关联）。
         const appImageTarget = process.env.APPIMAGE || null;
-        if (appImageTarget && installerPath.endsWith('.AppImage')) {
+        const isAppImage = !!appImageTarget && installerPath.endsWith('.AppImage');
+        // deb 脚本严格按【运行形态 + 资产形态】双守卫（review Med-2）：仅「非 AppImage 运行（=deb 安装态）+ .deb 资产」
+        // 才走 root apt 安装。杜绝「AppImage(loose) 用户因 release 只发 deb 被跨形态兜底选中 → 被 system-wide 装 deb」。
+        const isDeb = !appImageTarget && installerPath.endsWith('.deb');
+        if (isAppImage || isDeb) {
           const { spawn } = require('child_process');
           const scriptPath = path.join(app.getPath('temp'), 'flowz_update.sh');
-          const scriptContent = buildLinuxAppImageScript({ installerPath, appImageTarget });
+          const scriptContent = isAppImage
+            ? buildLinuxAppImageScript({ installerPath, appImageTarget: appImageTarget as string })
+            : buildLinuxDebScript({ installerPath, exePath: app.getPath('exe') });
           fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
           const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' });
           child.unref();
-          this.logManager.addLog('info', `AppImage 原位更新: ${appImageTarget}`, 'UpdateService');
+          this.logManager.addLog(
+            'info',
+            isAppImage
+              ? `AppImage 原位更新: ${appImageTarget}`
+              : 'deb 原位升级（pkexec apt-get install + 重启）',
+            'UpdateService'
+          );
         } else {
+          // 形态错配（AppImage 运行却拿到 .deb / deb 态拿到 .AppImage 等跨形态兜底）：不强制 root 安装，回退交系统
+          // 处理（openPath）让用户手动决定，安全优先。
           await shell.openPath(installerPath);
-          this.logManager.addLog('info', '安装程序已启动，正在退出应用...', 'UpdateService');
+          this.logManager.addLog(
+            'warn',
+            `更新包形态与运行形态不匹配，交系统处理: ${installerPath}`,
+            'UpdateService'
+          );
         }
         setTimeout(() => {
           this.destroyTrayForExit();

--- a/src/main/services/__tests__/update-install-script.test.ts
+++ b/src/main/services/__tests__/update-install-script.test.ts
@@ -5,6 +5,7 @@
 import {
   buildWindowsUpdateVbs,
   buildLinuxAppImageScript,
+  buildLinuxDebScript,
   buildMacUpdateScript,
   macAppBundleFromExe,
 } from '../update-install-script';
@@ -56,6 +57,29 @@ describe('buildLinuxAppImageScript', () => {
       appImageTarget: '/a/b.AppImage',
     });
     expect(s).toContain("NEW='/tmp/it'\\''s.AppImage'");
+  });
+});
+
+describe('buildLinuxDebScript', () => {
+  it('pkexec apt-get install 原位升级 + 删 deb + 重启；失败回退 xdg-open 下载目录', () => {
+    const s = buildLinuxDebScript({
+      installerPath: '/tmp/FlowZ-4.1.8.deb',
+      exePath: '/opt/FlowZ/flowz',
+    });
+    expect(s).toContain("DEB='/tmp/FlowZ-4.1.8.deb'");
+    expect(s).toContain("EXE='/opt/FlowZ/flowz'");
+    expect(s).toContain('pkexec apt-get install -y'); // apt 解依赖+版本升级（非 openPath→App Center）
+    expect(s).toContain('Dpkg::Options::=--force-confold'); // 无 tty conffile 防阻断（Low-1）
+    expect(s).toMatch(/pkexec apt-get install .*"\$DEB"/); // deb 路径作末参
+    expect(s).toContain('rm -f "$DEB"'); // 成功删临时 deb
+    expect(s).toContain('nohup "$EXE"'); // 同路径覆盖后从原 exe 启动新版
+    expect(s).toContain('xdg-open "$(dirname "$DEB")"'); // 取消/失败回退（不回 openPath）
+    expect(s.startsWith('#!/bin/bash')).toBe(true);
+  });
+
+  it('单引号路径安全转义', () => {
+    const s = buildLinuxDebScript({ installerPath: "/tmp/it's.deb", exePath: '/o/f' });
+    expect(s).toContain("DEB='/tmp/it'\\''s.deb'");
   });
 });
 

--- a/src/main/services/update-install-script.ts
+++ b/src/main/services/update-install-script.ts
@@ -95,6 +95,41 @@ export function buildLinuxAppImageScript(opts: {
 }
 
 /**
+ * Linux deb 安装态原位升级脚本：`pkexec apt-get install` 原位升级（apt 比较版本 + 解依赖 + 同包名升级，dpkg 同
+ * 路径覆盖）+ 重启新版。取代旧 `shell.openPath(.deb)`——Ubuntu 24.04+ 默认 .deb 处理器是 App Center，对本地 .deb
+ * 只按【包名】判「已安装」、不比较版本、不提供升级流程（已装即显示 Installed 灰按钮，deb 用户无法 app 内升级）。
+ * data 在 `~/.config/FlowZ` 独立于产物 → 升级零丢失。提权用 pkexec（PolicyKit GUI 授权框，Ubuntu 标准；app 已
+ * 退出，框独立弹出）；用户取消/失败 → 回退 `xdg-open` 下载目录让用户手动处理（不回退 openPath→App Center 死路）。
+ *
+ * 信任边界（review Med-1）：本脚本以 root 自动安装【下载的 deb】，信任源 = GitHub HTTPS release（与 core/AppImage
+ * 更新同边界）。未对下载件做 sha256 比对——完整性靠 HTTPS 传输；旧 openPath 行为同样安装未校验 deb，仅多一步用户手动
+ * 确认，信任源不变（仍是同一 release 资产）。sha256 校验作为后续统一增强（覆盖 deb/AppImage/core 三类下载件），不在本
+ * PR 范围；调用方仅在「形态为 .deb」时才走本脚本（见 installUpdate 的 .deb 守卫，Med-2）。
+ */
+export function buildLinuxDebScript(opts: { installerPath: string; exePath: string }): string {
+  const deb = shq(opts.installerPath);
+  const exe = shq(opts.exePath);
+  return [
+    '#!/bin/bash',
+    'sleep 2',
+    `DEB=${deb}`,
+    `EXE=${exe}`,
+    // apt-get install 本地 deb（apt 1.1+ 支持绝对路径 deb）：解依赖 + 同包名版本升级。-y 免交互确认（apt 层）。
+    // -o Dpkg::Options::=--force-conf*：无 tty/detached 下若 deb 含 conffile 冲突，保留旧配置不阻断 install
+    // （Electron 应用通常无 conffiles，防御性，review Low-1）。pkexec 弹 PolicyKit GUI 授权框（root 提权）。
+    // 成功 → 删临时 deb + 从原 exe 路径启动新版（dpkg 同路径覆盖）。
+    'if pkexec apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold "$DEB"; then',
+    '  rm -f "$DEB" 2>/dev/null',
+    '  nohup "$EXE" >/dev/null 2>&1 &',
+    'else',
+    // 用户取消授权 / apt 失败 → 打开下载目录让用户手动（不回退 openPath，那会落回 App Center「Installed 无升级」死路）。
+    '  xdg-open "$(dirname "$DEB")" >/dev/null 2>&1 &',
+    'fi',
+    '',
+  ].join('\n');
+}
+
+/**
  * macOS 更新脚本（原子替换，避免 DMG 累积）。appBundlePath 非空=自动替换 .app；为空（定位不到 .app）=回退 open DMG。
  * 提权策略：先**无提权** mv 原子替换（/Applications 对 admin 用户组可写，绝大多数免密码）；失败才 osascript 一次性
  * 管理员授权（系统原生密码框，**不依赖常驻 helper**）。


### PR DESCRIPTION
## 问题
Linux deb 安装态点 app 内更新 → 打开 Ubuntu App Center,显示「Installed」灰按钮、**无升级**(截图 4.1.7)。

## 根因
`installUpdate` deb 分支走 `shell.openPath(.deb)` 交系统默认 .deb 处理器。Ubuntu 24.04+ 默认是 App Center,对本地 deb 只按**包名**判已安装、不比较版本、不提供升级流程 → deb 用户无法 app 内升级。(对比 AppImage/Win/Mac 都用专门 build*Script 原位脚本,deb 是唯一依赖系统默认关联的。)

## 方案
新增 `buildLinuxDebScript`:`pkexec apt-get install -y` 原位升级(apt 比较版本+解依赖+同包升级,dpkg 同路径覆盖;data 在 ~/.config/FlowZ 独立 → 零丢失;PolicyKit GUI 提权;取消/失败回退 `xdg-open` 目录,不回 App Center)+ 重启。与 AppImage 统一走 spawn detached bash。

## 独立 review 修复(无 High/Med 阻断,Low/Nit 全修零)
- 双守卫(运行形态+资产形态):仅「非 AppImage 运行 + .deb 资产」走 root apt,杜绝 AppImage 用户被 system-wide 装 deb;错配回退 openPath。
- conffile 防阻断:`-o Dpkg::Options::=--force-confdef/--force-confold`。
- `electron-builder deb.recommends policykit-1`(保证 pkexec 可用,缺失已优雅降级)。
- 单测钉死脚本 + shq 引号转义;tsc+lint+jest 全绿。

## 待验证(真机,Ubuntu deb 安装态)
1. pkexec PolicyKit 框在 app 退出后独立弹出 + apt 实际触发同包升级 + 升级后 exe 路径重启新版。
2. 点 Cancel 的回退路径(xdg-open 目录)。

## 信任边界(已知项,文档化)
root 自动安装下载的 deb 无 sha256 比对,信任源 = GitHub HTTPS release(与 core/AppImage 更新同边界);sha256 校验作为后续统一增强(覆盖三类下载件),不在本 PR。