### PR TITLE
feat(main): renderer 内存 watchdog——超阈值轻量回收兜底泄漏本体（#242 批次4）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,11 @@ import { ProtocolParser } from './services/ProtocolParser';
 import { LogManager } from './services/LogManager';
 import { TrayManager } from './services/TrayManager';
 import { releaseWindowMemory } from './services/window-memory';
+import {
+  parseRendererRssLimitMb,
+  rendererRssMbFromMetrics,
+  decideRendererMemoryAction,
+} from './services/renderer-memory-watchdog';
 import { shouldQuitOnAllWindowsClosed } from './window-close-policy';
 import { ProxyManager } from './services/ProxyManager';
 import { DiagnosticService } from './services/DiagnosticService';
@@ -248,6 +253,68 @@ async function checkIdleAutoModes(): Promise<void> {
     }
   } catch {
     // ignore
+  }
+}
+
+// 渲染进程内存 watchdog（issue #242 §4 视图生命周期）：批次 2/3 的 change-driven / 订阅驱动只把更新降频，泄漏
+// 本体（若在 Blink/V8/Electron 层）未根除；本 watchdog 是对其的**确定性兜底**——渲染 RSS 超阈值时隐藏态 destroy
+// 窗口全额回收、可见态只告警。定位=lifecycle hygiene（同浏览器 tab discard），非泄漏修复。high 阈值 1.5GB 远超
+// 正常 ~250MB，隐藏态回收对用户透明 → 「用户永远看不到 2GB」。**always-on 安全网**（非 gate 在 autoLightweightMode：
+// 那是用户偏好的空闲省电，本 watchdog 是防失控的红线兜底，两者正交；隐藏态回收无副作用，无需开关门）。
+const RENDERER_RSS_LIMIT_MB = parseRendererRssLimitMb(process.env.FLOWZ_RENDERER_RSS_LIMIT_MB);
+const RENDERER_MEM_WARN_COOLDOWN_MS = 5 * 60 * 1000; // 可见态告警冷却 5min，防刷屏
+let lastRendererWarnAt = 0;
+let rendererDiscardCount = 0; // 本会话隐藏态回收次数（诊断导出）
+let rendererWarnCount = 0; // 本会话可见态告警次数（诊断导出）
+
+/**
+ * 渲染进程内存 watchdog 一轮采样 + 处置（接在 idleCheckInterval 的 60s 节拍，watchdog 对小时级泄漏足够，不新增
+ * interval）。取渲染主窗口 pid → getAppMetrics 采其 RSS → 纯决策：
+ * - 'discard'（超阈值 + 窗口隐藏）：走既有轻量原语 enterLightweightMode 销毁窗口全额回收（ensureWindow 下次 show
+ *   重建；轻量原语内 markLightweightModeTransition 已保「有托盘不误退 app」，仅无托盘僵尸态才退——与空闲轻量同语义）。
+ * - 'warn'（超阈值 + 窗口可见）：主进程无现成通用 toast-to-renderer 通道（既有 EVENT 均为专用 payload）→ 退化为
+ *   app.log 面包屑 + 诊断计数（不硬造 renderer UI，见批次报告）；带 5min 冷却防刷屏。
+ * 全程 try/catch 吞异常：绝不因采样/回收失败崩掉空闲主循环。
+ */
+function checkRendererMemory(): void {
+  try {
+    const win = mainWindow;
+    const windowExists = !!win && !win.isDestroyed();
+    // 渲染主窗口 OS pid（与 getAppMetrics 的 pid 同口径）；无窗口/销毁 → null。
+    const rendererPid = windowExists ? win!.webContents.getOSProcessId() : null;
+    const rssMb = rendererRssMbFromMetrics(app.getAppMetrics(), rendererPid);
+    // 可见 = 未隐藏且未最小化：Cmd+H / 关到托盘 / 最小化均判「不可见」→ 允许销毁回收；拖动中窗口仍可见 → 只告警
+    // 不销毁（故用 isVisible/!minimized，而非含 !isDragging 的 isUiBroadcastActive）。
+    const windowVisible = windowExists && win!.isVisible() && !win!.isMinimized();
+    const now = Date.now();
+    const action = decideRendererMemoryAction({
+      rssMb,
+      thresholdMb: RENDERER_RSS_LIMIT_MB,
+      windowExists,
+      windowVisible,
+      lastWarnAt: lastRendererWarnAt,
+      now,
+      warnCooldownMs: RENDERER_MEM_WARN_COOLDOWN_MS,
+    });
+    if (action === 'discard') {
+      logManager.addLog(
+        'warn',
+        `Renderer RSS ${rssMb}MB > ${RENDERER_RSS_LIMIT_MB}MB 且窗口隐藏，进入轻量模式回收`,
+        'Main'
+      );
+      rendererDiscardCount++;
+      trayManager?.enterLightweightMode();
+    } else if (action === 'warn') {
+      logManager.addLog(
+        'warn',
+        `Renderer RSS ${rssMb}MB > ${RENDERER_RSS_LIMIT_MB}MB（窗口可见），建议刷新页面释放内存`,
+        'Main'
+      );
+      rendererWarnCount++;
+      lastRendererWarnAt = now;
+    }
+  } catch {
+    // 采样/回收失败不阻断空闲主循环（getAppMetrics 极端异常、窗口在途销毁等）
   }
 }
 
@@ -1456,8 +1523,12 @@ if (gotTheLock) {
     );
     coreUpdateScheduler.start();
 
-    // 自动空闲模式：powerMonitor 真实系统输入空闲轮询（app ready 后才可用），替代窗口 blur/hide 边沿武装
-    idleCheckInterval = setInterval(() => void checkIdleAutoModes(), IDLE_POLL_MS);
+    // 自动空闲模式：powerMonitor 真实系统输入空闲轮询（app ready 后才可用），替代窗口 blur/hide 边沿武装。
+    // 同节拍搭车渲染进程内存 watchdog（issue #242 §4）：60s 采一次 renderer RSS，超阈值兜底回收/告警（不新增 interval）。
+    idleCheckInterval = setInterval(() => {
+      void checkIdleAutoModes();
+      checkRendererMemory();
+    }, IDLE_POLL_MS);
 
     // 规则资源自动更新调度（sing-box 不自更新本地 .srs，由 FlowZ 周期重下载；静默、不打断连接）
     ruleResourceScheduler = new RuleResourceScheduler(
@@ -1630,7 +1701,13 @@ if (gotTheLock) {
           } catch {
             return null;
           }
-        }
+        },
+        // 渲染进程内存 watchdog 计数（issue #242 §4）：本会话隐藏态回收/可见态告警次数 + 阈值，随诊断导出。
+        () => ({
+          discardCount: rendererDiscardCount,
+          warnCount: rendererWarnCount,
+          thresholdMb: RENDERER_RSS_LIMIT_MB,
+        })
       );
       registerDiagnosticHandlers(diagnosticService);
     }

--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -51,7 +51,13 @@ export class DiagnosticService {
     private readonly systemProxyManager: ISystemProxyManager,
     private readonly privacyProvider: () => boolean = () => false,
     /** 渲染进程堆内省取数（index.ts 注入 executeJavaScript；缺省=不采）。issue #242 §6.2。 */
-    private readonly rendererIntrospect?: () => Promise<RendererHeapSample | null>
+    private readonly rendererIntrospect?: () => Promise<RendererHeapSample | null>,
+    /** 渲染进程内存 watchdog 计数取数（index.ts 注入本会话 discard/warn 次数 + 阈值；缺省=不纳入）。issue #242 §4。 */
+    private readonly rendererWatchdogStats?: () => {
+      discardCount: number;
+      warnCount: number;
+      thresholdMb: number;
+    }
   ) {}
 
   /** 读文件尾部最多 maxBytes 字节；不存在/失败返回占位串（绝不抛）。 */
@@ -155,6 +161,14 @@ export class DiagnosticService {
       memoryTimelineCsv = undefined;
     }
 
+    // 渲染进程内存 watchdog 计数（issue #242 §4）：本会话隐藏态回收/可见态告警次数 + 阈值；best-effort 不阻断报告。
+    let rendererWatchdog;
+    try {
+      rendererWatchdog = this.rendererWatchdogStats?.();
+    } catch {
+      rendererWatchdog = undefined;
+    }
+
     const effLevel = effectiveLogLevel(config.logLevel || 'info', this.privacyProvider());
     const captureActive = !!config.diagnosticCapture;
     const wantDeeper =
@@ -202,6 +216,7 @@ export class DiagnosticService {
       rendererHeap,
       coreProcess,
       memoryTimelineCsv,
+      rendererWatchdog,
       appLogTail,
       singboxLogTail,
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。

--- a/src/main/services/__tests__/renderer-memory-watchdog.test.ts
+++ b/src/main/services/__tests__/renderer-memory-watchdog.test.ts
@@ -1,0 +1,126 @@
+/**
+ * renderer-memory-watchdog 纯决策内核单测（issue #242 §4 视图生命周期）。
+ * 覆盖：env 阈值解析（合法/非法/缺省）、从 getAppMetrics 取渲染 RSS（匹配/pid null/未找到）、
+ * 决策全分支（无窗口/低于阈值/超阈值+隐藏→discard/超阈值+可见+冷却内→none/超阈值+可见+冷却过→warn）。
+ */
+import type { ProcessMetricLike } from '../../../shared/process-metrics';
+import {
+  DEFAULT_RENDERER_RSS_LIMIT_MB,
+  parseRendererRssLimitMb,
+  rendererRssMbFromMetrics,
+  decideRendererMemoryAction,
+} from '../renderer-memory-watchdog';
+
+function metric(pid: number, workingSetKb: number, type = 'Renderer'): ProcessMetricLike {
+  return { pid, type, memory: { workingSetSize: workingSetKb } };
+}
+
+describe('parseRendererRssLimitMb', () => {
+  it('缺省（undefined）→ 默认 1536', () => {
+    expect(parseRendererRssLimitMb(undefined)).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+    expect(DEFAULT_RENDERER_RSS_LIMIT_MB).toBe(1536);
+  });
+
+  it('合法正整数字符串 → 解析值（便于测试降阈值）', () => {
+    expect(parseRendererRssLimitMb('512')).toBe(512);
+    expect(parseRendererRssLimitMb('2048')).toBe(2048);
+  });
+
+  it('非正整数（0/负/小数/非数字/空）→ 回退默认（防污染阈值误触发或永不触发）', () => {
+    expect(parseRendererRssLimitMb('0')).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+    expect(parseRendererRssLimitMb('-100')).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+    expect(parseRendererRssLimitMb('768.5')).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+    expect(parseRendererRssLimitMb('abc')).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+    expect(parseRendererRssLimitMb('')).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+    expect(parseRendererRssLimitMb('  ')).toBe(DEFAULT_RENDERER_RSS_LIMIT_MB);
+  });
+});
+
+describe('rendererRssMbFromMetrics', () => {
+  const metrics = [
+    metric(100, 300 * 1024, 'Browser'),
+    metric(200, 1536 * 1024, 'Renderer'),
+    metric(300, 80 * 1024, 'GPU'),
+  ];
+
+  it('按 pid 匹配渲染进程 → RSS（KB→MB 四舍五入）', () => {
+    expect(rendererRssMbFromMetrics(metrics, 200)).toBe(1536);
+    expect(rendererRssMbFromMetrics(metrics, 100)).toBe(300);
+  });
+
+  it('pid 为 null（窗口已销毁/轻量态）→ null', () => {
+    expect(rendererRssMbFromMetrics(metrics, null)).toBeNull();
+  });
+
+  it('pid 采样里找不到（进程在途重建）→ null', () => {
+    expect(rendererRssMbFromMetrics(metrics, 999)).toBeNull();
+  });
+
+  it('KB 非整 MB → 四舍五入', () => {
+    // 1536.5 MB 的 KB 值 → 四舍五入到 1537（Math.round）
+    expect(rendererRssMbFromMetrics([metric(1, 1536.5 * 1024)], 1)).toBe(1537);
+  });
+});
+
+describe('decideRendererMemoryAction', () => {
+  const base = {
+    thresholdMb: 1536,
+    windowExists: true,
+    windowVisible: true,
+    lastWarnAt: 0,
+    now: 10 * 60 * 1000, // 10min，远超冷却
+    warnCooldownMs: 5 * 60 * 1000,
+  };
+
+  it('无窗口（windowExists false）→ none', () => {
+    expect(
+      decideRendererMemoryAction({
+        ...base,
+        windowExists: false,
+        rssMb: 9999,
+        windowVisible: false,
+      })
+    ).toBe('none');
+  });
+
+  it('RSS 不可得（null）→ none', () => {
+    expect(decideRendererMemoryAction({ ...base, rssMb: null, windowVisible: false })).toBe('none');
+  });
+
+  it('未超阈值（含恰等于阈值）→ none', () => {
+    expect(decideRendererMemoryAction({ ...base, rssMb: 1000, windowVisible: false })).toBe('none');
+    expect(decideRendererMemoryAction({ ...base, rssMb: 1536, windowVisible: false })).toBe('none');
+  });
+
+  it('超阈值 + 窗口隐藏 → discard（销毁回收）', () => {
+    expect(decideRendererMemoryAction({ ...base, rssMb: 1600, windowVisible: false })).toBe(
+      'discard'
+    );
+  });
+
+  it('超阈值 + 窗口可见 + 冷却已过 → warn（只告警，不销毁用户在看的窗口）', () => {
+    expect(decideRendererMemoryAction({ ...base, rssMb: 1600, windowVisible: true })).toBe('warn');
+  });
+
+  it('超阈值 + 窗口可见 + 冷却内 → none（防刷屏）', () => {
+    expect(
+      decideRendererMemoryAction({
+        ...base,
+        rssMb: 1600,
+        windowVisible: true,
+        lastWarnAt: 9 * 60 * 1000, // 上次告警在 9min，距 now(10min) 仅 1min < 5min 冷却
+      })
+    ).toBe('none');
+  });
+
+  it('超阈值 + 可见 + 冷却边界（恰 == cooldown）→ warn', () => {
+    expect(
+      decideRendererMemoryAction({
+        ...base,
+        rssMb: 1600,
+        windowVisible: true,
+        lastWarnAt: 5 * 60 * 1000, // now - lastWarnAt == 冷却 → 允许告警
+      })
+    ).toBe('warn');
+  });
+});

--- a/src/main/services/renderer-memory-watchdog.ts
+++ b/src/main/services/renderer-memory-watchdog.ts
@@ -1,0 +1,83 @@
+/**
+ * 渲染进程内存 watchdog 的纯决策内核（issue #242 §4 视图生命周期策略）。
+ *
+ * 定位：**lifecycle hygiene（同浏览器 tab discard），不是泄漏修复**。批次 2/3 的 change-driven / 订阅驱动
+ * 只把更新「降频」，泄漏本体（若在 Blink/V8/Electron 层）未根除；本模块是对其的**确定性防线**——渲染进程 RSS
+ * 超阈值时：窗口隐藏 → 走既有轻量原语 destroy 窗口全额回收（重建成本=首屏，用户无感）；窗口可见 → 只告警
+ * （绝不销毁用户正在看的窗口）。目标：「用户永远看不到 2GB」。
+ *
+ * 纯函数、无 electron 依赖（ProcessMetricLike 结构兼容 app.getAppMetrics() 结果），全可单测；副作用（取窗口 pid /
+ * 采样 / destroy / 日志 / 计数）留在 index.ts 的接线层。
+ */
+import type { ProcessMetricLike } from '../../shared/process-metrics';
+
+/**
+ * 默认阈值 1536 MB = 1.5 GB。远超正常渲染工作集（~250 MB），是「防 2GB」的兜底红线而非日常门——高阈值确保
+ * 只在真正失控时触发，隐藏态回收对用户透明。可经 FLOWZ_RENDERER_RSS_LIMIT_MB 覆盖（测试降阈值触发两分支）。
+ */
+export const DEFAULT_RENDERER_RSS_LIMIT_MB = 1536;
+
+/**
+ * 解析 FLOWZ_RENDERER_RSS_LIMIT_MB 环境覆盖。非正整数（NaN / 空 / 0 / 负 / 小数 / 非数字）一律回退默认——
+ * 防御：绝不让污染的环境变量把阈值降到 0（每轮误触发回收）或抬成 NaN（永不触发、兜底失效）。
+ */
+export function parseRendererRssLimitMb(env: string | undefined): number {
+  if (env === undefined) return DEFAULT_RENDERER_RSS_LIMIT_MB;
+  const n = Number(env);
+  if (!Number.isInteger(n) || n <= 0) return DEFAULT_RENDERER_RSS_LIMIT_MB;
+  return n;
+}
+
+/**
+ * 从 getAppMetrics() 结果里找渲染主窗口进程的 RSS（MB）。按 pid 精确匹配；pid 为 null（窗口已销毁/轻量态）或
+ * 采样里找不到该 pid（进程在途重建等）→ 返回 null（决策层据 null 判 'none'，不误触发）。
+ * 注意 workingSetSize 是 KB（Electron 口径），故 /1024 得 MB。
+ */
+export function rendererRssMbFromMetrics(
+  metrics: readonly ProcessMetricLike[],
+  rendererPid: number | null
+): number | null {
+  if (rendererPid == null) return null;
+  const m = metrics.find((x) => x.pid === rendererPid);
+  if (!m) return null;
+  return Math.round((m.memory?.workingSetSize ?? 0) / 1024);
+}
+
+/** watchdog 决策结果：销毁回收 / 可见告警 / 无动作。 */
+export type RendererMemoryAction = 'discard' | 'warn' | 'none';
+
+export interface RendererMemoryDecisionInput {
+  /** 渲染主窗口 RSS（MB）；采样不可得为 null。 */
+  rssMb: number | null;
+  /** 触发阈值（MB）。 */
+  thresholdMb: number;
+  /** 主窗口是否存在（!null && !destroyed）。 */
+  windowExists: boolean;
+  /** 主窗口是否对用户可见（可见 = isVisible && !minimized；隐藏/最小化/Cmd+H 均为 false）。 */
+  windowVisible: boolean;
+  /** 上次可见告警时刻（epoch ms）。 */
+  lastWarnAt: number;
+  /** 当前时刻（epoch ms）。 */
+  now: number;
+  /** 可见告警冷却（ms），防刷屏。 */
+  warnCooldownMs: number;
+}
+
+/**
+ * watchdog 决策（纯函数）：
+ * - 无窗口 / RSS 不可得 / 未超阈值 → 'none'。
+ * - 超阈值 且窗口隐藏 → 'discard'（销毁窗口全额回收，ensureWindow 下次 show 重建，透明）。
+ * - 超阈值 且窗口可见 → 冷却已过 'warn'（只告警，绝不销毁用户在看的窗口），冷却内 'none'（防刷屏）。
+ */
+export function decideRendererMemoryAction(
+  input: RendererMemoryDecisionInput
+): RendererMemoryAction {
+  const { rssMb, thresholdMb, windowExists, windowVisible, lastWarnAt, now, warnCooldownMs } =
+    input;
+  if (!windowExists) return 'none';
+  if (rssMb == null) return 'none';
+  if (rssMb <= thresholdMb) return 'none';
+  // 超阈值
+  if (!windowVisible) return 'discard';
+  return now - lastWarnAt >= warnCooldownMs ? 'warn' : 'none';
+}

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -356,11 +356,23 @@ describe('buildDiagnosticReport × issue #242 §6 观测随包新字段', () => 
     expect(md).toContain('2026-07-02T00:00:00.000Z,Browser,100,300');
   });
 
+  it('渲染进程内存看护：阈值 + discard/warn 计数逐行渲染（issue #242 §4）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      rendererWatchdog: { discardCount: 2, warnCount: 3, thresholdMb: 1536 },
+    });
+    expect(md).toContain('## 渲染进程内存看护');
+    expect(md).toContain('- 阈值：1536 MB');
+    expect(md).toContain('- 隐藏态回收（discard）：2 次');
+    expect(md).toContain('- 可见态告警（warn）：3 次');
+  });
+
   it('全部新字段缺省 → 不渲染任何观测新区块（向后兼容）', () => {
     const md = buildDiagnosticReport(base);
     expect(md).not.toContain('## 渲染进程堆分层');
     expect(md).not.toContain('## sing-box 核进程');
     expect(md).not.toContain('## 内存时间线');
+    expect(md).not.toContain('## 渲染进程内存看护');
   });
 });
 

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -308,6 +308,8 @@ export interface DiagnosticReportInput {
   coreProcess?: CoreProcessReport;
   /** 内存时间线（issue #242 §6.4）：每 5min 一帧（Electron 全进程 + 核 RSS）的紧凑 CSV，斜率判泄漏/高水位。 */
   memoryTimelineCsv?: string;
+  /** 渲染进程内存 watchdog（issue #242 §4）：本会话隐藏态回收(discard)/可见态告警(warn)次数 + 触发阈值，纯数字。 */
+  rendererWatchdog?: { discardCount: number; warnCount: number; thresholdMb: number };
   appLogTail: string;
   singboxLogTail: string;
   /** 节点标识符 → 占位符（P0.6）：构建末尾在全报告统一替换，打码节点身份（域名/IP/SNI/节点名），保留形态与跨段相关性。 */
@@ -457,6 +459,14 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
   if (input.memoryTimelineCsv) {
     tail.push('', '## 内存时间线（每 5min 一帧，最多 24h）', '');
     tail.push(fence('csv', input.memoryTimelineCsv));
+  }
+
+  if (input.rendererWatchdog) {
+    const rw = input.rendererWatchdog;
+    tail.push('', '## 渲染进程内存看护', '');
+    tail.push(`- 阈值：${rw.thresholdMb} MB`);
+    tail.push(`- 隐藏态回收（discard）：${rw.discardCount} 次`);
+    tail.push(`- 可见态告警（warn）：${rw.warnCount} 次`);
   }
 
   if (tail.length === 0) return redacted;


### PR DESCRIPTION
> **Stacked on #252**（batch3）→ #249 → #248。合并前显示四 commit；**batch4 净改动 = `f3aeae9`**。前序合并后自动只剩 batch4 diff。

## 背景

issue #242 泄漏本体在 Blink/V8/Electron 层——batch2（#249 change-driven）/batch3（#252 订阅驱动）只把更新**降频**（Mac 真机 agg 17Hz→0），未根除泄漏本身。batch4 是对其的**确定性防线**（设计 §4）：renderer RSS 超阈值 → 隐藏时走既有轻量原语销毁全额回收、可见时告警。定位=**lifecycle hygiene（同浏览器 tab discard），非泄漏修复**——即使下层泄漏不可修，"用户永远看不到 2GB"。

## 改动

- **renderer-memory-watchdog.ts**（纯决策内核，无 electron 依赖、全可单测）：
  - `decideRendererMemoryAction`：超阈值+隐藏→**discard**（销毁回收）/ 超阈值+可见→**warn**（只告警，绝不销毁用户在看的窗口，5min 冷却）/ 否则 none。
  - `parseRendererRssLimitMb`（默认 1536MB，非正整数防御回退）+ `rendererRssMbFromMetrics`（pid 精确匹配，采样不可得→null 不误触发）。
- **index.ts**：搭车既有 `idleCheckInterval`（60s，不新增 interval）采 renderer RSS；`discard`→复用**既有** `enterLightweightMode`（idle 轻量同款原语，`ensureWindow` 下次 show 重建、有托盘不误退）；`warn`→app.log 面包屑 + 计数。可见判定 `isVisible()&&!isMinimized()`（拖动中窗口可见→warn 不 discard，故**非** `isUiBroadcastActive`）；全程 try/catch 不阻断主循环。
- **诊断导出**：加「渲染进程内存看护」段（阈值 / discard / warn 计数）。

## 测试

- 单测：决策内核 14 例（无窗口/低于阈值/超阈值×隐藏→discard/超阈值×可见×冷却内→none/冷却过→warn）+ 解析防御 + pid 匹配 + 诊断段渲染。
- gate：tsc(main+renderer) 0 error、eslint 0 error、全量 jest **2450 passed / 0 failed**。

## 说明 / 决策点

- **阈值 1536MB** 远超正常 ~250MB，日常不触发；`FLOWZ_RENDERER_RSS_LIMIT_MB` 可覆盖（测试降阈值触发两分支）。
- **always-on**（不 gate 在 `cfg.autoLightweightMode`）：这是防 2GB 的红线兜底，与用户的空闲省电偏好正交。
- **可见告警退化为 app.log**：主进程无通用 toast-to-renderer 通道（既有 EVENT 均专用 payload），加 toast 需新通道 + renderer handler + 5 语言 mt——本 PR 不硬造 renderer UI。若需可见 toast 提示，另行跟进（决策点）。
- **无托盘边缘**：非 darwin + 无托盘 + 隐藏 + RSS>1.5GB → app 退出（与既有 idle-lightweight 同契约，非本 PR 新增风险，仅灾难性 RSS 下）。

Refs #242
