### PR TITLE
feat(stats): 订阅驱动数据面收口——StateSync 取代 GET/event 双路径（#242 批次3）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,7 @@ import {
   registerIpInfoHandlers,
   registerSystemHandlers,
   registerRuleResourceHandlers,
+  registerStatsSubscriptionHandlers,
 } from './ipc/handlers';
 import { setIpcLogger, registerIpcHandler } from './ipc/ipc-handler';
 import { createAutoStartManager } from './services/AutoStartManager';
@@ -55,6 +56,7 @@ import {
   type StatsHost,
 } from './services/StatsWorkerHost';
 import { StatsSimulator } from './services/StatsSimulator';
+import { StatsSubscriptionRegistry } from './services/StatsSubscriptionRegistry';
 import { PlatformPrivilegeService } from './services/PlatformPrivilegeService';
 import { IpInfoService } from './services/IpInfoService';
 import { RuleResourceManager } from './services/RuleResourceManager';
@@ -72,7 +74,7 @@ import { scheduleStartupTasks } from './startup-tasks';
 import { registerConfigChangeListener } from './config-change-handler';
 import { mainEventEmitter, MAIN_EVENTS } from './ipc/main-events';
 import { initUserDataPath } from './utils/paths';
-import { IPC_CHANNELS } from '../shared/ipc-channels';
+import { IPC_CHANNELS, type StatsTopic } from '../shared/ipc-channels';
 import { LOGIN_ITEMS_SETTINGS_URL } from '../shared/constants';
 import { effectiveLogLevel } from '../shared/log-level';
 import { resolveAutoLanguage, resolveEffectiveLanguage } from '../shared/language';
@@ -1334,12 +1336,47 @@ if (gotTheLock) {
     // 本宿主 fork/看护 worker、缓存最新快照、按 isUiBroadcastActive(可见 && !拖动) 门控后 sendToAll——把 Status/
     // Connections 长流的 per-frame 解析+物化移出主线程，消除拖动期事件循环争用。worker 据 getStatsApiEndpoint 重建
     // 自己的 gRPC client（端口随每次启动可能变 → 'api-client-ready' 时经 resubscribe 重发）。
+    // batch3 §3.7：订阅驱动数据面。registry 持 topic→订阅 wc 集，订阅即回初始帧（合并原 CONNECTIONS_AGGREGATE_GET/
+    // CONNECTIONS_GET 初值 pull）、只 relay 给对应 topic 订阅者、订阅变化即驱动 host demand。demand 源从「窗口可见」
+    // (isUiActive) 换成「渲染端按 topic 订阅」——非首页可见视图（设置页）下拓扑/明细流亦停（无订阅者逐级停机）；
+    // isUiActive 降为 relay 侧兜底安全门（订阅在但窗口不可见——如 Windows 拖动期——仍不发）。
+    const statsSubscriptionRegistry = new StatsSubscriptionRegistry({
+      // 订阅即回初始帧：取 host 缓存快照（核未起/未连时为零态，UI 自然落空态）。
+      getInitialFrame: (topic: StatsTopic) => {
+        if (topic === 'stats')
+          return (
+            statsService?.getSnapshot() ?? {
+              uploadSpeed: 0,
+              downloadSpeed: 0,
+              totalUpload: 0,
+              totalDownload: 0,
+              activeConnections: 0,
+            }
+          );
+        if (topic === 'aggregate')
+          return (
+            statsService?.getAggregateSnapshot() ?? {
+              total: 0,
+              hosts: [],
+              outbounds: [],
+              at: Date.now(),
+            }
+          );
+        return statsService?.getConnectionsSnapshot() ?? { connections: [], at: Date.now() };
+      },
+      // 订阅/退订即时重算 worker demand（连接页一打开 detail 即开流、一关即停，不等下个 status 帧的惰性同步）。
+      onDemandChange: () => statsService?.syncDemand(),
+    });
     const statsHostOptions: StatsWorkerHostOptions = {
       workerPath: path.join(__dirname, 'workers', 'stats-worker.js'),
-      onStats: (stats) => ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_STATS_UPDATED, stats),
-      onAggregate: (agg) =>
-        ipcEventEmitter.sendToAll(IPC_CHANNELS.EVENT_CONNECTIONS_AGGREGATE, agg),
+      // relay：只发给对应 topic 的订阅者（registry.broadcast）；host 侧已按 isUiActive 门控后才调这些。
+      onStats: (stats) => statsSubscriptionRegistry.broadcast('stats', stats),
+      onAggregate: (agg) => statsSubscriptionRegistry.broadcast('aggregate', agg),
+      onDetail: (conns) => statsSubscriptionRegistry.broadcast('detail', conns),
+      // relay 安全门（兜底，非 demand 源）：窗口不可见 / Windows 拖动中 → host 只缓存不 relay。
       isUiActive: isUiBroadcastActive,
+      // demand 源（取代 isUiActive）：某 topic 是否有渲染端订阅者。
+      hasSubscribers: (topic) => statsSubscriptionRegistry.hasSubscribers(topic),
       getEndpoint: () => proxyManager?.getStatsApiEndpoint() ?? null,
       log: (level, message) => logManager.addLog(level, message, 'StatsWorker'),
     };
@@ -1551,6 +1588,8 @@ if (gotTheLock) {
     registerServerHandlers(protocolParser, configManager, logManager);
     registerLogHandlers(logManager, proxyManager, isUiBroadcastActive);
     registerProxyHandlers(proxyManager, statsService);
+    // batch3 §3.7：STATS_SUBSCRIBE/STATS_UNSUBSCRIBE（渲染端 useStatsTopic 声明/撤销 topic 订阅）。
+    registerStatsSubscriptionHandlers(statsSubscriptionRegistry);
     registerIpInfoHandlers(ipInfoService);
     registerSystemHandlers();
     registerRuleResourceHandlers(ruleResourceManager);

--- a/src/main/ipc/handlers/index.ts
+++ b/src/main/ipc/handlers/index.ts
@@ -20,3 +20,4 @@ export * from './helper-handlers';
 export * from './ipinfo-handlers';
 export * from './system-handlers';
 export * from './rule-resource-handlers';
+export * from './stats-subscription-handlers';

--- a/src/main/ipc/handlers/proxy-handlers.ts
+++ b/src/main/ipc/handlers/proxy-handlers.ts
@@ -5,14 +5,7 @@
 
 import { IpcMainInvokeEvent } from 'electron';
 import { IPC_CHANNELS } from '../../../shared/ipc-channels';
-import type {
-  UserConfig,
-  ServerConfig,
-  ProxyStatus,
-  TrafficStats,
-  ConnectionsSnapshot,
-  ConnectionsAggregate,
-} from '../../../shared/types';
+import type { UserConfig, ServerConfig, ProxyStatus, TrafficStats } from '../../../shared/types';
 import { registerIpcHandler } from '../ipc-handler';
 import { ProxyManager } from '../../services/ProxyManager';
 import { tailscaleStateExists } from '../../services/tailscale-state';
@@ -43,7 +36,9 @@ export function registerProxyHandlers(
 ): void {
   // 注：系统代理 enable/clear 已收口于 ProxyManager（start reconcile + ensureSystemProxyCleared），
   // 本 handler 不再直接持有 systemProxyManager（拆双轨，修 C1/M4）。
-  // 流量统计快照（窗口重建/挂载时回填初值）
+  // 流量统计快照（一次性读；app-store.refreshStatistics 等非订阅型消费者，batch3 保留 STATS_GET）。连接明细
+  // （CONNECTIONS_GET）与拓扑聚合（CONNECTIONS_AGGREGATE_GET）已改订阅驱动（STATS_SUBSCRIBE + 订阅即回初始帧），
+  // 两 handler 随 batch3 删除。
   registerIpcHandler<void, TrafficStats>(IPC_CHANNELS.STATS_GET, async () =>
     statsService
       ? statsService.getSnapshot()
@@ -57,20 +52,6 @@ export function registerProxyHandlers(
     { ok: boolean; indeterminate?: boolean; error?: string }
   >(IPC_CHANNELS.KERNEL_PROBE_OUTBOUND, async (_event, args) =>
     proxyManager.probeOutbound(args?.outbound, args?.isEndpoint)
-  );
-
-  // 连接明细 pull（连接信息页打开时按 interval 拉；窗口重建/挂载回填）。非每秒全量 push（issue #227）。
-  registerIpcHandler<void, ConnectionsSnapshot>(IPC_CHANNELS.CONNECTIONS_GET, async () =>
-    statsService ? statsService.getConnectionsSnapshot() : { connections: [], at: Date.now() }
-  );
-
-  // 首页拓扑聚合回填（挂载初值；后续增量走 EVENT_CONNECTIONS_AGGREGATE 广播）。载荷 ~Top-N host + 出口数。
-  registerIpcHandler<void, ConnectionsAggregate>(
-    IPC_CHANNELS.CONNECTIONS_AGGREGATE_GET,
-    async () =>
-      statsService
-        ? statsService.getAggregateSnapshot()
-        : { total: 0, hosts: [], outbounds: [], at: Date.now() }
   );
 
   // 关单条连接：经 ProxyManager（9090 keep-alive agent + Bearer secret 内部封装）发 DELETE /connections/{id}，

--- a/src/main/ipc/handlers/stats-subscription-handlers.ts
+++ b/src/main/ipc/handlers/stats-subscription-handlers.ts
@@ -1,0 +1,35 @@
+/**
+ * stats 订阅 IPC 处理器（batch3 §3.7 订阅驱动数据面）。
+ *
+ * renderer 的 useStatsTopic 经 STATS_SUBSCRIBE / STATS_UNSUBSCRIBE 声明/撤销对某 topic（stats|aggregate|detail）的
+ * 订阅；主进程据订阅集派生 worker demand（无订阅者逐级停机）+ 只 relay 给对应订阅者。订阅 wc 取 event.sender（其
+ * destroyed 由 registry 兜底自动清，防 renderer 崩溃/重载泄漏）。订阅即回初始帧亦在 registry.subscribe 内完成。
+ */
+import type { IpcMainInvokeEvent } from 'electron';
+import { IPC_CHANNELS, type StatsTopic } from '../../../shared/ipc-channels';
+import { registerIpcHandler } from '../ipc-handler';
+import type { StatsSubscriptionRegistry } from '../../services/StatsSubscriptionRegistry';
+
+const VALID_TOPICS: readonly StatsTopic[] = ['stats', 'aggregate', 'detail'];
+
+/** IPC 边界防御：只接受三个已知 topic 字面量，畸形入参一律拒（不落进 registry）。 */
+function isStatsTopic(v: unknown): v is StatsTopic {
+  return typeof v === 'string' && (VALID_TOPICS as readonly string[]).includes(v);
+}
+
+export function registerStatsSubscriptionHandlers(registry: StatsSubscriptionRegistry): void {
+  registerIpcHandler<{ topic: StatsTopic }, void>(
+    IPC_CHANNELS.STATS_SUBSCRIBE,
+    (event: IpcMainInvokeEvent, args) => {
+      // 非法 topic 静默忽略（不抛：避免 renderer 侧订阅 promise reject 噪音；正常路径 topic 恒来自受控联合类型）。
+      if (isStatsTopic(args?.topic)) registry.subscribe(event.sender, args.topic);
+    }
+  );
+
+  registerIpcHandler<{ topic: StatsTopic }, void>(
+    IPC_CHANNELS.STATS_UNSUBSCRIBE,
+    (event: IpcMainInvokeEvent, args) => {
+      if (isStatsTopic(args?.topic)) registry.unsubscribe(event.sender, args.topic);
+    }
+  );
+}

--- a/src/main/services/StatsSimulator.ts
+++ b/src/main/services/StatsSimulator.ts
@@ -227,6 +227,11 @@ export class StatsSimulator implements StatsHost {
     this.log?.('info', 'stats 模拟器 stop()（dev 工具，ticker 持续，忽略）');
   }
 
+  /** batch3：合成器无 worker demand（ticker 自跑），registry 订阅变化对其无意义 → no-op。 */
+  syncDemand(): void {
+    /* 无 worker demand：合成 aggregate/stats 经 opts.onStats/onAggregate → registry.broadcast 已按订阅落地 */
+  }
+
   /** 拖动结束补推缓存最新（活跃才推），与 StatsWorkerHost.resume 语义一致。 */
   resume(): void {
     if (!this.isUiActive()) return;

--- a/src/main/services/StatsSubscriptionRegistry.ts
+++ b/src/main/services/StatsSubscriptionRegistry.ts
@@ -1,0 +1,123 @@
+/**
+ * StatsSubscriptionRegistry —— stats 数据面订阅表（batch3 §3.7，推翻-1/-3 收口）。
+ *
+ * 背景：batch2 把 worker demand 收敛成 setDemand，但 demand 的**源**仍是「窗口可见」（isUiActive）——非首页可见视图
+ * （设置页）下拓扑流仍在跑（Mac 真机 0.47Hz）。batch3 把源换成 renderer 按 topic 精确声明的订阅：无订阅者 → 逐级停机。
+ *
+ * 职责（收口三处各自订阅 + GET/event 双路径）：
+ *  - 维护 topic → 订阅 wc 集；订阅即回初始帧（合并原 CONNECTIONS_AGGREGATE_GET/CONNECTIONS_GET 初值 pull）。
+ *  - 订阅集变化驱动 host.syncDemand（订阅瞬间即让 worker 开流，免等下个 status 帧）。
+ *  - relay 只发给对应 topic 的订阅者（broadcast）——StatsWorkerHost 的 onStats/onAggregate/onDetail 经此落地。
+ *  - wc destroyed（renderer 崩溃/重载）自动清其全部 topic，防订阅泄漏。
+ *
+ * 纯逻辑、无运行期 electron 依赖（仅 type-only import WebContents）：wc 用最小 mock（{id,send,once,isDestroyed}）单测。
+ */
+import type { WebContents } from 'electron';
+import { STATS_TOPIC_EVENT, type StatsTopic } from '../../shared/ipc-channels';
+
+/** 全部 topic（集合初始化 + 遍历清理用）。 */
+const TOPICS: readonly StatsTopic[] = ['stats', 'aggregate', 'detail'];
+
+export interface StatsSubscriptionRegistryOptions {
+  /**
+   * 取某 topic 当前缓存帧（订阅即回初始帧）：来源 = StatsWorkerHost 的
+   * getSnapshot/getAggregateSnapshot/getConnectionsSnapshot。
+   */
+  getInitialFrame: (topic: StatsTopic) => unknown;
+  /**
+   * 订阅集变化后驱动 host 重算 demand（可选：simulator 无 worker demand 时传 no-op / 省略）。订阅/退订/destroyed
+   * 清理后调用，让 worker 尽快开/停对应上游流，不必等下一个 status 帧的惰性 syncDemand。
+   */
+  onDemandChange?: () => void;
+}
+
+export class StatsSubscriptionRegistry {
+  /** topic → 订阅 wc.id 集（成员真值；§3.7 状态模型 Map<Topic, Set<number>>）。 */
+  private readonly topics: Map<StatsTopic, Set<number>> = new Map(
+    TOPICS.map((t) => [t, new Set<number>()])
+  );
+  /** id → wc：subscribersOf / 初始帧 / broadcast 发送用（Set<number> 之外的解析表）。 */
+  private readonly wcs: Map<number, WebContents> = new Map();
+  /** 已挂 destroyed 清理监听的 wc id：防同 wc 多 topic 订阅重复挂监听。 */
+  private readonly destroyHooked: Set<number> = new Set();
+
+  constructor(private readonly opts: StatsSubscriptionRegistryOptions) {}
+
+  /**
+   * 订阅某 topic：加入订阅集 + 挂一次性 destroyed 清理 + **即回初始帧**（合并原 GET 初值路径）+ 驱动 demand 重算。
+   * 已 destroyed 的 wc / 未知 topic 一律忽略（IPC 边界防御）。
+   */
+  subscribe(wc: WebContents, topic: StatsTopic): void {
+    const set = this.topics.get(topic);
+    if (!set || wc.isDestroyed()) return;
+    this.wcs.set(wc.id, wc);
+    set.add(wc.id);
+    // 一次性 destroyed 清理：renderer 崩溃/重载 → 清其全部 topic（防订阅泄漏累积）。已挂过不重复挂。
+    if (!this.destroyHooked.has(wc.id)) {
+      this.destroyHooked.add(wc.id);
+      wc.once('destroyed', () => this.removeAll(wc.id));
+    }
+    // 订阅即回初始帧（第一个事件即当前缓存帧，取代 CONNECTIONS_AGGREGATE_GET/CONNECTIONS_GET 的初值 pull）。
+    this.sendFrame(wc, topic, this.opts.getInitialFrame(topic));
+    this.opts.onDemandChange?.();
+  }
+
+  /** 退订某 topic（unmount / 窗口隐藏 / 连接页暂停）。真发生退订才驱动 demand 重算。 */
+  unsubscribe(wc: WebContents, topic: StatsTopic): void {
+    const set = this.topics.get(topic);
+    if (!set) return;
+    if (set.delete(wc.id)) {
+      this.pruneWc(wc.id);
+      this.opts.onDemandChange?.();
+    }
+  }
+
+  /** 该 topic 是否有存活订阅者（供 host.syncDemand 派生 worker demand）。过滤已 destroyed（监听未及触发的兜底）。 */
+  hasSubscribers(topic: StatsTopic): boolean {
+    return this.subscribersOf(topic).length > 0;
+  }
+
+  /** 某 topic 的存活订阅 wc（relay 用；过滤 destroyed，不改集合——destroyed 监听负责清）。 */
+  subscribersOf(topic: StatsTopic): WebContents[] {
+    const set = this.topics.get(topic);
+    if (!set) return [];
+    const out: WebContents[] = [];
+    for (const id of set) {
+      const wc = this.wcs.get(id);
+      if (wc && !wc.isDestroyed()) out.push(wc);
+    }
+    return out;
+  }
+
+  /** relay：把某 topic 的帧发给其全部存活订阅者（初始帧 + 增量共用同一通道）。 */
+  broadcast(topic: StatsTopic, data: unknown): void {
+    for (const wc of this.subscribersOf(topic)) {
+      this.sendFrame(wc, topic, data);
+    }
+  }
+
+  /** 单 wc 单 topic 发送（初始帧 / broadcast 共用）；send 竞态（发送瞬间被销毁）吞掉。 */
+  private sendFrame(wc: WebContents, topic: StatsTopic, data: unknown): void {
+    if (wc.isDestroyed()) return;
+    try {
+      wc.send(STATS_TOPIC_EVENT[topic], data);
+    } catch {
+      /* wc 在 isDestroyed 检查与 send 之间被销毁：忽略（destroyed 监听会清订阅） */
+    }
+  }
+
+  /** wc destroyed：清其全部 topic 订阅 + 引用；有实际清除才驱动 demand 重算。 */
+  private removeAll(id: number): void {
+    let changed = false;
+    for (const set of this.topics.values()) changed = set.delete(id) || changed;
+    this.wcs.delete(id);
+    this.destroyHooked.delete(id);
+    if (changed) this.opts.onDemandChange?.();
+  }
+
+  /** 退订后：该 wc 若已无任何 topic 订阅 → 清 wc 引用（destroyed 监听保留到真 destroyed，无害幂等）。 */
+  private pruneWc(id: number): void {
+    for (const set of this.topics.values()) if (set.has(id)) return;
+    this.wcs.delete(id);
+  }
+}

--- a/src/main/services/StatsWorkerHost.ts
+++ b/src/main/services/StatsWorkerHost.ts
@@ -15,10 +15,7 @@
  */
 import { utilityProcess, type UtilityProcess } from 'electron';
 import type { TrafficStats, ConnectionsSnapshot, ConnectionsAggregate } from '../../shared/types';
-
-// batch2 §3.6：detail 需求存活窗口。连接页每次 pull（getConnectionsSnapshot）刷新 lastPullAt，此窗口内维持 detail
-// 上游明细传输；超时（页面关闭/停拉）则下发 detail=false，worker 停止跨进程克隆明细。
-const PULL_DEMAND_TTL = 5000;
+import type { StatsTopic } from '../../shared/ipc-channels';
 
 /** worker 重建 SingBoxApiClient 所需的运行期管理 API 端点（本地恒无 tls）。 */
 export interface StatsApiEndpoint {
@@ -45,6 +42,11 @@ export interface StatsHost extends StatsProvider {
   resubscribe(): void;
   stop(): void;
   resume(): void;
+  /**
+   * 重算并（变化时）下发 worker demand（batch3 §3.7）：订阅表变化后由 registry 立即调用，让 worker 尽快开/停
+   * 对应上游流，免等下一个 status 帧的惰性同步。StatsSimulator 无 worker demand → no-op。
+   */
+  syncDemand(): void;
   dispose(): void;
 }
 
@@ -52,9 +54,9 @@ export interface StatsHost extends StatsProvider {
 export type HostToWorkerMessage =
   | { type: 'connect'; endpoint: StatsApiEndpoint }
   | { type: 'stop' }
-  // batch2 §3.6（取代 setConnActive）：需求驱动。connectionsStream=是否订阅上游 SubscribeConnections（窗口可见→拓扑需
-  // aggregate；隐藏→连上游流一起停，削核 CPU）；detail=连接页近 PULL_DEMAND_TTL 内有 pull（true 时 worker 每帧跨进程
-  // 传全量明细）。status 帧不门控、始终流动，故 host 借其惰性下发本需求（见 syncDemand），无需窗口事件接线。
+  // batch3 §3.7（源从「窗口可见」换成「渲染端订阅」）：需求驱动。connectionsStream=是否订阅上游 SubscribeConnections
+  // （aggregate 或 detail 有订阅者→需拓扑/明细；均无→连上游流一起停，削核 CPU）；detail=明细页有订阅者（true 时
+  // worker 每帧跨进程传全量明细）。由 registry 订阅变化即时触发 + status 帧惰性重发（reconnect 自愈），见 syncDemand。
   | { type: 'setDemand'; connectionsStream: boolean; detail: boolean }
   | { type: 'dispose' };
 
@@ -84,12 +86,22 @@ function emptyAggregate(at: number): ConnectionsAggregate {
 export interface StatsWorkerHostOptions {
   /** 已编译 worker 入口绝对路径（dist 下 .js）。 */
   workerPath: string;
-  /** 流量快照广播到渲染端（main 侧门控后调用）。 */
+  /** 流量帧 relay（batch3：经 registry 只发给 'stats' 订阅者；main 侧 isUiActive 门控后调用）。 */
   onStats: (s: TrafficStats) => void;
-  /** 连接聚合广播到渲染端（首页拓扑，main 侧门控后调用，issue #227）。 */
+  /** 连接聚合 relay（首页拓扑；batch3：经 registry 只发给 'aggregate' 订阅者；门控后调用，issue #227）。 */
   onAggregate: (agg: ConnectionsAggregate) => void;
-  /** UI 广播活跃谓词：false（不可见/拖动中）时只缓存不广播。 */
+  /** 连接明细 relay（batch3 §3.7：detail 由 pull 改 push topic；经 registry 只发给 'detail' 订阅者；门控后调用）。 */
+  onDetail: (conns: ConnectionsSnapshot) => void;
+  /**
+   * relay 安全门（belt-and-suspenders）：false（窗口不可见 / Windows 拖动中）时只缓存不 relay。batch3 里订阅本身
+   * 已由渲染端 visibility 暂停，此为兜底（订阅在但窗口不可见——如拖动期——仍不发）。**非** demand 源（见 hasSubscribers）。
+   */
   isUiActive: () => boolean;
+  /**
+   * demand 源（batch3 §3.7，取代 isUiActive）：某 topic 是否有渲染端订阅者。syncDemand 据此派生 worker 上游流开关
+   * （connectionsStream = aggregate||detail 有订阅；detail = detail 有订阅）。无订阅者 → 逐级停机。
+   */
+  hasSubscribers: (topic: StatsTopic) => boolean;
   /** 取运行期管理 API 端点（核未起返回 null → worker 不开流）。 */
   getEndpoint: () => StatsApiEndpoint | null;
   /** 可选日志钩子（接 logManager）。 */
@@ -99,10 +111,10 @@ export interface StatsWorkerHostOptions {
 export class StatsWorkerHost implements StatsHost {
   private worker: UtilityProcess | null = null;
   private snapshot: TrafficStats = { ...ZERO_STATS };
-  // worker 'detail' 消息缓存的最近连接明细：仅供连接信息页 CONNECTIONS_GET 按需 pull，不 relay 给渲染端（旧放大器）。
+  // worker 'detail' 消息缓存的最近连接明细（batch3：detail 变 push topic）：relay 给 'detail' 订阅者 + 作订阅初始帧。
   private connections: ConnectionsSnapshot = { connections: [], at: 0 };
-  // worker 'aggregate' 消息缓存的最近拓扑聚合（batch2：聚合已下沉 worker，host 不再自算）：relay
-  // EVENT_CONNECTIONS_AGGREGATE + CONNECTIONS_AGGREGATE_GET 回填。
+  // worker 'aggregate' 消息缓存的最近拓扑聚合（batch2：聚合已下沉 worker，host 不再自算）：relay 给 'aggregate'
+  // 订阅者 + 作订阅初始帧（合并原 CONNECTIONS_AGGREGATE_GET 回填）。
   private aggregate: ConnectionsAggregate = emptyAggregate(0);
   /** 是否应处于订阅态（代理运行）。崩溃 respawn 后据此自动重连，不丢流。 */
   private started = false;
@@ -112,8 +124,6 @@ export class StatsWorkerHost implements StatsHost {
   /** 上次下发给 worker 的需求（batch2，取代 lastConnActiveSent）。null=未发过（reconnect/respawn 后重置，
    *  强制下个 status 帧重新下发 setDemand）。仅任一字段变化才重发。 */
   private lastDemandSent: { connectionsStream: boolean; detail: boolean } | null = null;
-  /** 连接页最近一次 pull（getConnectionsSnapshot 调用）时刻 epoch ms；驱动 detail 需求（近 PULL_DEMAND_TTL 内=需 detail）。 */
-  private lastPullAt = 0;
 
   constructor(private readonly opts: StatsWorkerHostOptions) {
     this.spawn();
@@ -172,17 +182,17 @@ export class StatsWorkerHost implements StatsHost {
   }
 
   /**
-   * 惰性下发需求（batch2 §3.6，取代 syncConnActive）：借「始终流动」的 status 帧驱动，仅需求变化才 post setDemand——
-   * 无需监听窗口 show/hide/minimize 事件，且 status 不门控 → worker 不会卡死在停用态。
-   * - connectionsStream = isUiActive()：窗口可见→拓扑需 aggregate（订阅上游 Connections 流）；隐藏→连上游流一起停
-   *   （worker cancel SubscribeConnections，削核 CPU 面）。自愈延迟 ≤1 个 status 间隔（~1s）。
-   * - detail = 连接页近 PULL_DEMAND_TTL 内有 pull（lastPullAt）：仅页面真正拉取时 worker 才跨进程传全量明细。
-   *   转 true 后明细恢复最坏 ~2 个流间隔（先 status 帧下发 detail=true，worker 再等下一 connections 帧才 post），
-   *   与旧 connActive 语义一致；隐藏期本无明细消费者，可接受。
+   * 重算并（变化时）下发 worker demand（batch3 §3.7，取代 batch2 的 isUiActive / lastPullAt 源）。两条驱动路径：
+   *  ① registry 订阅/退订后立即调（低延迟：连接页一打开 detail 即开流、一关即停，不等下个 status 帧）；
+   *  ② case 'stats' 每个 status 帧惰性调（reconnect/respawn 后 lastDemandSent 被 postConnect 复位 null → 借常流
+   *     status 帧把当前 demand 重发给新 worker，自愈）；无订阅变化时靠 lastDemandSent 去重、绝不重复 post。
+   * demand 源 = 订阅集（**非**窗口可见）：connectionsStream = 拓扑或明细有订阅（订上游 Connections 流；均无 →
+   * 连 aggregate 一起停，削核 CPU）；detail = 明细页有订阅（true 时 worker 才跨进程传全量明细）。
    */
-  private syncDemand(): void {
-    const connectionsStream = this.opts.isUiActive();
-    const detail = Date.now() - this.lastPullAt < PULL_DEMAND_TTL;
+  syncDemand(): void {
+    const connectionsStream =
+      this.opts.hasSubscribers('aggregate') || this.opts.hasSubscribers('detail');
+    const detail = this.opts.hasSubscribers('detail');
     const prev = this.lastDemandSent;
     if (!prev || prev.connectionsStream !== connectionsStream || prev.detail !== detail) {
       this.lastDemandSent = { connectionsStream, detail };
@@ -202,7 +212,7 @@ export class StatsWorkerHost implements StatsHost {
         // started 门控：stop() 后 worker 在途旧帧（stop 消息送达前 worker 可能刚 post 一帧非零）必须丢弃，
         // 否则缓存被旧值覆盖 + 广播残留非零速率/总量，直到下次 connect → 违反 stop「停止即清零」不变量。
         if (!this.started) return;
-        this.syncDemand(); // 借常流的 status 帧惰性下发 worker 的 setDemand（batch2）
+        this.syncDemand(); // 借常流 status 帧惰性重发 demand（reconnect 自愈路径；订阅变化的即时路径在 registry）
         this.snapshot = msg.payload;
         if (this.opts.isUiActive()) this.opts.onStats(this.snapshot);
         break;
@@ -215,9 +225,10 @@ export class StatsWorkerHost implements StatsHost {
         break;
       case 'detail':
         if (!this.started) return; // 停后在途旧帧丢弃，避免残留旧连接列表。
-        // 仅缓存供连接页 CONNECTIONS_GET pull，不 relay（每秒全量明细 relay 放大器已删，issue #227）。detail 仅
-        // detailDemand（连接页 pull 期）才由 worker post，故此缓存只在页面活跃期新鲜。
+        // batch3 §3.7：detail 由 pull 改 push topic——缓存 + 按可见性门控 relay 给 'detail' 订阅者（连接页）。worker
+        // 仅 detail 有订阅（detailDemand）时才 post，故此缓存只在连接页订阅期新鲜；也作后来订阅者的初始帧。
         this.connections = msg.payload;
+        if (this.opts.isUiActive()) this.opts.onDetail(this.connections);
         break;
     }
   }
@@ -230,7 +241,8 @@ export class StatsWorkerHost implements StatsHost {
     this.postConnect();
   }
 
-  /** 停止订阅 + 清零广播（对齐 StatsService.stop：不门控、直接清 UI，避免停后残留旧值）。 */
+  /** 停止订阅 + 清零直推（不门控、直接清 UI，避免停后残留旧值）。batch3：detail 亦为 push topic，须同样清空
+   *  推给订阅者（连接页），否则停止后旧连接列表滞留（旧 pull 模型靠下次 pull 拿空缓存自然清，push 模型须显式推）。 */
   stop(): void {
     this.started = false;
     this.post({ type: 'stop' });
@@ -239,15 +251,16 @@ export class StatsWorkerHost implements StatsHost {
     this.aggregate = emptyAggregate(Date.now());
     this.opts.onStats({ ...this.snapshot });
     this.opts.onAggregate(this.aggregate);
+    this.opts.onDetail(this.connections);
   }
 
-  /** 拖动结束：立即补推一帧缓存最新（免等 worker 下一帧滞后）。窗口由隐藏转可见时不另补推——stats/计数走恒流的
-   *  status 帧 ≤1s 自然广播；拓扑 aggregate 经 connectionsStream 需求重新激活后 ≤2 个流间隔恢复（见 syncDemand），
-   *  与原行为大致一致。 */
+  /** 拖动结束（Windows）：立即把缓存最新帧补推给各 topic 订阅者（免等 worker 下一帧 ~1s 滞后）。窗口由隐藏转可见
+   *  由渲染端重订自然拿初始帧（见 registry），无需在此另补。relay 均经 registry 落到对应 topic 订阅者（无订阅者即 no-op）。 */
   resume(): void {
     if (!this.opts.isUiActive()) return;
     this.opts.onStats({ ...this.snapshot });
     this.opts.onAggregate(this.aggregate);
+    this.opts.onDetail(this.connections);
   }
 
   getSnapshot(): TrafficStats {
@@ -255,15 +268,13 @@ export class StatsWorkerHost implements StatsHost {
   }
 
   getConnectionsSnapshot(): ConnectionsSnapshot {
-    // batch2：记录本次 pull 时刻，驱动 detail 需求（syncDemand 据 lastPullAt 判「连接页近 PULL_DEMAND_TTL 内活跃」→
-    // 下发 detail=true，worker 才跨进程传全量明细）。CONNECTIONS_GET 是唯一调用点（proxy-handlers），语义精确。
-    this.lastPullAt = Date.now();
-    // at 用 worker 真实采样时刻（this.connections.at），非拉取时刻：连接页速率差分以采样间隔为分母，避免 pull
-    // 节奏与 worker 帧节奏漂移时同一缓存被拉两次 → Δbytes=0 报速率 0、下次翻倍的抖动（review Low-2）。
+    // batch3：detail 订阅的初始帧来源（registry.getInitialFrame('detail')）。at 用 worker 真实采样时刻
+    // （this.connections.at），非读取时刻：连接页速率差分以采样间隔为分母，避免同一缓存被读两次 → Δbytes=0 报
+    // 速率 0、下次翻倍的抖动（review Low-2）。detail 需求已改由订阅驱动（hasSubscribers），不再记 lastPullAt。
     return { connections: this.connections.connections, at: this.connections.at };
   }
 
-  /** 首页拓扑挂载回填（CONNECTIONS_AGGREGATE_GET）：缓存的最近聚合（后续增量走 EVENT_CONNECTIONS_AGGREGATE）。 */
+  /** aggregate 订阅的初始帧来源（registry.getInitialFrame('aggregate')）：缓存的最近聚合（增量走同一通道 push）。 */
   getAggregateSnapshot(): ConnectionsAggregate {
     return this.aggregate;
   }

--- a/src/main/services/__tests__/StatsSubscriptionRegistry.test.ts
+++ b/src/main/services/__tests__/StatsSubscriptionRegistry.test.ts
@@ -1,0 +1,128 @@
+/**
+ * StatsSubscriptionRegistry 单测（batch3 §3.7 订阅驱动数据面）：订阅/退订、订阅即回初始帧、broadcast 只发对应
+ * 订阅者、destroyed 自动清全部 topic、hasSubscribers、subscribersOf 过滤 destroyed、同 wc 多 topic 只挂一次
+ * destroyed 监听、demand 变化回调。纯逻辑，wc 用最小 mock（{id,send,once,isDestroyed}），无 electron 运行期依赖。
+ */
+import { StatsSubscriptionRegistry } from '../StatsSubscriptionRegistry';
+import { STATS_TOPIC_EVENT } from '../../../shared/ipc-channels';
+import type { WebContents } from 'electron';
+
+interface FakeWc {
+  id: number;
+  send: jest.Mock;
+  once: jest.Mock;
+  isDestroyed: jest.Mock;
+  /** once 捕获的 destroyed 回调（手动触发模拟 renderer 销毁）。 */
+  fireDestroyed?: () => void;
+}
+
+function makeWc(id: number): FakeWc {
+  const wc: FakeWc = {
+    id,
+    send: jest.fn(),
+    once: jest.fn((_evt: string, cb: () => void) => {
+      wc.fireDestroyed = cb;
+    }),
+    isDestroyed: jest.fn(() => false),
+  };
+  return wc;
+}
+/** 最小 mock 结构性替身 → WebContents（registry 只碰 id/send/once/isDestroyed）。 */
+const asWc = (w: FakeWc): WebContents => w as unknown as WebContents;
+
+function makeRegistry(frames: Record<string, unknown> = {}) {
+  const getInitialFrame = jest.fn((topic: string) => frames[topic] ?? { topic });
+  const onDemandChange = jest.fn();
+  const registry = new StatsSubscriptionRegistry({ getInitialFrame, onDemandChange });
+  return { registry, getInitialFrame, onDemandChange };
+}
+
+describe('StatsSubscriptionRegistry', () => {
+  it('subscribe：加订阅 + 即回初始帧（对应 topic 通道）+ 驱动 demand', () => {
+    const { registry, onDemandChange } = makeRegistry({ aggregate: { total: 5 } });
+    const wc = makeWc(1);
+    registry.subscribe(asWc(wc), 'aggregate');
+    expect(registry.hasSubscribers('aggregate')).toBe(true);
+    expect(wc.send).toHaveBeenCalledWith(STATS_TOPIC_EVENT.aggregate, { total: 5 });
+    expect(onDemandChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe：移除订阅 + 驱动 demand', () => {
+    const { registry, onDemandChange } = makeRegistry();
+    const wc = makeWc(1);
+    registry.subscribe(asWc(wc), 'detail');
+    onDemandChange.mockClear();
+    registry.unsubscribe(asWc(wc), 'detail');
+    expect(registry.hasSubscribers('detail')).toBe(false);
+    expect(onDemandChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe 未订阅的 topic → 幂等、不驱动 demand', () => {
+    const { registry, onDemandChange } = makeRegistry();
+    const wc = makeWc(1);
+    registry.unsubscribe(asWc(wc), 'detail');
+    expect(onDemandChange).not.toHaveBeenCalled();
+  });
+
+  it('subscribersOf / hasSubscribers 过滤已 destroyed 的 wc', () => {
+    const { registry } = makeRegistry();
+    const a = makeWc(1);
+    const b = makeWc(2);
+    registry.subscribe(asWc(a), 'stats');
+    registry.subscribe(asWc(b), 'stats');
+    expect(registry.subscribersOf('stats')).toHaveLength(2);
+
+    b.isDestroyed.mockReturnValue(true); // b 销毁但 destroyed 监听未及触发
+    const live = registry.subscribersOf('stats');
+    expect(live).toHaveLength(1);
+    expect(live[0]).toBe(a);
+    expect(registry.hasSubscribers('stats')).toBe(true); // a 仍在
+  });
+
+  it('broadcast：只发给该 topic 存活订阅者（对应通道）', () => {
+    const { registry } = makeRegistry();
+    const a = makeWc(1);
+    const b = makeWc(2);
+    registry.subscribe(asWc(a), 'aggregate');
+    registry.subscribe(asWc(b), 'detail');
+    a.send.mockClear();
+    b.send.mockClear();
+    registry.broadcast('aggregate', { total: 9 });
+    expect(a.send).toHaveBeenCalledWith(STATS_TOPIC_EVENT.aggregate, { total: 9 });
+    expect(b.send).not.toHaveBeenCalled(); // detail 订阅者不收 aggregate
+  });
+
+  it('wc destroyed → 一次性监听清其全部 topic + 驱动 demand', () => {
+    const { registry, onDemandChange } = makeRegistry();
+    const wc = makeWc(1);
+    registry.subscribe(asWc(wc), 'aggregate');
+    registry.subscribe(asWc(wc), 'detail');
+    expect(registry.hasSubscribers('aggregate')).toBe(true);
+    expect(registry.hasSubscribers('detail')).toBe(true);
+    onDemandChange.mockClear();
+
+    wc.fireDestroyed!(); // 模拟 renderer 崩溃/重载
+    expect(registry.hasSubscribers('aggregate')).toBe(false);
+    expect(registry.hasSubscribers('detail')).toBe(false);
+    expect(onDemandChange).toHaveBeenCalledTimes(1); // 清理驱动一次 demand 重算
+  });
+
+  it('同 wc 多 topic 订阅只挂一次 destroyed 监听（不重复挂）', () => {
+    const { registry } = makeRegistry();
+    const wc = makeWc(1);
+    registry.subscribe(asWc(wc), 'stats');
+    registry.subscribe(asWc(wc), 'aggregate');
+    registry.subscribe(asWc(wc), 'detail');
+    expect(wc.once).toHaveBeenCalledTimes(1);
+  });
+
+  it('已 destroyed 的 wc subscribe 被忽略（不入表、不回初始帧、不驱动 demand）', () => {
+    const { registry, onDemandChange } = makeRegistry();
+    const wc = makeWc(1);
+    wc.isDestroyed.mockReturnValue(true);
+    registry.subscribe(asWc(wc), 'stats');
+    expect(registry.hasSubscribers('stats')).toBe(false);
+    expect(wc.send).not.toHaveBeenCalled();
+    expect(onDemandChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/__tests__/stats-simulator.test.ts
+++ b/src/main/services/__tests__/stats-simulator.test.ts
@@ -19,7 +19,10 @@ function makeSim(rawConfig: string, active = true) {
     workerPath: '/fake/stats-worker.js',
     onStats,
     onAggregate,
+    // batch3 新增字段：合成器不产 detail、无 worker demand（onDetail/hasSubscribers 仅为满足 options 形状）。
+    onDetail: jest.fn(),
     isUiActive: () => state.active,
+    hasSubscribers: () => false,
     getEndpoint: () => null,
     log: (level, message) => logs.push({ level, message }),
   };

--- a/src/main/services/__tests__/stats-worker-host.test.ts
+++ b/src/main/services/__tests__/stats-worker-host.test.ts
@@ -1,11 +1,12 @@
 /**
- * StatsWorkerHost 单测（T4，issue #225；batch2 协议更新，issue #242）。覆盖 main 侧宿主逻辑（worker 由 mock
- * electron.utilityProcess 替身）：
+ * StatsWorkerHost 单测（T4，issue #225；batch3 §3.7 订阅驱动数据面，issue #242）。覆盖 main 侧宿主逻辑（worker 由
+ * mock electron.utilityProcess 替身）：
  *  1) 构造即 fork worker；resubscribe 下发最新端点 connect / 端点为 null 下发 stop。
- *  2) worker 数据消息（batch2 聚合下沉 worker）：'aggregate' 缓存 + 按 isUiActive 门控 relay 给拓扑；'detail' 仅缓存
- *     供连接页 pull（不 relay）；'stats' 缓存 + 门控广播。host 不再自算聚合。
- *  3) setDemand 惰性下发（取代 connActive）：connectionsStream=isUiActive、detail 由连接页 pull 活跃度驱动，变化才发。
- *  4) resume 补推缓存最新（活跃才推）；stop 不门控清零广播；停后在途旧帧经 started 丢弃。
+ *  2) worker 数据消息（聚合下沉 worker）：'aggregate'/'detail'/'stats' 缓存 + 按 isUiActive 门控 relay（detail
+ *     batch3 由 pull 改 push topic，缓存 + relay）。host 不再自算聚合。
+ *  3) demand 由**订阅集**派生（batch3 取代 batch2 的 isUiActive/lastPullAt）：connectionsStream=aggregate||detail、
+ *     detail=detail，变化才 post；registry 订阅变化经 host.syncDemand() 即时触发 + status 帧惰性重发（reconnect 自愈）。
+ *  4) resume 补推缓存最新（stats+aggregate+detail，活跃才推）；stop 不门控清零直推（含 detail）；停后在途旧帧经 started 丢弃。
  *  5) getSnapshot/getConnectionsSnapshot/getAggregateSnapshot 读缓存；'ready' 握手 / 崩溃 respawn / dispose 生命周期。
  */
 import type {
@@ -37,6 +38,7 @@ jest.mock('electron', () => {
 });
 
 import { StatsWorkerHost, type StatsApiEndpoint } from '../StatsWorkerHost';
+import type { StatsTopic } from '../../../shared/ipc-channels';
 
 const electron = require('electron');
 type FakeWorker = import('events').EventEmitter & { postMessage: jest.Mock; kill: jest.Mock };
@@ -57,7 +59,7 @@ const SAMPLE_CONNS: ConnectionsSnapshot = {
   ],
   at: 123,
 };
-// batch2：worker 直接 post 聚合（聚合下沉 worker），host 只缓存/relay。此固定值等于 aggregateConnections(SAMPLE_CONNS)。
+// worker 直接 post 聚合（聚合下沉 worker），host 只缓存/relay。此固定值等于 aggregateConnections(SAMPLE_CONNS)。
 const SAMPLE_AGG: ConnectionsAggregate = {
   total: 1,
   hosts: [{ name: 'a.com', count: 1, flows: [{ outbound: 'proxy', count: 1 }] }],
@@ -68,15 +70,20 @@ const SAMPLE_AGG: ConnectionsAggregate = {
 function makeHost() {
   const onStats = jest.fn();
   const onAggregate = jest.fn();
+  const onDetail = jest.fn();
   const state = { active: true, endpoint: ENDPOINT as StatsApiEndpoint | null };
+  // 订阅集（batch3 demand 源）：测试直接拨动，模拟 registry 订阅态；host.hasSubscribers 读它。
+  const subs: Record<StatsTopic, boolean> = { stats: false, aggregate: false, detail: false };
   const host = new StatsWorkerHost({
     workerPath: '/fake/stats-worker.js',
     onStats,
     onAggregate,
+    onDetail,
     isUiActive: () => state.active,
+    hasSubscribers: (topic) => subs[topic],
     getEndpoint: () => state.endpoint,
   });
-  return { host, onStats, onAggregate, state };
+  return { host, onStats, onAggregate, onDetail, state, subs };
 }
 
 beforeEach(() => electron.__reset());
@@ -120,7 +127,7 @@ describe('StatsWorkerHost 数据面门控 (T4)', () => {
     expect(host.getSnapshot()).toEqual(SAMPLE_STATS); // 缓存仍更新
   });
 
-  it('aggregate 消息门控（batch2 聚合下沉 worker）：不活跃只缓存不广播，活跃广播', () => {
+  it('aggregate 消息门控（聚合下沉 worker）：不活跃只缓存不广播，活跃广播', () => {
     const { onAggregate, host, state } = makeHost();
     host.resubscribe(); // started=true
     state.active = false;
@@ -133,79 +140,102 @@ describe('StatsWorkerHost 数据面门控 (T4)', () => {
     expect(onAggregate).toHaveBeenCalledWith(SAMPLE_AGG); // 活跃 → relay 拓扑
   });
 
-  it('detail 消息仅缓存供 pull，不 relay（明细放大器已删，issue #227）', () => {
-    const { onAggregate, onStats, host } = makeHost();
-    host.resubscribe(); // started=true（active 默认 true）
+  it('detail 消息缓存 + 按可见性门控 relay 给 detail 订阅者（batch3：pull 改 push topic）', () => {
+    const { onDetail, host, state } = makeHost();
+    host.resubscribe(); // started=true
+    state.active = false;
     lastWorker().emit('message', { type: 'detail', payload: SAMPLE_CONNS });
-    expect(onAggregate).not.toHaveBeenCalled(); // detail 从不 relay
-    expect(onStats).not.toHaveBeenCalled();
-    expect(host.getConnectionsSnapshot().connections).toEqual(SAMPLE_CONNS.connections); // 缓存供 CONNECTIONS_GET
+    expect(onDetail).not.toHaveBeenCalled(); // 不可见 → 只缓存不 relay（安全门）
+    expect(host.getConnectionsSnapshot().connections).toEqual(SAMPLE_CONNS.connections); // 缓存供初始帧
+
+    state.active = true;
+    lastWorker().emit('message', { type: 'detail', payload: SAMPLE_CONNS });
+    expect(onDetail).toHaveBeenCalledWith(SAMPLE_CONNS); // 可见 → relay 给连接页
   });
 
-  it('resume 活跃时补推缓存最新；不活跃不推', () => {
-    const { onStats, onAggregate, host, state } = makeHost();
+  it('resume 活跃时补推缓存最新（stats+aggregate+detail）；不活跃不推', () => {
+    const { onStats, onAggregate, onDetail, host, state } = makeHost();
     host.resubscribe(); // started=true
     state.active = false;
     lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
     lastWorker().emit('message', { type: 'aggregate', payload: SAMPLE_AGG });
+    lastWorker().emit('message', { type: 'detail', payload: SAMPLE_CONNS });
     onStats.mockClear();
     onAggregate.mockClear();
+    onDetail.mockClear();
 
     host.resume(); // 仍不活跃 → 不推
     expect(onStats).not.toHaveBeenCalled();
 
     state.active = true;
-    host.resume(); // 活跃 → 补推缓存（stats + 聚合）
+    host.resume(); // 活跃 → 补推缓存（stats + 聚合 + 明细）
     expect(onStats).toHaveBeenCalledWith(SAMPLE_STATS);
     expect(onAggregate).toHaveBeenCalledWith(SAMPLE_AGG);
+    expect(onDetail).toHaveBeenCalledWith(SAMPLE_CONNS);
   });
 
-  it('stop 不门控、清零广播', () => {
-    const { onStats, onAggregate, host, state } = makeHost();
+  it('stop 不门控、清零直推（含 detail）', () => {
+    const { onStats, onAggregate, onDetail, host, state } = makeHost();
     host.resubscribe(); // started=true，下面的帧进缓存
     lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    lastWorker().emit('message', { type: 'detail', payload: SAMPLE_CONNS });
     expect(host.getSnapshot().activeConnections).toBe(3); // 缓存确为非零
     onStats.mockClear();
     onAggregate.mockClear();
-    state.active = false; // 即便不活跃，stop 仍广播清零
+    onDetail.mockClear();
+    state.active = false; // 即便不活跃，stop 仍直推清零
 
     host.stop();
     expect(onStats).toHaveBeenCalledWith(
       expect.objectContaining({ uploadSpeed: 0, downloadSpeed: 0, activeConnections: 0 })
     );
     expect(onAggregate).toHaveBeenCalledWith(expect.objectContaining({ total: 0, hosts: [] }));
+    expect(onDetail).toHaveBeenCalledWith(expect.objectContaining({ connections: [] })); // 连接页清空
     expect(host.getSnapshot().activeConnections).toBe(0);
+    expect(host.getConnectionsSnapshot().connections).toEqual([]);
   });
 
   // Medium-A 回归：stop 后 worker 在途旧帧（stop 消息送达前 post 的非零帧）必须被 started 门控丢弃，
   // 否则缓存被旧值覆盖 + 广播残留非零，违反 stop「停止即清零」。
   it('stop 后 worker 在途旧帧被丢弃（!started 门控，不广播不覆盖缓存）', () => {
-    const { onStats, host } = makeHost();
+    const { onStats, onDetail, host } = makeHost();
     host.resubscribe(); // started=true
     lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS });
     expect(host.getSnapshot()).toEqual(SAMPLE_STATS);
 
-    host.stop(); // started=false + 清零
+    host.stop(); // started=false + 清零直推
     onStats.mockClear();
+    onDetail.mockClear();
     lastWorker().emit('message', { type: 'stats', payload: SAMPLE_STATS }); // 在途旧帧
     lastWorker().emit('message', { type: 'aggregate', payload: SAMPLE_AGG });
     lastWorker().emit('message', { type: 'detail', payload: SAMPLE_CONNS });
     expect(onStats).not.toHaveBeenCalled();
+    expect(onDetail).not.toHaveBeenCalled(); // 在途 detail 亦被丢弃
     expect(host.getSnapshot().activeConnections).toBe(0); // 缓存仍为 stop 的零值
     expect(host.getConnectionsSnapshot().connections).toEqual([]);
     expect(host.getAggregateSnapshot().total).toBe(0); // 聚合缓存亦为 stop 的零值（在途 aggregate 被丢弃）
   });
 });
 
-describe('StatsWorkerHost setDemand 需求同步 (batch2)', () => {
-  it('借 status 帧下发 setDemand：connectionsStream=isUiActive、detail 由 pull 活跃度驱动，变化才发', () => {
-    const { host, state } = makeHost();
+describe('StatsWorkerHost demand 由订阅集派生 (batch3 §3.7)', () => {
+  it('connectionsStream=aggregate||detail、detail=detail，变化才 post；syncDemand 即时触发', () => {
+    const { host, subs } = makeHost();
     host.resubscribe();
     const w = lastWorker();
     w.postMessage.mockClear();
 
-    // 首个 status 帧（active=true，未 pull → detail=false，lastSent=null）→ 下发 {stream:true, detail:false}
+    // 无订阅 → 首个 status 帧下发 {stream:false, detail:false}（lastDemandSent=null 强制首发）
     w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(w.postMessage).toHaveBeenCalledWith({
+      type: 'setDemand',
+      connectionsStream: false,
+      detail: false,
+    });
+    w.postMessage.mockClear();
+
+    // aggregate 订阅出现 → registry 经 host.syncDemand() 即时触发 → {stream:true, detail:false}
+    subs.aggregate = true;
+    host.syncDemand();
     expect(w.postMessage).toHaveBeenCalledWith({
       type: 'setDemand',
       connectionsStream: true,
@@ -213,13 +243,9 @@ describe('StatsWorkerHost setDemand 需求同步 (batch2)', () => {
     });
     w.postMessage.mockClear();
 
-    // 需求未变 → 不重复下发（任何消息都不 post）
-    w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
-    expect(w.postMessage).not.toHaveBeenCalled();
-
-    // 连接页 pull（getConnectionsSnapshot 刷新 lastPullAt）→ 下个 status 帧 detail 转 true
-    host.getConnectionsSnapshot();
-    w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    // detail 订阅出现 → {stream:true, detail:true}
+    subs.detail = true;
+    host.syncDemand();
     expect(w.postMessage).toHaveBeenCalledWith({
       type: 'setDemand',
       connectionsStream: true,
@@ -227,21 +253,31 @@ describe('StatsWorkerHost setDemand 需求同步 (batch2)', () => {
     });
     w.postMessage.mockClear();
 
-    // 窗口隐藏（isUiActive=false）→ connectionsStream 转 false（detail 仍 true，刚 pull 过）
-    state.active = false;
+    // 需求未变 → status 帧不重复下发
     w.emit('message', { type: 'stats', payload: SAMPLE_STATS });
+    expect(w.postMessage).not.toHaveBeenCalled();
+
+    // aggregate 退订但 detail 仍在 → stream 由 detail 撑着，{true,true} 未变 → 不 post
+    subs.aggregate = false;
+    host.syncDemand();
+    expect(w.postMessage).not.toHaveBeenCalled();
+
+    // detail 也退订 → {stream:false, detail:false}
+    subs.detail = false;
+    host.syncDemand();
     expect(w.postMessage).toHaveBeenCalledWith({
       type: 'setDemand',
       connectionsStream: false,
-      detail: true,
+      detail: false,
     });
   });
 
-  it('reconnect 后重置需求态，强制下个 status 帧重新下发 setDemand', () => {
-    const { host } = makeHost();
+  it('reconnect 后重置需求态，借下个 status 帧按当前订阅重发 setDemand（自愈）', () => {
+    const { host, subs } = makeHost();
+    subs.aggregate = true;
     host.resubscribe();
     const w = lastWorker();
-    w.emit('message', { type: 'stats', payload: SAMPLE_STATS }); // 已下发一次 setDemand
+    w.emit('message', { type: 'stats', payload: SAMPLE_STATS }); // 已下发 {true,false}
     w.postMessage.mockClear();
 
     host.resubscribe(); // reconnect → postConnect 重置 lastDemandSent=null
@@ -250,7 +286,7 @@ describe('StatsWorkerHost setDemand 需求同步 (batch2)', () => {
       type: 'setDemand',
       connectionsStream: true,
       detail: false,
-    }); // 重新下发（未 pull → detail=false）
+    }); // 按当前订阅（aggregate=true）重发
   });
 });
 

--- a/src/renderer/bridge/api-wrapper.ts
+++ b/src/renderer/bridge/api-wrapper.ts
@@ -249,8 +249,7 @@ export function addEventListener(event: string, listener: (...args: any[]) => vo
       return api.config.onChanged(listener);
     case 'logReceivedBatch':
       return api.logs.onReceivedBatch(listener);
-    case 'statsUpdated':
-      return api.stats.onUpdated(listener);
+    // 'statsUpdated' 已删（batch3 §3.7：stats 改 useStatsTopic('stats') 订阅，api.stats.onUpdated 随之移除；本 bridge 无该 case 消费者）。
     default:
       return () => {};
   }

--- a/src/renderer/components/connections/connections-table.tsx
+++ b/src/renderer/components/connections/connections-table.tsx
@@ -42,6 +42,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/store/app-store';
 import { api } from '@/ipc';
+import { useStatsTopic } from '@/hooks/use-stats-topic';
 import { toast } from 'sonner';
 import { formatBytes } from '@/lib/format';
 import type { ConnectionEntry, ConnectionsSnapshot } from '../../../shared/types';
@@ -71,11 +72,6 @@ function ruleActionVariant(action: string): 'secondary' | 'destructive' | 'defau
 
 /** 稳定的零速率引用：speeds 无此 id 时传入，使 ConnectionRow memo 的 speed 比较恒定（不每帧新建对象）。 */
 const ZERO_SPEED: ConnSpeed = { up: 0, down: 0 };
-
-/** 连接明细 pull 间隔（issue #227）：本页打开期间每隔此时长拉一次 CONNECTIONS_GET，取代旧「每秒全量 push 给
- *  所有窗口」订阅——连接明细成本仅在用户主动查看本页时产生，且页面关闭即停。对齐旧 push 的 1s 节奏（连接页仅
- *  打开时拉，1s 无额外负担），关连接另有乐观更新即时反馈，不依赖本间隔。 */
-const PULL_INTERVAL_MS = 1000;
 
 /**
  * 全表共享秒级 tick（P3）：时长列每秒刷新原本随父组件 setNow 触发整表 reconcile（重跑 visible.map + diff ≤500 行）。
@@ -210,51 +206,20 @@ export function ConnectionsTable() {
   const [speeds, setSpeeds] = useState<Map<string, ConnSpeed>>(new Map());
   const [confirmCloseAll, setConfirmCloseAll] = useState(false);
 
-  // 暂停态用 ref 让订阅回调读到最新值（订阅只挂一次，不随 paused 重订阅）。
-  const pausedRef = useRef(paused);
-  pausedRef.current = paused;
   // per-conn 速率差分的上一帧缓存（不入 state，避免无谓重渲染）。
   const rateRef = useRef<RateState>(new Map());
-  // pull in-flight 守卫（review Low-B）：慢主进程/Windows 拖动期 setInterval 仍每秒派发，防 CONNECTIONS_GET
-  // 叠加排队、drag-end 一并 flush 的瞬时尖峰。
-  const inFlightRef = useRef(false);
 
-  // 数据（issue #227）：连接明细改【按需 pull】——本页打开期间每 PULL_INTERVAL_MS 拉一次 CONNECTIONS_GET，
-  // 不再订阅每秒全量 push。暂停 / 窗口隐藏时停拉（冻结当前帧 + 不推进速率基准）；页面卸载清 interval，无残留。
-  useEffect(() => {
-    let mounted = true;
-    const apply = (snap: ConnectionsSnapshot) => {
-      const { speeds: s, next } = computeConnSpeeds(snap.connections, rateRef.current, snap.at);
-      rateRef.current = next;
-      setSpeeds(s);
-      setConnections(snap.connections);
-    };
-    const pull = () => {
-      // 暂停 / 窗口隐藏：跳过拉取（无 UI 消费者；对齐 main 侧 isUiBroadcastActive 可见性门控，省隐藏期每秒
-      // CONNECTIONS_GET 的主线程 IPC + 序列化开销，review Med）。拖动期对齐需 main 推拖动态 → 记真机监控项。
-      // in-flight 守卫（Low-B）：上一次未 resolve 不叠加，防慢主进程/拖动期排队积压。
-      if (pausedRef.current || document.hidden || inFlightRef.current) return;
-      inFlightRef.current = true;
-      api.connections
-        .get()
-        .then((snap) => {
-          // 在途结果若期间已暂停则丢弃（gate 上移到 pull 后，apply 不再自查 paused，Low-A）。
-          if (mounted && !pausedRef.current) apply(snap);
-        })
-        .catch(() => {
-          /* 静默：核未运行 / 鉴权未就绪，空态由 proxyRunning gate 兜底 */
-        })
-        .finally(() => {
-          inFlightRef.current = false;
-        });
-    };
-    pull(); // 挂载即拉一次（回填初值）
-    const timer = setInterval(pull, PULL_INTERVAL_MS);
-    return () => {
-      mounted = false;
-      clearInterval(timer);
-    };
+  // 数据（batch3 §3.7）：连接明细改【订阅驱动 push】——订阅 'detail' topic，挂载即拿初始帧，之后 worker 每帧
+  // push（取代旧每 PULL_INTERVAL_MS 拉 CONNECTIONS_GET + in-flight 守卫）。暂停（enabled=!paused → 退订）停流
+  // （worker detail 逐级停机）+ 冻结当前帧；恢复重订拿最新初始帧。窗口隐藏由 useStatsTopic 自动退订。
+  const applyDetail = useCallback((snap: ConnectionsSnapshot) => {
+    // 速率差分照旧：push 帧带 worker 采样 at，computeConnSpeeds 以前后帧 + 采样间隔算速率（push 改造不影响差分）。
+    const { speeds: s, next } = computeConnSpeeds(snap.connections, rateRef.current, snap.at);
+    rateRef.current = next;
+    setSpeeds(s);
+    setConnections(snap.connections);
   }, []);
+  useStatsTopic<ConnectionsSnapshot>('detail', applyDetail, !paused);
 
   // 时长列刷新与整表 reconcile 解耦（P3）：秒级 tick 下沉到模块级共享 store，仅 DurationCell 订阅、
   // 自刷新文本，不再随 setNow 重跑 visible.map + reconcile ≤500 行。暂停时冻结 tick（与快照冻结一致）。

--- a/src/renderer/components/home/connection-topology.tsx
+++ b/src/renderer/components/home/connection-topology.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Network } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/store/app-store';
-import { api } from '@/ipc';
+import { useStatsTopic } from '@/hooks/use-stats-topic';
 import { toast } from 'sonner';
 import type { Rule, RuleAction, ConnectionsAggregate } from '../../../shared/types';
 import { getRuleActionStyle } from '@/lib/rule-action-style';
@@ -46,31 +46,16 @@ export function ConnectionTopology() {
     return () => resizeObserver.disconnect();
   }, []);
 
-  // issue #227：拓扑改消费 main 侧【连接聚合】（小载荷，与连接总数解耦），取代旧「每秒全量 ConnectionEntry[] 广播」。
-  // 挂载即用 CONNECTIONS_AGGREGATE_GET 回填初值，再订阅 EVENT_CONNECTIONS_AGGREGATE 收增量。main 连接流订阅跟随
-  // started（代理运行即推送），停止代理时 main 广播空聚合 → 自然落入空态。渲染端不再直连 :9090、不持 secret。
-  useEffect(() => {
-    let mounted = true;
-    api.connections.aggregate
-      .get()
-      .then((agg) => {
-        if (mounted) {
-          setAggregate(agg);
-          setLoading(false);
-        }
-      })
-      .catch(() => {
-        if (mounted) setLoading(false);
-      });
-    const unsub = api.connections.aggregate.onUpdated((agg) => {
+  // batch3 §3.7：拓扑订阅 'aggregate' topic——挂载即拿初始帧（= 原 CONNECTIONS_AGGREGATE_GET 回填），之后增量 push
+  // 同一通道；隐藏/卸载自动退订。非首页可见视图下本组件不挂载 → 无 aggregate 订阅者 → main 停上游 Connections 流
+  // （逐级停机）。载荷仍是小聚合（~Top-N host + 出口数），渲染端不直连 :9090、不持 secret。
+  useStatsTopic<ConnectionsAggregate>(
+    'aggregate',
+    useCallback((agg: ConnectionsAggregate) => {
       setAggregate(agg);
       setLoading(false);
-    });
-    return () => {
-      mounted = false;
-      unsub();
-    };
-  }, []);
+    }, [])
+  );
 
   const { nodes, links } = useMemo(
     () => computeTopologyLayout(aggregate, width, t),

--- a/src/renderer/hooks/__tests__/use-stats-topic-core.test.ts
+++ b/src/renderer/hooks/__tests__/use-stats-topic-core.test.ts
@@ -1,0 +1,75 @@
+/**
+ * createStatsTopicSubscription 单测（batch3 §3.7）：useStatsTopic 的纯订阅内核（无 React/DOM/ipcClient，node 可测）。
+ * 覆盖 attach 先挂监听再订阅（保初始帧不丢的顺序约束）、帧路由、幂等、detach 退监听+退订、detach 后重 attach 重订。
+ */
+import { createStatsTopicSubscription, type StatsTopicIpc } from '../use-stats-topic-core';
+import { IPC_CHANNELS, STATS_TOPIC_EVENT } from '../../../shared/ipc-channels';
+
+function makeIpc() {
+  const unlisten = jest.fn();
+  const listeners: Array<(d: unknown) => void> = [];
+  const on = jest.fn((_channel: string, listener: (d: unknown) => void) => {
+    listeners.push(listener);
+    return unlisten;
+  });
+  const invoke = jest.fn().mockResolvedValue(undefined);
+  const ipc: StatsTopicIpc = { invoke, on };
+  return { ipc, on, invoke, unlisten, listeners };
+}
+
+describe('createStatsTopicSubscription', () => {
+  it('attach：先挂 EVENT 监听再 invoke STATS_SUBSCRIBE（顺序保初始帧不丢）', () => {
+    const { ipc, on, invoke } = makeIpc();
+    const sub = createStatsTopicSubscription('aggregate', jest.fn(), ipc);
+    sub.attach();
+    expect(on).toHaveBeenCalledWith(STATS_TOPIC_EVENT.aggregate, expect.any(Function));
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.STATS_SUBSCRIBE, { topic: 'aggregate' });
+    // on 先于 invoke（监听须先就位，否则 main.subscribe 同步 send 的初始帧丢失）
+    expect(on.mock.invocationCallOrder[0]).toBeLessThan(invoke.mock.invocationCallOrder[0]);
+    expect(sub.isAttached()).toBe(true);
+  });
+
+  it('帧经监听路由到 onFrame', () => {
+    const { ipc, listeners } = makeIpc();
+    const onFrame = jest.fn();
+    const sub = createStatsTopicSubscription<{ total: number }>('aggregate', onFrame, ipc);
+    sub.attach();
+    listeners[0]({ total: 7 });
+    expect(onFrame).toHaveBeenCalledWith({ total: 7 });
+  });
+
+  it('attach 幂等：已订阅重复 attach 不重复挂监听/订阅', () => {
+    const { ipc, on, invoke } = makeIpc();
+    const sub = createStatsTopicSubscription('detail', jest.fn(), ipc);
+    sub.attach();
+    sub.attach();
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('detach：退监听 + invoke STATS_UNSUBSCRIBE；幂等', () => {
+    const { ipc, unlisten, invoke } = makeIpc();
+    const sub = createStatsTopicSubscription('detail', jest.fn(), ipc);
+    sub.attach();
+    invoke.mockClear();
+    sub.detach();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith(IPC_CHANNELS.STATS_UNSUBSCRIBE, { topic: 'detail' });
+    expect(sub.isAttached()).toBe(false);
+
+    invoke.mockClear();
+    sub.detach(); // 幂等：未订阅再 detach 不 invoke
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('detach 后重 attach：重新挂监听 + 重新订阅（重订拿新初始帧路径）', () => {
+    const { ipc, on, invoke } = makeIpc();
+    const sub = createStatsTopicSubscription('aggregate', jest.fn(), ipc);
+    sub.attach();
+    sub.detach();
+    sub.attach();
+    expect(on).toHaveBeenCalledTimes(2); // 两次挂监听
+    const subscribeCalls = invoke.mock.calls.filter((c) => c[0] === IPC_CHANNELS.STATS_SUBSCRIBE);
+    expect(subscribeCalls).toHaveLength(2); // 两次订阅
+  });
+});

--- a/src/renderer/hooks/use-native-events.ts
+++ b/src/renderer/hooks/use-native-events.ts
@@ -4,6 +4,7 @@
 
 import { useEffect } from 'react';
 import { api } from '../ipc';
+import { useStatsTopic } from './use-stats-topic';
 import { useAppStore } from '../store/app-store';
 import { useTailscaleLoginCacheStore } from '../store/use-tailscale-login-cache-store';
 import { ErrorHandler, ErrorCategory, proxyErrorCategory } from '../lib/error-handler';
@@ -33,7 +34,6 @@ interface NativeEventData {
     signal?: string | null;
   };
   configChanged: { key?: string; oldValue?: any; newValue?: any };
-  statsUpdated: TrafficStats;
   ipInfoUpdated: IpInfoSnapshot;
   navigateToPage: string;
   proxyModeSwitched: { success: boolean; newMode: string };
@@ -84,9 +84,6 @@ export function useNativeEvent<K extends keyof NativeEventData>(
         break;
       case 'configChanged':
         unsubscribe = api.config.onChanged(callback as any);
-        break;
-      case 'statsUpdated':
-        unsubscribe = api.stats.onUpdated(callback as any);
         break;
       case 'ipInfoUpdated':
         unsubscribe = api.ipInfo.onUpdated(callback as any);
@@ -189,8 +186,9 @@ function handleConfigChanged(data: NativeEventData['configChanged']) {
   }
 }
 
-function handleStatsUpdated(data: NativeEventData['statsUpdated']) {
-  // 事件 payload 即最新 TrafficStats，直接写 store（省去 refreshStatistics 的二次 IPC 拉取）
+// batch3 §3.7：stats 帧改经 useStatsTopic('stats') 订阅（取代旧全局 api.stats.onUpdated）。payload 即最新
+// TrafficStats，直接写 store（省去 refreshStatistics 的二次 IPC 拉取）。
+function handleStatsUpdated(data: TrafficStats) {
   useAppStore.setState({ stats: data });
 }
 
@@ -389,7 +387,8 @@ export function useNativeEventListeners() {
   useNativeEvent('processStopped', handleProcessStopped);
   useNativeEvent('processError', handleProcessError);
   useNativeEvent('configChanged', handleConfigChanged);
-  useNativeEvent('statsUpdated', handleStatsUpdated);
+  // batch3 §3.7：stats 走订阅驱动 useStatsTopic（App 常驻，可见即订阅、隐藏退订），取代全局 statsUpdated 事件。
+  useStatsTopic<TrafficStats>('stats', handleStatsUpdated);
   useNativeEvent('ipInfoUpdated', handleIpInfoUpdated);
   useNativeEvent('autoNodeSwitched', handleAutoNodeSwitched);
   useNativeEvent('invalidNodes', handleInvalidNodes);

--- a/src/renderer/hooks/use-stats-topic-core.ts
+++ b/src/renderer/hooks/use-stats-topic-core.ts
@@ -1,0 +1,58 @@
+/**
+ * useStatsTopic 的纯订阅控制器（React / DOM 无关，node 可单测）——batch3 §3.7 订阅驱动数据面。
+ *
+ * 管理某 topic 的「监听 + 订阅」生命周期：
+ *  - attach：**先挂 EVENT_<topic> 监听再 invoke STATS_SUBSCRIBE**——main 侧 subscribe 内即 send 初始帧，监听须先
+ *    就位否则初始帧丢失（合并原 GET 初值路径的关键顺序约束）。
+ *  - detach：退监听 + invoke STATS_UNSUBSCRIBE。
+ *  - 幂等：重复 attach（已订阅）/ detach（未订阅）安全 no-op。
+ *
+ * 此层不碰 ipcClient / react，故其单测无需 jsdom / window（渲染端 hook 逻辑的可测内核）。
+ */
+import { IPC_CHANNELS, STATS_TOPIC_EVENT, type StatsTopic } from '../../shared/ipc-channels';
+
+/** controller 依赖的最小 IPC 面（生产接 ipcClient；测试传 mock）。 */
+export interface StatsTopicIpc {
+  /** invoke 订阅/退订（带 topic）；错误吞在 controller 内，不影响监听生命周期。 */
+  invoke: (channel: string, args: { topic: StatsTopic }) => Promise<unknown>;
+  /** 监听某通道，返回退订函数。 */
+  on: (channel: string, listener: (data: unknown) => void) => () => void;
+}
+
+export interface StatsTopicSubscription {
+  /** 挂监听 + 订阅（幂等：已 attach 则 no-op）。 */
+  attach: () => void;
+  /** 退监听 + 退订（幂等：未 attach 则 no-op）。 */
+  detach: () => void;
+  /** 当前是否已订阅（自检 / 测试用）。 */
+  isAttached: () => boolean;
+}
+
+export function createStatsTopicSubscription<T>(
+  topic: StatsTopic,
+  onFrame: (data: T) => void,
+  ipc: StatsTopicIpc
+): StatsTopicSubscription {
+  const channel = STATS_TOPIC_EVENT[topic];
+  let unlisten: (() => void) | null = null;
+
+  return {
+    attach() {
+      if (unlisten) return; // 已订阅，幂等
+      // 先挂监听再订阅：main.subscribe 同步 send 初始帧，监听须先就位否则初始帧丢失。
+      unlisten = ipc.on(channel, (d) => onFrame(d as T));
+      void ipc.invoke(IPC_CHANNELS.STATS_SUBSCRIBE, { topic }).catch(() => {
+        /* 订阅 invoke 失败（核未就绪等）：监听已挂、后续帧仍可达，静默 */
+      });
+    },
+    detach() {
+      if (!unlisten) return; // 未订阅，幂等
+      unlisten();
+      unlisten = null;
+      void ipc.invoke(IPC_CHANNELS.STATS_UNSUBSCRIBE, { topic }).catch(() => {});
+    },
+    isAttached() {
+      return unlisten !== null;
+    },
+  };
+}

--- a/src/renderer/hooks/use-stats-topic.ts
+++ b/src/renderer/hooks/use-stats-topic.ts
@@ -1,0 +1,45 @@
+/**
+ * useStatsTopic —— 渲染端按 topic 订阅 stats 数据面（batch3 §3.7，取代拓扑/连接页/流量三处各自订阅 + GET/event 双路径）。
+ *
+ * 挂载且可见 → 订阅（invoke STATS_SUBSCRIBE + 监听 EVENT_<topic>，订阅即拿初始帧）；unmount / 文档隐藏
+ * （document.visibilityState==='hidden'，Electron 窗口 hide/最小化即触发）→ 退订；可见恢复 → 重订（重订自然拿
+ * 初始帧 = 原 resume 补帧免费获得）。main 侧据订阅集派生 worker demand：无订阅者逐级停机（含非首页可见视图下拓扑流亦停）。
+ *
+ * onFrame 经 ref 稳定：帧到达时读最新 onFrame，useEffect 依赖仅 [topic, enabled]，不随每次渲染新建的 onFrame
+ * 抖动重订（参照 use-native-events 模块级 handler 稳定引用的教训）。
+ *
+ * @param enabled 消费方门控（默认 true）：连接页「暂停」时传 false → 退订停流（worker detail 逐级停机），恢复 true
+ *   → 重订拿最新初始帧。与可见性门控独立：两者任一不满足即退订。
+ */
+import { useEffect, useRef } from 'react';
+import { ipcClient } from '../ipc/ipc-client';
+import type { StatsTopic } from '../../shared/ipc-channels';
+import { createStatsTopicSubscription } from './use-stats-topic-core';
+
+export function useStatsTopic<T>(
+  topic: StatsTopic,
+  onFrame: (data: T) => void,
+  enabled = true
+): void {
+  // onFrame 经 ref 稳定：帧到达读最新 onFrame，effect 不因 onFrame 每渲染新建而重订（防抖动）。
+  const onFrameRef = useRef(onFrame);
+  onFrameRef.current = onFrame;
+
+  useEffect(() => {
+    const sub = createStatsTopicSubscription<T>(topic, (d) => onFrameRef.current(d), {
+      invoke: (channel, args) => ipcClient.invoke(channel, args),
+      on: (channel, listener) => ipcClient.on(channel, listener),
+    });
+    // 可见 + enabled 才订阅；隐藏 / 禁用则退订。visibilitychange 上同步。
+    const sync = () => {
+      if (enabled && document.visibilityState !== 'hidden') sub.attach();
+      else sub.detach();
+    };
+    sync(); // 挂载即按当前可见性 / enabled 决定
+    document.addEventListener('visibilitychange', sync);
+    return () => {
+      document.removeEventListener('visibilitychange', sync);
+      sub.detach();
+    };
+  }, [topic, enabled]);
+}

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -10,8 +10,6 @@ import type {
   ServerConfig,
   ProxyStatus,
   ProxyErrorCode,
-  ConnectionsSnapshot,
-  ConnectionsAggregate,
   LogEntry,
   TrafficStats,
   Rule,
@@ -498,39 +496,20 @@ export const autoStartApi = {
  */
 export const statsApi = {
   /**
-   * 获取流量统计
+   * 获取流量统计快照（一次性读，如 app-store.refreshStatistics）。batch3：stats 增量改走 useStatsTopic('stats')
+   * 订阅（EVENT_STATS_UPDATED），故此处 onUpdated 已删；一次性快照读仍保留 STATS_GET。
    */
   async get(): Promise<TrafficStats> {
     return ipcClient.invoke(IPC_CHANNELS.STATS_GET);
   },
-
-  /**
-   * 监听统计更新事件
-   */
-  onUpdated(listener: (stats: TrafficStats) => void): () => void {
-    return ipcClient.on(IPC_CHANNELS.EVENT_STATS_UPDATED, listener);
-  },
 };
 
 /**
- * 连接数据 API：渲染端不再直连 :9090、不持 secret。两条独立通道（issue #227 治本）：
- *  - aggregate：首页拓扑用。StatsWorkerHost 每帧 O(N) 聚合后推小载荷（~Top-N host + 出口数），与连接总数解耦。
- *  - get：连接信息页明细 pull。仅页面打开时按 interval 拉，不再「每秒全量 push 给所有窗口」。
+ * 连接数据 API（batch3 §3.7）：明细（detail）与拓扑聚合（aggregate）已改订阅驱动——渲染端经 useStatsTopic
+ * ('detail'/'aggregate') 订阅、订阅即回初始帧 + 增量 push，旧 CONNECTIONS_GET / CONNECTIONS_AGGREGATE_GET 双路径
+ * 随之删除。此处仅留关连接的命令式动作；渲染端不直连 :9090、不持 secret。
  */
 export const connectionsApi = {
-  /** 连接明细 pull（连接信息页打开时定时拉；非每秒 push）。 */
-  async get(): Promise<ConnectionsSnapshot> {
-    return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_GET);
-  },
-  /** 首页拓扑聚合（挂载回填 + 订阅增量广播）。 */
-  aggregate: {
-    async get(): Promise<ConnectionsAggregate> {
-      return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_AGGREGATE_GET);
-    },
-    onUpdated(listener: (agg: ConnectionsAggregate) => void): () => void {
-      return ipcClient.on(IPC_CHANNELS.EVENT_CONNECTIONS_AGGREGATE, listener);
-    },
-  },
   /** 关单条连接（main 经 9090 DELETE /connections/{id}；渲染端无 secret）。 */
   async close(id: string): Promise<{ ok: boolean }> {
     return ipcClient.invoke(IPC_CHANNELS.CONNECTIONS_CLOSE, { id });

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -77,10 +77,10 @@ export const IPC_CHANNELS = {
   AUTO_START_SET: 'autoStart:set',
   AUTO_START_GET_STATUS: 'autoStart:getStatus',
 
-  // 统计信息
-  STATS_GET: 'stats:get',
-  CONNECTIONS_GET: 'connections:get', // 连接信息页明细 pull（仅页面打开时定时拉，非每秒全量 push）
-  CONNECTIONS_AGGREGATE_GET: 'connections:aggregateGet', // 首页拓扑聚合回填（挂载初值；后续走 EVENT_CONNECTIONS_AGGREGATE）
+  // 统计信息（batch3 §3.7：订阅驱动数据面。renderer 按 topic 声明订阅，main 据订阅集派生 worker demand + 精确 relay）
+  STATS_GET: 'stats:get', // 一次性流量快照读（app-store.refreshStatistics 非订阅型消费者，保留）
+  STATS_SUBSCRIBE: 'stats:subscribe', // 订阅某 topic（stats|aggregate|detail）：main 挂订阅 + 即回初始帧（合并旧 GET 初值路径）
+  STATS_UNSUBSCRIBE: 'stats:unsubscribe', // 退订某 topic（unmount/窗口隐藏/暂停）：无订阅者 → worker 逐级停机
   CONNECTIONS_CLOSE: 'connections:close', // 关单条连接（main 经 9090 DELETE /connections/{id}）
   CONNECTIONS_CLOSE_ALL: 'connections:closeAll', // 关全部连接（main 经 9090 DELETE /connections，触发 ResetNetwork）
 
@@ -143,7 +143,11 @@ export const IPC_CHANNELS = {
   EVENT_STATS_UPDATED: 'event:statsUpdated',
   // 首页拓扑连接聚合（StatsWorkerHost 每帧 O(N) 聚合后广播，载荷 ~Top-N host + 出口数，与连接总数解耦）。
   // 取代旧 EVENT_CONNECTIONS_UPDATED（每秒全量 ConnectionEntry[] relay）——连接风暴下渲染端被全量明细拖死（issue #227）。
+  // batch3 §3.7：兼作 aggregate topic 的初始帧 + 增量 push 通道（订阅即回缓存帧，之后 seq 变更才推）。
   EVENT_CONNECTIONS_AGGREGATE: 'event:connectionsAggregate',
+  // 连接明细 push（batch3 §3.7）：detail topic 订阅期 worker→main→订阅 renderer 的全量连接快照（取代旧 CONNECTIONS_GET
+  // 按需 pull）。初始帧 + 增量同一通道；仅连接页订阅期流动，无订阅者 worker 不 post（逐级停机）。
+  EVENT_CONNECTIONS_DETAIL: 'event:connectionsDetail',
   EVENT_ENTER_PRIVACY_MODE: 'event:enterPrivacyMode',
   EVENT_EXIT_PRIVACY_MODE: 'event:exitPrivacyMode', // 退出隐私模式（解锁/idle 计时复位）
   EVENT_NAVIGATE: 'navigate', // 托盘菜单 -> 渲染端路由跳转
@@ -187,3 +191,19 @@ export const IPC_CHANNELS = {
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
+
+/**
+ * stats 订阅 topic（batch3 §3.7 订阅驱动数据面）：renderer 按 topic 精确声明订阅，main 据订阅集派生 worker
+ * demand（aggregate|detail → 上游 Connections 流；detail → 跨进程明细）并只 relay 给对应 topic 的订阅者。
+ */
+export type StatsTopic = 'stats' | 'aggregate' | 'detail';
+
+/**
+ * topic → 事件推送通道（订阅即回的初始帧 + 后续增量 push 共用同一通道）。主/渲两侧订阅与 relay 的单一真值，
+ * 防裸字符串通道名两处漂移（tsc 不查字符串值相等，见 IPC 通道收敛陷阱教训）。
+ */
+export const STATS_TOPIC_EVENT: Record<StatsTopic, IpcChannel> = {
+  stats: IPC_CHANNELS.EVENT_STATS_UPDATED,
+  aggregate: IPC_CHANNELS.EVENT_CONNECTIONS_AGGREGATE,
+  detail: IPC_CHANNELS.EVENT_CONNECTIONS_DETAIL,
+};

--- a/src/shared/types/runtime.ts
+++ b/src/shared/types/runtime.ts
@@ -111,7 +111,7 @@ export interface ConnectionEntry {
   start?: string; // 连接建立时刻（RFC3339）
 }
 
-/** 连接快照：连接信息页经 CONNECTIONS_GET 按需 pull（仅页面打开时定时拉，非每秒全量 push 广播）。 */
+/** 连接快照：连接信息页订阅 'detail' topic（batch3 §3.7）——订阅即回初始帧 + worker 每帧 push，仅页面打开且可见时传（无订阅者 → worker 逐级停机），非旧「每秒全量广播给所有窗口」。 */
 export interface ConnectionsSnapshot {
   connections: ConnectionEntry[];
   at: number; // 采样时刻 epoch ms


### PR DESCRIPTION
> **Stacked on #249**（batch2）→ #248（batch1）。合并前显示三 commit；**batch3 净改动 = `a88aee8`**。#249 合并后本 PR 自动只剩 batch3 diff。

## 背景

issue #242 治本重构收口（batch1 观测/harness #248、batch2 change-driven 聚合下沉 #249 已 Mac 真机验 778→21）。batch3 把 stats 数据面收敛成**订阅驱动**：worker demand 的**源**从「窗口可见」换成「渲染端按 topic 精确声明订阅」，无订阅者逐级停机；合并 GET+event 双路径。**收口「阀门叠 relay」路线**——每加消费者不再拧新阀。

## 改动（worker/host 已由 batch2 就位，本批主要在 registry + renderer）

- **StatsSubscriptionRegistry**（主进程）：`topic(stats|aggregate|detail)→订阅 wc 集`；订阅即回初始帧（合并 `CONNECTIONS_AGGREGATE_GET`/`CONNECTIONS_GET` 初值 pull）；relay 只发订阅者；wc `destroyed` 自动清（防泄漏）；订阅变化即时驱动 `host.syncDemand`。
- **StatsWorkerHost**：demand 源改 `hasSubscribers`（connectionsStream = aggregate‖detail 有订阅；detail = detail 有订阅），删 `lastPullAt`/`PULL_DEMAND_TTL`；detail 由 pull 改 **push topic**；`isUiActive` 降为 relay 兜底安全门（Windows 拖动期订阅在但仍不发）。
- **useStatsTopic** hook（+ 纯控制器 core，node 可测）：挂载/可见/enabled → 订阅（先挂监听再 subscribe，确保初始帧不丢）；unmount/隐藏/暂停 → 退订；可见恢复 → 重订自然拿初始帧。替换拓扑/连接页/流量三处各自订阅。
- **通道**：增 `STATS_SUBSCRIBE`/`STATS_UNSUBSCRIBE` + `EVENT_CONNECTIONS_DETAIL`；删 `CONNECTIONS_GET`/`CONNECTIONS_AGGREGATE_GET` + 连接页 pull interval。

## 测试

- 单测随批：StatsSubscriptionRegistry（订阅/初始帧/destroyed 清/hasSubscribers/subscribersOf 过滤 destroyed）、useStatsTopic 控制器（订阅/退订/重订/幂等）、StatsWorkerHost（demand 由 registry 派生、relay 只发订阅者、isUiActive 安全门、detail push、stop 清零）。
- gate：tsc(main+renderer) 0 error、eslint 0 error、全量 jest **2435 passed / 0 failed**。
- 完整性：`CONNECTIONS_GET`/`CONNECTIONS_AGGREGATE_GET`/`PULL_INTERVAL`/`api.stats.onUpdated` 代码零残留（磁盘 grep + 常量值人工核），仅迁移注释。

## 真机验证（macOS 已端到端坐实，2026-07-02）

arm64 部署 + CDP 事件探针，代理 TUN，逐视图切换：

| 视图 | agg | stats | detail | 坐实 |
|---|---|---|---|---|
| 首页 | 14/30s | 30 | 0 | aggregate 订阅正常投递（= batch2 平价，refactor 未断数据流） |
| **设置页** | **0** | 20 | 0 | **per-view 退订 → 上游流停**（batch2 此处仍 ~0.5Hz）——本批增量收益 |
| 首页(reload) | 7/15s | 16 | 0 | 订阅在 remount 重挂（resume） |
| **连接页** | 0 | 15 | **228/15s（57 行）** | **detail push topic 工作**；agg=0 证 aggregate 只投其订阅者 |

stats 全程贯穿（App 级常驻订阅）。**待真机（非阻塞，另行）**：Windows 拖动流畅性（依赖保留的 isUiActive 安全门；SSH GUI 不可见须桌面手动）。

## 说明

`StatsService.setConnectionsStreamEnabled`（batch2）+ 本批 registry 均纯加法/隔离；renderer 组件视觉零改动（只换数据订阅来源）。

Refs #242
