### PR TITLE
feat(diagnostics): stats 泄漏定证 harness + 逐进程/渲染堆/核进程/内存时间线观测（#242 批次1）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,7 +49,12 @@ import { CoreUpdateScheduler } from './services/CoreUpdateScheduler';
 import { SpeedTestService } from './services/SpeedTestService';
 import { AutoSwitchService } from './services/AutoSwitchService';
 import { SubscriptionScheduler } from './services/SubscriptionScheduler';
-import { StatsWorkerHost } from './services/StatsWorkerHost';
+import {
+  StatsWorkerHost,
+  type StatsWorkerHostOptions,
+  type StatsHost,
+} from './services/StatsWorkerHost';
+import { StatsSimulator } from './services/StatsSimulator';
 import { PlatformPrivilegeService } from './services/PlatformPrivilegeService';
 import { IpInfoService } from './services/IpInfoService';
 import { RuleResourceManager } from './services/RuleResourceManager';
@@ -257,7 +262,7 @@ let speedTestService: SpeedTestService;
 let autoSwitchService: AutoSwitchService;
 let subscriptionScheduler: SubscriptionScheduler;
 let coreUpdateScheduler: CoreUpdateScheduler | null = null;
-let statsService: StatsWorkerHost | null = null;
+let statsService: StatsHost | null = null;
 let ipInfoService: IpInfoService | null = null;
 let ruleResourceManager: RuleResourceManager | null = null;
 let ruleResourceScheduler: RuleResourceScheduler | null = null;
@@ -1296,7 +1301,7 @@ if (gotTheLock) {
     // 本宿主 fork/看护 worker、缓存最新快照、按 isUiBroadcastActive(可见 && !拖动) 门控后 sendToAll——把 Status/
     // Connections 长流的 per-frame 解析+物化移出主线程，消除拖动期事件循环争用。worker 据 getStatsApiEndpoint 重建
     // 自己的 gRPC client（端口随每次启动可能变 → 'api-client-ready' 时经 resubscribe 重发）。
-    statsService = new StatsWorkerHost({
+    const statsHostOptions: StatsWorkerHostOptions = {
       workerPath: path.join(__dirname, 'workers', 'stats-worker.js'),
       onStats: (stats) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_STATS_UPDATED, stats),
       onAggregate: (agg) =>
@@ -1304,7 +1309,13 @@ if (gotTheLock) {
       isUiActive: isUiBroadcastActive,
       getEndpoint: () => proxyManager?.getStatsApiEndpoint() ?? null,
       log: (level, message) => logManager.addLog(level, message, 'StatsWorker'),
-    });
+    };
+    // 泄漏定证 harness（issue #242 §5）：FLOWZ_STATS_SIM 存在时用合成 churn 注入器取代真实 stats worker——直接向
+    // UI 门控层灌 aggregate/stats（绕内核/流量/TUN），把 reporter 数天暴露压缩到小时级。dev-only，零业务行为变更；
+    // StatsSimulator 构造内经 logManager 打「模拟器激活」warn banner + 解析防御。
+    statsService = process.env.FLOWZ_STATS_SIM
+      ? new StatsSimulator(statsHostOptions, process.env.FLOWZ_STATS_SIM)
+      : new StatsWorkerHost(statsHostOptions);
     // 杀核前静默 StatsService：停其到管理 API 的 Status/Connections gRPC 流（核将死，提前 cancel 避免 RST 噪音）。
     proxyManager.setQuiesceStats(() => {
       statsService?.stop();
@@ -1534,7 +1545,20 @@ if (gotTheLock) {
         logManager,
         proxyManager,
         systemProxyManager,
-        getPrivacyMode
+        getPrivacyMode,
+        // 渲染进程堆内省（issue #242 §6.2）：main→renderer executeJavaScript 取一次；DiagnosticService 内 2s 超时
+        // 兜底，renderer 卡死（正是 #242 场景）不挂住导出。窗口不存在/销毁 → 返回 null（映射为 unavailable）。
+        async () => {
+          const win = mainWindow;
+          if (!win || win.isDestroyed()) return null;
+          try {
+            return await win.webContents.executeJavaScript(
+              'window.electron && window.electron.getRendererDiagnostics ? window.electron.getRendererDiagnostics() : null'
+            );
+          } catch {
+            return null;
+          }
+        }
       );
       registerDiagnosticHandlers(diagnosticService);
     }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -3,7 +3,8 @@
  * 在渲染进程中暴露安全的 IPC 接口
  */
 
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent, webFrame } from 'electron';
+import type { RendererHeapSample } from '../shared/process-metrics';
 
 /**
  * OS 偏好语言（有序）：主进程经 webPreferences.additionalArguments 注入 `--flowz-sys-langs=<JSON>`。
@@ -42,6 +43,32 @@ const electronAPI = {
   systemLanguages: readSystemLanguages(),
   // 界面语言选择（config.language 注入值）：i18n 初始化的真值源；空串=未注入/存量缺键（回退旧 localStorage）。
   languageChoice: readLanguageChoice(),
+  /**
+   * 渲染进程堆内省（issue #242 §6.2 泄漏观测）：main 经 executeJavaScript('window.electron.getRendererDiagnostics()')
+   * 取一次堆分层用于诊断导出。sandbox:false 下 preload 可用 process/webFrame；各取数独立 try/catch，任一取不到只
+   * 缺省该字段（不整体失败）。返回原始 Electron 口径（heap/processMemory=KB，resources=bytes），main 侧再换算 MB。
+   */
+  getRendererDiagnostics: async (): Promise<RendererHeapSample> => {
+    const out: RendererHeapSample = {};
+    try {
+      const p = process as NodeJS.Process & {
+        getHeapStatistics?: () => Record<string, number>;
+        getProcessMemoryInfo?: () => Promise<Record<string, number>>;
+      };
+      if (typeof p.getHeapStatistics === 'function')
+        out.heap = p.getHeapStatistics() as RendererHeapSample['heap'];
+      if (typeof p.getProcessMemoryInfo === 'function')
+        out.processMemory = (await p.getProcessMemoryInfo()) as RendererHeapSample['processMemory'];
+    } catch {
+      /* 忽略：字段缺省 */
+    }
+    try {
+      out.resources = webFrame.getResourceUsage() as unknown as RendererHeapSample['resources'];
+    } catch {
+      /* 忽略：字段缺省 */
+    }
+    return out;
+  },
   ipcRenderer: {
     /**
      * 调用主进程方法

--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -19,9 +19,15 @@ import {
   normalizeKey,
   collectNodeIdentifiers,
   type DiagnosticReportInput,
+  type CoreProcessReport,
 } from '../../shared/diagnostic-redact';
 import { effectiveLogLevel } from '../../shared/log-level';
-import { summarizeProcessMetrics } from '../../shared/process-metrics';
+import { summarizeProcessMetrics, type RendererHeapSample } from '../../shared/process-metrics';
+import {
+  collectRendererHeap,
+  sampleCoreProcess,
+  serializeMemoryTimelineCsv,
+} from './process-sampler';
 import { getLogsPath, getSingBoxLogPath } from '../utils/paths';
 import path from 'path';
 import type { LogManager } from './LogManager';
@@ -43,7 +49,9 @@ export class DiagnosticService {
     private readonly logManager: LogManager,
     private readonly proxyManager: ProxyManager,
     private readonly systemProxyManager: ISystemProxyManager,
-    private readonly privacyProvider: () => boolean = () => false
+    private readonly privacyProvider: () => boolean = () => false,
+    /** 渲染进程堆内省取数（index.ts 注入 executeJavaScript；缺省=不采）。issue #242 §6.2。 */
+    private readonly rendererIntrospect?: () => Promise<RendererHeapSample | null>
   ) {}
 
   /** 读文件尾部最多 maxBytes 字节；不存在/失败返回占位串（绝不抛）。 */
@@ -121,6 +129,32 @@ export class DiagnosticService {
       processMetrics = undefined;
     }
 
+    // 渲染进程堆分层（issue #242 §6.2）：向 renderer 取一次 V8 堆 + RSS + Blink 资源缓存。**2s 超时兜底**——
+    // renderer 卡死正是 #242 场景，collectRendererHeap 超时/无窗口/失败均返回 unavailable，绝不挂住导出。
+    const rendererHeap = await collectRendererHeap(this.rendererIntrospect);
+
+    // sing-box 核进程 RSS/CPU（issue #242 §6.3）：核不在 Electron 进程树（processMetrics 覆盖不到）。核 PID 取
+    // getStatus().pid（wrapper 模式=真实 singboxPid，直启=spawn pid）；helper 托管路径无 pid → unavailable。
+    let coreProcess: CoreProcessReport;
+    if (status.running && status.pid) {
+      const s = await sampleCoreProcess(status.pid).catch(() => null);
+      coreProcess = s
+        ? { pid: s.pid, rssMb: s.rssMb, cpuPercent: s.cpuPercent }
+        : { unavailable: 'unavailable（核进程采样失败/平台不支持，如 Windows 本批未采）' };
+    } else {
+      coreProcess = {
+        unavailable: 'unavailable（代理未运行，或核 PID 不可得，如 Linux helper 托管路径）',
+      };
+    }
+
+    // 内存时间线（issue #242 §6.4）：ProxyManager 周期采样维护的 5min/帧 ring → 紧凑 CSV（斜率判泄漏/高水位）。
+    let memoryTimelineCsv: string | undefined;
+    try {
+      memoryTimelineCsv = serializeMemoryTimelineCsv(this.proxyManager.getMemoryTimelineFrames());
+    } catch {
+      memoryTimelineCsv = undefined;
+    }
+
     const effLevel = effectiveLogLevel(config.logLevel || 'info', this.privacyProvider());
     const captureActive = !!config.diagnosticCapture;
     const wantDeeper =
@@ -165,6 +199,9 @@ export class DiagnosticService {
       redactedUserConfig,
       redactedSingboxConfig: redactedSingbox,
       processMetrics,
+      rendererHeap,
+      coreProcess,
+      memoryTimelineCsv,
       appLogTail,
       singboxLogTail,
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -103,6 +103,11 @@ import { ruleConditions } from '../../shared/rules';
 import { planCustomRule, buildCustomRuleFiles, condMatcherFields } from './custom-rule-files';
 import { resolveWinTunInterfaceName } from '../../shared/tun-interface';
 import { findMemoryOffenders } from '../../shared/process-metrics';
+import {
+  MemoryTimelineRing,
+  sampleProcessRssMb,
+  type MemoryTimelineFrame,
+} from './process-sampler';
 import { probeWinTunAdapterPresent, waitForAdapterReleased } from './win-tun-adapter';
 import {
   probeTcpReachable,
@@ -410,6 +415,11 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private static readonly RSS_WARN_THRESHOLD = 1024 * 1024 * 1024; // 1GB/进程
   private static readonly MEMORY_WARN_COOLDOWN_MS = 5 * 60 * 1000; // 5 分钟内不重复告警
   private lastMemoryWarnAt = 0;
+  // 内存时间线（issue #242 §6.4）：跟随健康检查节拍（10s）但降频到每 5min 记一帧（Electron 全进程 + 核 RSS），
+  // 环形上限 288 帧（24h）。斜率比单点更能区分泄漏/高水位；诊断导出以紧凑 CSV 承载（几十 KB 量级，可忽略）。
+  private static readonly TIMELINE_FRAME_INTERVAL_MS = 5 * 60 * 1000; // 5min/帧
+  private readonly memoryTimeline = new MemoryTimelineRing(288); // 288 帧 = 24h
+  private lastTimelineFrameAt = 0;
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly HEALTH_CHECK_INTERVAL = 10000; // 10秒检查一次
 
@@ -4842,6 +4852,42 @@ exit 0
   }
 
   /**
+   * 内存时间线记一帧（issue #242 §6.4）：每 TIMELINE_FRAME_INTERVAL_MS（5min）记一次 Electron 全进程 + sing-box
+   * 核的 RSS（MB），入环形 ring（上限 288 帧=24h）。核 RSS 经 process-sampler 异步采（/proc 或 ps），故本方法 async；
+   * 由 performHealthCheck fire-and-forget 调，best-effort：任何异常吞掉，绝不阻断健康检查。
+   */
+  private async recordMemoryTimelineFrame(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastTimelineFrameAt < ProxyManager.TIMELINE_FRAME_INTERVAL_MS) return;
+    this.lastTimelineFrameAt = now;
+    try {
+      const procs: MemoryTimelineFrame['procs'] = [];
+      for (const m of app.getAppMetrics()) {
+        procs.push({
+          label: m.name || m.serviceName || m.type,
+          pid: m.pid,
+          rssMb: Math.round((m.memory?.workingSetSize ?? 0) / 1024),
+        });
+      }
+      // 核不在 Electron 进程树：单独采 RSS。PID 取法与 getStatus 一致（wrapper=singboxPid，直启=pid）。
+      const wrapperMode = this.needsOsascript() || this.needsWindowsUAC();
+      const corePid = wrapperMode ? this.singboxPid : this.singboxPid || this.pid;
+      if (corePid) {
+        const rssMb = await sampleProcessRssMb(corePid).catch(() => null);
+        if (rssMb != null) procs.push({ label: 'sing-box', pid: corePid, rssMb });
+      }
+      this.memoryTimeline.push({ t: now, procs });
+    } catch {
+      /* 采样失败不阻断健康检查 */
+    }
+  }
+
+  /** 内存时间线全部帧（最老→最新）：诊断导出序列化为 CSV。issue #242 §6.4。 */
+  getMemoryTimelineFrames(): readonly MemoryTimelineFrame[] {
+    return this.memoryTimeline.frames();
+  }
+
+  /**
    * 执行健康检查
    */
   private async performHealthCheck(): Promise<void> {
@@ -4853,6 +4899,8 @@ exit 0
     // 主进程内存自检（issue #210 可观测性）：跟随健康检查节拍（10s），但仅在非重启态执行（上方 isRestarting
     // 早退已过滤重启期）。重启循环通常很短，跳过其间的内存采样无碍——长会话泄漏在稳态运行期会持续被采样。
     this.checkMemoryUsage();
+    // 内存时间线采样（issue #242 §6.4）：同节拍触发、内部按 5min 降频记一帧；async best-effort，绝不阻断健康检查。
+    void this.recordMemoryTimelineFrame();
 
     // 判定依据与 getStatus 一致：经包装进程(osascript/UAC)启动才取 singboxPid，否则取 pid。
     // 修复 Linux TUN（直接 spawn，singboxPid 恒 null）下健康检查/自动重启完全失效（issue #33）。

--- a/src/main/services/StatsSimulator.ts
+++ b/src/main/services/StatsSimulator.ts
@@ -1,0 +1,258 @@
+/**
+ * StatsSimulator —— 合成 churn 注入器（issue #242 §5 泄漏定证 harness）。
+ *
+ * 背景：#242 renderer RSS 数天涨到 2GB，但泄漏机制在应用层之下、本机不一定能稳定复现。本模块**制造**复现：
+ * 构造一个假连接池，用**真实的** aggregateConnections 聚合后，经与 StatsWorkerHost 相同的 isUiActive 门控把
+ * aggregate/stats 灌给渲染端——绕过内核/流量/TUN，以可调速率把 reporter 数天暴露压缩到小时级，供 CDP heap
+ * 三连拍定位滞留层。**dev-only 工具、零业务行为变更**：仅 FLOWZ_STATS_SIM 存在时替换真实 stats worker。
+ *
+ * 语义刻意与代理生命周期解耦（dev 工具）：构造即启动 ticker；stop()/resubscribe() 只记日志、不停 ticker
+ * （代理起停不该打断定证跑批）；仅 dispose()（app 退出）才停并 clearInterval。对外面实现 StatsHost，与
+ * StatsWorkerHost 可在 index.ts 处直接替换。
+ */
+import type {
+  TrafficStats,
+  ConnectionsSnapshot,
+  ConnectionsAggregate,
+  ConnectionEntry,
+} from '../../shared/types';
+import { aggregateConnections } from './connections-aggregate';
+import type { StatsHost, StatsWorkerHostOptions } from './StatsWorkerHost';
+
+/** 合成器参数（FLOWZ_STATS_SIM=intervalMs,connCount,churnPerFrame 解析而来）。 */
+export interface StatsSimConfig {
+  /** tick 间隔（ms）：每 tick 一次聚合 + 一次 stats。 */
+  intervalMs: number;
+  /** 假连接池恒定大小（= aggregate.total / activeConnections）。 */
+  connCount: number;
+  /** 每 tick 关掉最老、开同数量新连接的条数（驱动 aggregate 签名变化）。 */
+  churnPerFrame: number;
+}
+
+/** 缺省参数：1s、200 连接、每帧换 20 条（与设计示例一致）。 */
+export const DEFAULT_STATS_SIM_CONFIG: StatsSimConfig = {
+  intervalMs: 1000,
+  connCount: 200,
+  churnPerFrame: 20,
+};
+
+/** 假域名池（~30）：新连接从中取 host，制造多样 host 节点。 */
+const FAKE_HOSTS: readonly string[] = [
+  'example.com',
+  'api.example.com',
+  'cdn.example.net',
+  'img.example.org',
+  'video.stream.tv',
+  'chat.im',
+  'mail.provider.com',
+  'docs.office.io',
+  'push.notify.dev',
+  'auth.login.net',
+  'analytics.track.co',
+  'ads.serve.io',
+  'update.pkg.org',
+  'git.code.dev',
+  'registry.npm.js',
+  'pypi.python.org',
+  'search.engine.com',
+  'map.tiles.net',
+  'weather.now.io',
+  'news.feed.rss',
+  'social.graph.co',
+  'photo.album.me',
+  'music.play.fm',
+  'game.match.gg',
+  'shop.cart.store',
+  'pay.checkout.io',
+  'bank.secure.com',
+  'crm.sales.app',
+  'metrics.grafana.io',
+  'log.ingest.dev',
+];
+
+/** 假出口池（5）：新连接从中取 outbound（chains[0]）。 */
+const FAKE_OUTBOUNDS: readonly string[] = ['proxy-a', 'proxy-b', 'proxy-c', 'direct', 'block'];
+
+/**
+ * 解析 FLOWZ_STATS_SIM=intervalMs,connCount,churnPerFrame。防御式：任一字段非法（非正整数/缺失）→ 该字段
+ * 回退缺省并 warn（不因一个字段拖垮整体）。纯函数，供单测。
+ */
+export function parseStatsSimConfig(
+  raw: string | undefined,
+  warn?: (message: string) => void
+): StatsSimConfig {
+  const d = DEFAULT_STATS_SIM_CONFIG;
+  const parts = (raw ?? '').split(',');
+  const bad: string[] = [];
+
+  const pick = (idx: number, fallback: number, label: string): number => {
+    const n = Number.parseInt((parts[idx] ?? '').trim(), 10);
+    if (!Number.isFinite(n) || n <= 0) {
+      bad.push(label);
+      return fallback;
+    }
+    return n;
+  };
+
+  const intervalMs = pick(0, d.intervalMs, 'intervalMs');
+  const connCount = pick(1, d.connCount, 'connCount');
+  const churnPerFrame = pick(2, d.churnPerFrame, 'churnPerFrame');
+
+  if (bad.length > 0) {
+    warn?.(
+      `FLOWZ_STATS_SIM 解析非法字段 [${bad.join(', ')}]（原值 "${raw ?? ''}"），已回退缺省 ` +
+        `${d.intervalMs},${d.connCount},${d.churnPerFrame}`
+    );
+  }
+  return { intervalMs, connCount, churnPerFrame };
+}
+
+export class StatsSimulator implements StatsHost {
+  private readonly config: StatsSimConfig;
+  private readonly onStats: (s: TrafficStats) => void;
+  private readonly onAggregate: (agg: ConnectionsAggregate) => void;
+  private readonly isUiActive: () => boolean;
+  private readonly log?: (level: 'info' | 'warn' | 'error', message: string) => void;
+
+  private readonly pool: ConnectionEntry[] = [];
+  private readonly churnPerFrame: number;
+  private nextId = 1;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  private snapshot: TrafficStats;
+  private aggregate: ConnectionsAggregate;
+
+  /**
+   * @param opts 与 StatsWorkerHost 同形（复用 index.ts 装配的 onStats/onAggregate/isUiActive/log）；workerPath/
+   *   getEndpoint 对合成器无意义，刻意忽略。
+   * @param rawConfig FLOWZ_STATS_SIM 原始串（构造内解析 + 打激活/防御 banner）。
+   */
+  constructor(opts: StatsWorkerHostOptions, rawConfig: string | undefined) {
+    this.onStats = opts.onStats;
+    this.onAggregate = opts.onAggregate;
+    this.isUiActive = opts.isUiActive;
+    this.log = opts.log;
+    this.config = parseStatsSimConfig(rawConfig, (m) => this.log?.('warn', m));
+    // churn 不超过池大小（否则整池每 tick 全换、老连接切片越界语义无意义）。
+    this.churnPerFrame = Math.min(this.config.churnPerFrame, this.config.connCount);
+
+    this.log?.(
+      'warn',
+      `stats 模拟器激活（FLOWZ_STATS_SIM=${rawConfig ?? ''} → intervalMs=${this.config.intervalMs}, ` +
+        `connCount=${this.config.connCount}, churnPerFrame=${this.churnPerFrame}），仅用于泄漏定证`
+    );
+
+    // 初始填满连接池，使首个 tick 起 aggregate.total 即等于 connCount。
+    for (let i = 0; i < this.config.connCount; i++) this.pool.push(this.makeConnection());
+    this.snapshot = {
+      uploadSpeed: 0,
+      downloadSpeed: 0,
+      totalUpload: 0,
+      totalDownload: 0,
+      activeConnections: this.pool.length,
+    };
+    this.aggregate = aggregateConnections(this.pool, Date.now());
+
+    // 构造即启动 ticker（dev 工具语义，不跟随代理生命周期）。
+    this.timer = setInterval(() => this.tick(), this.config.intervalMs);
+  }
+
+  /** 造一条假连接：id 递增、host/outbound 随机取自假池、字节从 0 起。 */
+  private makeConnection(): ConnectionEntry {
+    const id = `sim-${this.nextId++}`;
+    const host = FAKE_HOSTS[Math.floor(Math.random() * FAKE_HOSTS.length)];
+    const outbound = FAKE_OUTBOUNDS[Math.floor(Math.random() * FAKE_OUTBOUNDS.length)];
+    return {
+      id,
+      chains: [outbound],
+      rule: 'sim',
+      rulePayload: '',
+      metadata: { host, network: 'tcp' },
+      upload: 0,
+      download: 0,
+      start: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * 单 tick：churn 连接池（关最老 churn 条 + 开同数量新）→ 真实聚合 → 门控 onAggregate；随机游走速率 + 累加
+   * totals → 门控 onStats。快照恒更新（getters 读缓存），门控只挡广播（与 StatsWorkerHost 一致）。
+   */
+  private tick(): void {
+    // 1) churn：关最老 churnPerFrame 条，开同数量新连接（池大小恒定）。
+    this.pool.splice(0, this.churnPerFrame);
+    for (let i = 0; i < this.churnPerFrame; i++) this.pool.push(this.makeConnection());
+    // 存量连接字节随 tick 推进（模拟持续传输，使明细每帧微变）。**替换新对象**而非原地变异——与
+    // StatsWorkerHost 每帧 post 全新对象的语义一致，使已发出的快照条目不被后续 tick 改动（引用隔离）。
+    // 否则消费端两次 pull 差分算速率时「上一次快照」被原地改新 → Δ 恒 0 → 明细页速率恒显 0。
+    for (let i = 0; i < this.pool.length; i++) {
+      const c = this.pool[i];
+      this.pool[i] = {
+        ...c,
+        upload: (c.upload ?? 0) + Math.floor(Math.random() * 4096),
+        download: (c.download ?? 0) + Math.floor(Math.random() * 16384),
+      };
+    }
+
+    const now = Date.now();
+    this.aggregate = aggregateConnections(this.pool, now);
+    if (this.isUiActive()) this.onAggregate(this.aggregate);
+
+    // 2) 速率随机游走，clamp 到 [50KB/s, 500KB/s]；totals 累加；activeConnections = 池大小。
+    const walk = (v: number): number => {
+      const next = v + (Math.random() - 0.5) * 100 * 1024;
+      return Math.max(50 * 1024, Math.min(500 * 1024, next));
+    };
+    const uploadSpeed = walk(this.snapshot.uploadSpeed || 200 * 1024);
+    const downloadSpeed = walk(this.snapshot.downloadSpeed || 200 * 1024);
+    this.snapshot = {
+      uploadSpeed: Math.round(uploadSpeed),
+      downloadSpeed: Math.round(downloadSpeed),
+      totalUpload: this.snapshot.totalUpload + Math.round(uploadSpeed),
+      totalDownload: this.snapshot.totalDownload + Math.round(downloadSpeed),
+      activeConnections: this.pool.length,
+    };
+    if (this.isUiActive()) this.onStats(this.snapshot);
+  }
+
+  // ── StatsHost 对外面 ────────────────────────────────────────────────────────
+
+  /** dev 工具：不跟随代理生命周期，仅记日志、不重启 ticker。 */
+  resubscribe(): void {
+    this.log?.('info', 'stats 模拟器 resubscribe()（dev 工具，ticker 不受代理生命周期影响，忽略）');
+  }
+
+  /** dev 工具：不跟随代理生命周期，仅记日志、不停 ticker。 */
+  stop(): void {
+    this.log?.('info', 'stats 模拟器 stop()（dev 工具，ticker 持续，忽略）');
+  }
+
+  /** 拖动结束补推缓存最新（活跃才推），与 StatsWorkerHost.resume 语义一致。 */
+  resume(): void {
+    if (!this.isUiActive()) return;
+    this.onStats(this.snapshot);
+    this.onAggregate(this.aggregate);
+  }
+
+  getSnapshot(): TrafficStats {
+    return { ...this.snapshot };
+  }
+
+  getConnectionsSnapshot(): ConnectionsSnapshot {
+    // 浅拷贝数组：条目已由 tick 不可变替换（引用隔离），故 slice 即足以让快照在消费前不随后续 tick 漂移。
+    return { connections: this.pool.slice(), at: Date.now() };
+  }
+
+  getAggregateSnapshot(): ConnectionsAggregate {
+    return this.aggregate;
+  }
+
+  /** app 退出：停 ticker。唯一停止入口。 */
+  dispose(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.log?.('info', 'stats 模拟器 dispose()，ticker 已停');
+  }
+}

--- a/src/main/services/StatsWorkerHost.ts
+++ b/src/main/services/StatsWorkerHost.ts
@@ -32,6 +32,19 @@ export interface StatsProvider {
   getAggregateSnapshot(): ConnectionsAggregate;
 }
 
+/**
+ * index.ts 装配点 + 生命周期钩子对 stats 宿主的完整对外面（读快照 + 订阅生命周期）。StatsWorkerHost（生产）
+ * 与 StatsSimulator（issue #242 §5 泄漏定证 harness）两者均实现，使 index.ts 的 statsService 可在两者间替换、
+ * 装配 diff 最小。成员集与 index.ts/proxy-handlers 实际调用点一一对应（resubscribe/stop/resume/dispose +
+ * StatsProvider 三读），无 getStatus——刻意不含未被调用的成员，避免虚假接口面。
+ */
+export interface StatsHost extends StatsProvider {
+  resubscribe(): void;
+  stop(): void;
+  resume(): void;
+  dispose(): void;
+}
+
 /** main → worker 控制消息。 */
 export type HostToWorkerMessage =
   | { type: 'connect'; endpoint: StatsApiEndpoint }
@@ -76,7 +89,7 @@ export interface StatsWorkerHostOptions {
   log?: (level: 'info' | 'warn' | 'error', message: string) => void;
 }
 
-export class StatsWorkerHost implements StatsProvider {
+export class StatsWorkerHost implements StatsHost {
   private worker: UtilityProcess | null = null;
   private snapshot: TrafficStats = { ...ZERO_STATS };
   // worker post 来的最近连接明细快照：仅供连接信息页 CONNECTIONS_GET 按需 pull，不再 relay 给渲染端（旧放大器）。

--- a/src/main/services/__tests__/process-sampler.test.ts
+++ b/src/main/services/__tests__/process-sampler.test.ts
@@ -1,0 +1,279 @@
+/**
+ * process-sampler 单测（issue #242 §6 观测随包）：
+ *  1) /proc/status VmRSS、/proc/stat utime/stime 解析（comm 含空格/括号的鲁棒性）；
+ *  2) CPU% 两次采样差分算术（含墙钟 0、计数器回绕）；
+ *  3) sampleCoreProcess / sampleProcessRssMb 平台分支 + 进程消失返回 null 不抛（io 注入 fixture）；
+ *  4) MemoryTimelineRing 上限环绕 + serializeMemoryTimelineCsv 格式；
+ *  5) mapRendererHeapSample 单位换算/字段存在性；collectRendererHeap 成功/空/异常/**超时**分支。
+ * 纯解析/算术 + io 注入，无需真实进程/electron。
+ */
+import {
+  parseVmRssKb,
+  parseProcStat,
+  cpuPercentFromDelta,
+  sampleCoreProcess,
+  sampleProcessRssMb,
+  MemoryTimelineRing,
+  serializeMemoryTimelineCsv,
+  mapRendererHeapSample,
+  collectRendererHeap,
+  type ProcessSamplerIo,
+  type MemoryTimelineFrame,
+} from '../process-sampler';
+import type { RendererHeapSample } from '../../../shared/process-metrics';
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+const STATUS = [
+  'Name:\tsing-box',
+  'Umask:\t0022',
+  'State:\tS (sleeping)',
+  'VmPeak:\t  300000 kB',
+  'VmRSS:\t  262144 kB', // 256 MB
+  'Threads:\t12',
+].join('\n');
+
+// /proc/<pid>/stat：comm 故意含空格与括号，验证「最后一个 )」定位。字段 14=utime、15=stime。
+const STAT1 = '1234 (sing box (rev)) S 1 1234 1234 0 -1 4194560 100 0 0 0 500 200 0 0 20 0 1 0 999';
+const STAT2 = '1234 (sing box (rev)) S 1 1234 1234 0 -1 4194560 110 0 0 0 505 205 0 0 20 0 1 0 999';
+
+function linuxIo(overrides?: Partial<ProcessSamplerIo>): Partial<ProcessSamplerIo> {
+  let statCall = 0;
+  let nowCall = 0;
+  return {
+    platform: 'linux',
+    clockHz: 100,
+    delay: () => Promise.resolve(),
+    now: () => (nowCall++ === 0 ? 1000 : 1200), // wallMs = 200
+    readTextFile: (p: string) => {
+      if (p.endsWith('/status')) return Promise.resolve(STATUS);
+      statCall++;
+      return Promise.resolve(statCall === 1 ? STAT1 : STAT2);
+    },
+    run: () => Promise.resolve(''),
+    ...overrides,
+  };
+}
+
+describe('parseVmRssKb', () => {
+  it('解析 VmRSS 行（KB）', () => {
+    expect(parseVmRssKb(STATUS)).toBe(262144);
+  });
+  it('无 VmRSS 行 → null', () => {
+    expect(parseVmRssKb('Name:\tx\nState:\tS')).toBeNull();
+  });
+});
+
+describe('parseProcStat', () => {
+  it('comm 含空格/括号：按最后一个 ) 定位 utime(14)/stime(15)', () => {
+    expect(parseProcStat(STAT1)).toEqual({ utimeTicks: 500, stimeTicks: 200 });
+    expect(parseProcStat(STAT2)).toEqual({ utimeTicks: 505, stimeTicks: 205 });
+  });
+  it('无 ) → null', () => {
+    expect(parseProcStat('1234 no-paren S 1 1')).toBeNull();
+  });
+  it('utime/stime 非数字 → null', () => {
+    expect(parseProcStat('1 (c) S a b c d e f g h i j k l')).toBeNull();
+  });
+});
+
+describe('cpuPercentFromDelta', () => {
+  it('Δ10 节拍 / 100Hz = 0.1s cpu ÷ 0.2s 墙钟 = 50%', () => {
+    expect(cpuPercentFromDelta(700, 710, 200, 100)).toBe(50);
+  });
+  it('墙钟 0 → 0（不除零）', () => {
+    expect(cpuPercentFromDelta(700, 710, 0, 100)).toBe(0);
+  });
+  it('计数器回绕（next < prev）→ 0（不出负值）', () => {
+    expect(cpuPercentFromDelta(710, 700, 200, 100)).toBe(0);
+  });
+  it('满载一核：Δ100 节拍 / 100Hz = 1s ÷ 1s = 100%', () => {
+    expect(cpuPercentFromDelta(0, 100, 1000, 100)).toBe(100);
+  });
+});
+
+describe('sampleCoreProcess', () => {
+  it('Linux：RSS(MB) + 两次差分 CPU%', async () => {
+    // t0=500+200=700, t1=505+205=710, Δ=10 节拍/100Hz=0.1s, 墙钟 200ms=0.2s → 50%
+    const s = await sampleCoreProcess(1234, linuxIo());
+    expect(s).toEqual({ pid: 1234, rssMb: 256, cpuPercent: 50 });
+  });
+
+  it('Linux：进程消失（readTextFile 抛 ENOENT）→ null 不抛', async () => {
+    const io = linuxIo({
+      readTextFile: () => Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+    });
+    await expect(sampleCoreProcess(1234, io)).resolves.toBeNull();
+  });
+
+  it('macOS：ps -o rss=,pcpu= → RSS(MB) + CPU%', async () => {
+    const io: Partial<ProcessSamplerIo> = {
+      platform: 'darwin',
+      run: () => Promise.resolve('  262144 12.7 \n'),
+    };
+    const s = await sampleCoreProcess(1234, io);
+    expect(s).toEqual({ pid: 1234, rssMb: 256, cpuPercent: 13 });
+  });
+
+  it('macOS：ps 空输出（进程消失）→ null', async () => {
+    const io: Partial<ProcessSamplerIo> = { platform: 'darwin', run: () => Promise.resolve('\n') };
+    await expect(sampleCoreProcess(1234, io)).resolves.toBeNull();
+  });
+
+  it('Windows：本批不采 → null', async () => {
+    await expect(sampleCoreProcess(1234, { platform: 'win32' })).resolves.toBeNull();
+  });
+});
+
+describe('sampleProcessRssMb（ring 用单读）', () => {
+  it('Linux VmRSS → MB', async () => {
+    const io: Partial<ProcessSamplerIo> = {
+      platform: 'linux',
+      readTextFile: () => Promise.resolve(STATUS),
+    };
+    expect(await sampleProcessRssMb(1234, io)).toBe(256);
+  });
+  it('Linux 进程消失 → null', async () => {
+    const io: Partial<ProcessSamplerIo> = {
+      platform: 'linux',
+      readTextFile: () => Promise.reject(new Error('ENOENT')),
+    };
+    expect(await sampleProcessRssMb(1234, io)).toBeNull();
+  });
+  it('macOS ps -o rss= → MB', async () => {
+    const io: Partial<ProcessSamplerIo> = {
+      platform: 'darwin',
+      run: () => Promise.resolve('262144\n'),
+    };
+    expect(await sampleProcessRssMb(1234, io)).toBe(256);
+  });
+  it('Windows → null', async () => {
+    expect(await sampleProcessRssMb(1234, { platform: 'win32' })).toBeNull();
+  });
+});
+
+describe('MemoryTimelineRing', () => {
+  const frame = (t: number): MemoryTimelineFrame => ({
+    t,
+    procs: [{ label: 'Browser', pid: 100, rssMb: t }],
+  });
+
+  it('未满：按序保留，size 递增', () => {
+    const ring = new MemoryTimelineRing(3);
+    ring.push(frame(1));
+    ring.push(frame(2));
+    expect(ring.size).toBe(2);
+    expect(ring.frames().map((f) => f.t)).toEqual([1, 2]);
+  });
+
+  it('满后环绕覆盖最老（cap=3，推 5 帧 → 保留最新 3 帧、按序）', () => {
+    const ring = new MemoryTimelineRing(3);
+    for (let t = 1; t <= 5; t++) ring.push(frame(t));
+    expect(ring.size).toBe(3);
+    expect(ring.frames().map((f) => f.t)).toEqual([3, 4, 5]);
+  });
+
+  it('默认上限 288：推 290 帧 → 保留 288 帧（第 3..290）', () => {
+    const ring = new MemoryTimelineRing();
+    for (let t = 1; t <= 290; t++) ring.push(frame(t));
+    expect(ring.size).toBe(288);
+    const ts = ring.frames().map((f) => f.t);
+    expect(ts).toHaveLength(288);
+    expect(ts[0]).toBe(3); // 最老保留帧
+    expect(ts[287]).toBe(290); // 最新
+  });
+});
+
+describe('serializeMemoryTimelineCsv', () => {
+  it('长表 CSV：表头 + 每 (帧,进程) 一行（t 为 ISO）', () => {
+    const t = Date.UTC(2026, 6, 2, 10, 0, 0);
+    const iso = new Date(t).toISOString();
+    const csv = serializeMemoryTimelineCsv([
+      {
+        t,
+        procs: [
+          { label: 'Browser', pid: 100, rssMb: 300 },
+          { label: 'sing-box', pid: 200, rssMb: 90 },
+        ],
+      },
+    ]);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('t,label,pid,rssMb');
+    expect(lines[1]).toBe(`${iso},Browser,100,300`);
+    expect(lines[2]).toBe(`${iso},sing-box,200,90`);
+  });
+
+  it('空帧 → 仅表头', () => {
+    expect(serializeMemoryTimelineCsv([])).toBe('t,label,pid,rssMb');
+  });
+
+  it('label 含逗号 → 替换为空格防破坏列', () => {
+    const csv = serializeMemoryTimelineCsv([{ t: 0, procs: [{ label: 'a,b', pid: 1, rssMb: 5 }] }]);
+    expect(csv.split('\n')[1]).toContain('a b,1,5');
+  });
+});
+
+describe('mapRendererHeapSample', () => {
+  it('KB→MB / bytes→MB 换算 + 字段存在', () => {
+    const raw: RendererHeapSample = {
+      heap: { usedHeapSize: 2048, totalHeapSize: 4096, heapSizeLimit: 8192 }, // KB
+      processMemory: { residentSet: 1048576 }, // KB → 1024 MB
+      resources: {
+        images: { count: 1, size: 3 * 1024 * 1024, liveSize: 2 * 1024 * 1024 },
+        fonts: { count: 1, size: 1024 * 1024, liveSize: 1024 * 1024 },
+      },
+    };
+    expect(mapRendererHeapSample(raw)).toEqual({
+      usedHeapMb: 2,
+      totalHeapMb: 4,
+      heapLimitMb: 8,
+      residentSetMb: 1024,
+      blinkResourceMb: 3, // (2+1) MB liveSize 汇总
+    });
+  });
+
+  it('空样本 {}（preload 取数全失败）→ unavailable，不渲染空节', () => {
+    const r = mapRendererHeapSample({});
+    expect(r.unavailable).toContain('渲染进程取数为空');
+    expect(r.usedHeapMb).toBeUndefined();
+    expect(r.blinkResourceMb).toBeUndefined();
+  });
+
+  it('部分样本（仅 heap、无 resources）→ 正常映射、blinkResourceMb 缺省、非 unavailable', () => {
+    const r = mapRendererHeapSample({ heap: { usedHeapSize: 2048 } });
+    expect(r.unavailable).toBeUndefined();
+    expect(r.usedHeapMb).toBe(2);
+    expect(r.blinkResourceMb).toBeUndefined();
+  });
+});
+
+describe('collectRendererHeap', () => {
+  it('introspect 缺失 → unavailable', async () => {
+    const r = await collectRendererHeap(undefined);
+    expect(r.unavailable).toContain('无渲染窗口');
+  });
+
+  it('introspect 返回 null（无窗口）→ unavailable', async () => {
+    const r = await collectRendererHeap(async () => null);
+    expect(r.unavailable).toBeDefined();
+  });
+
+  it('introspect 成功 → 映射后的报告（字段存在）', async () => {
+    const r = await collectRendererHeap(async () => ({
+      heap: { usedHeapSize: 2048 },
+    }));
+    expect(r.unavailable).toBeUndefined();
+    expect(r.usedHeapMb).toBe(2);
+  });
+
+  it('introspect 抛异常 → unavailable（不外抛）', async () => {
+    const r = await collectRendererHeap(async () => {
+      throw new Error('boom');
+    });
+    expect(r.unavailable).toContain('boom');
+  });
+
+  it('introspect 超时（never resolve）→ unavailable（超时兜底，绝不挂住）', async () => {
+    const r = await collectRendererHeap(() => new Promise(() => {}), 20);
+    expect(r.unavailable).toContain('超时');
+  });
+});

--- a/src/main/services/__tests__/stats-simulator.test.ts
+++ b/src/main/services/__tests__/stats-simulator.test.ts
@@ -1,0 +1,253 @@
+/**
+ * StatsSimulator 单测（issue #242 §5 泄漏定证 harness）：
+ *  1) parseStatsSimConfig：合法/非法/缺省/部分 → 防御式回退 + warn。
+ *  2) churn 逻辑：池大小恒定、每 tick 换 K 条（最老出、新入）。
+ *  3) 聚合：aggregate.total = 池大小。
+ *  4) 门控：isUiActive=false → onStats/onAggregate 零调用（但快照缓存仍更新）。
+ *  5) 生命周期：构造即启动 ticker；stop/resubscribe 不停 ticker；dispose 停 ticker。
+ * 纯逻辑（aggregateConnections 是纯函数、无 electron 依赖），用 jest fake timers 驱动 ticker。
+ */
+import { StatsSimulator, parseStatsSimConfig, DEFAULT_STATS_SIM_CONFIG } from '../StatsSimulator';
+import type { StatsWorkerHostOptions } from '../StatsWorkerHost';
+
+function makeSim(rawConfig: string, active = true) {
+  const onStats = jest.fn();
+  const onAggregate = jest.fn();
+  const logs: Array<{ level: string; message: string }> = [];
+  const state = { active };
+  const opts: StatsWorkerHostOptions = {
+    workerPath: '/fake/stats-worker.js',
+    onStats,
+    onAggregate,
+    isUiActive: () => state.active,
+    getEndpoint: () => null,
+    log: (level, message) => logs.push({ level, message }),
+  };
+  const sim = new StatsSimulator(opts, rawConfig);
+  return { sim, onStats, onAggregate, logs, state };
+}
+
+describe('parseStatsSimConfig', () => {
+  it('合法 "1000,200,20" → 精确解析，不 warn', () => {
+    const warn = jest.fn();
+    expect(parseStatsSimConfig('1000,200,20', warn)).toEqual({
+      intervalMs: 1000,
+      connCount: 200,
+      churnPerFrame: 20,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('合法非默认 "2000,50,5" → 精确解析', () => {
+    expect(parseStatsSimConfig('2000,50,5')).toEqual({
+      intervalMs: 2000,
+      connCount: 50,
+      churnPerFrame: 5,
+    });
+  });
+
+  it('全非法 "abc" → 全回退缺省 + warn', () => {
+    const warn = jest.fn();
+    expect(parseStatsSimConfig('abc', warn)).toEqual(DEFAULT_STATS_SIM_CONFIG);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('部分非法 "1000,-5,20"（connCount ≤0）→ 仅该字段回退 + warn', () => {
+    const warn = jest.fn();
+    expect(parseStatsSimConfig('1000,-5,20', warn)).toEqual({
+      intervalMs: 1000,
+      connCount: DEFAULT_STATS_SIM_CONFIG.connCount,
+      churnPerFrame: 20,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('connCount');
+  });
+
+  it('字段缺失 "500"（只有 intervalMs）→ 其余回退缺省 + warn', () => {
+    const warn = jest.fn();
+    expect(parseStatsSimConfig('500', warn)).toEqual({
+      intervalMs: 500,
+      connCount: DEFAULT_STATS_SIM_CONFIG.connCount,
+      churnPerFrame: DEFAULT_STATS_SIM_CONFIG.churnPerFrame,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('空串 / undefined → 全缺省 + warn', () => {
+    const warn = jest.fn();
+    expect(parseStatsSimConfig('', warn)).toEqual(DEFAULT_STATS_SIM_CONFIG);
+    expect(parseStatsSimConfig(undefined, warn)).toEqual(DEFAULT_STATS_SIM_CONFIG);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('非整数 "1000.5,200,20"（parseInt 截断为 1000）→ 合法', () => {
+    // Number.parseInt('1000.5') = 1000（>0 合法），刻意接受（不追求严格整数校验，能跑即可）。
+    expect(parseStatsSimConfig('1000.5,200,20').intervalMs).toBe(1000);
+  });
+});
+
+describe('StatsSimulator 生命周期与激活 banner', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('构造即打「模拟器激活」warn banner', () => {
+    const { logs } = makeSim('1000,200,20');
+    const banner = logs.find((l) => l.level === 'warn' && l.message.includes('模拟器激活'));
+    expect(banner).toBeDefined();
+    expect(banner!.message).toContain('仅用于泄漏定证');
+  });
+
+  it('构造即启动 ticker：advance 一个 interval → onAggregate/onStats 各触发', () => {
+    const { onStats, onAggregate } = makeSim('1000,200,20');
+    expect(onStats).not.toHaveBeenCalled(); // 构造时不立即 tick
+    jest.advanceTimersByTime(1000);
+    expect(onAggregate).toHaveBeenCalledTimes(1);
+    expect(onStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop()/resubscribe() 只记日志、不停 ticker', () => {
+    const { sim, onStats, logs } = makeSim('1000,200,20');
+    sim.stop();
+    sim.resubscribe();
+    expect(logs.some((l) => l.message.includes('stop()'))).toBe(true);
+    expect(logs.some((l) => l.message.includes('resubscribe()'))).toBe(true);
+    jest.advanceTimersByTime(1000);
+    expect(onStats).toHaveBeenCalledTimes(1); // ticker 仍在跑
+  });
+
+  it('dispose() 停 ticker：之后 advance 不再触发', () => {
+    const { sim, onStats } = makeSim('1000,200,20');
+    jest.advanceTimersByTime(1000);
+    expect(onStats).toHaveBeenCalledTimes(1);
+    sim.dispose();
+    jest.advanceTimersByTime(5000);
+    expect(onStats).toHaveBeenCalledTimes(1); // dispose 后不再 tick
+  });
+});
+
+describe('StatsSimulator churn 与聚合', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('池大小恒定 = connCount；aggregate.total = 池大小', () => {
+    const { sim } = makeSim('1000,50,10');
+    expect(sim.getConnectionsSnapshot().connections).toHaveLength(50);
+    expect(sim.getAggregateSnapshot().total).toBe(50);
+    jest.advanceTimersByTime(3000); // 3 tick
+    expect(sim.getConnectionsSnapshot().connections).toHaveLength(50);
+    expect(sim.getAggregateSnapshot().total).toBe(50);
+  });
+
+  it('每 tick 换 churnPerFrame 条：最老 K 条出、K 条新入', () => {
+    const { sim } = makeSim('1000,50,10');
+    const before = sim.getConnectionsSnapshot().connections.map((c) => c.id);
+    jest.advanceTimersByTime(1000); // 1 tick
+    const after = sim.getConnectionsSnapshot().connections.map((c) => c.id);
+
+    expect(after).toHaveLength(50);
+    const removed = before.filter((id) => !after.includes(id));
+    const added = after.filter((id) => !before.includes(id));
+    expect(removed).toHaveLength(10);
+    expect(added).toHaveLength(10);
+    // 移除的正是最老的 10 条（数组头部）。
+    expect(removed).toEqual(before.slice(0, 10));
+  });
+
+  it('churnPerFrame 被 clamp 到不超过 connCount', () => {
+    const { sim } = makeSim('1000,5,100'); // churn 100 > connCount 5
+    const before = sim.getConnectionsSnapshot().connections.map((c) => c.id);
+    jest.advanceTimersByTime(1000);
+    const after = sim.getConnectionsSnapshot().connections.map((c) => c.id);
+    expect(after).toHaveLength(5);
+    // clamp 到 5：整池换新，无重叠。
+    expect(after.filter((id) => before.includes(id))).toHaveLength(0);
+  });
+
+  it('快照引用隔离：tick 替换新对象，旧快照条目字节不被改动，新快照差分为正', () => {
+    // 固定 Math.random，使字节推进确定（upload +2048、download +8192），差分严格为正、可断言。
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    try {
+      const { sim } = makeSim('1000,50,10'); // churn 掐掉最老 10 条（索引 0..9），索引 10 起跨 tick 存活
+      const snap1 = sim.getConnectionsSnapshot().connections;
+      const survivor = snap1[10];
+      const beforeUp = survivor.upload;
+      const beforeDown = survivor.download;
+
+      jest.advanceTimersByTime(1000); // 1 tick
+
+      const snap2 = sim.getConnectionsSnapshot().connections;
+      const after = snap2.find((c) => c.id === survivor.id);
+      expect(after).toBeDefined(); // 确系跨 tick 存活条目
+
+      // 引用隔离：snap1 持有的旧对象未被 tick 原地改动（in-place 变异会让此断言失败）。
+      expect(survivor.upload).toBe(beforeUp);
+      expect(survivor.download).toBe(beforeDown);
+      // tick 替换而非原地变异：新旧快照的存活条目不是同一对象引用。
+      expect(after).not.toBe(survivor);
+      // 差分为正：新快照字节严格大于旧快照（消费端两次 pull 才能算出非零速率）。
+      expect(after!.upload! + after!.download!).toBeGreaterThan(beforeUp! + beforeDown!);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it('stats 速率随机游走恒在 [50KB, 500KB]；activeConnections = 池大小', () => {
+    const { sim } = makeSim('1000,200,20');
+    jest.advanceTimersByTime(5000); // 5 tick
+    const s = sim.getSnapshot();
+    expect(s.uploadSpeed).toBeGreaterThanOrEqual(50 * 1024);
+    expect(s.uploadSpeed).toBeLessThanOrEqual(500 * 1024);
+    expect(s.downloadSpeed).toBeGreaterThanOrEqual(50 * 1024);
+    expect(s.downloadSpeed).toBeLessThanOrEqual(500 * 1024);
+    expect(s.activeConnections).toBe(200);
+    expect(s.totalUpload).toBeGreaterThan(0); // totals 累加
+  });
+});
+
+describe('StatsSimulator UI 门控', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('isUiActive=false → onStats/onAggregate 零调用，但快照缓存仍更新', () => {
+    const { sim, onStats, onAggregate } = makeSim('1000,50,10', false);
+    jest.advanceTimersByTime(3000); // 3 tick
+    expect(onStats).not.toHaveBeenCalled();
+    expect(onAggregate).not.toHaveBeenCalled();
+    // 门控只挡广播、不挡缓存：getters 反映最新池/速率。
+    expect(sim.getAggregateSnapshot().total).toBe(50);
+    expect(sim.getSnapshot().activeConnections).toBe(50);
+  });
+
+  it('转活跃后下一 tick 恢复广播', () => {
+    const { onStats, state } = makeSim('1000,50,10', false);
+    jest.advanceTimersByTime(2000);
+    expect(onStats).not.toHaveBeenCalled();
+    state.active = true;
+    jest.advanceTimersByTime(1000);
+    expect(onStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('resume() 活跃时补推缓存最新；不活跃不推', () => {
+    const { sim, onStats, onAggregate, state } = makeSim('1000,50,10', false);
+    jest.advanceTimersByTime(1000);
+    onStats.mockClear();
+    onAggregate.mockClear();
+
+    sim.resume(); // 不活跃 → 不推
+    expect(onStats).not.toHaveBeenCalled();
+
+    state.active = true;
+    sim.resume(); // 活跃 → 补推缓存
+    expect(onStats).toHaveBeenCalledTimes(1);
+    expect(onAggregate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/services/process-sampler.ts
+++ b/src/main/services/process-sampler.ts
@@ -1,0 +1,301 @@
+/**
+ * process-sampler —— sing-box 核进程采样 + 内存时间线 ring + 渲染进程堆内省收集（issue #242 §6 观测随包）。
+ *
+ * 三件事，均为「随包观测」的取数/纯逻辑，与业务行为无关：
+ *  1) sing-box 核进程 RSS/CPU 采样：核不在 Electron 进程树（getAppMetrics 覆盖不到），#242 的 53% CPU 全靠
+ *     reporter 截图偶然带出。Linux 读 /proc/<pid>/status(VmRSS) + /proc/<pid>/stat(utime/stime) 两次差分算 CPU%；
+ *     macOS 用 `ps -o rss=,pcpu=`；Windows 本批不做（见 sampleCoreProcess 的 TODO）。
+ *  2) 内存时间线 ring：每 5min 一帧（Electron 全进程 + 核的 RSS），环形上限 288 帧（24h）——斜率比单点更能区分
+ *     泄漏/高水位。序列化成紧凑 CSV 供诊断导出。
+ *  3) 渲染进程堆内省收集：main 经注入的 introspect 回调向 renderer 取一次堆分层，**带超时兜底**（renderer 卡死
+ *     正是 #242 场景，绝不能挂住诊断导出）。
+ *
+ * IO 经可注入接口，纯解析/算术与超时逻辑均可单测（无需真实进程/electron）。
+ */
+import { readFile } from 'fs/promises';
+import { execFile } from 'child_process';
+import type { RendererHeapSample } from '../../shared/process-metrics';
+import type { RendererHeapReport } from '../../shared/diagnostic-redact';
+
+// ── 可注入 IO（默认真实实现；测试注入 fixture）────────────────────────────────
+export interface ProcessSamplerIo {
+  /** 读文本文件（默认 fs.promises.readFile utf8）。 */
+  readTextFile(path: string): Promise<string>;
+  /** 跑命令取 stdout（默认 child_process.execFile；macOS ps 用）。 */
+  run(cmd: string, args: string[]): Promise<string>;
+  /** 睡眠（CPU 两次采样之间；测试注入 no-op）。 */
+  delay(ms: number): Promise<void>;
+  now(): number;
+  platform: NodeJS.Platform;
+  /** 时钟节拍/秒（Linux USER_HZ，几乎恒为 100；Node 不暴露 sysconf，故硬编码兜底）。 */
+  clockHz: number;
+}
+
+const defaultIo: ProcessSamplerIo = {
+  readTextFile: (p) => readFile(p, 'utf8'),
+  run: (cmd, args) =>
+    new Promise<string>((resolve, reject) => {
+      execFile(cmd, args, { timeout: 3000 }, (err, stdout) => {
+        if (err) reject(err);
+        else resolve(stdout);
+      });
+    }),
+  delay: (ms) => new Promise((r) => setTimeout(r, ms)),
+  now: () => Date.now(),
+  platform: process.platform,
+  clockHz: 100,
+};
+
+function io(override?: Partial<ProcessSamplerIo>): ProcessSamplerIo {
+  return override ? { ...defaultIo, ...override } : defaultIo;
+}
+
+// ── 纯解析 / 算术 ─────────────────────────────────────────────────────────────
+
+/** 从 /proc/<pid>/status 文本解析 VmRSS（KB）。无该行/非法 → null。 */
+export function parseVmRssKb(statusText: string): number | null {
+  const m = statusText.match(/^VmRSS:\s+(\d+)\s*kB/m);
+  if (!m) return null;
+  const kb = Number.parseInt(m[1], 10);
+  return Number.isFinite(kb) ? kb : null;
+}
+
+/**
+ * 从 /proc/<pid>/stat 解析 utime/stime（时钟节拍）。comm(字段2)在括号内且可含空格/括号，故按**最后一个** ')'
+ * 定位——其后空格分隔的第 0 段是 state(字段3)，utime=字段14→索引11、stime=字段15→索引12。
+ */
+export function parseProcStat(statText: string): { utimeTicks: number; stimeTicks: number } | null {
+  const rp = statText.lastIndexOf(')');
+  if (rp < 0) return null;
+  const rest = statText
+    .slice(rp + 1)
+    .trim()
+    .split(/\s+/);
+  // rest[0]=state(字段3) → 字段 N 落在 rest[N-3]
+  const utime = Number.parseInt(rest[11], 10);
+  const stime = Number.parseInt(rest[12], 10);
+  if (!Number.isFinite(utime) || !Number.isFinite(stime)) return null;
+  return { utimeTicks: utime, stimeTicks: stime };
+}
+
+/** 两次采样的 CPU%：Δ(utime+stime) 节拍 ÷ 节拍/秒 ÷ 墙钟秒 ×100。墙钟 ≤0 → 0。四舍五入整数。 */
+export function cpuPercentFromDelta(
+  prevTicks: number,
+  nextTicks: number,
+  wallMs: number,
+  clockHz: number
+): number {
+  if (wallMs <= 0 || clockHz <= 0) return 0;
+  const cpuSeconds = (nextTicks - prevTicks) / clockHz;
+  const wallSeconds = wallMs / 1000;
+  const pct = (cpuSeconds / wallSeconds) * 100;
+  return pct > 0 ? Math.round(pct) : 0;
+}
+
+// ── 核进程采样 ────────────────────────────────────────────────────────────────
+
+export interface CoreProcessSample {
+  pid: number;
+  rssMb: number;
+  cpuPercent: number;
+}
+
+/** 单次 RSS（MB）：内存时间线 ring 用（无需 CPU，单读即可）。进程消失/平台不支持 → null，绝不抛。 */
+export async function sampleProcessRssMb(
+  pid: number,
+  override?: Partial<ProcessSamplerIo>
+): Promise<number | null> {
+  const h = io(override);
+  try {
+    if (h.platform === 'linux') {
+      const kb = parseVmRssKb(await h.readTextFile(`/proc/${pid}/status`));
+      return kb == null ? null : Math.round(kb / 1024);
+    }
+    if (h.platform === 'darwin') {
+      const out = await h.run('ps', ['-o', 'rss=', '-p', String(pid)]);
+      const kb = Number.parseInt(out.trim(), 10);
+      return Number.isFinite(kb) && kb > 0 ? Math.round(kb / 1024) : null;
+    }
+    return null; // Windows 本批不做
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 核进程 RSS + CPU%。Linux：VmRSS(单读) + stat 两次差分算 CPU%；macOS：ps -o rss=,pcpu=（pcpu 已是 %）；
+ * Windows 本批不做（TODO：后续可用 typeperf / Get-Process 或原生 API 采 WorkingSet + CPU）。任何异常
+ * （进程消失 ENOENT / 命令失败）→ null，绝不抛（best-effort 观测，不阻断诊断导出）。
+ */
+export async function sampleCoreProcess(
+  pid: number,
+  override?: Partial<ProcessSamplerIo>
+): Promise<CoreProcessSample | null> {
+  const h = io(override);
+  try {
+    if (h.platform === 'linux') {
+      const rssKb = parseVmRssKb(await h.readTextFile(`/proc/${pid}/status`));
+      if (rssKb == null) return null;
+      const t0 = parseProcStat(await h.readTextFile(`/proc/${pid}/stat`));
+      const w0 = h.now();
+      await h.delay(200);
+      const t1 = parseProcStat(await h.readTextFile(`/proc/${pid}/stat`));
+      const w1 = h.now();
+      let cpuPercent = 0;
+      if (t0 && t1) {
+        cpuPercent = cpuPercentFromDelta(
+          t0.utimeTicks + t0.stimeTicks,
+          t1.utimeTicks + t1.stimeTicks,
+          w1 - w0,
+          h.clockHz
+        );
+      }
+      return { pid, rssMb: Math.round(rssKb / 1024), cpuPercent };
+    }
+    if (h.platform === 'darwin') {
+      const out = await h.run('ps', ['-o', 'rss=,pcpu=', '-p', String(pid)]);
+      const parts = out.trim().split(/\s+/);
+      const rssKb = Number.parseInt(parts[0], 10);
+      const pcpu = Number.parseFloat(parts[1]);
+      if (!Number.isFinite(rssKb) || rssKb <= 0) return null;
+      return {
+        pid,
+        rssMb: Math.round(rssKb / 1024),
+        cpuPercent: Number.isFinite(pcpu) ? Math.round(pcpu) : 0,
+      };
+    }
+    return null; // Windows 本批不做（TODO）
+  } catch {
+    return null;
+  }
+}
+
+// ── 内存时间线 ring ───────────────────────────────────────────────────────────
+
+export interface MemoryTimelineProc {
+  label: string;
+  pid: number;
+  rssMb: number;
+}
+
+export interface MemoryTimelineFrame {
+  t: number; // epoch ms
+  procs: MemoryTimelineProc[];
+}
+
+/**
+ * 环形缓冲：满后覆盖最老。默认上限 288 帧（每 5min 一帧 = 24h）。存小对象，内存占用 O(帧×进程)，
+ * 稳态 ~7 进程 × 288 帧的量级（几十 KB），相对 #242 的 2GB 可忽略。
+ */
+export class MemoryTimelineRing {
+  private readonly cap: number;
+  private readonly buf: MemoryTimelineFrame[] = [];
+  private start = 0; // 最老帧索引（满后环绕）
+
+  constructor(capacity = 288) {
+    this.cap = Math.max(1, Math.floor(capacity));
+  }
+
+  push(frame: MemoryTimelineFrame): void {
+    if (this.buf.length < this.cap) {
+      this.buf.push(frame);
+    } else {
+      this.buf[this.start] = frame;
+      this.start = (this.start + 1) % this.cap;
+    }
+  }
+
+  /** 按时间先后返回全部帧（最老→最新）。 */
+  frames(): MemoryTimelineFrame[] {
+    if (this.buf.length < this.cap) return this.buf.slice();
+    return [...this.buf.slice(this.start), ...this.buf.slice(0, this.start)];
+  }
+
+  get size(): number {
+    return this.buf.length;
+  }
+}
+
+/** 内存时间线 → 紧凑 CSV（长表：一行一 (帧, 进程)）。诊断导出以 csv 代码块承载，便于外部画斜率。 */
+export function serializeMemoryTimelineCsv(frames: readonly MemoryTimelineFrame[]): string {
+  const rows: string[] = ['t,label,pid,rssMb'];
+  for (const f of frames) {
+    const iso = new Date(f.t).toISOString();
+    for (const p of f.procs) {
+      // label 去逗号防破坏 CSV 列（进程名理论上不含逗号，防御性替换）。
+      const label = p.label.replace(/,/g, ' ');
+      rows.push(`${iso},${label},${p.pid},${p.rssMb}`);
+    }
+  }
+  return rows.join('\n');
+}
+
+// ── 渲染进程堆内省收集 ────────────────────────────────────────────────────────
+
+/** 渲染端原始内省样本（KB/bytes，Electron 口径）→ 报告用 RendererHeapReport（MB）。纯映射，可单测。 */
+export function mapRendererHeapSample(raw: RendererHeapSample): RendererHeapReport {
+  const kbToMb = (kb?: number): number | undefined =>
+    typeof kb === 'number' ? Math.round(kb / 1024) : undefined;
+  const out: RendererHeapReport = {
+    usedHeapMb: kbToMb(raw.heap?.usedHeapSize),
+    totalHeapMb: kbToMb(raw.heap?.totalHeapSize),
+    heapLimitMb: kbToMb(raw.heap?.heapSizeLimit),
+    residentSetMb: kbToMb(raw.processMemory?.residentSet),
+  };
+  const res = raw.resources;
+  if (res) {
+    let liveBytes = 0;
+    let any = false;
+    for (const v of Object.values(res)) {
+      if (v && typeof v.liveSize === 'number') {
+        liveBytes += v.liveSize;
+        any = true;
+      }
+    }
+    if (any) out.blinkResourceMb = Math.round(liveBytes / 1024 / 1024);
+  }
+  // 全字段为空（preload 两个 try/catch 全失败 → 传入 {}）：置 unavailable，否则诊断报告会渲染出只有
+  // 「渲染进程堆分层」标题、无任何内容的空节。
+  if (
+    out.usedHeapMb === undefined &&
+    out.totalHeapMb === undefined &&
+    out.heapLimitMb === undefined &&
+    out.residentSetMb === undefined &&
+    out.blinkResourceMb === undefined
+  ) {
+    return { unavailable: 'unavailable（渲染进程取数为空）' };
+  }
+  return out;
+}
+
+/**
+ * 向 renderer 取一次堆分层，**带超时兜底**：introspect 未在 timeoutMs 内返回（renderer 卡死 = #242 场景）→
+ * 返回 unavailable，绝不挂住诊断导出。introspect 缺失/返回 null（无窗口）/抛异常 → 同样 unavailable。
+ */
+export async function collectRendererHeap(
+  introspect: (() => Promise<RendererHeapSample | null>) | undefined,
+  timeoutMs = 2000
+): Promise<RendererHeapReport> {
+  if (!introspect) return { unavailable: 'unavailable（无渲染窗口）' };
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<RendererHeapReport>((resolve) => {
+    timer = setTimeout(
+      () => resolve({ unavailable: `unavailable（渲染进程内省超时 >${timeoutMs}ms，疑窗口卡死）` }),
+      timeoutMs
+    );
+  });
+  const attempt = (async (): Promise<RendererHeapReport> => {
+    try {
+      const raw = await introspect();
+      if (!raw) return { unavailable: 'unavailable（窗口不存在或取数为空）' };
+      return mapRendererHeapSample(raw);
+    } catch (e) {
+      return { unavailable: `unavailable（内省失败: ${(e as Error)?.message ?? e}）` };
+    }
+  })();
+  try {
+    return await Promise.race([attempt, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -217,9 +217,9 @@ describe('buildDiagnosticReport', () => {
       },
     });
     expect(md).toContain('## 进程内存');
-    expect(md).toContain('| 类型 | PID | 内存(MB) | CPU(%) | 标识 |');
-    expect(md).toContain('| Utility | 374035 | 2048 | 1 | flowz-stats |');
-    expect(md).toContain('| Browser | 373944 | 300 | 0 |  |');
+    expect(md).toContain('| 类型 | PID | 内存(MB) | 峰值(MB) | CPU(%) | 标识 | 创建时刻 |');
+    expect(md).toContain('| Utility | 374035 | 2048 |  | 1 | flowz-stats |  |');
+    expect(md).toContain('| Browser | 373944 | 300 |  | 0 |  |  |');
     expect(md).toContain('2348 MB');
   });
 
@@ -239,7 +239,7 @@ describe('buildDiagnosticReport', () => {
       },
     });
     // 表在 redact 之后拼接 → 表内 PID/内存的 2048 原样保留，定位价值不被毁
-    expect(md).toContain('| Utility | 2048 | 2048 | 1 | flowz-stats |');
+    expect(md).toContain('| Utility | 2048 | 2048 |  | 1 | flowz-stats |');
     // 但表以外（日志）的同名节点仍被正常打码，脱敏不受影响
     expect(md).toContain('node <node-1> connected');
   });
@@ -260,6 +260,107 @@ describe('buildDiagnosticReport', () => {
       redactedUserConfig: { name: 'a```b' },
     });
     expect(md).toContain('````json');
+  });
+});
+
+describe('buildDiagnosticReport × issue #242 §6 观测随包新字段', () => {
+  const base: DiagnosticReportInput = {
+    generatedAt: '2026-07-02T00:00:00.000Z',
+    app: { flowzVersion: '4.1.9', coreVersion: '1.13.0', os: 'linux x64 6.0', electron: '42.0.0' },
+    runtime: {
+      proxyMode: 'smart',
+      proxyModeType: 'tun',
+      proxyRunning: true,
+      logLevel: 'info',
+      captureActive: false,
+    },
+    redactedUserConfig: {},
+    redactedSingboxConfig: {},
+    appLogTail: '',
+    singboxLogTail: '',
+  };
+
+  it('进程内存表含峰值(MB)/创建时刻列（源字段存在时填充）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      processMetrics: {
+        totalMemoryMb: 2048,
+        rows: [
+          {
+            type: 'Utility',
+            pid: 100,
+            memoryMb: 2048,
+            cpuPercent: 5,
+            label: 'flowz-stats',
+            peakMemoryMb: 2200,
+            creationTime: Date.UTC(2026, 6, 2, 8, 0, 0),
+          },
+        ],
+      },
+    });
+    expect(md).toContain('| 类型 | PID | 内存(MB) | 峰值(MB) | CPU(%) | 标识 | 创建时刻 |');
+    expect(md).toContain(
+      `| Utility | 100 | 2048 | 2200 | 5 | flowz-stats | ${new Date(Date.UTC(2026, 6, 2, 8, 0, 0)).toISOString()} |`
+    );
+  });
+
+  it('渲染进程堆分层：可用时逐字段渲染', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      rendererHeap: {
+        usedHeapMb: 120,
+        totalHeapMb: 180,
+        heapLimitMb: 4096,
+        residentSetMb: 2200,
+        blinkResourceMb: 64,
+      },
+    });
+    expect(md).toContain('## 渲染进程堆分层');
+    expect(md).toContain('- V8 usedHeap：120 MB');
+    expect(md).toContain('- 进程 residentSet：2200 MB');
+    expect(md).toContain('- Blink 资源缓存(live)：64 MB');
+  });
+
+  it('渲染进程堆分层：unavailable 时只渲染原因行', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      rendererHeap: { unavailable: 'unavailable（渲染进程内省超时 >2000ms，疑窗口卡死）' },
+    });
+    expect(md).toContain('## 渲染进程堆分层');
+    expect(md).toContain('内省超时');
+    expect(md).not.toContain('V8 usedHeap');
+  });
+
+  it('sing-box 核进程：可用渲染 PID/RSS/CPU；unavailable 渲染原因', () => {
+    const ok = buildDiagnosticReport({
+      ...base,
+      coreProcess: { pid: 374000, rssMb: 180, cpuPercent: 53 },
+    });
+    expect(ok).toContain('## sing-box 核进程');
+    expect(ok).toContain('PID 374000：RSS 180 MB，CPU 53%');
+
+    const na = buildDiagnosticReport({
+      ...base,
+      coreProcess: { unavailable: 'unavailable（代理未运行）' },
+    });
+    expect(na).toContain('unavailable（代理未运行）');
+  });
+
+  it('内存时间线：CSV 以代码块承载', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      memoryTimelineCsv: 't,label,pid,rssMb\n2026-07-02T00:00:00.000Z,Browser,100,300',
+    });
+    expect(md).toContain('## 内存时间线');
+    expect(md).toContain('```csv');
+    expect(md).toContain('2026-07-02T00:00:00.000Z,Browser,100,300');
+  });
+
+  it('全部新字段缺省 → 不渲染任何观测新区块（向后兼容）', () => {
+    const md = buildDiagnosticReport(base);
+    expect(md).not.toContain('## 渲染进程堆分层');
+    expect(md).not.toContain('## sing-box 核进程');
+    expect(md).not.toContain('## 内存时间线');
   });
 });
 

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -252,6 +252,27 @@ export function redactIdentifiers(text: string, ids: readonly NodeIdentifier[]):
   return out;
 }
 
+/**
+ * 渲染进程堆分层（issue #242 §6.2）：main 经 executeJavaScript 向 renderer 取一次，映射到 MB。取不到/超时/无窗口
+ * → unavailable 置原因串，其余字段缺省。全 optional 使构建器逐字段渲染。
+ */
+export interface RendererHeapReport {
+  unavailable?: string; // 存在即视为不可用（超时/无窗口/失败），其余字段无意义
+  usedHeapMb?: number;
+  totalHeapMb?: number;
+  heapLimitMb?: number;
+  residentSetMb?: number;
+  blinkResourceMb?: number; // webFrame 资源缓存 liveSize 汇总
+}
+
+/** sing-box 核进程采样（issue #242 §6.3）：核不在 Electron 进程树，单独采 RSS/CPU。取不到 → unavailable。 */
+export interface CoreProcessReport {
+  unavailable?: string;
+  pid?: number;
+  rssMb?: number;
+  cpuPercent?: number;
+}
+
 /** 诊断报告输入（全部已脱敏 / 已 tail；构建器只拼装，不做任何 IO 或脱敏）。 */
 export interface DiagnosticReportInput {
   generatedAt: string; // ISO
@@ -281,6 +302,12 @@ export interface DiagnosticReportInput {
   redactedSingboxConfig: unknown;
   /** 逐进程内存/CPU 快照（issue #242）：一眼看出是哪个子进程内存偏高；type/pid/内存/CPU 非敏感，无需脱敏。 */
   processMetrics?: ProcessMetricsSummary;
+  /** 渲染进程堆分层（issue #242 §6.2）：V8 堆 + 进程 RSS + Blink 资源缓存；取不到为 unavailable。 */
+  rendererHeap?: RendererHeapReport;
+  /** sing-box 核进程 RSS/CPU（issue #242 §6.3）：核不在 Electron 进程树，单独采样。 */
+  coreProcess?: CoreProcessReport;
+  /** 内存时间线（issue #242 §6.4）：每 5min 一帧（Electron 全进程 + 核 RSS）的紧凑 CSV，斜率判泄漏/高水位。 */
+  memoryTimelineCsv?: string;
   appLogTail: string;
   singboxLogTail: string;
   /** 节点标识符 → 占位符（P0.6）：构建末尾在全报告统一替换，打码节点身份（域名/IP/SNI/节点名），保留形态与跨段相关性。 */
@@ -383,18 +410,55 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
   // P0.6：末尾在全报告（配置块 + 日志 + 运行态）统一打码节点标识符，跨段占位一致便于关联诊断。
   const redacted = redactIdentifiers(lines.join('\n'), input.nodeIdentifiers ?? []);
 
-  // 进程内存表（issue #242）刻意放在 redactIdentifiers **之后**拼接：表内只有进程 type/pid/内存/CPU/自身进程名，
-  // 无节点标识符、无需脱敏；若纳入打码 pass，机场把节点命名成纯数字（如 "2048"）会撞上表里的内存/PID 数字被误
-  // 替成占位符，反而毁掉本表的定位价值。故与打码隔离，单独在末尾渲染。
-  if (!input.processMetrics) return redacted;
-  const pm = input.processMetrics;
-  const metricsLines = ['', '## 进程内存', ''];
-  metricsLines.push(`- 合计：${pm.totalMemoryMb} MB（${pm.rows.length} 个进程，按内存降序）`, '');
-  metricsLines.push('| 类型 | PID | 内存(MB) | CPU(%) | 标识 |', '|---|---|---|---|---|');
-  for (const r of pm.rows) {
-    metricsLines.push(
-      `| ${r.type} | ${r.pid} | ${r.memoryMb} | ${r.cpuPercent} | ${r.label ?? ''} |`
+  // 技术观测段（进程内存表 + 渲染堆分层 + 核进程 + 内存时间线 CSV，issue #242）刻意放在 redactIdentifiers
+  // **之后**拼接：段内只有进程 type/pid/内存/CPU/进程名/时刻等数字，无节点标识符、无需脱敏；若纳入打码 pass，
+  // 机场把节点命名成纯数字（如 "2048"）会撞上其中的内存/PID 数字被误替成占位符，反而毁掉定位价值。故与打码隔离。
+  const tail: string[] = [];
+
+  if (input.processMetrics) {
+    const pm = input.processMetrics;
+    tail.push('', '## 进程内存', '');
+    tail.push(`- 合计：${pm.totalMemoryMb} MB（${pm.rows.length} 个进程，按内存降序）`, '');
+    tail.push(
+      '| 类型 | PID | 内存(MB) | 峰值(MB) | CPU(%) | 标识 | 创建时刻 |',
+      '|---|---|---|---|---|---|---|'
     );
+    for (const r of pm.rows) {
+      const created =
+        typeof r.creationTime === 'number' ? new Date(r.creationTime).toISOString() : '';
+      tail.push(
+        `| ${r.type} | ${r.pid} | ${r.memoryMb} | ${r.peakMemoryMb ?? ''} | ${r.cpuPercent} | ${r.label ?? ''} | ${created} |`
+      );
+    }
   }
-  return redacted + '\n' + metricsLines.join('\n') + '\n';
+
+  if (input.rendererHeap) {
+    const rh = input.rendererHeap;
+    tail.push('', '## 渲染进程堆分层', '');
+    if (rh.unavailable) {
+      tail.push(`- ${rh.unavailable}`);
+    } else {
+      if (rh.usedHeapMb !== undefined) tail.push(`- V8 usedHeap：${rh.usedHeapMb} MB`);
+      if (rh.totalHeapMb !== undefined) tail.push(`- V8 totalHeap：${rh.totalHeapMb} MB`);
+      if (rh.heapLimitMb !== undefined) tail.push(`- V8 heapLimit：${rh.heapLimitMb} MB`);
+      if (rh.residentSetMb !== undefined) tail.push(`- 进程 residentSet：${rh.residentSetMb} MB`);
+      if (rh.blinkResourceMb !== undefined)
+        tail.push(`- Blink 资源缓存(live)：${rh.blinkResourceMb} MB`);
+    }
+  }
+
+  if (input.coreProcess) {
+    const cp = input.coreProcess;
+    tail.push('', '## sing-box 核进程', '');
+    if (cp.unavailable) tail.push(`- ${cp.unavailable}`);
+    else tail.push(`- PID ${cp.pid ?? ''}：RSS ${cp.rssMb ?? ''} MB，CPU ${cp.cpuPercent ?? ''}%`);
+  }
+
+  if (input.memoryTimelineCsv) {
+    tail.push('', '## 内存时间线（每 5min 一帧，最多 24h）', '');
+    tail.push(fence('csv', input.memoryTimelineCsv));
+  }
+
+  if (tail.length === 0) return redacted;
+  return redacted + '\n' + tail.join('\n') + '\n';
 }

--- a/src/shared/process-metrics.ts
+++ b/src/shared/process-metrics.ts
@@ -15,8 +15,9 @@
 export interface ProcessMetricLike {
   pid: number;
   type: string; // 'Browser'（主）/ 'Renderer'|'Tab' / 'GPU' / 'Utility' / ...
-  memory: { workingSetSize: number }; // KB
+  memory: { workingSetSize: number; peakWorkingSetSize?: number }; // KB（peak=进程生命周期内工作集峰值）
   cpu?: { percentCPUUsage?: number };
+  creationTime?: number; // 进程创建时刻（epoch ms，getAppMetrics 提供）——排查「谁重启过/新拉起」
   // 注意 name/serviceName 的实际填法与直觉相反（本机 xvfb 探针实测坐实，见 process-metrics.test.ts）：
   // Electron utilityProcess.fork(path, args, {serviceName:'flowz-stats'}) 传入的自定义名最终落在 `.name`，
   // 而 `.serviceName` 恒是 Chromium 的通用接口名（如 'node.mojom.NodeService'，等价于该进程命令行里的
@@ -33,6 +34,26 @@ export interface ProcessMetricRow {
   memoryMb: number; // 四舍五入 MB
   cpuPercent: number; // 四舍五入整数百分比
   label?: string; // name 优先、serviceName 兜底（utility 辨识用，见 ProcessMetricLike 注释），无则省略
+  peakMemoryMb?: number; // 工作集峰值 MB（源含 peakWorkingSetSize 才有）：与当前值差大=曾高水位后回收
+  creationTime?: number; // 进程创建时刻 epoch ms（源含才有）
+}
+
+/**
+ * 渲染进程堆内省的**原始**样本（preload 经 contextBridge 暴露、main executeJavaScript 取回；issue #242 §6.2）。
+ * 字段单位随 Electron 口径：heap/processMemory 为 **KB**（getHeapStatistics / getProcessMemoryInfo），
+ * resources 为 **bytes**（webFrame.getResourceUsage 的 liveSize）。全 optional：sandbox/平台差异下取不到即缺省，
+ * 映射侧（process-sampler.mapRendererHeapSample）按缺失处理。刻意不 import electron，主/渲染/单测共用。
+ */
+export interface RendererHeapSample {
+  heap?: {
+    usedHeapSize?: number;
+    totalHeapSize?: number;
+    heapSizeLimit?: number;
+    mallocedMemory?: number;
+    peakMallocedMemory?: number;
+  };
+  processMemory?: { residentSet?: number; private?: number; shared?: number };
+  resources?: Record<string, { count?: number; size?: number; liveSize?: number } | undefined>;
 }
 
 export interface ProcessMetricsSummary {
@@ -46,7 +67,17 @@ function toRow(m: ProcessMetricLike): ProcessMetricRow {
   const memoryMb = Math.round((m.memory?.workingSetSize ?? 0) / KB_PER_MB);
   const cpuPercent = Math.round(m.cpu?.percentCPUUsage ?? 0);
   const label = m.name || m.serviceName || undefined;
-  return { type: m.type, pid: m.pid, memoryMb, cpuPercent, ...(label ? { label } : {}) };
+  const peak = m.memory?.peakWorkingSetSize;
+  const peakMemoryMb = typeof peak === 'number' ? Math.round(peak / KB_PER_MB) : undefined;
+  return {
+    type: m.type,
+    pid: m.pid,
+    memoryMb,
+    cpuPercent,
+    ...(label ? { label } : {}),
+    ...(peakMemoryMb !== undefined ? { peakMemoryMb } : {}),
+    ...(typeof m.creationTime === 'number' ? { creationTime: m.creationTime } : {}),
+  };
 }
 
 /** 汇总逐进程内存/CPU，按内存降序。诊断导出表与自检共用。 */


### PR DESCRIPTION
## 背景

issue #242 报告 Linux 下 FlowZ 某进程 RSS 涨到 2.2GB。逆向截图 + spawn 顺序定位到该进程是 **renderer**（非 stats worker），增长 ~100KB/s 级、低 CPU；同时截图带出 **sing-box 核 53% CPU@25 连接**（核不在 Electron 进程树，此前无采样）。renderer 应用层全量扫描零滞留，机制在应用代码之下（context-bridge / V8 / Blink / Electron 层），本机不一定能稳定复现。

本 PR 是根治重构（StateSync 数据面）的**批次 1**：先补齐**复现工具**与**随包观测**，**零业务行为变更**。让下一份诊断报告自带定位数据，并为后续泄漏定证提供确定复现器。

## 改动

**StatsSimulator（合成 churn 注入器，dev-only）**
- `FLOWZ_STATS_SIM=intervalMs,connCount,churnPerFrame` 环境变量激活时，取代真实 stats worker
- 维护假连接池，用**真实的** `aggregateConnections` 聚合，经**与 StatsWorkerHost 相同的 isUiActive 门控**灌 aggregate/stats 给渲染端——绕内核/流量/TUN，把 reporter 数天暴露压缩到小时级，供 heap snapshot 定位滞留层
- 防御式参数解析（非法字段回退缺省 + warn）；激活时打 warn banner

**诊断导出增强（随包观测）**
- 逐进程明细补全：`name`（utilityProcess serviceName）、CPU、工作集峰值、创建时刻
- **renderer 堆分层**：preload 经 contextBridge 暴露内省（`getHeapStatistics` + `getProcessMemoryInfo` + `webFrame.getResourceUsage`），main 经 `executeJavaScript` 取一次，**2s 超时兜底**（renderer 卡死正是 #242 场景，超时/无窗口/异常一律 unavailable，绝不挂住导出）
- **sing-box 核进程采样**：核不在 Electron 进程树，Linux 读 `/proc/<pid>/status`(VmRSS) + `/proc/<pid>/stat`(utime/stime 差分算 CPU%)，macOS 用 `ps`
- **内存时间线 ring**：每 5min 一帧（Electron 全进程 + 核 RSS），环形 288 帧（24h），诊断以紧凑 CSV 承载——斜率比单点更能区分泄漏/高水位

`process-sampler.ts` 的 IO 全经可注入接口，解析/算术/超时逻辑均纯逻辑可单测。

## 测试

- 单测随批：`stats-simulator.test.ts`（env 解析 / churn / 聚合 / 门控 / 生命周期 / 快照引用隔离）、`process-sampler.test.ts`（/proc·stat 解析 / CPU 差分 / 平台分支 / 进程消失 / ring 环绕 / CSV / 堆映射 / 内省超时）、`diagnostic-redact` 新字段渲染
- gate：tsc(main+renderer) 0 error、eslint 0 error、全量 jest **2403 passed / 0 failed**
- **本机冒烟**（xvfb + CDP，独立 userData/端口，不碰宿主网络）：
  - `FLOWZ_STATS_SIM` 实测推送链 `simulator→main→renderer` 端到端 —— renderer 收到 `aggregate.total=200`（=connCount）、`stats.activeConnections=200`
  - contextBridge 内省实测取回**实时** V8 堆 + renderer RSS + 6 类 webFrame 资源
  - process-sampler 打**真实 /proc**（本机内核）：VmRSS 解析、CPU 差分、进程消失兜底均正确
  - 三诊断新段以真实值渲染 + unavailable/超时分支正确

## 说明

- **零业务行为变更**：无 `FLOWZ_STATS_SIM` 时行为与合入前完全一致；观测仅在诊断导出时采集
- 批次 2（StateSync 数据面：订阅驱动取代 event-relay，根治放大器）将另行提交；本 PR 独立可出货
- Windows 核进程采样本批未做（代码 TODO 注明）

Refs #242
