### PR TITLE
feat(diagnostics): 逐进程内存快照（诊断导出 + 自检告警），对症 issue #242

### DIFF
--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -21,6 +21,7 @@ import {
   type DiagnosticReportInput,
 } from '../../shared/diagnostic-redact';
 import { effectiveLogLevel } from '../../shared/log-level';
+import { summarizeProcessMetrics } from '../../shared/process-metrics';
 import { getLogsPath, getSingBoxLogPath } from '../utils/paths';
 import path from 'path';
 import type { LogManager } from './LogManager';
@@ -111,6 +112,15 @@ export class DiagnosticService {
       redactedUserConfig = { error: `脱敏失败: ${e?.message ?? e}` };
     }
 
+    // 逐进程内存/CPU 快照（issue #242）：一次导出即可定位是哪个子进程内存偏高，取代靠用户截系统监视器猜。
+    // best-effort：getAppMetrics 极端异常不阻断报告。
+    let processMetrics;
+    try {
+      processMetrics = summarizeProcessMetrics(app.getAppMetrics());
+    } catch {
+      processMetrics = undefined;
+    }
+
     const effLevel = effectiveLogLevel(config.logLevel || 'info', this.privacyProvider());
     const captureActive = !!config.diagnosticCapture;
     const wantDeeper =
@@ -154,6 +164,7 @@ export class DiagnosticService {
       },
       redactedUserConfig,
       redactedSingboxConfig: redactedSingbox,
+      processMetrics,
       appLogTail,
       singboxLogTail,
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -3,7 +3,7 @@
  * 负责 sing-box 进程的生命周期管理和配置生成
  */
 
-import { BrowserWindow, shell, powerMonitor } from 'electron';
+import { app, BrowserWindow, shell, powerMonitor } from 'electron';
 import { notifyUser } from '../notify-user';
 import { mt } from '../i18n';
 import { spawn, ChildProcess, execFile } from 'child_process';
@@ -102,6 +102,7 @@ import {
 import { ruleConditions } from '../../shared/rules';
 import { planCustomRule, buildCustomRuleFiles, condMatcherFields } from './custom-rule-files';
 import { resolveWinTunInterfaceName } from '../../shared/tun-interface';
+import { findMemoryOffenders } from '../../shared/process-metrics';
 import { probeWinTunAdapterPresent, waitForAdapterReleased } from './win-tun-adapter';
 import {
   probeTcpReachable,
@@ -403,10 +404,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // 长会话 debug 日志无限增长会撑满磁盘，超过此上限即截断 singbox.log
   // （sing-box 以 O_APPEND 模式写，截断后从 offset 0 续写，不产生 sparse 空洞）
   private static readonly MAX_LOG_FILE_SIZE = 20 * 1024 * 1024; // 20MB
-  // 主进程内存自检阈值（issue #210 可观测性）：健康检查（10s 周期）顺带采样 RSS，超过此值记 warn 日志
-  // 便于早期定位泄漏（pendingWrites 积压 / gRPC 长流保留 / connMap 膨胀等）。仅观测告警，不强制干预——
-  // 阈值取较宽松的 1GB（FlowZ 常态 < 300MB），避免误报；命中后降频记录防刷屏（MEMORY_WARN_COOLDOWN_MS）。
-  private static readonly RSS_WARN_THRESHOLD = 1024 * 1024 * 1024; // 1GB
+  // 逐进程内存自检阈值（issue #210 主进程 + #242 扩展到全进程）：健康检查（10s 周期）经 getAppMetrics 采样每个
+  // 进程，任一超此值记 warn 日志便于早期定位泄漏。仅观测告警，不强制干预——阈值取较宽松的 1GB/进程（FlowZ 单进程
+  // 常态远低于此，#242 的问题进程达 2GB），避免误报；命中后降频记录防刷屏（MEMORY_WARN_COOLDOWN_MS）。
+  private static readonly RSS_WARN_THRESHOLD = 1024 * 1024 * 1024; // 1GB/进程
   private static readonly MEMORY_WARN_COOLDOWN_MS = 5 * 60 * 1000; // 5 分钟内不重复告警
   private lastMemoryWarnAt = 0;
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
@@ -4801,27 +4802,29 @@ exit 0
   }
 
   /**
-   * 主进程内存自检（issue #210 可观测性）：采样 RSS，超 RSS_WARN_THRESHOLD 记 warn 日志。
-   * 与健康检查同频（10s）调用，但降频记录（MEMORY_WARN_COOLDOWN_MS 内不重复）防刷屏。
-   * 仅观测告警，不强制 GC/干预——为泄漏定位提供早期信号（pendingWrites 积压/gRPC 长流保留等）。
+   * 逐进程内存自检（issue #210 主进程 + #242 扩展到全进程）：经 app.getAppMetrics() 采样每个进程（主/渲染/GPU/
+   * utility），任一超 RSS_WARN_THRESHOLD 记 warn 日志。#242 根因是某子进程内存暴涨、系统监视器分不清是哪个——
+   * getAppMetrics 天然带 type/pid，把「哪个进程在涨」直接写进 app.log，问题在用户察觉前就有据可查（监控闭环）。
+   * 与健康检查同频（10s）调用，但降频记录（MEMORY_WARN_COOLDOWN_MS 内不重复）防刷屏。仅观测告警，不强制 GC/干预。
    */
   private checkMemoryUsage(): void {
-    let rss = 0;
+    let offenders;
     try {
-      rss = process.memoryUsage().rss;
+      offenders = findMemoryOffenders(app.getAppMetrics(), ProxyManager.RSS_WARN_THRESHOLD);
     } catch {
-      return; // memoryUsage 极端异常不阻断健康检查
+      return; // getAppMetrics 极端异常不阻断健康检查
     }
-    if (rss < ProxyManager.RSS_WARN_THRESHOLD) return;
+    if (offenders.length === 0) return;
     const now = Date.now();
     if (now - this.lastMemoryWarnAt < ProxyManager.MEMORY_WARN_COOLDOWN_MS) return;
     this.lastMemoryWarnAt = now;
-    const mb = Math.round(rss / 1024 / 1024);
+    const thresholdMb = Math.round(ProxyManager.RSS_WARN_THRESHOLD / 1024 / 1024);
+    const detail = offenders
+      .map((o) => `${o.type}${o.label ? `(${o.label})` : ''} pid=${o.pid} ${o.memoryMb}MB`)
+      .join('; ');
     this.logToManager(
       'warn',
-      `主进程内存占用 ${mb}MB 偏高（阈值 ${Math.round(
-        ProxyManager.RSS_WARN_THRESHOLD / 1024 / 1024
-      )}MB），可能存在内存泄漏，建议关注日志量/连接数`,
+      `进程内存偏高（阈值 ${thresholdMb}MB/进程）：${detail}；疑内存泄漏，建议「设置→关于→报告问题」导出诊断报告查看逐进程内存`,
       'ProxyManager'
     );
   }

--- a/src/main/services/__tests__/proxy-manager-memory-check.test.ts
+++ b/src/main/services/__tests__/proxy-manager-memory-check.test.ts
@@ -1,8 +1,8 @@
 /**
- * ProxyManager 内存自检单测（issue #210 P4 可观测性）。
+ * ProxyManager 逐进程内存自检单测（issue #210 主进程 + #242 扩展到全进程）。
  *
- * 验证 checkMemoryUsage：RSS > 阈值时记 warn（经 logToManager），冷却期内（5min）不重复告警。
- * 私有方法经 (svc as any) 直调，mock process.memoryUsage，不启动 sing-box。
+ * 验证 checkMemoryUsage：经 app.getAppMetrics() 采样，任一进程内存 > 阈值时记 warn（含 type/pid 定位是哪个
+ * 进程），冷却期内（5min）不重复告警。私有方法经 (svc as any) 直调，mock getAppMetrics，不启动 sing-box。
  */
 const os = require('os');
 const path = require('path');
@@ -10,8 +10,17 @@ const fsSync = require('fs');
 
 const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-mem-'));
 
+// mock 前缀允许被 jest.mock 工厂引用；测试内 mockReturnValue 控制每个 case 的进程指标。
+const mockGetAppMetrics = jest.fn();
+
 jest.mock('electron', () => ({
-  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  app: {
+    getPath: () => TMP,
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => TMP,
+    getAppMetrics: () => mockGetAppMetrics(),
+  },
   BrowserWindow: class {},
   Notification: class {},
   net: {},
@@ -41,76 +50,86 @@ function makeSvc(): any {
 const THRESHOLD = (ProxyManager as any).RSS_WARN_THRESHOLD as number;
 const COOLDOWN = (ProxyManager as any).MEMORY_WARN_COOLDOWN_MS as number;
 
-/** mock process.memoryUsage 返回指定 rss（其余字段补 0）。返回还原函数。 */
-function mockRss(rss: number): () => void {
-  const real = process.memoryUsage;
-  // 新版 @types/node 的 memoryUsage 是方法链对象；用 any 绕过精确类型，运行时只调 rss()。
-  (process as any).memoryUsage = () => ({
-    rss,
-    heapTotal: 0,
-    heapUsed: 0,
-    external: 0,
-    arrayBuffers: 0,
-  });
-  return () => {
-    (process as any).memoryUsage = real;
+/** 造一个进程指标（workingSetSize 单位 KB，与 Electron 口径一致）。 */
+function proc(type: string, pid: number, memKb: number, serviceName?: string) {
+  return {
+    type,
+    pid,
+    memory: { workingSetSize: memKb },
+    cpu: { percentCPUUsage: 0 },
+    ...(serviceName ? { serviceName } : {}),
   };
 }
 
-describe('issue #210 P4 — 内存自检 checkMemoryUsage', () => {
-  it('RSS < 阈值 → 不告警（lastMemoryWarnAt 不变）', () => {
-    const restore = mockRss(100 * 1024 * 1024);
-    try {
-      const svc = makeSvc();
-      const before = svc.lastMemoryWarnAt;
-      svc.checkMemoryUsage();
-      expect(svc.lastMemoryWarnAt).toBe(before);
-    } finally {
-      restore();
-    }
+const KB = 1024;
+const overKb = Math.ceil((THRESHOLD + 1) / KB); // 略超阈值的 workingSetSize（KB）
+
+beforeEach(() => mockGetAppMetrics.mockReset());
+
+describe('逐进程内存自检 checkMemoryUsage（#210 + #242）', () => {
+  it('全部进程 < 阈值 → 不告警（lastMemoryWarnAt 不变）', () => {
+    mockGetAppMetrics.mockReturnValue([
+      proc('Browser', 1, 300 * KB), // 300MB
+      proc('Renderer', 2, 150 * KB),
+      proc('GPU', 3, 80 * KB),
+    ]);
+    const svc = makeSvc();
+    const before = svc.lastMemoryWarnAt;
+    svc.checkMemoryUsage();
+    expect(svc.lastMemoryWarnAt).toBe(before);
   });
 
-  it('RSS > 阈值 → 记 warn（lastMemoryWarnAt 更新）', () => {
-    const restore = mockRss(THRESHOLD + 1);
-    try {
-      const svc = makeSvc();
-      const logSpy = jest.spyOn(svc as any, 'logToManager').mockImplementation(() => {});
-      svc.checkMemoryUsage();
-      expect(svc.lastMemoryWarnAt).toBeGreaterThan(0);
-      expect(logSpy).toHaveBeenCalledTimes(1);
-      expect(logSpy.mock.calls[0][0]).toBe('warn'); // 级别为 warn
-      logSpy.mockRestore();
-    } finally {
-      restore();
-    }
+  it('某子进程 > 阈值 → 记 warn，且日志含该进程 type/pid（定位是哪个）', () => {
+    mockGetAppMetrics.mockReturnValue([
+      proc('Browser', 100, 300 * KB),
+      proc('Utility', 374035, overKb, 'flowz-stats'), // #242 场景：utility 子进程暴涨
+    ]);
+    const svc = makeSvc();
+    const logSpy = jest.spyOn(svc as any, 'logToManager').mockImplementation(() => {});
+    svc.checkMemoryUsage();
+    expect(svc.lastMemoryWarnAt).toBeGreaterThan(0);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toBe('warn');
+    const msg = String(logSpy.mock.calls[0][1]);
+    expect(msg).toContain('Utility');
+    expect(msg).toContain('374035');
+    expect(msg).toContain('flowz-stats');
+    logSpy.mockRestore();
   });
 
-  it('冷却期内不重复告警（5min 内 RSS 持续超标只 warn 一次）', () => {
-    const restore = mockRss(THRESHOLD + 100);
+  it('getAppMetrics 抛异常 → 不告警、不抛（不阻断健康检查）', () => {
+    mockGetAppMetrics.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const svc = makeSvc();
+    const logSpy = jest.spyOn(svc as any, 'logToManager').mockImplementation(() => {});
+    expect(() => svc.checkMemoryUsage()).not.toThrow();
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it('冷却期内不重复告警（5min 内持续超标只 warn 一次，超冷却再告警）', () => {
+    mockGetAppMetrics.mockReturnValue([proc('Renderer', 5, overKb)]);
+    const svc = makeSvc();
+    const logSpy = jest.spyOn(svc as any, 'logToManager').mockImplementation(() => {});
+
+    svc.checkMemoryUsage();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    // 冷却期内再次检查（不推进时间）→ 不重复
+    svc.checkMemoryUsage();
+    svc.checkMemoryUsage();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    // 推进超过冷却 → 再次告警
+    const realNow = Date.now;
+    Date.now = () => svc.lastMemoryWarnAt + COOLDOWN + 1;
     try {
-      const svc = makeSvc();
-      const logSpy = jest.spyOn(svc as any, 'logToManager').mockImplementation(() => {});
-
       svc.checkMemoryUsage();
-      expect(logSpy).toHaveBeenCalledTimes(1);
-
-      // 冷却期内再次检查（不推进时间）→ 不重复
-      svc.checkMemoryUsage();
-      svc.checkMemoryUsage();
-      expect(logSpy).toHaveBeenCalledTimes(1);
-
-      // 推进超过冷却 → 再次告警
-      const realNow = Date.now;
-      Date.now = () => svc.lastMemoryWarnAt + COOLDOWN + 1;
-      try {
-        svc.checkMemoryUsage();
-        expect(logSpy).toHaveBeenCalledTimes(2);
-      } finally {
-        Date.now = realNow;
-      }
-      logSpy.mockRestore();
+      expect(logSpy).toHaveBeenCalledTimes(2);
     } finally {
-      restore();
+      Date.now = realNow;
     }
+    logSpy.mockRestore();
   });
 });

--- a/src/main/services/__tests__/proxy-manager-memory-check.test.ts
+++ b/src/main/services/__tests__/proxy-manager-memory-check.test.ts
@@ -50,14 +50,19 @@ function makeSvc(): any {
 const THRESHOLD = (ProxyManager as any).RSS_WARN_THRESHOLD as number;
 const COOLDOWN = (ProxyManager as any).MEMORY_WARN_COOLDOWN_MS as number;
 
-/** 造一个进程指标（workingSetSize 单位 KB，与 Electron 口径一致）。 */
-function proc(type: string, pid: number, memKb: number, serviceName?: string) {
+/**
+ * 造一个进程指标（workingSetSize 单位 KB，与 Electron 口径一致）。
+ * name/serviceName 语义见 shared/process-metrics.ts 顶部注释：Electron utilityProcess.fork 传入的
+ * 自定义 serviceName 选项实际落在 getAppMetrics() 的 `.name`，`.serviceName` 恒是 Chromium 通用接口名
+ * （如 'node.mojom.NodeService'）——本机 xvfb 探针实测坐实，非猜测。
+ */
+function proc(type: string, pid: number, memKb: number, name?: string) {
   return {
     type,
     pid,
     memory: { workingSetSize: memKb },
     cpu: { percentCPUUsage: 0 },
-    ...(serviceName ? { serviceName } : {}),
+    ...(name ? { name, serviceName: 'node.mojom.NodeService' } : {}),
   };
 }
 

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -205,6 +205,45 @@ describe('buildDiagnosticReport', () => {
     expect(md).toContain('建议开启诊断采集');
   });
 
+  it('有 processMetrics 时渲染逐进程内存表（issue #242）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      processMetrics: {
+        totalMemoryMb: 2348,
+        rows: [
+          { type: 'Utility', pid: 374035, memoryMb: 2048, cpuPercent: 1, label: 'flowz-stats' },
+          { type: 'Browser', pid: 373944, memoryMb: 300, cpuPercent: 0 },
+        ],
+      },
+    });
+    expect(md).toContain('## 进程内存');
+    expect(md).toContain('| 类型 | PID | 内存(MB) | CPU(%) | 标识 |');
+    expect(md).toContain('| Utility | 374035 | 2048 | 1 | flowz-stats |');
+    expect(md).toContain('| Browser | 373944 | 300 | 0 |  |');
+    expect(md).toContain('2348 MB');
+  });
+
+  it('无 processMetrics 时不渲染进程内存区块（getAppMetrics 失败兜底）', () => {
+    const md = buildDiagnosticReport(base);
+    expect(md).not.toContain('## 进程内存');
+  });
+
+  it('进程内存表不被节点标识符打码误伤（机场把节点命名成纯数字撞表内 PID/内存数字）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      appLogTail: 'node 2048 connected', // 日志里的节点名 "2048" 应被正常打码
+      nodeIdentifiers: [{ value: '2048', placeholder: '<node-1>' }],
+      processMetrics: {
+        totalMemoryMb: 2048,
+        rows: [{ type: 'Utility', pid: 2048, memoryMb: 2048, cpuPercent: 1, label: 'flowz-stats' }],
+      },
+    });
+    // 表在 redact 之后拼接 → 表内 PID/内存的 2048 原样保留，定位价值不被毁
+    expect(md).toContain('| Utility | 2048 | 2048 | 1 | flowz-stats |');
+    // 但表以外（日志）的同名节点仍被正常打码，脱敏不受影响
+    expect(md).toContain('node <node-1> connected');
+  });
+
   it('F1 回归：日志含 ``` 不破坏围栏（动态升级到更长围栏）', () => {
     // 机场可控的节点名/日志含三反引号 → 朴素 fence 会被提前闭合。动态围栏须用更长的反引号包裹。
     const evil = 'before\n```\n# injected\nafter';

--- a/src/shared/__tests__/process-metrics.test.ts
+++ b/src/shared/__tests__/process-metrics.test.ts
@@ -40,16 +40,24 @@ describe('summarizeProcessMetrics', () => {
     expect(s.totalMemoryMb).toBe(2048 + 300 + 80);
   });
 
-  it('cpu 四舍五入整数；label 取 serviceName 优先、其次 name、都无则省略', () => {
+  it('cpu 四舍五入整数；label 取 name 优先、其次 serviceName、都无则省略', () => {
+    // 优先级坐实自本机 xvfb 探针实测 getAppMetrics() 真实字段（非猜测）：Electron utilityProcess.fork
+    // 传入的自定义 serviceName 选项最终落在 `.name`，而 `.serviceName` 恒是 Chromium 通用接口名
+    // （如 FlowZ 实际 stats worker 的 name='flowz-stats' / serviceName='node.mojom.NodeService'）——
+    // 对所有 Electron 自 fork 的 utilityProcess 都是这个泛型值，分不出具体是哪一个，故不能优先取它。
     const s = summarizeProcessMetrics([
-      proc('Utility', 1, 10 * MB_IN_KB, { cpu: 53.7, serviceName: 'flowz-stats', name: 'x' }),
-      proc('Renderer', 2, 10 * MB_IN_KB, { name: 'main-window' }),
+      proc('Utility', 1, 10 * MB_IN_KB, {
+        cpu: 53.7,
+        name: 'flowz-stats',
+        serviceName: 'node.mojom.NodeService',
+      }),
+      proc('Utility', 2, 10 * MB_IN_KB, { serviceName: 'network.mojom.NetworkService' }),
       proc('GPU', 3, 10 * MB_IN_KB),
     ]);
     const byPid = Object.fromEntries(s.rows.map((r) => [r.pid, r]));
     expect(byPid[1].cpuPercent).toBe(54);
-    expect(byPid[1].label).toBe('flowz-stats'); // serviceName 优先
-    expect(byPid[2].label).toBe('main-window'); // 无 serviceName → name
+    expect(byPid[1].label).toBe('flowz-stats'); // name 优先（FlowZ 自己 fork 的 worker，有辨识度）
+    expect(byPid[2].label).toBe('network.mojom.NetworkService'); // 无 name → serviceName 兜底
     expect(byPid[3].label).toBeUndefined(); // 都无
   });
 

--- a/src/shared/__tests__/process-metrics.test.ts
+++ b/src/shared/__tests__/process-metrics.test.ts
@@ -1,0 +1,92 @@
+/**
+ * process-metrics 纯分析单测（issue #242）：summarizeProcessMetrics 汇总/降序/MB 换算/label；
+ * findMemoryOffenders 阈值筛查（KB↔字节换算、空/无超标）。
+ */
+import {
+  summarizeProcessMetrics,
+  findMemoryOffenders,
+  type ProcessMetricLike,
+} from '../process-metrics';
+
+const KB = 1024;
+const MB_IN_KB = 1024;
+
+function proc(
+  type: string,
+  pid: number,
+  memKb: number,
+  extra?: { cpu?: number; serviceName?: string; name?: string }
+): ProcessMetricLike {
+  return {
+    type,
+    pid,
+    memory: { workingSetSize: memKb },
+    ...(extra?.cpu !== undefined ? { cpu: { percentCPUUsage: extra.cpu } } : {}),
+    ...(extra?.serviceName ? { serviceName: extra.serviceName } : {}),
+    ...(extra?.name ? { name: extra.name } : {}),
+  };
+}
+
+describe('summarizeProcessMetrics', () => {
+  it('按内存降序 + MB 换算 + 合计', () => {
+    const s = summarizeProcessMetrics([
+      proc('Browser', 1, 300 * MB_IN_KB),
+      proc('Utility', 2, 2048 * MB_IN_KB), // 2GB
+      proc('GPU', 3, 80 * MB_IN_KB),
+    ]);
+    expect(s.rows.map((r) => r.pid)).toEqual([2, 1, 3]); // 降序：2048/300/80
+    expect(s.rows[0]).toMatchObject({ type: 'Utility', pid: 2, memoryMb: 2048 });
+    expect(s.rows[1].memoryMb).toBe(300);
+    expect(s.totalMemoryMb).toBe(2048 + 300 + 80);
+  });
+
+  it('cpu 四舍五入整数；label 取 serviceName 优先、其次 name、都无则省略', () => {
+    const s = summarizeProcessMetrics([
+      proc('Utility', 1, 10 * MB_IN_KB, { cpu: 53.7, serviceName: 'flowz-stats', name: 'x' }),
+      proc('Renderer', 2, 10 * MB_IN_KB, { name: 'main-window' }),
+      proc('GPU', 3, 10 * MB_IN_KB),
+    ]);
+    const byPid = Object.fromEntries(s.rows.map((r) => [r.pid, r]));
+    expect(byPid[1].cpuPercent).toBe(54);
+    expect(byPid[1].label).toBe('flowz-stats'); // serviceName 优先
+    expect(byPid[2].label).toBe('main-window'); // 无 serviceName → name
+    expect(byPid[3].label).toBeUndefined(); // 都无
+  });
+
+  it('空输入 → 合计 0、空行', () => {
+    const s = summarizeProcessMetrics([]);
+    expect(s.totalMemoryMb).toBe(0);
+    expect(s.rows).toEqual([]);
+  });
+});
+
+describe('findMemoryOffenders', () => {
+  const oneGb = 1024 * 1024 * 1024;
+
+  it('仅返回 >= 阈值（字节）的进程，按内存降序', () => {
+    const off = findMemoryOffenders(
+      [
+        proc('Browser', 1, 300 * MB_IN_KB), // 300MB < 1GB
+        proc('Utility', 2, 2048 * MB_IN_KB), // 2GB >= 1GB
+        proc('Renderer', 3, 1536 * MB_IN_KB), // 1.5GB >= 1GB
+      ],
+      oneGb
+    );
+    expect(off.map((r) => r.pid)).toEqual([2, 3]); // 降序，300MB 的被排除
+  });
+
+  it('全部低于阈值 → 空数组', () => {
+    expect(findMemoryOffenders([proc('Browser', 1, 500 * MB_IN_KB)], oneGb)).toEqual([]);
+  });
+
+  it('KB↔字节换算正确：workingSetSize 恰好等于阈值 → 命中', () => {
+    const thresholdKb = oneGb / KB; // 阈值对应的 KB 数
+    const off = findMemoryOffenders([proc('GPU', 9, thresholdKb)], oneGb);
+    expect(off).toHaveLength(1);
+    expect(off[0].pid).toBe(9);
+  });
+
+  it('空输入 → 空数组', () => {
+    expect(findMemoryOffenders([], oneGb)).toEqual([]);
+  });
+});

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -10,6 +10,7 @@
  */
 
 import { isIpv4 } from './ip';
+import type { ProcessMetricsSummary } from './process-metrics';
 
 /** 打码占位符（定长，不泄露原值长度信息）。 */
 export const REDACTED = '<redacted>';
@@ -278,6 +279,8 @@ export interface DiagnosticReportInput {
   };
   redactedUserConfig: unknown;
   redactedSingboxConfig: unknown;
+  /** 逐进程内存/CPU 快照（issue #242）：一眼看出是哪个子进程内存偏高；type/pid/内存/CPU 非敏感，无需脱敏。 */
+  processMetrics?: ProcessMetricsSummary;
   appLogTail: string;
   singboxLogTail: string;
   /** 节点标识符 → 占位符（P0.6）：构建末尾在全报告统一替换，打码节点身份（域名/IP/SNI/节点名），保留形态与跨段相关性。 */
@@ -378,5 +381,20 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
   lines.push('');
 
   // P0.6：末尾在全报告（配置块 + 日志 + 运行态）统一打码节点标识符，跨段占位一致便于关联诊断。
-  return redactIdentifiers(lines.join('\n'), input.nodeIdentifiers ?? []);
+  const redacted = redactIdentifiers(lines.join('\n'), input.nodeIdentifiers ?? []);
+
+  // 进程内存表（issue #242）刻意放在 redactIdentifiers **之后**拼接：表内只有进程 type/pid/内存/CPU/自身进程名，
+  // 无节点标识符、无需脱敏；若纳入打码 pass，机场把节点命名成纯数字（如 "2048"）会撞上表里的内存/PID 数字被误
+  // 替成占位符，反而毁掉本表的定位价值。故与打码隔离，单独在末尾渲染。
+  if (!input.processMetrics) return redacted;
+  const pm = input.processMetrics;
+  const metricsLines = ['', '## 进程内存', ''];
+  metricsLines.push(`- 合计：${pm.totalMemoryMb} MB（${pm.rows.length} 个进程，按内存降序）`, '');
+  metricsLines.push('| 类型 | PID | 内存(MB) | CPU(%) | 标识 |', '|---|---|---|---|---|');
+  for (const r of pm.rows) {
+    metricsLines.push(
+      `| ${r.type} | ${r.pid} | ${r.memoryMb} | ${r.cpuPercent} | ${r.label ?? ''} |`
+    );
+  }
+  return redacted + '\n' + metricsLines.join('\n') + '\n';
 }

--- a/src/shared/process-metrics.ts
+++ b/src/shared/process-metrics.ts
@@ -17,7 +17,13 @@ export interface ProcessMetricLike {
   type: string; // 'Browser'（主）/ 'Renderer'|'Tab' / 'GPU' / 'Utility' / ...
   memory: { workingSetSize: number }; // KB
   cpu?: { percentCPUUsage?: number };
-  serviceName?: string; // utility 子类型名（如 stats worker 的 serviceName），辨识用
+  // 注意 name/serviceName 的实际填法与直觉相反（本机 xvfb 探针实测坐实，见 process-metrics.test.ts）：
+  // Electron utilityProcess.fork(path, args, {serviceName:'flowz-stats'}) 传入的自定义名最终落在 `.name`，
+  // 而 `.serviceName` 恒是 Chromium 的通用接口名（如 'node.mojom.NodeService'，等价于该进程命令行里的
+  // --utility-sub-type 值）——对 Electron 自己 fork 出的所有 utilityProcess 都长这样，分不出具体是哪一个。
+  // 故 toRow 取 label 须 name 优先、serviceName 兜底（顺序颠倒会让 FlowZ 自己的 worker 显示成无辨识度的
+  // 泛型接口名，而不是 fork 时起的名字——正是这张表最该认出来的那个进程）。
+  serviceName?: string;
   name?: string;
 }
 
@@ -26,7 +32,7 @@ export interface ProcessMetricRow {
   pid: number;
   memoryMb: number; // 四舍五入 MB
   cpuPercent: number; // 四舍五入整数百分比
-  label?: string; // serviceName / name（utility 辨识用），无则省略
+  label?: string; // name 优先、serviceName 兜底（utility 辨识用，见 ProcessMetricLike 注释），无则省略
 }
 
 export interface ProcessMetricsSummary {
@@ -39,7 +45,7 @@ const KB_PER_MB = 1024;
 function toRow(m: ProcessMetricLike): ProcessMetricRow {
   const memoryMb = Math.round((m.memory?.workingSetSize ?? 0) / KB_PER_MB);
   const cpuPercent = Math.round(m.cpu?.percentCPUUsage ?? 0);
-  const label = m.serviceName || m.name || undefined;
+  const label = m.name || m.serviceName || undefined;
   return { type: m.type, pid: m.pid, memoryMb, cpuPercent, ...(label ? { label } : {}) };
 }
 

--- a/src/shared/process-metrics.ts
+++ b/src/shared/process-metrics.ts
@@ -1,0 +1,67 @@
+/**
+ * 逐进程内存/CPU 指标的纯分析（issue #242 诊断可靠性）。
+ *
+ * 背景：#242 报告 Linux 下 FlowZ 单个子进程内存涨到 2GB+，但系统监视器只显示 basename「flowz」重复多行、
+ * 分不清是主进程 / 渲染进程 / GPU / utility 里的哪一个。app.getAppMetrics() 天然按进程给出 type/pid/内存/CPU，
+ * 一次采样即可定位是哪个子进程在涨。本模块把 getAppMetrics() 的结果做纯分析（汇总排序 / 超阈值筛查），
+ * 供「诊断导出的逐进程表」与「ProxyManager 周期自检的告警」共用，纯函数、无 electron 依赖、可单测。
+ */
+
+/**
+ * app.getAppMetrics() 单进程指标的最小子集。刻意不 import electron 的 ProcessMetric 类型——
+ * 本模块在 shared/ 下（主/渲染/单测共用），保持零平台依赖；调用方直接传 getAppMetrics() 结果即结构兼容。
+ * 注意 memory.workingSetSize 是 **KB**（Electron 口径），非字节。
+ */
+export interface ProcessMetricLike {
+  pid: number;
+  type: string; // 'Browser'（主）/ 'Renderer'|'Tab' / 'GPU' / 'Utility' / ...
+  memory: { workingSetSize: number }; // KB
+  cpu?: { percentCPUUsage?: number };
+  serviceName?: string; // utility 子类型名（如 stats worker 的 serviceName），辨识用
+  name?: string;
+}
+
+export interface ProcessMetricRow {
+  type: string;
+  pid: number;
+  memoryMb: number; // 四舍五入 MB
+  cpuPercent: number; // 四舍五入整数百分比
+  label?: string; // serviceName / name（utility 辨识用），无则省略
+}
+
+export interface ProcessMetricsSummary {
+  totalMemoryMb: number;
+  rows: ProcessMetricRow[]; // 按内存降序（最大的排最前，一眼看出谁在涨）
+}
+
+const KB_PER_MB = 1024;
+
+function toRow(m: ProcessMetricLike): ProcessMetricRow {
+  const memoryMb = Math.round((m.memory?.workingSetSize ?? 0) / KB_PER_MB);
+  const cpuPercent = Math.round(m.cpu?.percentCPUUsage ?? 0);
+  const label = m.serviceName || m.name || undefined;
+  return { type: m.type, pid: m.pid, memoryMb, cpuPercent, ...(label ? { label } : {}) };
+}
+
+/** 汇总逐进程内存/CPU，按内存降序。诊断导出表与自检共用。 */
+export function summarizeProcessMetrics(
+  metrics: readonly ProcessMetricLike[]
+): ProcessMetricsSummary {
+  const rows = metrics.map(toRow).sort((a, b) => b.memoryMb - a.memoryMb);
+  const totalMemoryMb = rows.reduce((sum, r) => sum + r.memoryMb, 0);
+  return { totalMemoryMb, rows };
+}
+
+/**
+ * 筛出内存超 thresholdBytes 的进程行（自检告警用），按内存降序。
+ * 阈值以字节传入，与 workingSetSize（KB）换算比较；空/无超标返回 []。
+ */
+export function findMemoryOffenders(
+  metrics: readonly ProcessMetricLike[],
+  thresholdBytes: number
+): ProcessMetricRow[] {
+  return metrics
+    .filter((m) => (m.memory?.workingSetSize ?? 0) * 1024 >= thresholdBytes)
+    .map(toRow)
+    .sort((a, b) => b.memoryMb - a.memoryMb);
+}


### PR DESCRIPTION
## 背景（issue #242）

#242 报告 Linux 下 FlowZ 某进程内存涨到 2GB+，但系统监视器只显示可执行文件 basename「flowz」重复多行、分不清是主进程 / 渲染进程 / GPU / utility 里哪一个在涨；FlowZ 诊断体系原本也只报主进程 RSS，定位不了子进程。本 PR 经 `app.getAppMetrics()`（天然带 type / pid / 内存 / CPU）补齐逐进程可观测，让下次同类报告一次导出即可定位。

> 说明：这是 #242 的**诊断可靠性提升**（定位手段），不是其内存暴涨的完整修复——具体根因需拿到带逐进程数据的诊断报告后进一步定位。

## 改动

- **新增 `shared/process-metrics`（纯函数、可单测）**：`summarizeProcessMetrics`（逐进程按内存降序 + 合计）、`findMemoryOffenders`（超阈值筛查）。`workingSetSize` 为 KB（Electron 口径），统一换算。
- **诊断导出新增「进程内存」表**：`DiagnosticService` 采集 `getAppMetrics()`，报告渲染 type / pid / 内存(MB) / CPU(%) / 进程标识，按内存降序——一次导出即可看出是哪个子进程内存偏高，取代靠用户截系统监视器猜。
- **内存自检从主进程扩展到逐进程**：`ProxyManager` 原只查主进程 RSS（#210），改为经 `getAppMetrics()` 逐进程查，任一超 1GB/进程记 warn（含 type/pid 定位），问题在用户察觉前就写进 app.log（监控闭环）。
- **进程内存表刻意放在节点标识符打码 pass 之后拼接**：表内只有进程 type/pid/数字、无节点标识符、无需脱敏；若纳入打码，机场把节点命名成纯数字（如 `2048`）会撞上表内 PID/内存数字被误替成占位符、反毁定位价值。

## 测试

- 新增单测：`process-metrics`（换算 / 降序 / 阈值 / 边界）；`proxy-manager-memory-check` 改 mock `getAppMetrics`（验 #242 utility 子进程暴涨告警含 type/pid/label）；`diagnostic-redact` 进程表渲染 + 纯数字节点名不误伤表内数字的回归。
- typecheck（main+renderer）+ lint + 全量单测全绿。
- 经独立 agent code review（换算/性能/健壮性核过；修复「进程表被节点标识符打码误伤」）。

## 说明

- 独立于 #243（渲染进程内存生命周期整治），二者同源自本次 #242 排查但关注点不同，故拆分。
- Windows/Linux 真机验证待做（本特性纯观测、`getAppMetrics` 为标准跨平台 API，逻辑已单测全覆盖）。