### PR TITLE
fix(update): Windows 便携自更新治本——移入新版本名+删旧版本名，治退出重开复原旧版

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -53,6 +53,15 @@ const MESSAGES = {
     ru: 'Все файлы',
     fa: 'همه فایل‌ها',
   },
+  // —— Windows 便携自更新覆盖失败提示（update-install-script VBS MsgBox；路径由 VBS 拼接，故末尾留冒号） ——
+  portableUpdateManualReplace: {
+    'zh-CN': 'FlowZ 自动更新未能替换便携程序。新版已下载到下方路径，请手动替换：',
+    'zh-TW': 'FlowZ 自動更新未能替換便攜程式。新版已下載到下方路徑，請手動替換：',
+    'en-US':
+      'FlowZ auto-update could not replace the portable executable. The new version was downloaded to the path below — please replace it manually:',
+    ru: 'FlowZ не смог заменить переносимый файл при автообновлении. Новая версия загружена по пути ниже — замените её вручную:',
+    fa: 'به‌روزرسانی خودکار FlowZ نتوانست فایل قابل‌حمل را جایگزین کند. نسخهٔ جدید در مسیر زیر دانلود شد — لطفاً به‌صورت دستی جایگزین کنید:',
+  },
   // —— 桌面通知（notify-user 出口） ——
   proxyErrorTitle: {
     'zh-CN': 'FlowZ 代理出错',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import { registerIconProtocolSchemes, registerIconProtocol } from './icon-protoc
 import { notifyUser, setDesktopNotificationsEnabled } from './notify-user';
 import { mt, setMainLanguage } from './i18n';
 import { runCliEarlyExit } from './cli-early-exit';
+import { selectPortableStaleOld } from './services/update-install-script';
 import { SubscriptionService } from './services/SubscriptionService';
 import { registerPrivacyHandlers } from './ipc/handlers/privacy-handlers';
 import {
@@ -1004,6 +1005,21 @@ if (gotTheLock) {
   registerIconProtocolSchemes();
   app.whenReady().then(async () => {
     startupMark('whenReady');
+    // Windows 便携自更新遗留的 .exe.old（旧版本被 stub 锁、上次 rename 挪开的）→ 启动期清理（此刻无进程占用，可删）。
+    if (process.env.PORTABLE_EXECUTABLE_DIR) {
+      try {
+        const portableDir = process.env.PORTABLE_EXECUTABLE_DIR;
+        for (const f of selectPortableStaleOld(fs.readdirSync(portableDir))) {
+          try {
+            fs.unlinkSync(path.join(portableDir, f));
+          } catch {
+            /* 仍被占用 → 下次启动再清 */
+          }
+        }
+      } catch {
+        /* readdir 失败忽略 */
+      }
+    }
     // 初始化服务
     configManager = new ConfigManager();
     protocolParser = new ProtocolParser();

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -26,6 +26,7 @@ import {
   buildMacUpdateScript,
   macAppBundleFromExe,
 } from './update-install-script';
+import { mt } from '../i18n';
 
 // 下载停滞超时：连接/下载 30s 无数据即视为卡死 → abort + 失败兜底（github 链接自动换镜像重试一次）。
 // 防永久挂起致更新永不 resolve（进度窗/对话框永久转圈）。正常下载持续有 data、不断重置、不会误触发。
@@ -280,14 +281,26 @@ export class UpdateService {
         const vbsPath = path.join(app.getPath('temp'), 'flowz_update.vbs');
 
         const portableTarget = process.env.PORTABLE_EXECUTABLE_FILE || null;
+        // B（移入新版本名 + 删旧版本名）：新版本名文件放回原目录（原目录 + 下载件文件名），保留 GitHub release
+        // 带版本号的命名。
+        const portableNewPath = portableTarget
+          ? path.join(path.dirname(portableTarget), path.basename(installerPath))
+          : null;
         this.logManager.addLog(
           'info',
-          portableTarget ? '便携版：覆盖原 exe 原位更新' : 'NSIS：运行安装器原位升级',
+          portableTarget ? '便携版：移入新版本名文件 + 删旧版本名' : 'NSIS：运行安装器原位升级',
           'UpdateService'
         );
-        const vbsContent = buildWindowsUpdateVbs({ installerPath, portableTarget });
+        const vbsContent = buildWindowsUpdateVbs({
+          installerPath,
+          portableTarget,
+          portableNewPath,
+          fallbackMessage: mt('portableUpdateManualReplace'),
+        });
 
-        fs.writeFileSync(vbsPath, vbsContent, 'utf-8');
+        // .vbs 必须 UTF-16 LE + BOM：wscript 只认它为 Unicode；UTF-8 无 BOM 会按系统 ANSI 代码页解读 →
+        // 非 ASCII 用户名/路径（如中文账户的 %TEMP%/便携目录）错乱致文件操作失败、多语 MsgBox 乱码。
+        fs.writeFileSync(vbsPath, '\ufeff' + vbsContent, 'utf16le');
 
         // 使用 wscript 运行 VBS（完全无窗口）
         const vbs = spawn(system32('wscript.exe'), [vbsPath], {

--- a/src/main/services/__tests__/update-install-script.test.ts
+++ b/src/main/services/__tests__/update-install-script.test.ts
@@ -8,31 +8,85 @@ import {
   buildLinuxDebScript,
   buildMacUpdateScript,
   macAppBundleFromExe,
+  selectPortableStaleOld,
 } from '../update-install-script';
 
 describe('buildWindowsUpdateVbs', () => {
-  const tmp = 'C:\\Users\\u\\AppData\\Local\\Temp\\FlowZ-portable.exe';
+  const tmp = 'C:\\Users\\u\\AppData\\Local\\Temp\\FlowZ-4.1.7-win-x64-portable.exe';
 
-  it('便携态：覆盖回原 exe 原位 + 启动原位 + 删临时；含覆盖失败回退', () => {
+  it('便携态（B 移入新名+删旧名）：写新版本名到原目录 + 删旧名(被锁则 rename 兜底) + 启新名 + 不静默 fallback', () => {
+    const oldExe = 'D:\\Apps\\FlowZ-4.1.5-win-x64-portable.exe';
+    const newExe = 'D:\\Apps\\FlowZ-4.1.7-win-x64-portable.exe';
+    const s = buildWindowsUpdateVbs({
+      installerPath: tmp,
+      portableTarget: oldExe,
+      portableNewPath: newExe,
+      fallbackMessage: 'UPD_FAIL_MSG',
+    });
+    // 变量赋值（双反斜杠转义）
+    expect(s).toContain('newExe = "D:\\\\Apps\\\\FlowZ-4.1.7-win-x64-portable.exe"');
+    expect(s).toContain('oldExe = "D:\\\\Apps\\\\FlowZ-4.1.5-win-x64-portable.exe"');
+    // 写新版本名文件到原目录（新名不撞锁）
+    expect(s).toContain('fso.CopyFile src, newExe, True');
+    // 旧名被 stub 锁 → DeleteFile 失败则 rename 到 .old；同名时跳过删旧
+    expect(s).toContain('LCase(oldExe) <> LCase(newExe)');
+    expect(s).toContain('fso.DeleteFile oldExe, True');
+    expect(s).toContain('fso.MoveFile oldExe, oldExe & ".old"');
+    // 启动新版本名文件
+    expect(s).toContain('WshShell.Run """" & newExe & """", 1, False');
+    // 残留 .old 清理（新旧两路径）+ newExe 预存则先 rename 挪开
+    expect(s).toContain(
+      'If fso.FileExists(newExe & ".old") Then fso.DeleteFile newExe & ".old", True'
+    );
+    expect(s).toContain(
+      'If fso.FileExists(oldExe & ".old") Then fso.DeleteFile oldExe & ".old", True'
+    );
+    expect(s).toContain('If fso.FileExists(newExe) Then fso.MoveFile newExe, newExe & ".old"');
+    // 写新名失败 fallback：跑临时 src + MsgBox（含注入文案 + 单反斜杠原路径，非双写反斜杠）
+    expect(s).toContain('WshShell.Run """" & src & """", 1, False');
+    expect(s).toContain('MsgBox "UPD_FAIL_MSG"');
+    expect(s).toContain('"C:\\Users\\u\\AppData\\Local\\Temp\\FlowZ-4.1.7-win-x64-portable.exe"');
+    expect(s).toMatch(/\r\n/); // VBS 用 CRLF
+  });
+
+  it('便携态 portableNewPath 缺省 → 退化为覆盖同名（newExe == oldExe）', () => {
     const target = 'D:\\Apps\\FlowZ.exe';
     const s = buildWindowsUpdateVbs({ installerPath: tmp, portableTarget: target });
-    // 覆盖回原 exe（双反斜杠转义）
-    expect(s).toContain(
-      'fso.CopyFile "C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-portable.exe", "D:\\\\Apps\\\\FlowZ.exe", True'
-    );
-    // 成功 → 跑原位 + 删临时
-    expect(s).toContain('WshShell.Run """D:\\\\Apps\\\\FlowZ.exe"""');
-    expect(s).toContain('If Err.Number = 0 Then');
-    expect(s).toContain('Else'); // 覆盖失败回退跑临时
-    expect(s).toMatch(/\r\n/); // VBS 用 CRLF
+    expect(s).toContain('newExe = "D:\\\\Apps\\\\FlowZ.exe"');
+    expect(s).toContain('oldExe = "D:\\\\Apps\\\\FlowZ.exe"');
   });
 
   it('NSIS 态：跑下载的 setup、无 CopyFile（原行为）', () => {
     const s = buildWindowsUpdateVbs({ installerPath: tmp, portableTarget: null });
     expect(s).toContain(
-      'WshShell.Run """C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-portable.exe"""'
+      'WshShell.Run """C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-4.1.7-win-x64-portable.exe"""'
     );
     expect(s).not.toContain('fso.CopyFile');
+  });
+});
+
+describe('selectPortableStaleOld', () => {
+  it('只筛本产品 <prefix>…portable.exe.old，不误删同目录他人 .exe.old', () => {
+    expect(
+      selectPortableStaleOld([
+        'FlowZ-4.1.5-win-x64-portable.exe.old',
+        'FlowZ-4.1.7-win-x64-portable.exe',
+        'Other.EXE.OLD', // 他家工具 → 不删
+        'Foo-portable.exe.old', // 非 FlowZ 前缀 → 不删
+        'data',
+        'config.json',
+      ])
+    ).toEqual(['FlowZ-4.1.5-win-x64-portable.exe.old']);
+  });
+
+  it('自定义 productPrefix', () => {
+    expect(selectPortableStaleOld(['MyApp-1.0-portable.exe.old'], 'MyApp-')).toEqual([
+      'MyApp-1.0-portable.exe.old',
+    ]);
+  });
+
+  it('无匹配（非 portable 的 .old / 缺前缀）→ 空数组', () => {
+    expect(selectPortableStaleOld(['a.exe', 'b.txt', 'c.old', 'FlowZ-x.exe'])).toEqual([]);
   });
 });
 

--- a/src/main/services/update-install-script.ts
+++ b/src/main/services/update-install-script.ts
@@ -21,34 +21,88 @@ import { shq } from '../utils/shell-quote';
 /** VBS 字符串字面量里的反斜杠按既有约定双写（与旧 installUpdate 一致，Windows 容忍双反斜杠路径）。 */
 const vbsPath = (p: string): string => p.replace(/\\/g, '\\\\');
 
+/** VBS 字符串字面量里的双引号双写转义（MsgBox 等含文本的串）。 */
+const vbsStr = (s: string): string => s.replace(/"/g, '""');
+
 /**
- * Windows 更新 VBS。portableTarget 非空=便携态（覆盖回原 exe 再启动）；否则=NSIS（运行下载的 setup，原行为逐字保留）。
- * 便携只覆盖 exe 一个文件，exe 同级 `data\`（config/core_update/rules）原样保留。
+ * portable 自更新遗留的【本产品】`.exe.old`（旧版本被 stub 锁时 rename 留下）筛选——只匹配
+ * 「<productPrefix>…portable.exe.old」，避免误删同目录其它便携工具的 `.exe.old`；IO 分离便于单测，启动期据此清理。
+ */
+export function selectPortableStaleOld(fileNames: string[], productPrefix = 'FlowZ-'): string[] {
+  const p = productPrefix.toLowerCase();
+  return fileNames.filter((f) => {
+    const l = f.toLowerCase();
+    return l.startsWith(p) && l.endsWith('portable.exe.old');
+  });
+}
+
+/**
+ * Windows 更新 VBS。portableTarget 非空=便携态；否则=NSIS（运行下载的 setup，原行为逐字保留）。
+ *
+ * 便携态（B：移入新版本名 + 删旧版本名）：把下载的【新版本名】文件移入原目录、删除【旧版本名】文件——保留
+ * GitHub release 带版本号的命名（手动下载可区分版本），更新后目录里只剩对齐实际版本的那个文件。
+ * 关键（治"退出重开复原旧版"bug）：portable 原 exe 是被 stub launcher 锁住的自解压包，**不能被覆盖/删除，但能被
+ * rename**（Windows loader 用 FILE_SHARE_DELETE 映射映像）。故：
+ *  - 新版本名文件原本不存在 → 直接写（不撞锁）；若同名已存在（重装同版本）则先 rename 挪开。
+ *  - 旧版本名文件被锁 → DeleteFile 失败时**才** rename 到 `.old`（删旧的兜底，运行中可 rename），下次启动清
+ *    （selectPortableStaleOld）。即主操作是「移入 + 删旧」，rename 仅删旧失败时兜锁，非「改名」。
+ * exe 同级 `data\`（config/core_update/rules）不动 → 用户配置 + 已更新内核零丢失。
+ * portableNewPath 缺省=portableTarget（退化为覆盖同名）。覆盖最终失败 → 不静默：跑临时新版 + MsgBox 提示手动替换。
  */
 export function buildWindowsUpdateVbs(opts: {
   installerPath: string;
   portableTarget?: string | null;
+  /** 新版本名文件在原目录的目标路径（= 原目录 + 下载件文件名）；缺省退化为覆盖 portableTarget 同名。 */
+  portableNewPath?: string | null;
+  /** 覆盖最终失败时的 MsgBox 提示（i18n，调用方注入；默认英文）。 */
+  fallbackMessage?: string;
 }): string {
   const src = vbsPath(opts.installerPath);
   if (opts.portableTarget) {
-    const dst = vbsPath(opts.portableTarget);
+    const oldExe = vbsPath(opts.portableTarget);
+    const newExe = vbsPath(opts.portableNewPath || opts.portableTarget);
+    const msg = vbsStr(
+      opts.fallbackMessage ||
+        'FlowZ auto-update could not replace the portable executable. The new version was downloaded to the path below — please replace it manually:'
+    );
+    // MsgBox 显示用单反斜杠原路径（src 变量是双写反斜杠、给文件操作"容忍"用，直接展示/粘贴资源管理器不友好）。
+    const srcDisplay = vbsStr(opts.installerPath);
     return [
       'WScript.Sleep 2000',
       'Set WshShell = CreateObject("WScript.Shell")',
       'Set fso = CreateObject("Scripting.FileSystemObject")',
+      `src = "${src}"`,
+      `oldExe = "${oldExe}"`,
+      `newExe = "${newExe}"`,
       'On Error Resume Next',
-      // 只覆盖便携 exe 这一个文件（运行进程实跑在 %TEMP% 解压副本，原 exe 未被锁，可覆盖）；
-      // exe 同级 data\ 不动 → 用户配置 + 已更新内核(core_update) 零丢失。
-      `fso.CopyFile "${src}", "${dst}", True`,
+      // 清上次残留 .old（新旧两路径都清）
+      'If fso.FileExists(newExe & ".old") Then fso.DeleteFile newExe & ".old", True',
+      'If fso.FileExists(oldExe & ".old") Then fso.DeleteFile oldExe & ".old", True',
+      'Err.Clear',
+      // 新版本名文件若已存在（重装同版本/残留且被锁）→ rename 挪开，腾出原名
+      'If fso.FileExists(newExe) Then fso.MoveFile newExe, newExe & ".old"',
+      'Err.Clear',
+      // 写新版本名文件到原目录（新名通常不存在、不撞锁，直接成功）
+      'fso.CopyFile src, newExe, True',
       'If Err.Number = 0 Then',
       '  Err.Clear',
-      // 覆盖成功 → 从原位置启动新版（持久更新），并清掉临时下载包
-      `  WshShell.Run """${dst}""", 1, False`,
-      `  fso.DeleteFile "${src}", True`,
-      'Else',
+      // 移除旧版本名文件（与新名不同时）：被 stub 锁 → DeleteFile 失败则 rename 到 .old，下次启动清
+      '  If LCase(oldExe) <> LCase(newExe) Then',
+      '    fso.DeleteFile oldExe, True',
+      '    If Err.Number <> 0 Then',
+      '      Err.Clear',
+      '      fso.MoveFile oldExe, oldExe & ".old"',
+      '    End If',
+      '  End If',
       '  Err.Clear',
-      // 覆盖失败（原位只读/占用）→ 退回跑临时副本，至少本次拿到新版（不删临时包）
-      `  WshShell.Run """${src}""", 1, False`,
+      // 从原目录新版本名文件启动新版 + 删临时下载件
+      '  WshShell.Run """" & newExe & """", 1, False',
+      '  fso.DeleteFile src, True',
+      'Else',
+      // 写新名失败（极罕见：原目录只读）→ 不静默：跑临时新版 + 明确提示用户手动替换
+      '  Err.Clear',
+      '  WshShell.Run """" & src & """", 1, False',
+      `  MsgBox "${msg}" & vbCrLf & "${srcDisplay}", 48, "FlowZ"`,
       'End If',
       'On Error Goto 0',
       'fso.DeleteFile WScript.ScriptFullName, True',


### PR DESCRIPTION
## 问题
Windows **便携(portable)**自更新后，退出重开**复原旧版本**——用户以为更新成功，实际原便携包没更新。

## 根因
便携原 `.exe` 是被 stub launcher 进程锁住的自解压包。旧 VBS 用 `CopyFile overwrite` 覆盖它 → Windows **不允许覆盖被进程映像锁定的文件** → 撞锁失败 → 静默 fallback 跑 `%TEMP%` 临时新版（用户看到新版的假象）→ 原包未更新 → 重开旧版。

## 治本（移入新版本名 + 删旧版本名，保留 GitHub release 带版本号命名）
- 下载件本身带新版本名 → **移入原目录**（新名不存在、不撞锁，`CopyFile` 直接成功）。
- **删旧版本名**；被 stub 锁 `DeleteFile` 失败时 `rename → .old`（Windows 允许 rename 运行中/被 `FILE_SHARE_DELETE` 锁的 exe），下次启动 `selectPortableStaleOld` 清理（仅匹配本产品 `FlowZ-…portable.exe.old`，不误删他人）。
- 即便「锁住的旧 exe 能否 rename」这个假设失败，写新名仍成功并启动新版——「复原旧版」根治，最坏只旧 exe 残留。
- 覆盖最终失败（原目录只读）→ **不静默**：`MsgBox` 提示手动替换（i18n 5 语，单反斜杠原路径）。
- 文件名始终对齐实际版本；快捷方式按 portable 惯例不处理。

## review 修复（两轮全绿）
- **H-1**：`.vbs` 改 UTF-16 LE + BOM 落盘——wscript 只认它为 Unicode；UTF-8 无 BOM 按 ANSI 读会让非 ASCII 用户名/路径（中文账户）错乱致更新失败 + 多语 MsgBox 乱码。
- **M-1**：`selectPortableStaleOld` 收窄本产品命名，不误删同目录他人 `.exe.old`。
- **L-2**：MsgBox 单反斜杠原路径。

## 测试
- `buildWindowsUpdateVbs` portable 移入/删旧/rename 兜底/同名退化/fallback + `selectPortableStaleOld` 单测。
- gate：tsc(main+renderer) + jest + eslint 全绿。
- **mac arm64 + Windows 便携交叉构建成功**。

## 真机验证
**Windows 真机（doveh）实测：4.1.6 便携 → 自更新到 4.1.7 → 退出重开为新版，不复原旧版，无异常。** ✅
（非 ASCII 用户名路径的 H-1 编码靠字节级 review + code 论证，需中文账户进一步闭环。）


## 关联 issue
Closes #238 —— 该工单报「Windows 自动更新后原安装目录未更新、新版本落在 temp 运行、托盘图标缺失」，根因正是便携自更新未把新版本持久化回原 `PORTABLE_EXECUTABLE_FILE`（便携进程实跑在 `%TEMP%` 解压副本、原 exe 未被覆盖）。本 PR 移入新版本名到原 exe 目录 + 删旧名，使更新落回原位置；下次启动从原位 exe 运行（非 temp 残留），托盘图标随之恢复。