### PR TITLE
fix(macOS): app bundle 声明中文本地化，原生 UI（文件框/菜单）跟随系统语言

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -93,6 +93,10 @@
     "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
     "identity": null,
     "gatekeeperAssess": false,
+    "extendInfo": {
+      "CFBundleLocalizations": ["en", "zh-Hans", "zh-Hant", "ru", "fa"],
+      "CFBundleAllowMixedLocalizations": true
+    },
     "extraResources": [
       {
         "from": "resources/mac-${arch}",


### PR DESCRIPTION
## 问题
macOS 中文系统下,所有**原生 UI**(NSOpenPanel 文件对话框、右键菜单、系统菜单项)仍显英文——即便系统语言中文、app 界面(i18next)全中文。

## 根因(第一性)
macOS 原生 UI(AppKit)的语言由 **app bundle 声明的本地化(`CFBundleLocalizations`)** 决定,**不是系统语言**。Electron 默认 app bundle 只声明 `en`(这也是 `app.getLocale()` 恒返 en 的同一个根);`electronLanguages` 只 prune Electron Framework 的 lproj(Chromium 层),**不创建 app bundle 的本地化声明**。app 不声称支持中文 → AppKit effective localization fallback 到 en → 所有原生 UI 英文。

## 方案
`electron-builder.json` `mac.extendInfo` 注入:
- `CFBundleLocalizations: [en, zh-Hans, zh-Hant, ru, fa]`(声明 app 支持这些语言)
- `CFBundleAllowMixedLocalizations: true`

app 声称支持中文后,AppKit effective localization 跟随系统偏好语言 → NSOpenPanel 等原生 UI 用系统 AppKit 的中文资源。

## 验证
- Info.plist 注入确认:`CFBundleLocalizations = [en, zh-Hans, zh-Hant, ru, fa]`。
- **mac arm64 真机实测:文件对话框(NSOpenPanel)已转中文。** ✅

## 平台说明
**仅 macOS 需要**此处理。Windows 文件对话框(IFileOpenDialog)跟随系统 UI 语言、Linux(GTK/portal)跟随系统 locale,均系统级天然跟随,无需改动。
