### PR TITLE
fix: 非 GUI 环境（flowz -V / headless）优雅退出，避免卡死与 segfault

### DIFF
--- a/src/main/__tests__/cli-early-exit.test.ts
+++ b/src/main/__tests__/cli-early-exit.test.ts
@@ -1,0 +1,157 @@
+import {
+  resolveCliEarlyExit,
+  cliHelpText,
+  systemLanguagesFromEnv,
+  runCliEarlyExit,
+  type CliEarlyExitIo,
+} from '../cli-early-exit';
+
+describe('resolveCliEarlyExit', () => {
+  const withDisplay = { DISPLAY: ':0' };
+  const noDisplay = {};
+
+  it('-V / --version → version（三平台通用，与显示环境无关）', () => {
+    expect(resolveCliEarlyExit(['-V'], noDisplay, 'linux')).toBe('version');
+    expect(resolveCliEarlyExit(['--version'], withDisplay, 'darwin')).toBe('version');
+    expect(resolveCliEarlyExit(['--version'], noDisplay, 'win32')).toBe('version');
+  });
+
+  it('-h / --help → help', () => {
+    expect(resolveCliEarlyExit(['-h'], withDisplay, 'win32')).toBe('help');
+    expect(resolveCliEarlyExit(['--help'], noDisplay, 'linux')).toBe('help');
+  });
+
+  it('CLI flag 优先于 headless（-V + 无 DISPLAY → version，不是 headless）', () => {
+    expect(resolveCliEarlyExit(['-V'], noDisplay, 'linux')).toBe('version');
+  });
+
+  it('Linux 无 DISPLAY/WAYLAND + 非 flag → headless', () => {
+    expect(resolveCliEarlyExit([], noDisplay, 'linux')).toBe('headless');
+  });
+
+  it('Linux 有 DISPLAY 或 WAYLAND_DISPLAY → none（正常启动）', () => {
+    expect(resolveCliEarlyExit([], withDisplay, 'linux')).toBe('none');
+    expect(resolveCliEarlyExit([], { WAYLAND_DISPLAY: 'wayland-0' }, 'linux')).toBe('none');
+  });
+
+  it('macOS / Windows 无 DISPLAY + 非 flag → none（headless 早退仅覆盖 Linux）', () => {
+    expect(resolveCliEarlyExit([], noDisplay, 'darwin')).toBe('none');
+    expect(resolveCliEarlyExit([], noDisplay, 'win32')).toBe('none');
+  });
+
+  it('正常 GUI 启动（无 flag + 有 DISPLAY）→ none', () => {
+    expect(resolveCliEarlyExit(['/path/to/app'], withDisplay, 'linux')).toBe('none');
+  });
+});
+
+describe('cliHelpText', () => {
+  it('含版本 + 用法 + flag 说明', () => {
+    const t = cliHelpText('4.1.7');
+    expect(t).toContain('FlowZ 4.1.7');
+    expect(t).toContain('Usage:');
+    expect(t).toContain('--version');
+    expect(t).toContain('--help');
+  });
+});
+
+describe('systemLanguagesFromEnv', () => {
+  it('LANGUAGE 冒号分隔优先级列表按序展开', () => {
+    expect(systemLanguagesFromEnv({ LANGUAGE: 'de_DE:ru_RU:en_US' })).toEqual([
+      'de-DE',
+      'ru-RU',
+      'en-US',
+    ]);
+  });
+
+  it('剥 .codeset / @modifier，保留地区子标签（zh_HK.UTF-8 → zh-HK 可判繁体）', () => {
+    expect(systemLanguagesFromEnv({ LANG: 'zh_HK.UTF-8' })).toEqual(['zh-HK']);
+    expect(systemLanguagesFromEnv({ LANG: 'sr_RS.UTF-8@latin' })).toEqual(['sr-RS']);
+  });
+
+  it('GNU 优先级 LANGUAGE > LC_ALL > LC_MESSAGES > LANG', () => {
+    expect(
+      systemLanguagesFromEnv({
+        LANGUAGE: 'ru_RU',
+        LC_ALL: 'fa_IR',
+        LC_MESSAGES: 'en_US',
+        LANG: 'zh_CN',
+      })
+    ).toEqual(['ru-RU', 'fa-IR', 'en-US', 'zh-CN']);
+  });
+
+  it('C / POSIX / 空值滤除；全空 → 空列表', () => {
+    expect(systemLanguagesFromEnv({ LANG: 'C' })).toEqual([]);
+    expect(systemLanguagesFromEnv({ LC_ALL: 'POSIX', LANG: '' })).toEqual([]);
+    expect(systemLanguagesFromEnv({})).toEqual([]);
+  });
+
+  it('C-override：messages locale 为 C/POSIX(含 C.UTF-8) → 忽略 LANGUAGE，落空(→en fallback)', () => {
+    expect(systemLanguagesFromEnv({ LANGUAGE: 'de_DE:ru_RU', LANG: 'C' })).toEqual([]);
+    expect(systemLanguagesFromEnv({ LANGUAGE: 'de_DE', LC_ALL: 'C.UTF-8' })).toEqual([]);
+    // messages 非 C → LANGUAGE 正常生效
+    expect(systemLanguagesFromEnv({ LANGUAGE: 'ru_RU', LANG: 'en_US.UTF-8' })).toEqual([
+      'ru-RU',
+      'en-US',
+    ]);
+  });
+});
+
+describe('runCliEarlyExit（IO 注入编排）', () => {
+  const baseIo = (
+    over: Partial<CliEarlyExitIo>
+  ): { io: CliEarlyExitIo; calls: Record<string, jest.Mock> } => {
+    const calls = {
+      writeStdout: jest.fn(),
+      writeStderr: jest.fn(),
+      setLanguage: jest.fn(),
+      exit: jest.fn(),
+    };
+    const io: CliEarlyExitIo = {
+      argv: [],
+      env: {},
+      platform: 'linux',
+      getVersion: () => '9.9.9',
+      writeStdout: calls.writeStdout,
+      writeStderr: calls.writeStderr,
+      setLanguage: calls.setLanguage,
+      headlessMessage: () => 'HEADLESS_MSG',
+      exit: calls.exit,
+      ...over,
+    };
+    return { io, calls };
+  };
+
+  it('version：stdout 写版本 + exit(0)，返 true，不碰 stderr/语言', () => {
+    const { io, calls } = baseIo({ argv: ['-V'] });
+    expect(runCliEarlyExit(io)).toBe(true);
+    expect(calls.writeStdout).toHaveBeenCalledWith('FlowZ 9.9.9\n');
+    expect(calls.exit).toHaveBeenCalledWith(0);
+    expect(calls.writeStderr).not.toHaveBeenCalled();
+    expect(calls.setLanguage).not.toHaveBeenCalled();
+  });
+
+  it('help：stdout 写用法 + exit(0)', () => {
+    const { io, calls } = baseIo({ argv: ['--help'] });
+    expect(runCliEarlyExit(io)).toBe(true);
+    expect(calls.writeStdout.mock.calls[0][0]).toContain('Usage:');
+    expect(calls.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('headless：setLanguage 收 env 解析列表 → stderr 写提示 + exit(1)', () => {
+    const { io, calls } = baseIo({ argv: [], env: { LANG: 'ru_RU.UTF-8' } });
+    expect(runCliEarlyExit(io)).toBe(true);
+    expect(calls.setLanguage).toHaveBeenCalledWith(['ru-RU']); // 经 systemLanguagesFromEnv
+    expect(calls.writeStderr).toHaveBeenCalledWith('HEADLESS_MSG\n');
+    expect(calls.exit).toHaveBeenCalledWith(1);
+    expect(calls.writeStdout).not.toHaveBeenCalled();
+  });
+
+  it('none（有 DISPLAY，无 flag）：零副作用，返 false', () => {
+    const { io, calls } = baseIo({ argv: [], env: { DISPLAY: ':0' } });
+    expect(runCliEarlyExit(io)).toBe(false);
+    expect(calls.writeStdout).not.toHaveBeenCalled();
+    expect(calls.writeStderr).not.toHaveBeenCalled();
+    expect(calls.setLanguage).not.toHaveBeenCalled();
+    expect(calls.exit).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/__tests__/i18n.test.ts
+++ b/src/main/__tests__/i18n.test.ts
@@ -4,7 +4,7 @@
  */
 jest.mock('electron', () => ({ app: {} }));
 
-import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from '../../shared/language';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, resolveAutoLanguage } from '../../shared/language';
 import { mt, setMainLanguage, getMainLanguage, MAIN_MESSAGE_KEYS } from '../i18n';
 
 // 自动覆盖全部文案键（通知 + 托盘 + 对话框 + 未来新增），无需手维护清单。
@@ -63,5 +63,33 @@ describe('mt', () => {
         expect(mt(key).trim().length).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+// headless 早退提示跟随系统 locale 的完整链路（index.ts: setMainLanguage(resolveAutoLanguage(systemLanguagesFromEnv(process.env)))）。
+// 验收门「提示满足系统语言、禁硬编码」：region 化 locale（ru-RU / zh-Hans-CN）须智能匹配到对应语言，
+// 不得静默回退英文。直接把裸 locale 传 setMainLanguage 会走精确匹配、ru-RU 落英文——此处钉死该 i18n 不变量。
+describe('headless 提示跟随系统 locale（H1 回归）', () => {
+  const headlessFor = (sysLocale: string): string => {
+    setMainLanguage(resolveAutoLanguage([sysLocale]));
+    return mt('headlessNoDisplay');
+  };
+
+  it('ru-RU 系统 locale → 俄语文案（含西里尔字母，非英文回退）', () => {
+    expect(headlessFor('ru-RU')).toMatch(/[А-Яа-я]/);
+  });
+
+  it('zh-Hans-CN / zh-CN → 简体中文文案（含汉字）', () => {
+    expect(headlessFor('zh-Hans-CN')).toMatch(/[一-鿿]/);
+    expect(headlessFor('zh-CN')).toMatch(/[一-鿿]/);
+  });
+
+  it('fa-IR → 波斯语文案（含阿拉伯/波斯字母）', () => {
+    expect(headlessFor('fa-IR')).toMatch(/[؀-ۿ]/);
+  });
+
+  it('en-US → 英文；不支持的 de-DE → 兜底英文（仅此情形允许英文）', () => {
+    expect(headlessFor('en-US')).toContain('GUI application');
+    expect(headlessFor('de-DE')).toContain('GUI application');
   });
 });

--- a/src/main/cli-early-exit.ts
+++ b/src/main/cli-early-exit.ts
@@ -1,0 +1,122 @@
+/**
+ * CLI / 非 GUI 早退（纯函数判定 + IO 注入编排，便于单测；实际副作用由 index.ts 注入的 io 执行）。
+ *
+ * 背景：FlowZ 是 Electron GUI app，main 进程默认走 `whenReady → createWindow` 路径。在无显示服务环境
+ * （SSH / CI / headless / `flowz -V` 查版本）启动时，Electron GUI 平台（Ozone/X11）初始化失败
+ * （"Missing X server or $DISPLAY" / "platform failed to initialize"），且 native 层清理不净 → 进程卡死、
+ * 用户 Ctrl-C 后 segfault(core dumped)。CLI 查询（-V/-h）本不需要 GUI。
+ *
+ * 早退在 Electron GUI 初始化（requestSingleInstanceLock / whenReady）之前跑，据 argv + 显示环境决定：
+ *  - version/help：CLI 查询，三平台通用，直接输出 + exit(0)，根本不触发 GUI 初始化。
+ *  - headless：无图形环境正常启动（GUI app 需桌面），提示用户 + exit(1)，避免走到崩溃/segfault。
+ *  - none：正常 GUI 启动，继续走原流程。
+ */
+export type CliEarlyExit = 'version' | 'help' | 'headless' | 'none';
+
+/** 早退判定所需的环境变量子集（显示服务 + POSIX locale 来源）。process.env 结构兼容此类型。 */
+export interface CliEnv {
+  DISPLAY?: string;
+  WAYLAND_DISPLAY?: string;
+  LANGUAGE?: string;
+  LC_ALL?: string;
+  LC_MESSAGES?: string;
+  LANG?: string;
+}
+
+export function resolveCliEarlyExit(
+  argv: string[],
+  env: CliEnv,
+  platform: NodeJS.Platform
+): CliEarlyExit {
+  const has = (...flags: string[]): boolean => flags.some((f) => argv.includes(f));
+  if (has('-V', '--version')) return 'version';
+  if (has('-h', '--help')) return 'help';
+  // 无图形环境正常启动：仅 Linux 用 DISPLAY/WAYLAND 判定（X11/Wayland 缺失=必崩）。macOS（WindowServer）/
+  // Windows（桌面 session）通常有显示服务，且无等价的简单环境变量信号，本早退暂不覆盖（CLI flag 早退仍三平台通用）。
+  if (platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY) return 'headless';
+  return 'none';
+}
+
+/** -h/--help 的用法文本（CLI 通用英文，与 i18n 无关——CLI 帮助按惯例英文）。version 由调用方拼 app.getVersion()。 */
+export function cliHelpText(version: string): string {
+  return (
+    `FlowZ ${version}\n\n` +
+    `Usage: flowz [options]\n` +
+    `  -V, --version   Show version and exit\n` +
+    `  -h, --help      Show this help and exit\n`
+  );
+}
+
+/** POSIX locale（lang_TERRITORY.codeset@modifier）→ BCP47 子串（剥 .codeset/@modifier、`_`→`-`，滤 C/POSIX）；无效返 null。 */
+function normalizePosixLocale(loc: string): string | null {
+  const base = loc.trim().split('.')[0].split('@')[0].trim();
+  if (!base) return null;
+  const upper = base.toUpperCase();
+  if (upper === 'C' || upper === 'POSIX') return null;
+  return base.replace(/_/g, '-');
+}
+
+/**
+ * 从环境变量解析系统语言优先级列表（headless 早退在 app ready 前，app.getPreferredSystemLanguages 不可用时的来源）。
+ * GNU gettext 优先级：LANGUAGE（冒号分隔的优先级列表）> LC_ALL > LC_MESSAGES > LANG。喂 resolveAutoLanguage 逐个匹配。
+ * 比单一 Intl 主 locale 更全：主语言不受支持但次选受支持时仍能命中（与 normal 路径用完整有序列表一致）。
+ * C-override（GNU 真实语义）：messages category（LC_ALL>LC_MESSAGES>LANG）为 C/POSIX 时用户显式要英文，LANGUAGE 整体忽略。
+ */
+export function systemLanguagesFromEnv(env: CliEnv): string[] {
+  const out: string[] = [];
+  const add = (raw: string | undefined, isList: boolean): void => {
+    if (!raw) return;
+    for (const part of isList ? raw.split(':') : [raw]) {
+      const norm = normalizePosixLocale(part);
+      if (norm) out.push(norm);
+    }
+  };
+  // messages locale 为 C/POSIX（normalizePosixLocale 对其及空值返 null）→ 忽略 LANGUAGE，落 en-US fallback。
+  const messages = env.LC_ALL || env.LC_MESSAGES || env.LANG;
+  const messagesIsC = !!messages && normalizePosixLocale(messages) === null;
+  if (!messagesIsC) add(env.LANGUAGE, true);
+  add(env.LC_ALL, false);
+  add(env.LC_MESSAGES, false);
+  add(env.LANG, false);
+  return out;
+}
+
+/** 早退编排的 IO 边界（index.ts 注入真实实现；单测注入 spy 验证编排，绕开 index 顶层块 import 期不可测）。 */
+export interface CliEarlyExitIo {
+  readonly argv: string[];
+  readonly env: CliEnv;
+  readonly platform: NodeJS.Platform;
+  getVersion(): string;
+  writeStdout(text: string): void;
+  writeStderr(text: string): void;
+  /** 据系统语言列表设定主进程语言（index 实现：setMainLanguage(resolveAutoLanguage(langs))）。 */
+  setLanguage(langs: string[]): void;
+  /** 取已设定语言下的 headless 提示文案（index 实现：mt('headlessNoDisplay')，须在 setLanguage 之后调用）。 */
+  headlessMessage(): string;
+  exit(code: number): void;
+}
+
+/**
+ * CLI / 非 GUI 早退编排。命中 version/help/headless 则输出 + exit 并返 true；none 返 false（继续 GUI 启动）。
+ * 调用方 exit 实现须同步终止（process.exit），返回值仅供单测/防御——理论上 exit 后不再返回。
+ */
+export function runCliEarlyExit(io: CliEarlyExitIo): boolean {
+  const kind = resolveCliEarlyExit(io.argv, io.env, io.platform);
+  switch (kind) {
+    case 'version':
+      io.writeStdout(`FlowZ ${io.getVersion()}\n`);
+      io.exit(0);
+      return true;
+    case 'help':
+      io.writeStdout(cliHelpText(io.getVersion()));
+      io.exit(0);
+      return true;
+    case 'headless':
+      io.setLanguage(systemLanguagesFromEnv(io.env));
+      io.writeStderr(`${io.headlessMessage()}\n`);
+      io.exit(1);
+      return true;
+    default:
+      return false;
+  }
+}

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -20,6 +20,17 @@ import {
 
 /** key → 各受支持语言文案。satisfies 保证每键 5 语齐全；新增主进程用户可见串在此扩展。 */
 const MESSAGES = {
+  // —— CLI / 非 GUI 早退（cli-early-exit，main 进程顶层；headless 提示走系统 locale，禁硬编码） ——
+  headlessNoDisplay: {
+    'zh-CN':
+      'FlowZ 是图形界面应用，需要桌面环境运行；当前未检测到显示服务（DISPLAY/Wayland）。查看版本请运行：flowz --version',
+    'zh-TW':
+      'FlowZ 是圖形介面應用，需要桌面環境執行；目前未偵測到顯示服務（DISPLAY/Wayland）。查看版本請執行：flowz --version',
+    'en-US':
+      'FlowZ is a GUI application and needs a desktop environment; no display server (DISPLAY/Wayland) was detected. To check the version, run: flowz --version',
+    ru: 'FlowZ — графическое приложение, которому нужна среда рабочего стола; сервер отображения (DISPLAY/Wayland) не обнаружен. Чтобы узнать версию, выполните: flowz --version',
+    fa: 'FlowZ یک برنامهٔ گرافیکی است و به محیط دسکتاپ نیاز دارد؛ هیچ سرور نمایشی (DISPLAY/Wayland) شناسایی نشد. برای دیدن نسخه اجرا کنید: flowz --version',
+  },
   // —— 桌面通知（notify-user 出口） ——
   proxyErrorTitle: {
     'zh-CN': 'FlowZ 代理出错',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, Menu, powerMonitor, shell } from 'electron';
 import * as path from 'path';
+import * as fs from 'fs';
 import { ConfigManager } from './services/ConfigManager';
 import { ProtocolParser } from './services/ProtocolParser';
 import { LogManager } from './services/LogManager';
@@ -12,6 +13,7 @@ import { resourceManager } from './services/ResourceManager';
 import { registerIconProtocolSchemes, registerIconProtocol } from './icon-protocol';
 import { notifyUser, setDesktopNotificationsEnabled } from './notify-user';
 import { mt, setMainLanguage } from './i18n';
+import { runCliEarlyExit } from './cli-early-exit';
 import { SubscriptionService } from './services/SubscriptionService';
 import { registerPrivacyHandlers } from './ipc/handlers/privacy-handlers';
 import {
@@ -87,6 +89,24 @@ function logStartupTimingOnce(): void {
     'Main'
   );
 }
+
+// ── CLI / 非 GUI 早退（必须在 Electron GUI 平台初始化前；无 DISPLAY 下 GUI 初始化失败会卡死 + segfault）──
+// 编排/判定全在 cli-early-exit（纯函数 + IO 注入，可单测）；此处仅注入真实 IO：
+// - writeStdout/Stderr 用 fs.writeSync(同步落 fd)：process.stdout.write 写管道是异步缓冲，紧跟 exit 会丢
+//   `flowz -V | cat` / `$(flowz -V)` 的输出。
+// - exit 用 process.exit(而非 app.exit)：保证同步终止、绝不 fall-through 落回下方 GUI init（ready 前无 GUI 状态需清理）。
+// - setLanguage 经 resolveAutoLanguage 智能匹配系统 locale(ru-RU→ru / zh_HK→zh-TW)，与 normal 路径一致，禁硬编码。
+runCliEarlyExit({
+  argv: process.argv.slice(1),
+  env: process.env,
+  platform: process.platform,
+  getVersion: () => app.getVersion(),
+  writeStdout: (text) => fs.writeSync(1, text),
+  writeStderr: (text) => fs.writeSync(2, text),
+  setLanguage: (langs) => setMainLanguage(resolveAutoLanguage(langs)),
+  headlessMessage: () => mt('headlessNoDisplay'),
+  exit: (code) => process.exit(code),
+});
 
 // 初始化用户数据路径（必须在 app.requestSingleInstanceLock() 之前调用）
 // 以确保便携模式下，锁文件和所有 Electron 数据都重定向到正确的目录


### PR DESCRIPTION
## 问题
`flowz -V`（或任何无显示服务环境启动，如 SSH / headless）触发 Electron GUI 平台（Ozone/X11）初始化失败（`Missing X server or $DISPLAY`），native 层清理不净 → 进程卡死，用户 Ctrl-C 后 segfault(core dumped)。CLI 查询（`-V`/`-h`）本不需要 GUI。

## 根因
main 进程默认走 `whenReady → createWindow`，GUI 平台初始化先于任何 CLI flag 处理；无 DISPLAY 时 GUI 初始化即崩，进程无从优雅退出。

## 方案
在 Electron GUI 初始化（`requestSingleInstanceLock` / `whenReady`）**之前**拦截（`cli-early-exit`，纯函数判定 + IO 注入编排）：
- `-V/--version` → 输出版本 + `exit(0)`；`-h/--help` → 用法 + `exit(0)`。三平台通用，根本不触发 X11/Ozone。
- Linux 无 `DISPLAY`/`WAYLAND_DISPLAY` 正常启动 → i18n 提示（跟随系统语言）+ `exit(1)`，干净退出不崩。macOS（WindowServer）/ Windows（桌面 session）通常有显示服务且无等价简单环境信号，headless 分支暂不覆盖（CLI flag 早退仍三平台通用）。

## 实现要点
- 判定 / 编排全在 `cli-early-exit`（`resolveCliEarlyExit` + `runCliEarlyExit`），`index.ts` 顶层仅注入真实 IO，绕开顶层块 import 期不可单测的限制。
- headless 提示语言来源 `systemLanguagesFromEnv`：按 GNU 优先级 `LANGUAGE`(冒号列表) > `LC_ALL` > `LC_MESSAGES` > `LANG` 解析（剥 `.codeset`/`@modifier`、滤 `C`/`POSIX`、含 C-override），喂 `resolveAutoLanguage` 智能匹配（`ru-RU`→`ru` / `zh_HK`→`zh-TW`），与 normal 路径一致、禁硬编码；提示文案 5 语。
- 输出用 `fs.writeSync` 同步落 fd（避免 `process.stdout.write` 写管道异步缓冲被 `exit` 截断，如 `flowz -V | cat` / `$(flowz -V)`）；`process.exit` 保证同步终止、不 fall-through 落回 GUI init。

## 测试
- `cli-early-exit.test.ts`：判定全 case + `systemLanguagesFromEnv`（GNU 优先级 / codeset 剥离 / C-override）+ `runCliEarlyExit` 编排（version/help/headless/none）。
- `i18n.test.ts`：headless 提示跟随系统 locale 回归（`ru-RU`→俄语、`zh-Hans-CN`→简中、`fa-IR`→波斯、`de-DE`→兜底英文）。
- gate 全绿：`tsc`(main) + `jest`(27) + `eslint`。

## 真机待验（Linux headless）
- [ ] `flowz -V` / `flowz -h` 输出版本/用法、退出码 0、无 segfault。
- [ ] 无 `DISPLAY` 直启 → 提示 + `exit(1)`；`LANG=ru_RU.UTF-8` / `zh_CN` / `fa_IR` 下提示字形正确。
- [ ] `flowz -V | cat`、`$(flowz -V)` 输出不截断。
