### PR TITLE
fix: Windows 卸载残留——中文用户名 userData 删错 + 便携本体删不掉

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -123,6 +123,17 @@ const MESSAGES = {
     ru: 'Понятно',
     fa: 'متوجه شدم',
   },
+  // Windows 便携版本体（exe）跨磁盘卷时无法自动移除（同卷靠 move/rename 移出，跨卷退化为复制+删源、删源撞运行锁失败）。
+  // detail 末尾拼接本体实际路径，故以冒号结尾。
+  uninstallPortableBody: {
+    'zh-CN': '便携版程序位于其它磁盘卷时可能无法自动删除。卸载完成后若以下位置仍存在，请手动删除：',
+    'zh-TW':
+      '便攜版程式位於其它磁碟磁碟區時可能無法自動刪除。解除安裝完成後若以下位置仍存在，請手動刪除：',
+    'en-US':
+      'The portable program may not be removed automatically when it resides on a different drive. If the location below still exists after uninstall, please delete it manually:',
+    ru: 'Переносимая программа может не удалиться автоматически, если она находится на другом диске. Если указанное ниже расположение сохранится после удаления, удалите его вручную:',
+    fa: 'برنامهٔ قابل‌حمل ممکن است هنگام قرار داشتن روی درایوی دیگر به‌صورت خودکار حذف نشود. اگر مسیر زیر پس از حذف نصب همچنان باقی ماند، آن را به‌صورت دستی حذف کنید:',
+  },
 
   // —— 托盘菜单（TrayManager） ——
   trayStatusError: {

--- a/src/main/ipc/handlers/helper-handlers.ts
+++ b/src/main/ipc/handlers/helper-handlers.ts
@@ -18,6 +18,7 @@ import type { IProxyManager } from '../../services/ProxyManager';
 import { getSingboxDashboardDir } from '../../utils/paths';
 import { mapElectronLocaleToDashboardLang } from '../../utils/dashboard-locale';
 import { mt } from '../../i18n';
+import { buildUninstallSidecar, resolveUninstallBody } from '../../services/uninstall-sidecar';
 
 /**
  * 清 sing-box 官方面板资源缓存目录（dashboard.path）。删后核下次启动因目录为空 → 从 download_url 重拉新 zip。
@@ -263,57 +264,85 @@ export function registerHelperHandlers(
           // 卸载器 /S 静默（用户已在应用内确认完全卸载）；helper 已在第 1 步零提权卸掉 → customUnInstall 钩子 sc query
           // 落空 → 不二次弹 UAC。portable 无卸载器时 rmdir 安装目录（best-effort：装 Program Files 时普通用户无权删，残留由下次安装幂等清理兜底）。
           try {
-            const exePath = app.getPath('exe');
-            const exeDir = path.dirname(exePath);
+            // 便携态 app.getPath('exe') 是 %TEMP% 解压副本（stub 退出自清）、非用户原始本体；原始本体（用户报「残留」
+            // 的对象）在 PORTABLE_EXECUTABLE_FILE/DIR。卸载须清原始本体，故经 resolveUninstallBody 取（NSIS 态无 env
+            // 回落真实 exe）。userData 已由 paths.ts 重定向到 PORTABLE_EXECUTABLE_DIR\data（原始目录），无需在此修正。
+            const { exePath, exeDir } = resolveUninstallBody(process.env, app.getPath('exe'));
             const userData = app.getPath('userData');
             const flowzPid = process.pid;
-            let uninstaller = path.join(exeDir, 'Uninstall FlowZ.exe');
-            if (!fs.existsSync(uninstaller)) {
-              const hit = fs.readdirSync(exeDir).find((f) => /^Uninstall FlowZ.*\.exe$/i.test(f));
-              if (hit) uninstaller = path.join(exeDir, hit);
+            // 定位 NSIS 卸载器（存在=installed，null=portable）。
+            // 便携态（有 PORTABLE_EXECUTABLE_FILE）一律 null：便携无 NSIS 卸载器，且 exeDir 此时是用户可控目录（如
+            // Downloads）——若在此扫 `Uninstall FlowZ*.exe`，恰有同名混放文件会被误判 installed 并静默 /S 执行该任意 exe
+            // （安全/误删面）。故仅 NSIS 安装态（无 PORTABLE_* env、exeDir=受控安装目录）才探测卸载器。
+            let uninstaller: string | null = null;
+            if (!process.env.PORTABLE_EXECUTABLE_FILE) {
+              const defaultUn = path.join(exeDir, 'Uninstall FlowZ.exe');
+              if (fs.existsSync(defaultUn)) {
+                uninstaller = defaultUn;
+              } else {
+                const hit = fs.readdirSync(exeDir).find((f) => /^Uninstall FlowZ.*\.exe$/i.test(f));
+                if (hit) uninstaller = path.join(exeDir, hit);
+              }
             }
-            const hasUninstaller = fs.existsSync(uninstaller);
-            // portable 无卸载器：目录名含 FlowZ（专属目录）才 rmdir 整目录，否则只删 exe 自身
-            // （避免误删用户自选的非专属目录如 D:\Tools\，portable 仍可恢复）。
-            const portableCleanup = exeDir.toLowerCase().includes('flowz')
-              ? `rmdir /s /q "${exeDir}"`
-              : `del /f /q "${exePath}"`;
             const stamp = Date.now();
             const batPath = path.join(os.tmpdir(), `flowz-uninstall-${flowzPid}-${stamp}.bat`);
             const vbsPath = path.join(os.tmpdir(), `flowz-uninstall-${flowzPid}-${stamp}.vbs`);
-            // CRLF 行尾 + GBK 安全（纯 ASCII，路径走变量不内联中文）。
-            const lines = [
-              '@echo off',
-              `set "FLOWZ_PID=${flowzPid}"`,
-              'set "WAIT=0"',
-              ':wait',
-              // 精确等本进程 PID 退出；60×~1s=60s 上限防卡死。
-              `"${system32('tasklist.exe')}" /fi "PID eq %FLOWZ_PID%" 2>nul | "${system32('find.exe')}" "%FLOWZ_PID%" >nul || goto clean`,
-              'set /a WAIT+=1',
-              'if %WAIT% GEQ 60 goto clean',
-              `"${system32('ping.exe')}" 127.0.0.1 -n 2 >nul`,
-              'goto wait',
-              ':clean',
-              `rmdir /s /q "${userData}"`,
-              hasUninstaller ? `if exist "${uninstaller}" "${uninstaller}" /S` : portableCleanup,
-              `del /f /q "${vbsPath}"`, // 清隐藏启动器自身
-              'del "%~f0"',
-              '',
-            ];
-            fs.writeFileSync(batPath, lines.join('\r\n'), 'utf8');
-            // VBScript 隐藏启动器：WScript.Shell.Run(cmd, 0, False) 以隐藏窗口(0)、不等待(False)拉起 .bat。
-            // 规避 Node `spawn('cmd', {detached:true, windowsHide:true})` 在 Windows 上仍弹出 cmd 控制台窗口的已知坑
-            // （detached 新建进程组与 windowsHide 冲突 → 卸载残留终端窗口需手动关闭）。wscript //B 无 UI 随即退出，
-            // 其 .Run 出的 cmd/bat 成为独立后台进程、全程无终端窗口；bat 收尾删 .vbs + 自删。
-            // VBS 字符串内 "" 即字面量 "，故 `cmd /c "<bat>"` 正确加引号容纳带空格路径。
-            const vbs = `Set s = CreateObject("WScript.Shell")\r\ns.Run """${system32('cmd.exe')}"" /c ""${batPath}""", 0, False\r\n`;
-            fs.writeFileSync(vbsPath, vbs, 'utf8');
+            // portable 本体移出目标（%TEMP% 下一次性文件）：sidecar move 本体到此（同卷=rename，运行中亦可）。
+            const bodyTmpPath = path.join(
+              os.tmpdir(),
+              `flowz-uninstall-body-${flowzPid}-${stamp}.exe`
+            );
+            // 非 ASCII 路径（中文用户名的 userData/exeDir/uninstaller）全走 .vbs 设的进程环境变量（.vbs UTF-16 → 值
+            // 为 Unicode），.bat 纯 ASCII 用 %VAR%；batPath 内联进 .vbs 的 .Run 行（同靠 .vbs UTF-16 保 Unicode，非 env）
+            // ——绕开 cmd 代码页 + .vbs/.bat 编码坑（见 uninstall-sidecar）。
+            const { bat, vbs } = buildUninstallSidecar({
+              flowzPid,
+              userData,
+              exeDir,
+              exePath,
+              uninstaller,
+              // portable 无卸载器：目录名含 flowz（专属目录）才 rmdir 整目录，否则只移出 exe 自身（避免误删 D:\Tools\ 等非专属目录）。
+              portableRmdir: exeDir.toLowerCase().includes('flowz'),
+              bodyTmpPath,
+              batPath,
+              vbsPath,
+              sys: {
+                cmd: system32('cmd.exe'),
+                tasklist: system32('tasklist.exe'),
+                find: system32('find.exe'),
+                ping: system32('ping.exe'),
+              },
+            });
+            // .bat 纯 ASCII（路径走 %VAR%）→ utf8 安全；.vbs 含非 ASCII 路径字面 + wscript 读 → 必须 UTF-16 LE+BOM。
+            fs.writeFileSync(batPath, bat, 'utf8');
+            fs.writeFileSync(vbsPath, '\ufeff' + vbs, 'utf16le');
+            // wscript //B 无 UI 随即退出，其 .Run 出的 cmd/bat 成独立后台进程、全程无终端窗口（规避 Node spawn cmd
+            // detached+windowsHide 仍弹控制台的坑）；bat 收尾删 .vbs + 自删。
             spawn(system32('wscript.exe'), ['//B', '//Nologo', vbsPath], {
               detached: true,
               stdio: 'ignore',
               windowsHide: true,
               cwd: os.tmpdir(),
             }).unref();
+            // portable 本体跨卷无法 move（exe 与 %TEMP% 不同盘 → move 退化复制+删源、删源撞运行锁失败、本体留原位）：
+            // 退出前弹阻塞 dialog 引导手动删（数据已清；toast 随 app 退出丢失）。同卷（多数情形）move=rename 必成 → 不打扰。
+            // 有卸载器（installed）由 NSIS 卸载器处理本体，不在此列。
+            if (
+              !uninstaller &&
+              path.parse(exePath).root.toLowerCase() !== path.parse(bodyTmpPath).root.toLowerCase()
+            ) {
+              const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+              const bodyTarget = exeDir.toLowerCase().includes('flowz') ? exeDir : exePath;
+              const opts = {
+                type: 'info' as const,
+                title: mt('uninstallManualTitle'),
+                message: mt('uninstallManualMessage'),
+                detail: `${mt('uninstallPortableBody')}\n\n${bodyTarget}`,
+                buttons: [mt('uninstallManualOk')],
+              };
+              if (win) await dialog.showMessageBox(win, opts);
+              else await dialog.showMessageBox(opts);
+            }
           } catch {
             /* 唤起 sidecar 失败不阻断退出（用户仍可经「添加或删除程序」卸载，含同款 helper 清理钩子） */
           }

--- a/src/main/services/__tests__/uninstall-sidecar.test.ts
+++ b/src/main/services/__tests__/uninstall-sidecar.test.ts
@@ -1,0 +1,133 @@
+/**
+ * 卸载 sidecar 脚本生成单测：钉死「非 ASCII 路径全走环境变量、.bat 零非 ASCII 字面」这个治本不变量 + 三种删本体分支。
+ * 执行/编码落盘是真机项；本测验生成的字符串结构。
+ */
+import { buildUninstallSidecar, resolveUninstallBody } from '../uninstall-sidecar';
+
+const sys = {
+  cmd: 'C:\\Windows\\System32\\cmd.exe',
+  tasklist: 'C:\\Windows\\System32\\tasklist.exe',
+  find: 'C:\\Windows\\System32\\find.exe',
+  ping: 'C:\\Windows\\System32\\ping.exe',
+};
+
+// 中文用户名路径——本修复的核心场景。
+const base = {
+  flowzPid: 1234,
+  userData: 'C:\\Users\\张三\\AppData\\Roaming\\flowz',
+  exeDir: 'C:\\Users\\张三\\FlowZ',
+  exePath: 'C:\\Users\\张三\\FlowZ\\FlowZ.exe',
+  bodyTmpPath: 'C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-body-1234-99.exe',
+  batPath: 'C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-1234-99.bat',
+  vbsPath: 'C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-1234-99.vbs',
+  sys,
+};
+
+describe('buildUninstallSidecar', () => {
+  it('.bat 纯 ASCII：非 ASCII 路径不内联（全走 %VAR%），含 PID 轮询 + System32 绝对路径', () => {
+    const { bat } = buildUninstallSidecar({ ...base, uninstaller: null, portableRmdir: true });
+    expect([...bat].every((c) => c.charCodeAt(0) <= 0x7f)).toBe(true); // 治本不变量：.bat 里零非 ASCII 字面
+    expect(bat).toContain('rmdir /s /q "%FLOWZ_USERDATA%"');
+    // 删本体治本：move 本体到 %TEMP%（同卷=rename，运行中亦可，不撞 stub 运行锁），rmdir 态再删剩余安装目录
+    expect(bat).toContain('move /y "%FLOWZ_EXE%" "%FLOWZ_BODYTMP%" >nul 2>nul');
+    expect(bat).toContain('rmdir /s /q "%FLOWZ_EXEDIR%"'); // rmdir 态：移出 exe 后删剩余目录
+    // 顺序不变量：必先 move 出 exe（解锁目录）再 rmdir 剩余，否则 rmdir 撞被锁 exe 失败
+    expect(bat.indexOf('move /y "%FLOWZ_EXE%"')).toBeLessThan(
+      bat.indexOf('rmdir /s /q "%FLOWZ_EXEDIR%"')
+    );
+    expect(bat).not.toContain(':delbody'); // 不再 del 重试（del 撞运行锁删不掉，实测残留）
+    expect(bat).not.toContain('del /f /q "%FLOWZ_EXE%"');
+    expect(bat).toContain('del /f /q "%FLOWZ_VBS%"');
+    expect(bat).toContain('del "%~f0"'); // N3：自删
+    expect(bat).toContain('set "FLOWZ_PID=1234"');
+    expect(bat).toContain('C:\\Windows\\System32\\tasklist.exe');
+    expect(bat).toContain('if %WAIT% GEQ 60 goto clean'); // 60s 上限防卡死
+    expect(bat).toMatch(/\r\n/);
+  });
+
+  it('.vbs 设环境变量为 Unicode 路径（含中文）+ 隐藏启动 cmd', () => {
+    const { vbs } = buildUninstallSidecar({ ...base, uninstaller: null, portableRmdir: true });
+    expect(vbs).toContain('Set e = s.Environment("PROCESS")');
+    expect(vbs).toContain('e("FLOWZ_USERDATA") = "C:\\Users\\张三\\AppData\\Roaming\\flowz"');
+    expect(vbs).toContain('e("FLOWZ_EXE") = "C:\\Users\\张三\\FlowZ\\FlowZ.exe"'); // move 源
+    expect(vbs).toContain(
+      'e("FLOWZ_BODYTMP") = "C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-body-1234-99.exe"'
+    ); // move 目标
+    expect(vbs).toContain('e("FLOWZ_EXEDIR") = "C:\\Users\\张三\\FlowZ"'); // rmdir 剩余目录
+    // N3：.vbs 须设 FLOWZ_VBS（否则 .bat 删不掉 .vbs，残留 temp）+ batPath 内联进 .Run（中文 batPath 靠 UTF-16）。
+    expect(vbs).toContain(
+      'e("FLOWZ_VBS") = "C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-1234-99.vbs"'
+    );
+    expect(vbs).toContain(
+      's.Run """C:\\Windows\\System32\\cmd.exe"" /c ""C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-1234-99.bat""", 0, False'
+    );
+    expect(vbs).toMatch(/\r\n/);
+  });
+
+  it('installed（有卸载器）：bat 走卸载器 /S + vbs 设 FLOWZ_UNINSTALLER', () => {
+    const un = 'C:\\Users\\张三\\FlowZ\\Uninstall FlowZ.exe';
+    const { bat, vbs } = buildUninstallSidecar({ ...base, uninstaller: un, portableRmdir: false });
+    expect(bat).toContain('if exist "%FLOWZ_UNINSTALLER%" "%FLOWZ_UNINSTALLER%" /S');
+    expect(bat).not.toContain('FLOWZ_EXEDIR');
+    expect(bat).not.toContain('FLOWZ_BODYTMP'); // 卸载器分支不 move 本体
+    expect(bat).not.toContain('FLOWZ_EXE"'); // 不走 move exe 分支
+    expect(vbs).toContain('e("FLOWZ_UNINSTALLER") = "C:\\Users\\张三\\FlowZ\\Uninstall FlowZ.exe"');
+  });
+
+  it('portable del（exeDir 非专属目录）：bat 仅 move exe（不 rmdir 目录，避免误删混放）+ vbs 设 FLOWZ_EXE/FLOWZ_BODYTMP', () => {
+    const { bat, vbs } = buildUninstallSidecar({
+      ...base,
+      uninstaller: null,
+      portableRmdir: false,
+    });
+    expect(bat).toContain('move /y "%FLOWZ_EXE%" "%FLOWZ_BODYTMP%" >nul 2>nul');
+    expect(bat).not.toContain('FLOWZ_EXEDIR'); // 非专属目录不删整目录
+    expect(vbs).toContain('e("FLOWZ_EXE") = "C:\\Users\\张三\\FlowZ\\FlowZ.exe"');
+    expect(vbs).toContain(
+      'e("FLOWZ_BODYTMP") = "C:\\Users\\张三\\AppData\\Local\\Temp\\flowz-uninstall-body-1234-99.exe"'
+    );
+    expect(vbs).not.toContain('FLOWZ_EXEDIR');
+  });
+
+  it('VBS 双引号路径转义（双写）', () => {
+    const { vbs } = buildUninstallSidecar({
+      ...base,
+      userData: 'C:\\a"b\\flowz',
+      uninstaller: null,
+      portableRmdir: true,
+    });
+    expect(vbs).toContain('e("FLOWZ_USERDATA") = "C:\\a""b\\flowz"');
+  });
+});
+
+describe('resolveUninstallBody', () => {
+  // 便携态核心修复：app.getPath('exe') 是 %TEMP% 解压副本，须改取 PORTABLE_EXECUTABLE_FILE/DIR（用户原始本体）。
+  it('便携态：优先取 PORTABLE_EXECUTABLE_FILE/DIR（原始本体），不用 %TEMP% 解压副本', () => {
+    const realExe = 'C:\\Users\\张三\\AppData\\Local\\Temp\\FlowZ\\FlowZ.exe'; // app.getPath('exe')
+    const r = resolveUninstallBody(
+      {
+        PORTABLE_EXECUTABLE_FILE: 'D:\\Downloads\\FlowZ-4.1.7-win-x64-portable.exe',
+        PORTABLE_EXECUTABLE_DIR: 'D:\\Downloads',
+      },
+      realExe
+    );
+    expect(r.exePath).toBe('D:\\Downloads\\FlowZ-4.1.7-win-x64-portable.exe'); // 原始 exe，非 temp 副本
+    expect(r.exeDir).toBe('D:\\Downloads');
+  });
+
+  it('便携专属目录：PORTABLE_EXECUTABLE_DIR 缺省时由原始 exe 取 win32 目录', () => {
+    const r = resolveUninstallBody(
+      { PORTABLE_EXECUTABLE_FILE: 'D:\\FlowZ\\FlowZ.exe' }, // 仅有 FILE，无 DIR
+      'C:\\Temp\\FlowZ\\FlowZ.exe'
+    );
+    expect(r.exePath).toBe('D:\\FlowZ\\FlowZ.exe');
+    expect(r.exeDir).toBe('D:\\FlowZ'); // path.win32.dirname，不受测试宿主（Linux）path 分隔符影响
+  });
+
+  it('NSIS 安装态（无 PORTABLE_* env）：回落 app.getPath(exe) 真实安装路径', () => {
+    const realExe = 'C:\\Program Files\\FlowZ\\FlowZ.exe';
+    const r = resolveUninstallBody({}, realExe);
+    expect(r.exePath).toBe(realExe);
+    expect(r.exeDir).toBe('C:\\Program Files\\FlowZ');
+  });
+});

--- a/src/main/services/uninstall-sidecar.ts
+++ b/src/main/services/uninstall-sidecar.ts
@@ -1,0 +1,121 @@
+/**
+ * Windows 完全卸载的分离 sidecar 脚本生成（纯字符串，便于单测钉死命令/编码/分支；执行是真机项）。
+ *
+ * 背景（review H-1 同类潜伏 bug）：原 sidecar 把 userData/exeDir/uninstaller 等**含 Windows 用户名的路径内联进
+ * .bat/.vbs**，且两者都 UTF-8 无 BOM 落盘——
+ *  - `.vbs`（wscript）：只认 UTF-16 LE+BOM 为 Unicode，UTF-8 无 BOM 按 ANSI 读 → 非 ASCII 路径错乱。
+ *  - `.bat`（cmd）：按系统 OEM 代码页（中文=GBK/936）读，UTF-8 内联的中文路径乱码 → rmdir/del 删错或失败。
+ * → 中文 Windows 用户名账户卸载清理失败（残留 userData/本体）。
+ *
+ * 治本：**所有非 ASCII 路径走进程环境变量**（.vbs 设、cmd 子进程继承）——
+ *  - `.vbs` 以 UTF-16 LE+BOM 落盘，`WshShell.Environment("PROCESS")` 设的值是 Unicode；
+ *  - `.bat` 纯 ASCII（命令 + `%VAR%` + System32 绝对路径，全 ASCII），用 `%FLOWZ_*%` 引用，cmd 内置命令
+ *    （rmdir/del/if exist）对环境变量的 Unicode 值按 Unicode 处理 → 中文路径正确。
+ * .bat 不再出现任何非 ASCII 字面，彻底绕开 cmd 代码页与 .bat 文件编码问题。
+ */
+
+import * as path from 'path';
+
+/** VBS 字符串字面量里的双引号双写转义（反斜杠在 VBS 字符串不转义，路径单反斜杠原样即可）。 */
+const vq = (s: string): string => s.replace(/"/g, '""');
+
+/**
+ * 解析「卸载要清理的应用本体」exe/目录。
+ *
+ * 便携态陷阱：`app.getPath('exe')` 在 7z SFX 便携形态下是 **%TEMP%\FlowZ\FlowZ.exe**（SFX 解压副本、electron 子
+ * 进程映像，stub 退出时本就自清），**不是**用户双击的原始 `Downloads\FlowZ.exe`。用户卸载后报「本体仍在」指的正是
+ * 那个原始 exe——它在 `PORTABLE_EXECUTABLE_FILE`（同据 paths.ts 用 `PORTABLE_EXECUTABLE_DIR` 定位 userData=原始
+ * 目录\data、UpdateService 用 `PORTABLE_EXECUTABLE_FILE` 作自更新覆盖目标）。故便携态优先取这两个 env；NSIS 安装态
+ * 无此 env → 回落 `app.getPath('exe')`（即真实安装 exe）。win32 路径语义，故用 path.win32.dirname（跨平台测试一致）。
+ */
+export function resolveUninstallBody(
+  env: { PORTABLE_EXECUTABLE_FILE?: string; PORTABLE_EXECUTABLE_DIR?: string },
+  realExe: string
+): { exePath: string; exeDir: string } {
+  const exePath = env.PORTABLE_EXECUTABLE_FILE || realExe;
+  const exeDir = env.PORTABLE_EXECUTABLE_DIR || path.win32.dirname(exePath);
+  return { exePath, exeDir };
+}
+
+export interface UninstallSidecarOpts {
+  flowzPid: number;
+  userData: string;
+  exeDir: string;
+  exePath: string;
+  /** 有 NSIS 卸载器时其路径；portable（无卸载器）为 null。 */
+  uninstaller: string | null;
+  /** portable 删本体方式：true=移出 exe 后 rmdir 整个安装目录（目录名含 flowz 的专属目录）；false=只移出 exe 自身。 */
+  portableRmdir: boolean;
+  /** portable 本体移出目标（%TEMP% 下的一次性文件名）：move 本体到此（同卷=rename，运行中亦可）。 */
+  bodyTmpPath: string;
+  batPath: string;
+  vbsPath: string;
+  /** System32 绝对路径（全 ASCII，由调用方 system32() 解析后传入）。 */
+  sys: { cmd: string; tasklist: string; find: string; ping: string };
+}
+
+/** 删本体的三种模式：有卸载器走卸载器；portable 按目录专属性 rmdir / del。 */
+type BodyMode = 'uninstaller' | 'rmdir' | 'del';
+
+/** 生成卸载 sidecar 的 .bat（纯 ASCII，路径走 %VAR%）+ .vbs（UTF-16 落盘，设环境变量 Unicode 路径）。 */
+export function buildUninstallSidecar(opts: UninstallSidecarOpts): { bat: string; vbs: string } {
+  const bodyMode: BodyMode = opts.uninstaller
+    ? 'uninstaller'
+    : opts.portableRmdir
+      ? 'rmdir'
+      : 'del';
+
+  // ── .bat：纯 ASCII，PID 轮询本进程退出（60×~1s 上限）→ 删 userData → 删本体 → 删 .vbs → 自删。
+  // 所有路径走 %FLOWZ_*% 环境变量（.vbs 设 Unicode 值），.bat 内零非 ASCII 字面。
+  const batLines: string[] = [
+    '@echo off',
+    `set "FLOWZ_PID=${opts.flowzPid}"`,
+    'set "WAIT=0"',
+    ':wait',
+    `"${opts.sys.tasklist}" /fi "PID eq %FLOWZ_PID%" 2>nul | "${opts.sys.find}" "%FLOWZ_PID%" >nul || goto clean`,
+    'set /a WAIT+=1',
+    'if %WAIT% GEQ 60 goto clean',
+    `"${opts.sys.ping}" 127.0.0.1 -n 2 >nul`,
+    'goto wait',
+    ':clean',
+    'rmdir /s /q "%FLOWZ_USERDATA%"',
+  ];
+  if (bodyMode === 'uninstaller') {
+    batLines.push('if exist "%FLOWZ_UNINSTALLER%" "%FLOWZ_UNINSTALLER%" /S');
+  } else {
+    // portable 本体（exe）= 便携 stub launcher 自身映像，进程存活期被锁：del 删不掉（实测 30×1s 重试仍残留，
+    // stub 清 %TEMP% 期间持锁）。但映像以 FILE_SHARE_DELETE 打开 → **改名/移动可行**：move 等价 rename，同卷=纯
+    // 元数据操作、运行中亦成（与 portable 自更新覆盖同机制，已真机验证）。故 move 本体到 %TEMP%：原位置（Downloads）
+    // 即净，%TEMP% 残留随系统清理。跨卷 move 退化为复制+删源 → 删源撞运行锁失败、本体留原位 → 由退出前 Electron
+    // dialog 提示手动删兜底（仅跨卷时弹，见 helper-handlers）。move 失败不阻断后续删 .vbs + 自删。
+    batLines.push('move /y "%FLOWZ_EXE%" "%FLOWZ_BODYTMP%" >nul 2>nul');
+    if (bodyMode === 'rmdir') {
+      // 专属安装目录：exe 已移出 + userData(data\) 已删 → 删剩余目录（已无被锁文件）。
+      batLines.push('rmdir /s /q "%FLOWZ_EXEDIR%"');
+    }
+  }
+  batLines.push('del /f /q "%FLOWZ_VBS%"', 'del "%~f0"', '');
+
+  // ── .vbs：设进程环境变量（含非 ASCII 路径，UTF-16 落盘后值为 Unicode）+ 隐藏启动 cmd /c bat。
+  const vbsLines: string[] = [
+    'Set s = CreateObject("WScript.Shell")',
+    'Set e = s.Environment("PROCESS")',
+    `e("FLOWZ_USERDATA") = "${vq(opts.userData)}"`,
+    `e("FLOWZ_VBS") = "${vq(opts.vbsPath)}"`,
+  ];
+  if (bodyMode === 'uninstaller') {
+    vbsLines.push(`e("FLOWZ_UNINSTALLER") = "${vq(opts.uninstaller as string)}"`);
+  } else {
+    // portable 两态都 move exe → %TEMP%；rmdir 态额外删剩余安装目录。
+    vbsLines.push(`e("FLOWZ_EXE") = "${vq(opts.exePath)}"`);
+    vbsLines.push(`e("FLOWZ_BODYTMP") = "${vq(opts.bodyTmpPath)}"`);
+    if (bodyMode === 'rmdir') {
+      vbsLines.push(`e("FLOWZ_EXEDIR") = "${vq(opts.exeDir)}"`);
+    }
+  }
+  // cmd / batPath 也可能含非 ASCII（batPath 在 %TEMP%\<用户名>）→ 但 .vbs 是 UTF-16，内联字面正确；
+  // .Run 的 cmd 行用三引号容纳带空格路径（"" 即字面 "）。
+  vbsLines.push(`s.Run """${vq(opts.sys.cmd)}"" /c ""${vq(opts.batPath)}""", 0, False`);
+
+  return { bat: batLines.join('\r\n'), vbs: vbsLines.join('\r\n') + '\r\n' };
+}


### PR DESCRIPTION
## 问题
Windows 卸载残留两个 bug：
1. **中文用户名账户卸载残留 userData**：分离卸载 sidecar 把含中文用户名的路径内联进 `.bat`/`.vbs` 且 UTF-8 无 BOM 落盘——`.vbs`(wscript) 只认 UTF-16 LE+BOM 为 Unicode、否则按 ANSI 误读；`.bat`(cmd) 按系统 OEM 代码页(中文=GBK/936)读 → 中文路径乱码 → `rmdir`/`del` 删错或失败。
2. **便携版卸载后本体 exe 删不掉**：sidecar 删的是 `app.getPath('exe')`，但 7z SFX 便携态它是 `%TEMP%\FlowZ\FlowZ.exe`(解压副本、stub 退出本就自清)，用户真正残留的原始 `Downloads\…-portable.exe`(=`PORTABLE_EXECUTABLE_FILE`) 从未被处理。

## 治本
1. **非 ASCII 路径全走进程环境变量**：`.vbs` 以 UTF-16 LE+BOM 落盘、`WshShell.Environment("PROCESS")` 设 Unicode 路径值；`.bat` 纯 ASCII(命令 + `%FLOWZ_*%` + System32 绝对路径)，cmd 内置命令对环境变量的 Unicode 值按 Unicode 处理 → 彻底绕开 cmd 代码页 + 文件编码坑。
2. **接对原始本体 + move 删除**：
   - `resolveUninstallBody()` 便携态取 `PORTABLE_EXECUTABLE_FILE/DIR`(原始本体)，NSIS 态回落 `app.getPath('exe')`(真实安装 exe)。
   - 原始 exe 是 stub 自身映像、存活期被锁，`del` 删不掉(实测重试仍残留)；改 `move` 到 `%TEMP%`——映像以 `FILE_SHARE_DELETE` 打开，同卷 rename 是元数据操作、运行中亦成(与便携自更新覆盖同机制)。
   - 跨卷 `move` 退化失败 → 退出前 Electron dialog 引导手动删(仅跨卷弹，同卷静默成功不打扰)。
   - 便携态(有 `PORTABLE_EXECUTABLE_FILE`)不探测 NSIS 卸载器：此时 exeDir 是用户可控目录(如 Downloads)，避免同名 `Uninstall*.exe` 误判 installed 并静默 `/S` 执行任意 exe。

## 验证
- 单测 8 项：sidecar 生成结构(纯 ASCII 不变量 / `move`↔`rmdir` 顺序 / 环境变量透传 / 卸载器与便携分支) + `resolveUninstallBody` 三态。
- Windows 真机实测：便携本体(原始 Downloads\exe)卸载后正常被删除，userData 同步清除。

## 已知取舍
- 同卷 `move` 把本体移入 `%TEMP%`(由系统清理)，非原位删除——为对 stub 运行锁免疫的必要代价。
- 跨卷弹窗按盘符启发式判定，subst/junction 等异形场景可能多弹一次(良性：move 始终照跑，不影响删除正确性)。