### PR TITLE
feat(tailscale): 单 TS 出口登录死锁根治 + 出口未配设备警示

### DIFF
--- a/src/main/ipc/handlers/proxy-handlers.ts
+++ b/src/main/ipc/handlers/proxy-handlers.ts
@@ -154,7 +154,11 @@ export function registerProxyHandlers(
   // 入参传整个 server（渲染端从 store 持有，含 id/tailscaleSettings）→ 主进程无需再 loadConfig。
   registerIpcHandler<
     { server: ServerConfig },
-    { started: boolean; reason?: 'alreadyLoggedIn' | 'inMainCore' | 'alreadyRunning' }
+    {
+      started: boolean;
+      reason?: 'alreadyLoggedIn' | 'inMainCore' | 'alreadyRunning';
+      authUrl?: string;
+    }
   >(IPC_CHANNELS.TAILSCALE_LOGIN, async (_event: IpcMainInvokeEvent, args) => {
     if (!args?.server) throw new Error('server required');
     return proxyManager.startTailscaleLogin(args.server);

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -71,6 +71,7 @@ import {
   meshSystemSupportedOnPlatform,
 } from '../../shared/endpoint-routes';
 import { resolveStartRetryBudget } from '../../shared/start-retry-policy';
+import { meshLoginFallbackShouldEngage } from '../../shared/mesh-login-fallback';
 import {
   classifyCoreBuild,
   decideCoreOverride,
@@ -280,6 +281,14 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // STATUS 流持续推帧，仅 Running 上升沿（首次见该选中节点 Running）发一次 'tailscale-selected-running'，避免每帧触发。
   // 切到别的节点 / 节点掉出 Running（停止/掉线）即清空，使下次重新 Running 能再发（覆盖重连）。
   private lastTsSelectedRunningId: string | null = null;
+  // 缺陷1 登录期出口让位：选中出口为账号制 TS 且隧道未就绪时，默认路由临时 hotSwitch→direct（零重启），
+  // 隧道 Running 后切回。engaged=当前是否处于让位态；serverId=让位所服务的选中出口 id（用户中途切换出口时据此
+  // 判 stale 复位）。仅运行期内存态，随停核/新会话复位。见 shared/mesh-login-fallback + engageLoginFallback。
+  private bootstrapFallbackEngaged = false;
+  private bootstrapFallbackServerId: string | null = null;
+  // reconcileLoginFallback 单飞：多路驱动（STATUS 帧 / switchMode / 健康检查）可能重入，PUT 前状态检查到翻 flag 之间
+  // 有 await 窗口 → 并发调用会各见旧 flag 双 PUT。用此标记序列化：在飞则丢弃后来者（下一 tick/帧会再对账，幂等收敛）。
+  private loginFallbackReconciling = false;
   // P2a：启用代理 / 切接管模式（两者均经 startInternal）后延迟一次「连接 flush」的延时器。stop()/再次 start 时清。
   private connectionFlushTimer: ReturnType<typeof setTimeout> | null = null;
   // 平台提权服务（T16：原提权脚本生成 / 文件权限 / 提权复制等纯函数迁出，经 setPrivilegeService 注入；
@@ -536,6 +545,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // 'tailscale-selected-running' 不发射 → 事件驱动出口 re-probe 丢失（退避仍兜底但失去「隧道就绪即抢先出口」）。
     // 与 handleTailscaleStatus 的清除逻辑不冲突：那是运行期掉线/切节点时清，此处只补会话起点的重置。
     this.lastTsSelectedRunningId = null;
+    // 登录期出口让位内存态随新会话复位（下方核起后按 shouldEngageLoginFallback 重新预置；不在此发 UI 事件，
+    // 预置若命中会发 engaged:true，未命中则 UI 无残留态需清）。
+    this.bootstrapFallbackEngaged = false;
+    this.bootstrapFallbackServerId = null;
     // 本次启动是否交互式（非交互=崩溃自动重启）：供 startSingBoxProcess 决定 helper 不可用时是否裸弹 osascript。
     this.startInteractive = options.interactive !== false;
     // 真正 start 即作废未决的去抖重启（崩溃自动重启直走 start、不经 stop，避免窗口内 crash 后被二次拉起）
@@ -1031,6 +1044,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       // .finally() 串接：reassert 把 selector 校正回 config 后才安排 flush，使 flush 的重连走的是正确出口。
       // reassert 仍 best-effort、不阻塞 start（链在 void promise 上，scheduleConnectionFlush 自身另有 1500ms 延时 +
       // 世代 token 守卫，被 stop/重启接管即放弃）。flush 绝不丢：reassert 成功或异常 finally 都会安排。
+      // 缺陷1 登录期出口让位【预置】折入 reassert stage1（据 state 目录判未登录则直接 PUT direct 并 markEngaged，
+      // 消除「核起→首帧」黑洞窗口）——不在此单独置 flag，避免 flag 与 selector 脱节（flag 只在 PUT 成功后置）。
       void this.reassertSelectorSelection(config).finally(() =>
         this.scheduleConnectionFlush(config)
       );
@@ -1061,9 +1076,18 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       if (!tag) break;
       const client = this.tailscaleApiClient;
       if (!client) break; // 管理 API 客户端未创建（核未起/无管理 API）→ 放弃，cache/default 兜底
+      // 缺陷1 登录期出口让位预置：选中 TS 未登录（据 state 目录判 tunnelReady）→ reassert 直接 PUT 'direct' 而非
+      // 未连上的 TS tag，消除「核起→首帧」黑洞。用 fresh 判定（loginFallbackEligible + !stateExists）而非读 flag，
+      // 且仅在 PUT 成功后 markLoginFallbackEngaged（flag 与 selector 一致，不脱节）。就绪/切走由 reconcile 撤销。
+      const wantDirect =
+        !!targetId &&
+        this.loginFallbackEligible(this.currentConfig ?? config) &&
+        !tailscaleStateExists(targetId as string);
+      const memberTag = wantDirect ? 'direct' : tag;
       try {
         // gRPC SelectOutbound throws on error（与 clash_api 的 {ok,status} 不同）：成功即跳出，异常进重试腿。
-        await client.selectOutbound('proxy-selector', tag);
+        await client.selectOutbound('proxy-selector', memberTag);
+        if (wantDirect) this.markLoginFallbackEngaged(targetId as string);
         break;
       } catch {
         // 管理 API 未就绪/瞬时失败 → 短延迟后重试
@@ -1184,6 +1208,14 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // Phase 2：停止/退出语境一并杀掉残留的瞬态登录核（无孤儿进程）。放早退之前——列表直接点登录时
     // 主核未运行，下方 `!singboxProcess && !singboxPid` 会早退，故在此先收瞬态核。
     this.killAllTailscaleLoginCores();
+    // 缺陷2：停核时清渲染端全部 TS 登录 URL。always-emit 路径的登录态在主核、无瞬态核可杀 → killAll 收不到它，
+    // finalize 不触发 → 渲染端 URL 残留 → 卡片卡「连接中」（此时核已停，点取消也无从收尾）。放在早退之前，
+    // 覆盖「主核未起/已崩溃」与正常停核两条路径。
+    this.broadcastClearTailscaleLogins();
+    // 缺陷1：停核复位登录期出口让位内存态 + 撤 UI 提示（核已停、无 selector 可切；下次 start 重新预置）。
+    this.resetLoginFallbackState();
+    // F1：作废缓存里各 TS 帧的 authURL（跨核会话失效），防下次会话首帧前 startTailscaleLogin 回传死 URL。
+    this.invalidateCachedAuthUrls();
     // issue #147：本地 race DNS server 随核停（绑主核生命周期）。
     this.nodeDnsRaceServer.stop();
     this.raceServerPort = 0;
@@ -1577,6 +1609,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
             void this.meshExitRoute.reconcile(newConfig, !!newConfig.enableIPv6);
           }
         }
+        // 缺陷1：热切换出口后对账登录期让位（切到未就绪 TS→engage；切走/切到就绪节点→撤销 stale 让位）。不等 STATUS 帧。
+        void this.reconcileLoginFallback(this.selectedExitBackendState());
         return;
       }
       this.logToManager('warn', '热切换失败，退回重启式切换');
@@ -1595,6 +1629,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       // 降级桥：上次有外化规则未落盘走 inline（文件无消费者）→ 改走重启重落盘，防「写了没人消费」的值陈旧。
       if (this.customRuleFilesDegraded) this.scheduleDebouncedRestart();
       else await this.syncCustomRuleFiles(newConfig);
+      // 缺陷1：此分支含「切登录期出口让位开关」（meshLoginFallbackDirect 已排除出 norm）→ 关开关须即刻 disengage
+      // 切回出口（不等 STATUS 帧/健康检查）。reconcile 幂等：未 engage / 开关仍开则 no-op。
+      void this.reconcileLoginFallback(this.selectedExitBackendState());
       return;
     }
 
@@ -1798,6 +1835,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       builtinGeoMeta: null,
       subscriptions: null,
       mainSessionViaProxy: null,
+      // 登录期出口让位开关：运行期由 ProxyManager live 读（shouldEngageLoginFallback），不喂 generateSingBoxConfig
+      // → 切它走 hotSwitchSelector 零重启，绝不触发整核重启断流。关开关的 disengage 由 switchMode 无重启腿处理（见 reconcileLoginFallback）。
+      meshLoginFallbackDirect: null,
       // 界面语言纯 UI 偏好，不影响 sing-box 生成 → 运行中切语言（写 config.language 触发 CONFIG_CHANGED→switchMode）
       // 不应重启内核断流。不排除的话每次切语言都会 norm 翻转 → 去抖重启 sing-box（旧 APP_SET_LANGUAGE 路径不写 config、零断流）。
       language: null,
@@ -2057,6 +2097,136 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     }
     this.logToManager('info', `已热切换 ${selectorTag} → ${memberTag}（管理 API，无重启）`);
     return true;
+  }
+
+  /**
+   * 缺陷1：选中出口在【配置层】是否符合登录期出口让位条件（全隧道账号制 TS 出口 + 开关开 + 非 direct 模式 + 无
+   * authKey）。就绪与否的【动态】判断不在此，由 reconcileLoginFallback 按 backendState 决策（本谓词传 tunnelReady=false
+   * 只为在「配置符合」时返回 true）。包 shared/mesh-login-fallback 纯谓词，读 currentConfig 派生输入。
+   */
+  private loginFallbackEligible(config: UserConfig): boolean {
+    const selected = config.servers?.find((s) => s.id === config.selectedServerId);
+    return meshLoginFallbackShouldEngage({
+      fallbackEnabled: config.meshLoginFallbackDirect !== false,
+      proxyModeDirect: (config.proxyMode || 'smart').toLowerCase() === 'direct',
+      selectedExitFallsBackDirect: meshSelectedExitFallsBackToDirect(config),
+      selectedIsTailscale: selected?.protocol?.toLowerCase() === 'tailscale',
+      selectedHasAuthKey: !!selected?.tailscaleSettings?.authKey?.trim(),
+      selectedTunnelReady: false,
+    });
+  }
+
+  /** 选中出口 STATUS 末帧 backendState（读缓存；key 过期视作 NeedsLogin 触发重新登录让位）。无选中/无帧→undefined。 */
+  private selectedExitBackendState(): string | undefined {
+    const selId = this.currentConfig?.selectedServerId;
+    if (!selId) return undefined;
+    const st = this.tailscaleStatusCache.get(selId);
+    if (!st) return undefined;
+    // key 过期即便 backendState 仍 Running 也需重新交互登录 → 视作 NeedsLogin，触发让位避免过期后走死出口黑洞。
+    if (st.expired) return 'NeedsLogin';
+    return st.backendState;
+  }
+
+  /** 置让位 flag（PUT 成功后调，flag 与 selector 一致）。幂等，仅首次 emit engaged:true。 */
+  private markLoginFallbackEngaged(serverId: string): void {
+    if (this.bootstrapFallbackEngaged && this.bootstrapFallbackServerId === serverId) return;
+    const first = !this.bootstrapFallbackEngaged;
+    this.bootstrapFallbackEngaged = true;
+    this.bootstrapFallbackServerId = serverId;
+    if (first) {
+      const name = this.currentConfig?.servers.find((s) => s.id === serverId)?.name;
+      this.logToManager(
+        'info',
+        `组网出口「${name ?? serverId}」尚未登录，登录期默认路由让位直连`,
+        'sing-box'
+      );
+      this.sendEventToRenderer(IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK, {
+        engaged: true,
+        serverName: name,
+      });
+    }
+  }
+
+  /**
+   * 缺陷1 登录期出口让位【对账】（单一入口，幂等可重入；PUT 成功才翻 flag → 杜绝「flag 与 selector 脱节永卡 direct」）。
+   * 三态决策（按选中出口 backendState）：
+   *  - 符合条件 且 NeedsLogin（含 key 过期）→ engage：hotSwitch proxy-selector→direct，成功才置 flag；失败不改、下次 tick 重试；
+   *  - 已让位 且（不再符合条件[关开关/切非 TS/direct/authKey] 或 已就绪 Running）→ disengage：
+   *      同一选中出口 → PUT 切回其 tag（关开关时切回=用户明确「宁可授权失败也不直连」）；切走出口 → 仅清 flag（selector 归 planHotSwitch）；
+   *  - 其余过渡态（NoState/Starting/Stopped/无帧）→ 维持现状，不翻转（避免 bootstrap 过渡期抖动 / 已登录节点起核闪直连）。
+   * 由 STATUS 帧 / switchMode 非重启腿 / 健康检查 / reassert 后 共同驱动；核未起时 hotSwitch 返 false → 不改 flag。
+   */
+  private async reconcileLoginFallback(backendState: string | undefined): Promise<void> {
+    if (this.loginFallbackReconciling) return; // 单飞：在飞对账中丢弃后来者（下一帧/tick 再对账，幂等收敛）
+    this.loginFallbackReconciling = true;
+    try {
+      const config = this.currentConfig;
+      if (!config) return;
+      const selId = config.selectedServerId ?? null;
+      const eligible = !!selId && this.loginFallbackEligible(config);
+
+      // engage：符合条件 且 明确需要交互登录（NeedsLogin / 过期）。
+      // 注意：**不**因「已 engaged」提前 return。原短路信任「flag=engaged ⟹ selector=direct」不变量，但 reassert 预置
+      // 与本 reconcile 是两个独立 proxy-selector 写者（reassert 的 raw selectOutbound 不在单飞内），expired-startup 下
+      // reassert 可能 PUT 死 tag 后落地、而 flag 已被本分支置 engaged → 短路会让健康检查永不重 PUT direct → 死锁复活无自愈
+      // （review round-2 N1）。改为 NeedsLogin 时每次都重 PUT direct（gRPC 选同成员=核侧 no-op，无害）→ 10s 健康检查即自愈；
+      // markLoginFallbackEngaged 的 first 守卫保证 UI 只 emit 一次，不刷屏。
+      if (eligible && backendState === 'NeedsLogin') {
+        const ok = await this.hotSwitchSelector('proxy-selector', 'direct');
+        if (!ok) return; // PUT 失败：不改 flag，下次 tick 重试
+        this.markLoginFallbackEngaged(selId!);
+        return;
+      }
+
+      // disengage 条件：已让位 且（不再符合条件 或 已就绪 Running）。过渡态一律维持现状。
+      const shouldDisengage =
+        this.bootstrapFallbackEngaged && (!eligible || backendState === 'Running');
+      if (!shouldDisengage) return;
+
+      const engagedId = this.bootstrapFallbackServerId;
+      if (engagedId && engagedId === selId) {
+        // 同一选中出口撤销让位（就绪 或 用户关开关）→ PUT 切回其 tag（成功才清 flag；关开关切回=用户明确不直连）。
+        const tag = this.currentIdToTagMap?.get(engagedId);
+        if (tag) {
+          const ok = await this.hotSwitchSelector('proxy-selector', tag);
+          if (!ok) return; // PUT 失败：不改 flag，下次 tick 重试
+        } else {
+          // tag 缺失（罕见：核停/gate 剔除）→ 无法 PUT 回；清 flag 避免永卡，selector 由 reassert/planHotSwitch 兜底。
+          this.logToManager(
+            'warn',
+            `组网出口让位撤销：找不到出口 tag（${engagedId}），跳过 selector 切回`,
+            'sing-box'
+          );
+        }
+        const name = config.servers.find((s) => s.id === engagedId)?.name;
+        this.bootstrapFallbackEngaged = false;
+        this.bootstrapFallbackServerId = null;
+        this.logToManager(
+          'info',
+          `组网出口「${name ?? engagedId}」让位撤销，默认路由切回该出口`,
+          'sing-box'
+        );
+        this.sendEventToRenderer(IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK, {
+          engaged: false,
+          serverName: name,
+        });
+      } else {
+        // 切走出口：selector 已由 planHotSwitch/config default PUT 到新目标，仅清 flag + 撤 UI（不 PUT，避免打架）。
+        this.bootstrapFallbackEngaged = false;
+        this.bootstrapFallbackServerId = null;
+        this.sendEventToRenderer(IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK, { engaged: false });
+      }
+    } finally {
+      this.loginFallbackReconciling = false;
+    }
+  }
+
+  /** 复位登录期出口让位内存态 + 撤销 UI 提示（若在让位中）。停核/清理调用；不切 selector（核已停/将停）。 */
+  private resetLoginFallbackState(): void {
+    if (!this.bootstrapFallbackEngaged && this.bootstrapFallbackServerId === null) return;
+    this.bootstrapFallbackEngaged = false;
+    this.bootstrapFallbackServerId = null;
+    this.sendEventToRenderer(IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK, { engaged: false });
   }
 
   /**
@@ -4611,6 +4781,12 @@ exit 0
     // Tailscale 登录 URL 去重集随核会话收尾清空（绑定核会话而非整进程）：下个核会话若再触发交互登录，
     // 同一 URL 应重新弹「需登录」提示。tailscaleAuthPolling 有自身 delete 收尾，不在此动（勿破在飞登录）。
     this.tailscaleAuthSeen.clear();
+    // 缺陷2：崩溃/giveUp 路径也清渲染端 TS 登录 URL（核已死，always-emit 路径的登录态不会再有收尾信号）。
+    this.broadcastClearTailscaleLogins();
+    // 缺陷1：崩溃/giveUp 路径复位登录期出口让位内存态 + 撤 UI 提示。
+    this.resetLoginFallbackState();
+    // F1：崩溃/giveUp 路径同样作废缓存 authURL（跨会话失效），防重启后回传死 URL。
+    this.invalidateCachedAuthUrls();
   }
 
   /** 注入 macOS 提权 helper（index.ts 启动时调用）。 */
@@ -4905,7 +5081,11 @@ exit 0
         // 完全清理
         this.cleanup();
       }
+      return; // 进程已死：不再对账让位（cleanup 已复位或即将重启由 reassert 重建）
     }
+    // 缺陷1 出口让位无帧安全网：STATUS 是 push-on-change、稳态可能不再来帧，若 engage/restore 的 PUT 曾失败则 flag 与
+    // selector 脱节、无后续帧重试 → 每 10s 健康检查读缓存末帧对账一次（幂等，到位则 no-op；核在跑才对账）。
+    void this.reconcileLoginFallback(this.selectedExitBackendState());
   }
 
   /**
@@ -5692,7 +5872,9 @@ exit 0
     }
   }
 
-  /** 已推送过的 Tailscale 登录 URL（核会重复打印同一行，按 url 去重防刷屏）。urls 为一次性 token、量小，不清理。 */
+  /** 已推送过的 Tailscale 登录 URL，按 url 去重防重复上报。注：1.14 内核每登录会话只生成一份 URL、不轮换，sing-box
+   *  watchState 亦按 reportedAuthURL 去重（fork 禁用了上游周期重打循环），故此 Set 实为冗余第二层；真正可靠的当前
+   *  authURL 来源是 tailscaleStatusCache（STATUS 末帧），取消后重开授权页走它兜底，见 startTailscaleLogin/§F.3。 */
   private tailscaleAuthSeen = new Set<string>();
 
   /**
@@ -5761,9 +5943,13 @@ exit 0
    *
    * @returns started=true 已起核（或已在飞）；started=false 时 reason 说明（alreadyLoggedIn / inMainCore）。
    */
-  async startTailscaleLogin(
-    server: ServerConfig
-  ): Promise<{ started: boolean; reason?: 'alreadyLoggedIn' | 'inMainCore' | 'alreadyRunning' }> {
+  async startTailscaleLogin(server: ServerConfig): Promise<{
+    started: boolean;
+    reason?: 'alreadyLoggedIn' | 'inMainCore' | 'alreadyRunning';
+    /** inMainCore/alreadyRunning 时回传主核 STATUS 末帧的当前 authURL（渲染端点「连接」可靠重开授权页，补掉取消后
+     *  的无限空窗——核每会话只生成一份 URL、不轮换，STATUS 事件驱动无 ticker，取消清了 store 就没帧回填，见设计 §F.3）。 */
+    authUrl?: string;
+  }> {
     if (!server || server.protocol?.toLowerCase() !== 'tailscale') {
       throw new Error('startTailscaleLogin: 非 Tailscale 节点');
     }
@@ -5772,18 +5958,17 @@ exit 0
     if (server.tailscaleSettings?.authKey?.trim()) {
       return { started: false, reason: 'alreadyLoggedIn' };
     }
-    // 双写防护：endpoint 已在运行主核里 → 不起瞬态核（避免双写 state_directory 冲突）。
-    if (
-      tailscaleEndpointInRunningCore(
-        server.id,
-        this.getStatus().running,
-        this.currentConfig,
-        tailscaleStateExists(server.id)
-      )
-    ) {
-      return { started: false, reason: 'inMainCore' };
+    // 主核 STATUS 末帧的当前 authURL：作 inMainCore/alreadyRunning 时渲染端重开授权页的可靠来源（取消清了 store 也仍在此）。
+    const liveAuthUrl = this.tailscaleStatusCache.get(server.id)?.authURL || undefined;
+    // 双写防护：endpoint 已在运行主核里 → 不起瞬态核（避免双写 state_directory 冲突）。always-emit 后
+    // 判据 = 节点在运行配置里即在主核（不再看 selected/authKey/stateExists，见 tailscaleEndpointInRunningCore）。
+    if (tailscaleEndpointInRunningCore(server.id, this.getStatus().running, this.currentConfig)) {
+      return { started: false, reason: 'inMainCore', authUrl: liveAuthUrl };
     }
     // 每节点单飞：已有在飞瞬态核则复用（不重复 spawn / 不重复开浏览器）。
+    // 不回传 liveAuthUrl（F2）：瞬态核的 URL 从不进 tailscaleStatusCache（emitTailscaleStatus includeAuthURL=false
+    // 覆盖成 undefined），此处 liveAuthUrl 只可能是 undefined 或别会话的 stale URL；瞬态核会自 stdout 拿 URL 自动开
+    // 浏览器 + 推 store，渲染端「进行中」toast 诚实，回落 store 缓存的新鲜 URL 即可，勿让 stale 压过它。
     if (this.tailscaleLoginCores.has(server.id)) {
       return { started: false, reason: 'alreadyRunning' };
     }
@@ -5978,12 +6163,16 @@ exit 0
     this.logToManager('info', `Tailscale 节点「${server.name}」已打开浏览器登录页`, 'sing-box');
   }
 
-  /** 取消某节点在飞的瞬态登录核（用户手动取消，IPC 入口）。无在飞核为 no-op。 */
+  /** 取消某节点登录（用户手动取消，IPC 入口）。杀在飞瞬态核（若有）+ 恒清渲染端登录态。 */
   cancelTailscaleLogin(serverId: string): void {
     if (this.tailscaleLoginCores.has(serverId)) {
       this.logToManager('info', `已取消 Tailscale 节点登录`, 'sing-box');
     }
     this.killTailscaleLogin(serverId);
+    // 缺陷2：always-emit 路径下 endpoint 在主核里、Map 无瞬态核项 → killTailscaleLogin 是 no-op、finalize 不触发，
+    // 渲染端 tailscaleAuthUrls[serverId] 永不被清 → 卡片卡「连接中」，点取消也无效。故取消恒广播空 AUTH_URL
+    // 清渲染端（不重启核）。瞬态核路径的 finalize 也会发空 URL，重复无害（store 删 key 幂等）。
+    this.sendEventToRenderer(IPC_CHANNELS.EVENT_TAILSCALE_AUTH_URL, { serverId, url: '' });
   }
 
   /** sing-box 管理 API（services[{type:api}] + 状态订阅）是否可用：要求核 ≥1.14。§5 守卫已保证 start 路径恒满足；
@@ -6005,10 +6194,11 @@ exit 0
         (s) => s.protocol?.toLowerCase() === 'tailscale' && s.name === ep.endpointTag
       );
       if (!server) continue;
-      this.emitTailscaleStatus(server.id, ep);
-      // item 1 事件驱动出口 re-probe：选中节点是账号制 TS 且其隧道 STATUS 翻 Running（DERP/peer 握手完成、
-      // 路由已下发=隧道就绪）→ 立即触发一次代理出口 re-probe（不等满退避）。仅选中节点、仅 Running 上升沿
-      // （lastTsSelectedRunningId 去重，STATUS 持续推帧不会每帧触发）。Starting/NeedsLogin 不算就绪、不触发。
+      this.emitTailscaleStatus(server.id, ep); // 先更新 tailscaleStatusCache（下方 reconcile 读末帧）
+      // item 1 事件驱动出口 re-probe：选中节点是账号制 TS 且其隧道 STATUS 翻 Running（DERP/peer 握手完成、路由已下发
+      // =就绪）→ 触发一次代理出口 re-probe（不等满退避）。仅选中节点、仅 Running 上升沿（lastTsSelectedRunningId 去重）。
+      // 注：出口让位 engage/restore 已【不再】复用此去重（改由下方 reconcileLoginFallback 每帧对账，杜绝 PUT 失败被
+      // 去重扼杀永卡 direct，见 review finding 2）；此去重只服务 re-probe。
       if (
         server.id === selectedId &&
         isAccountBasedProtocol(server.protocol) &&
@@ -6025,6 +6215,9 @@ exit 0
     if (!selectedRunning && this.lastTsSelectedRunningId !== null) {
       this.lastTsSelectedRunningId = null;
     }
+    // 缺陷1 出口让位对账：读选中出口 STATUS 末帧（emitTailscaleStatus 已更新缓存）。每帧对账 → engage/restore 的 PUT
+    // 失败会在后续帧重试，不被上面的 re-probe 去重扼杀。
+    void this.reconcileLoginFallback(this.selectedExitBackendState());
   }
 
   /**
@@ -6091,8 +6284,7 @@ exit 0
     const inRunningCore = tailscaleEndpointInRunningCore(
       serverId,
       this.getStatus().running,
-      this.currentConfig,
-      tailscaleStateExists(serverId)
+      this.currentConfig
     );
     // 节点在运行主核里 → 经 api 让内核原生登出该 endpoint（endpointTag=server.name）。api 不可达/未起则吞错，
     // 仍走下方清 state 目录兜底（瞬态核登录写的会话）。
@@ -6142,6 +6334,41 @@ exit 0
   private killAllTailscaleLoginCores(): void {
     for (const serverId of Array.from(this.tailscaleLoginCores.keys())) {
       this.killTailscaleLogin(serverId);
+    }
+  }
+
+  /**
+   * 停核/清理时清渲染端全部 TS 登录 URL：遍历当前配置的 TS 节点各发一次空 AUTH_URL（缺陷2）。
+   * 停核只 killAllTailscaleLoginCores（杀瞬态核），但 always-emit 路径的登录 URL 是主核经 STATUS/AUTH_URL 推的、
+   * 无瞬态核可杀、finalize 不触发 → 渲染端 URL 残留 → 卡片卡「连接中」。停核时统一广播空 URL，让渲染端各 TS
+   * 卡片退出「连接中」回「需登录/未连接」。渲染端 setTailscaleAuthUrl('') 会一并清 loginInitiated 标记。
+   */
+  private broadcastClearTailscaleLogins(): void {
+    for (const server of this.currentConfig?.servers || []) {
+      if (server.protocol?.toLowerCase() === 'tailscale') {
+        this.sendEventToRenderer(IPC_CHANNELS.EVENT_TAILSCALE_AUTH_URL, {
+          serverId: server.id,
+          url: '',
+        });
+      }
+    }
+  }
+
+  /**
+   * F1：停核/清理时作废 tailscaleStatusCache 里各帧的 authURL（一次性登录 token、跨核会话即失效——核每登录会话
+   * 只生成一份 URL、重启核会换新 URL，见 §F.3.1）。**不整表 clear**：内网 IP/peers 是「代理关时显示上次已知 + 灰显」
+   * 的有意设计（mesh-info-popover 依赖 TAILSCALE_GET_STATUS 陈旧值），只清会话作废的 authURL——否则下次会话首帧到达前
+   * startTailscaleLogin 会回传上会话的死 URL、渲染端开死页并回填 store（F1 反例）。
+   */
+  private invalidateCachedAuthUrls(): void {
+    for (const [id, payload] of this.tailscaleStatusCache) {
+      // 同时作废 backendState（跨会话失效的会话态）为空串：否则新会话首帧到达前，switchMode 非重启腿驱动的 reconcile
+      // 可能读到上会话 stale 'Running' → 对新 NeedsLogin 会话误判 disengage、PUT 未连上的 TS tag（Fable F1 附带 Nit）。
+      // 空串经 selectedExitBackendState 既非 'NeedsLogin' 也非 'Running' → reconcile 维持现状(hold)，安全；渲染端
+      // backendState 只从 live 事件读、不读快照，故清空不影响 UI（下会话首帧即覆盖回真值）。
+      if (payload.authURL !== undefined || payload.backendState !== '') {
+        this.tailscaleStatusCache.set(id, { ...payload, authURL: undefined, backendState: '' });
+      }
     }
   }
 

--- a/src/main/services/__tests__/proxy-manager-tailscale-login.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tailscale-login.test.ts
@@ -275,15 +275,16 @@ describe('finalize 发空 authUrl 清「登录中」（取消/崩溃 → 清；�
     );
   }
 
-  it('用户取消（cancelTailscaleLogin → proc exit）→ 发空 authUrl 退出「登录中」', async () => {
+  it('用户取消（cancelTailscaleLogin → proc exit）→ 发空 authUrl 退出「登录中」（缺陷2：cancel 直发 + finalize 各一次，均幂等）', async () => {
     const { svc, sent } = makeSvc();
     await svc.startTailscaleLogin(tsServer({ id: 'srv-1', name: 'my-ts' }));
     const proc = spawnedProcs[0];
 
-    svc.cancelTailscaleLogin('srv-1'); // 用户手动取消 → killTailscaleLogin → SIGTERM
-    proc.emit('exit', 0, null); // 进程退出 → finalize
+    svc.cancelTailscaleLogin('srv-1'); // 用户手动取消 → 直发空 authUrl（缺陷2）+ killTailscaleLogin → SIGTERM
+    proc.emit('exit', 0, null); // 进程退出 → finalize 再发一次（!loginCompleted）
 
-    expect(emptyAuthUrlEvents(sent, 'srv-1')).toHaveLength(1);
+    // cancel 直发 1 次 + finalize 1 次 = 2；store 删 key 幂等，重复无害。缺陷2 治法：主核路径无瞬态核时仅 cancel 直发那次生效。
+    expect(emptyAuthUrlEvents(sent, 'srv-1')).toHaveLength(2);
   });
 
   it('核自行崩溃（无取消，直接 proc exit）→ 发空 authUrl 退出「登录中」', async () => {
@@ -316,5 +317,41 @@ describe('finalize 发空 authUrl 清「登录中」（取消/崩溃 → 清；�
     proc.emit('exit', 0, null); // 被杀退出 → finalize
 
     expect(emptyAuthUrlEvents(sent, 'srv-1')).toHaveLength(0);
+  });
+});
+
+// 缺陷2：主核 always-emit 路径（endpoint 在主核里、无瞬态核）取消 / 停核清渲染端登录态。
+describe('缺陷2 主核路径清「连接中」（无瞬态核）', () => {
+  function emptyAuthUrlEvents(sent: { channel: string; data: any }[], serverId: string) {
+    return sent.filter(
+      (e) =>
+        e.channel === IPC_CHANNELS.EVENT_TAILSCALE_AUTH_URL &&
+        e.data?.serverId === serverId &&
+        e.data?.url === ''
+    );
+  }
+
+  it('cancelTailscaleLogin 无在飞瞬态核（主核路径）→ 仍发一次空 authUrl 清渲染端', () => {
+    const { svc, sent } = makeSvc();
+    // 不 startTailscaleLogin：tailscaleLoginCores 里无 srv-1（模拟 always-emit 主核路径，登录 URL 由主核推）。
+    expect(svc.tailscaleLoginCores.has('srv-1')).toBe(false);
+    svc.cancelTailscaleLogin('srv-1');
+    expect(emptyAuthUrlEvents(sent, 'srv-1')).toHaveLength(1);
+  });
+
+  it('broadcastClearTailscaleLogins：对 currentConfig 每个 TS 节点各发一次空 authUrl（非 TS 跳过）', () => {
+    const { svc, sent } = makeSvc();
+    svc.currentConfig = {
+      selectedServerId: 'ts-a',
+      servers: [
+        tsServer({ id: 'ts-a', name: 'a' }),
+        tsServer({ id: 'ts-b', name: 'b' }),
+        { id: 'vmess-1', name: 'v', protocol: 'vmess', address: 'x', port: 1 },
+      ],
+    };
+    svc.broadcastClearTailscaleLogins();
+    expect(emptyAuthUrlEvents(sent, 'ts-a')).toHaveLength(1);
+    expect(emptyAuthUrlEvents(sent, 'ts-b')).toHaveLength(1);
+    expect(emptyAuthUrlEvents(sent, 'vmess-1')).toHaveLength(0); // 非 TS 不发
   });
 });

--- a/src/main/services/__tests__/proxy-manager-ts-selected-running.test.ts
+++ b/src/main/services/__tests__/proxy-manager-ts-selected-running.test.ts
@@ -38,6 +38,7 @@ jest.mock('../ResourceManager', () => ({
 }));
 
 import { ProxyManager } from '../ProxyManager';
+import { IPC_CHANNELS } from '../../../shared/ipc-channels';
 import type { ServerConfig, UserConfig } from '../../../shared/types';
 
 afterAll(() => {
@@ -62,9 +63,10 @@ function tsServer(over: Partial<ServerConfig> = {}): ServerConfig {
 
 /** 构造 ProxyManager + fake mainWindow（webContents.send no-op，仅吸收 emitTailscaleStatus）。 */
 function makeSvc() {
+  const sent: { channel: string; data: any }[] = [];
   const mainWindow: any = {
     isDestroyed: () => false,
-    webContents: { send: jest.fn() },
+    webContents: { send: (channel: string, data: any) => sent.push({ channel, data }) },
   };
   const svc: any = new ProxyManager(
     { addLog: jest.fn() } as any,
@@ -72,7 +74,7 @@ function makeSvc() {
     path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`),
     '/fake/sing-box'
   );
-  return { svc };
+  return { svc, sent };
 }
 
 /** currentConfig：选中一个 TS 节点为全局出口。 */
@@ -85,6 +87,9 @@ function configWithSelectedTs(): UserConfig {
 
 const RUNNING = [{ endpointTag: 'my-ts', backendState: 'Running', authURL: '' }];
 const STARTING = [{ endpointTag: 'my-ts', backendState: 'Starting', authURL: '' }];
+const NEEDS_LOGIN = [
+  { endpointTag: 'my-ts', backendState: 'NeedsLogin', authURL: 'https://login.tailscale.com/a/x' },
+];
 
 describe('选中 TS 节点 Running 上升沿 → emit tailscale-selected-running（去重）', () => {
   it('首帧 Running → emit + 置 lastTsSelectedRunningId；持续 Running 帧不重复 emit', () => {
@@ -164,5 +169,213 @@ describe('会话起点重置 lastTsSelectedRunningId（修 stop 后重连同节�
     svc.currentConfig = configWithSelectedTs();
     svc.handleTailscaleStatus(RUNNING);
     expect(emitted).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('缺陷1 登录期出口让位对账（reconcileLoginFallback，经 handleTailscaleStatus 驱动）', () => {
+  // 微任务 flush：reconcile 是 async void（handleTailscaleStatus 内 void 掉）→ PUT+翻 flag 在 await 之后，
+  // 断言前须 flush（setImmediate 排到宏任务尾，微任务链已清）。
+  const flush = () => new Promise((r) => setImmediate(r));
+
+  // 选中一个【承载全隧道】的 TS 出口——P0b 后 meshAllowsInternet(TS) 由 exit_node 派生，故须配 exitNode 才承载全隧道
+  // （meshSelectedExitFallsBackToDirect=false）、符合让位条件。（旧 fixture 只 allowInternet:true 无 exitNode → P0b 后
+  // 回退 direct、不符合让位——见 §H F1 + 下方 S-b 反例用例。）
+  function fullTunnelTsConfig(over: Partial<UserConfig> = {}): UserConfig {
+    return {
+      selectedServerId: 'srv-ts',
+      proxyMode: 'smart',
+      servers: [tsServer({ tailscaleSettings: { allowInternet: true, exitNode: '100.64.0.1' } })],
+      ...over,
+    } as unknown as UserConfig;
+  }
+
+  it('选中 TS 出口 NeedsLogin → engage：hotSwitch(proxy-selector,direct) + PUT 成功才置 flag', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(hot).toHaveBeenCalledWith('proxy-selector', 'direct');
+    expect(svc.bootstrapFallbackEngaged).toBe(true);
+    expect(svc.bootstrapFallbackServerId).toBe('srv-ts');
+  });
+
+  it('engage 效果幂等：连续 NeedsLogin 帧 flag 稳定 + UI 只 emit engaged:true 一次（N1 修复：允许重 PUT direct 自愈）', async () => {
+    const { svc, sent } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    // 效果幂等：flag 稳定 engaged；N1 修复后每帧重 PUT direct（核侧 no-op 自愈），但 UI engaged:true 仅一次（first 守卫）。
+    expect(svc.bootstrapFallbackEngaged).toBe(true);
+    expect(svc.bootstrapFallbackServerId).toBe('srv-ts');
+    const engagedTrueEmits = sent.filter(
+      (e) => e.channel === IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK && e.data?.engaged === true
+    );
+    expect(engagedTrueEmits).toHaveLength(1);
+  });
+
+  it('[review N1] engaged 期间 selector 被外部改回死 tag（模拟 reassert 竞态）→ 后续 NeedsLogin 帧重 PUT direct 自愈', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN); // engage
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(true);
+    hot.mockClear();
+    // N1 反例：flag 仍 engaged，但（并发 reassert）selector 已被 PUT 回死 tag。下一 NeedsLogin 帧（或 10s 健康检查）
+    // 须【重】PUT direct 自愈——短路存在时此处 hot 不会被调用（旧 bug），修复后必被调用。
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(hot).toHaveBeenCalledWith('proxy-selector', 'direct');
+  });
+
+  it('[review finding 2] engage PUT 失败 → 不置 flag，后续帧重试（不被永久扼杀）', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(false); // PUT 失败
+
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(false); // 失败不置 flag（避免 flag 与 selector 脱节）
+    expect(hot).toHaveBeenCalledTimes(1);
+
+    hot.mockResolvedValue(true); // 下一帧管理 API 恢复
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(true); // 重试成功（未被去重扼杀）
+    expect(hot).toHaveBeenCalledTimes(2);
+  });
+
+  it('隧道 Running → restore：hotSwitch 切回 TS tag + PUT 成功才清 flag', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+
+    svc.handleTailscaleStatus(NEEDS_LOGIN); // engage
+    await flush();
+    hot.mockClear();
+    svc.handleTailscaleStatus(RUNNING); // restore
+    await flush();
+    expect(hot).toHaveBeenCalledWith('proxy-selector', 'my-ts');
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+    expect(svc.bootstrapFallbackServerId).toBeNull();
+  });
+
+  it('[review finding 2] restore PUT 失败 → 保持 engaged，后续 Running 帧重试（不永久卡 direct）', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN); // engage
+    await flush();
+
+    hot.mockResolvedValue(false); // restore PUT 失败
+    svc.handleTailscaleStatus(RUNNING);
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(true); // 失败仍 engaged（未谎报切回、未清 flag）
+
+    hot.mockResolvedValue(true); // 又一 Running 帧（管理 API 恢复）→ 重试成功
+    svc.handleTailscaleStatus(RUNNING);
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+    expect(hot).toHaveBeenLastCalledWith('proxy-selector', 'my-ts');
+  });
+
+  it('切出口（selectedServerId 变为非 TS/其它）→ disengage 清 flag，不 PUT 回旧 tag', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN); // engage srv-ts
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(true);
+    hot.mockClear();
+
+    // 用户切到别的出口：selectedServerId 变（该节点无 STATUS 缓存帧 → backendState undefined）。
+    svc.currentConfig = { ...svc.currentConfig, selectedServerId: 'other' };
+    svc.handleTailscaleStatus(RUNNING); // 仍是 my-ts 帧，但选中已是 other
+    await flush();
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+    expect(svc.bootstrapFallbackServerId).toBeNull();
+    expect(hot).not.toHaveBeenCalledWith('proxy-selector', 'my-ts'); // 切走→不 PUT（planHotSwitch 管）
+  });
+
+  it('[finding 8] 让位中关开关（reconcile 见 eligible=false）→ PUT 切回出口 tag + 清 flag', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN); // engage
+    await flush();
+    hot.mockClear();
+
+    // 关开关：同一选中出口，eligible 变 false → 撤销让位并 PUT 回出口 tag（用户明确「宁可授权失败也不直连」）。
+    svc.currentConfig = { ...svc.currentConfig, meshLoginFallbackDirect: false };
+    await svc.reconcileLoginFallback('NeedsLogin');
+    expect(hot).toHaveBeenCalledWith('proxy-selector', 'my-ts');
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+  });
+
+  it('开关关闭（meshLoginFallbackDirect=false）→ NeedsLogin 不 engage', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig({ meshLoginFallbackDirect: false });
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(hot).not.toHaveBeenCalled();
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+  });
+
+  it('子网段-only TS 出口（无 exit_node）→ 不 engage（final 已直连，无死锁）', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = {
+      selectedServerId: 'srv-ts',
+      proxyMode: 'smart',
+      servers: [tsServer({ tailscaleSettings: { allowInternet: false } })],
+    } as unknown as UserConfig;
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(hot).not.toHaveBeenCalled();
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+  });
+
+  it('[P0b/S-b] 选中 TS 有 allowInternet:true 但【无 exit_node】+ NeedsLogin → 不 engage（P0b 后 final 回退 direct，授权页本就可达）', async () => {
+    const { svc } = makeSvc();
+    // quick-join 造出的 S-b 态：allowInternet:true 但无 exit_node。P0b 后 meshAllowsInternet 由 exit_node 派生=false
+    // → meshSelectedExitFallsBackToDirect=true → loginFallbackEligible=false → 不 engage（正确收敛，非死锁）。
+    svc.currentConfig = {
+      selectedServerId: 'srv-ts',
+      proxyMode: 'smart',
+      servers: [tsServer({ tailscaleSettings: { allowInternet: true } })],
+    } as unknown as UserConfig;
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(NEEDS_LOGIN);
+    await flush();
+    expect(hot).not.toHaveBeenCalled();
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
+  });
+
+  it('过渡态（Starting）不翻转：未 engage 保持不动（避免已登录节点起核闪直连）', async () => {
+    const { svc } = makeSvc();
+    svc.currentConfig = fullTunnelTsConfig();
+    svc.currentIdToTagMap = new Map([['srv-ts', 'my-ts']]);
+    const hot = jest.spyOn(svc, 'hotSwitchSelector').mockResolvedValue(true);
+    svc.handleTailscaleStatus(STARTING);
+    await flush();
+    expect(hot).not.toHaveBeenCalled();
+    expect(svc.bootstrapFallbackEngaged).toBe(false);
   });
 });

--- a/src/main/services/__tests__/tailscale-login-core.test.ts
+++ b/src/main/services/__tests__/tailscale-login-core.test.ts
@@ -2,8 +2,8 @@
  * tailscale-login-core 单测（Phase 2 按需瞬态登录核的纯逻辑）：
  * - buildTailscaleLoginConfig：登录专用 config 生成（无 inbound、log.level=info+timestamp、state_directory 正确、
  *   auth_key 永不出现、controlUrl/hostname/ephemeral 透传）。
- * - tailscaleEndpointInRunningCore：双写防护判定（节点在运行主核中→true，按 buildOutbounds 发射门控
- *   「选中 OR 就绪(authKey||state)」逐档覆盖）。
+ * - tailscaleEndpointInRunningCore：双写防护判定（always-emit 后：核在运行 且 该 TS 节点在运行配置里 → true，
+ *   不再看 selected/authKey/stateExists）。
  *
  * getUserDataPath 依赖 electron app → mock 成可控 tmp 根，使 tailscaleStateDir 落到该 tmp。
  */
@@ -116,7 +116,7 @@ describe('buildTailscaleLoginConfig', () => {
   });
 });
 
-describe('tailscaleEndpointInRunningCore（双写防护判定）', () => {
+describe('tailscaleEndpointInRunningCore（双写防护判定：always-emit）', () => {
   const runningCfg = (over: Partial<UserConfig> = {}): UserConfig =>
     ({
       servers: [],
@@ -125,39 +125,34 @@ describe('tailscaleEndpointInRunningCore（双写防护判定）', () => {
     }) as UserConfig;
 
   it('主核未运行 → false（可起瞬态核）', () => {
-    expect(tailscaleEndpointInRunningCore('s1', false, runningCfg(), false)).toBe(false);
+    expect(tailscaleEndpointInRunningCore('s1', false, runningCfg())).toBe(false);
   });
 
   it('运行配置为 null → false', () => {
-    expect(tailscaleEndpointInRunningCore('s1', true, null, false)).toBe(false);
+    expect(tailscaleEndpointInRunningCore('s1', true, null)).toBe(false);
   });
 
   it('节点不在运行配置里 → false（主核没带它的 endpoint）', () => {
     const cfg = runningCfg({ servers: [tsServer({ id: 'other' })] });
-    expect(tailscaleEndpointInRunningCore('s1', true, cfg, false)).toBe(false);
+    expect(tailscaleEndpointInRunningCore('s1', true, cfg)).toBe(false);
   });
 
-  it('在配置里但既未选中也未就绪（无 authKey、无 state）→ false（主核就绪门控未发射）', () => {
+  it('在配置里即 true（always-emit）——未选中、无 authKey、无 state 也 true', () => {
     const cfg = runningCfg({ servers: [tsServer({ id: 's1' })], selectedServerId: 'other' });
-    expect(tailscaleEndpointInRunningCore('s1', true, cfg, false)).toBe(false);
+    expect(tailscaleEndpointInRunningCore('s1', true, cfg)).toBe(true);
   });
 
-  it('被选中 → true（选中即发射，主核已带 endpoint）', () => {
+  it('被选中 → true', () => {
     const cfg = runningCfg({ servers: [tsServer({ id: 's1' })], selectedServerId: 's1' });
-    expect(tailscaleEndpointInRunningCore('s1', true, cfg, false)).toBe(true);
+    expect(tailscaleEndpointInRunningCore('s1', true, cfg)).toBe(true);
   });
 
-  it('就绪：有 authKey → true', () => {
+  it('有 authKey → true', () => {
     const cfg = runningCfg({
       servers: [tsServer({ id: 's1', tailscaleSettings: { authKey: 'k' } })],
       selectedServerId: 'other',
     });
-    expect(tailscaleEndpointInRunningCore('s1', true, cfg, false)).toBe(true);
-  });
-
-  it('就绪：state 目录存在（stateExists=true）→ true', () => {
-    const cfg = runningCfg({ servers: [tsServer({ id: 's1' })], selectedServerId: 'other' });
-    expect(tailscaleEndpointInRunningCore('s1', true, cfg, true)).toBe(true);
+    expect(tailscaleEndpointInRunningCore('s1', true, cfg)).toBe(true);
   });
 
   it('非 tailscale 协议的同 id 节点 → false（只防 tailscale 双写）', () => {
@@ -165,7 +160,7 @@ describe('tailscaleEndpointInRunningCore（双写防护判定）', () => {
       servers: [tsServer({ id: 's1', protocol: 'wireguard' })],
       selectedServerId: 's1',
     });
-    expect(tailscaleEndpointInRunningCore('s1', true, cfg, true)).toBe(false);
+    expect(tailscaleEndpointInRunningCore('s1', true, cfg)).toBe(false);
   });
 });
 

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -856,7 +856,6 @@ export function buildOutbounds(
       // 出口看角标按需点开（详见 detectTailscaleAuthUrl + 渲染端登录态）。登录态(loggedIn)真值只由 STATUS 流
       // （Running/Starting && !expired）给，不复用 state 目录为判据 → 不重蹈 #132。
       if (server.protocol.toLowerCase() === 'tailscale') {
-        const ts = server.tailscaleSettings;
         try {
           const ep = buildTailscaleEndpoint(server, tag);
           if (downgradeMeshToGvisor) {
@@ -865,15 +864,8 @@ export function buildOutbounds(
           }
           pendingEndpoints.push(ep);
           nodeTags.push(tag);
-          // TS 不承载全隧道（=关外网；system 模式不再失效 exit_node，见 meshNodeCarriesFullTunnel 协议口径）但填了
-          // exitNode：exit_node 已被 buildTailscaleEndpoint 丢弃（仅承载 tailnet/routes）。warn 便于排查。
-          if (!meshNodeCarriesFullTunnel(server) && ts?.exitNode?.trim()) {
-            const why = meshNonFullTunnelReason();
-            deps.log(
-              'warn',
-              `组网节点「${server.name}」${why}：已忽略 exit_node，仅访问 tailnet / 子网路由`
-            );
-          }
+          // P0b 后 meshNodeCarriesFullTunnel(TS) ⟺ !!exitNode，故「不承载全隧道但填了 exitNode」组合不可能存在
+          // （原 warn 分支恒 false 死代码，已删）。TS 是否承载全隧道 = 是否配 exit_node，无需再单独 warn「忽略 exit_node」。
         } catch (e: any) {
           deps.log(
             'warn',

--- a/src/main/services/tailscale-login-core.ts
+++ b/src/main/services/tailscale-login-core.ts
@@ -81,30 +81,24 @@ export function buildTailscaleLoginConfig(
  * 双写防护判定（关键正确性）：该节点的 tailscale endpoint **是否已在运行中的主核里**。
  *
  * 两个 sing-box 进程同时写同一 state_directory（tailscaled.state 等）会冲突 → 若主核已带该 endpoint，
- * 则**不要**再起瞬态核。主核带该 endpoint 的条件 = buildOutbounds 的就绪门控（singbox-outbound-builder
- * 行 732-740）：核在运行 且（节点被选中 OR 已就绪 authKey||stateExists）。
+ * 则**不要**再起瞬态核。1.14 起 buildOutbounds 对 TS endpoint 已改为 **always-emit**（无就绪/选中门控，见
+ * singbox-outbound-builder「Tailscale：always-emit」段）：只要节点在运行配置里，主核就带它的 endpoint。故本
+ * 判定 = 核在运行 且 该 TS 节点在运行配置里，不再看 selected/authKey/stateExists（旧就绪门控与 always-emit
+ * 脱节，会对未选中未就绪节点误放行瞬态核 → 与主核双写同一 state_directory）。
  *
- * 返回 true（已在主核）时，调用方拒绝起瞬态核——此时该节点要么已登录（state 已落盘），要么主核路径
- * 已在出 URL（Phase 1 的选中即触发登录）。
+ * 返回 true（已在主核）时，调用方拒绝起瞬态核——此时该节点的登录由主核 always-emit 路径承载（STATUS/AUTH_URL）。
  *
  * @param isRunning 主核是否在运行（ProxyManager 进程存活）
  * @param runningConfig 主核当前运行配置（this.currentConfig）；null=未运行
- * @param stateExists 该节点 state 目录是否存在（注入，便于单测；运行期传 tailscaleStateExists(serverId)）
  */
 export function tailscaleEndpointInRunningCore(
   serverId: string,
   isRunning: boolean,
-  runningConfig: UserConfig | null,
-  stateExists: boolean
+  runningConfig: UserConfig | null
 ): boolean {
   if (!isRunning || !runningConfig) return false;
-  const server = runningConfig.servers.find(
+  // always-emit：主核带每个配置的 TS endpoint → 节点在运行配置里即已在主核。
+  return runningConfig.servers.some(
     (s) => s.id === serverId && s.protocol?.toLowerCase() === 'tailscale'
   );
-  if (!server) return false; // 节点不在运行配置里 → 主核没带它的 endpoint
-  // buildOutbounds 发射门控：选中 OR 就绪（authKey || state 目录存在）。
-  const hasAuthKey = !!server.tailscaleSettings?.authKey?.trim();
-  const selected = runningConfig.selectedServerId === serverId;
-  const ready = hasAuthKey || stateExists;
-  return selected || ready;
 }

--- a/src/main/services/tailscale-state.ts
+++ b/src/main/services/tailscale-state.ts
@@ -4,7 +4,8 @@
  * 交互登录（无 auth_key）产出的是该目录下的会话文件（跨重启免重认证）。1.14 起登录态判定全量迁移到
  * 管理 API STATUS 流（见 docs/design/tailscale-1.14-management-api.md），此模块仅余两用途：
  * 1) `tailscaleStateDir`：buildTailscaleEndpoint 的 state_directory + 删节点/登出时清理目录；
- * 2) `tailscaleStateExists`：tailscaleEndpointInRunningCore 的双写防护/运行核就绪判定（注入参数）。
+ * 2) `tailscaleStateExists`：proxy-handlers 登录态秒显兜底 + startInternal reassert 登录期出口让位预置的
+ *    「是否曾登录」判据（tailscaleEndpointInRunningCore 改 always-emit 后已不再用它，见该函数）。
  * 已剥离登录成功轮询（pollTailscaleLoginSuccess，stateExists 误判未认证为已登录是 #132 根因）。
  */
 

--- a/src/renderer/components/home/connection-status-card.tsx
+++ b/src/renderer/components/home/connection-status-card.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { deriveConnectionStatus } from './connection-status';
 import { isDirectSelection } from '@shared/direct-selection';
+import { TsExitWarning } from './ts-exit-warning';
 
 export function ConnectionStatusCard() {
   const connectionStatus = useAppStore((state) => state.connectionStatus);
@@ -217,6 +218,9 @@ export function ConnectionStatusCard() {
                 </Select>
               </div>
             </div>
+
+            {/* §H：选中 TS 当出口但出不了公网（未选出口设备 / 设备离线）→ 出口下拉正下方行内 warning 注脚。none→null。 */}
+            <TsExitWarning />
 
             {/* 全局直连：未命中规则的流量直连、仅按规则走代理（与「直连模式」不同，规则仍生效） */}
             {isDirect ? (

--- a/src/renderer/components/home/proxy-control-card.tsx
+++ b/src/renderer/components/home/proxy-control-card.tsx
@@ -67,9 +67,12 @@ export function ProxyControlCard() {
     : hasError || '';
   // D7（+Phase2）：选中「不承载全隧道」的组网节点为主节点（可连接，非置灰）→ 外网回退直连、仅其网段经此节点。
   // 不承载全隧道 = 关外网 或 system 内核接口（meshNodeCarriesFullTunnel），与 meshSelectedExitFallsBackToDirect 对齐。非阻断提示。
+  // §H：TS 收窄排除——TS「未选出口设备→公网回退直连」由 ConnectionStatusCard 行内警示（TsExitWarning）专门承载
+  // （文案可执行=选出口设备），此处不再对 TS 重复提示（否则双提示）。WG/WARP 保留原「外网回退直连」提示原位。
   const meshExitDirect =
     !!selectedServer &&
     isEndpointProtocol(selectedServer.protocol) &&
+    selectedServer.protocol?.toLowerCase() !== 'tailscale' &&
     !meshNodeCarriesFullTunnel(selectedServer) &&
     !meshNoInternet &&
     (config?.proxyMode || 'smart').toLowerCase() !== 'direct';
@@ -212,7 +215,7 @@ export function ProxyControlCard() {
             )}
           </Button>
           {meshExitDirect && (
-            <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">
+            <p className="mt-1 text-xs text-warning">
               {t(
                 'home.meshExitDirectHint',
                 '所选组网节点未开启外网访问：外网流量走直连，仅其网段经此节点。'

--- a/src/renderer/components/home/ts-exit-warning.tsx
+++ b/src/renderer/components/home/ts-exit-warning.tsx
@@ -1,0 +1,56 @@
+/**
+ * 首页「Tailscale 出口名不副实」行内警示（§H）。挂在 ConnectionStatusCard「当前服务器」下拉正下方：选中 TS 当出口
+ * 但出不了公网（未选出口设备 / 出口设备离线）时给一行 warning 注脚 +「选择出口设备」链接直达 TS 设置。
+ * 判定单一真值 = deriveTsExitWarning。none → 渲染 null。纯 renderer 视图态、零 IPC/config-gen/重启。取代旧 §G nudge。
+ */
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useAppStore } from '@/store/app-store';
+import { deriveTsExitWarning } from '@shared/tailscale-exit-warning';
+
+export function TsExitWarning() {
+  const { t } = useTranslation();
+  const config = useAppStore((s) => s.config);
+  const setCurrentView = useAppStore((s) => s.setCurrentView);
+  const setServerPageAction = useAppStore((s) => s.setServerPageAction);
+  const proxyRunning = useAppStore((s) => !!s.connectionStatus?.proxyCore?.running);
+
+  const selectedServer = config?.servers.find((x) => x.id === config?.selectedServerId);
+  const tsId =
+    selectedServer?.protocol?.toLowerCase() === 'tailscale' ? selectedServer.id : undefined;
+  const loggedIn = useAppStore((s) => (tsId ? !!s.tailscaleLoginStates[tsId] : false));
+  const peers = useAppStore((s) => (tsId ? s.tailscalePeers[tsId] : undefined));
+
+  const warning = deriveTsExitWarning({
+    selectedServer,
+    loggedIn,
+    proxyModeDirect: (config?.proxyMode || 'smart').toLowerCase() === 'direct',
+    proxyRunning,
+    peers,
+  });
+  if (warning === 'none') return null;
+
+  // 「选择出口设备」→ 打开组网卡的 TS 设置弹窗（内含出口设备选择）。TS=选中出口时 server-page 自动落 mesh tab。
+  const goPickExitNode = () => {
+    setServerPageAction('ts-settings');
+    setCurrentView('server');
+  };
+
+  return (
+    <div className="flex items-start gap-1.5 pt-1">
+      <AlertTriangle className="mt-px h-3.5 w-3.5 shrink-0 text-warning" />
+      <p className="min-w-0 text-xs text-muted-foreground">
+        {warning === 'no-exit-device'
+          ? t('home.tsExitNoDeviceWarn', '已设为出口，但未选择出口设备，公网流量仍走直连。')
+          : t('home.tsExitDeviceOfflineWarn', '出口设备当前离线，公网可能无法经 Tailscale 出网。')}
+        <button
+          type="button"
+          onClick={goPickExitNode}
+          className="ms-1 text-warning underline underline-offset-2 hover:opacity-80"
+        >
+          {t('home.tsExitPickDevice', '选择出口设备')}
+        </button>
+      </p>
+    </div>
+  );
+}

--- a/src/renderer/components/settings/network-settings.tsx
+++ b/src/renderer/components/settings/network-settings.tsx
@@ -602,6 +602,20 @@ export function NetworkSettings() {
               onCheckedChange={(c) => setBool('autoSwitchNode', c)}
             />
           </SettingsRow>
+          {/* 缺陷1 组网登录期出口让位：选中 TS 出口未连上时登录/授权期默认路由临时直连（否则授权页被导向死出口打不开→死锁），
+              连接成功自动切回。关闭则宁可授权失败也不直连（无引导期直连泄漏窗口）。默认开（!== false）。 */}
+          <SettingsRow
+            label={t('settings.network.meshLoginFallback', '组网登录期出口让位')}
+            description={t(
+              'settings.network.meshLoginFallbackDesc',
+              '所选 Tailscale 出口尚未连接时，登录/授权期间默认路由临时走直连（避免授权页打不开导致卡死），连接成功后自动切回该出口。关闭则登录期不直连（宁可授权失败也不产生直连流量）。'
+            )}
+          >
+            <Switch
+              checked={config.meshLoginFallbackDirect !== false}
+              onCheckedChange={(c) => setBool('meshLoginFallbackDirect', c)}
+            />
+          </SettingsRow>
           <SettingsCollapsible
             label={t('settings.network.advancedTraffic', '高级流量')}
             defaultOpen

--- a/src/renderer/components/settings/tailscale-connection-card.tsx
+++ b/src/renderer/components/settings/tailscale-connection-card.tsx
@@ -13,7 +13,7 @@
  * 复用现成 api：连接=api.server.add(+runTailscaleLogin)、断开=tailscaleLogout、删除=tailscaleLogout+delete、
  * 取消=tailscaleLoginCancel。设置=复用 TailscaleForm（包进 Dialog），onSubmit 走 useServerActions().saveServer。
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { Check, Loader2, Link as LinkIcon, KeyRound, Settings, Plug, Trash2 } from 'lucide-react';
@@ -41,7 +41,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import type { ServerConfig } from '@/bridge/types';
 import { deriveTsCardState } from '../../../shared/tailscale-conn-state';
-import { runTailscaleLogin } from '../../lib/tailscale-login';
+import { runTailscaleLogin, openTailscaleLogin } from '../../lib/tailscale-login';
 import { TailscaleForm } from './tailscale-form';
 import { useServerActions } from '../../pages/use-server-actions';
 import { MeshInfoPopover } from './mesh-info-popover';
@@ -51,9 +51,17 @@ interface TailscaleConnectionCardProps {
   tsNode: ServerConfig | undefined;
   /** 代理是否运行——决定副标题文案（已连接·实时 IP vs 已登录·上次），不进状态派生。 */
   proxyRunning: boolean;
+  /** §H：一次性外部指令——首页「选择出口设备」导航进来时自动打开设置弹窗（内含出口设备选择）。消费后回调清除。 */
+  autoOpenSettings?: boolean;
+  onAutoOpenConsumed?: () => void;
 }
 
-export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConnectionCardProps) {
+export function TailscaleConnectionCard({
+  tsNode,
+  proxyRunning,
+  autoOpenSettings,
+  onAutoOpenConsumed,
+}: TailscaleConnectionCardProps) {
   const { t } = useTranslation();
   const { saveServer, deleteServer, selectServer } = useServerActions();
 
@@ -64,7 +72,15 @@ export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConne
   const hasAuthUrl = useAppStore((s) =>
     serverId ? s.tailscaleAuthUrls[serverId] !== undefined : false
   );
+  // 缓存的登录 URL（供「打开登录页」重开；缺失时 openTailscaleLogin 回落 runTailscaleLogin → main 兜底取 live URL）。
+  const authUrl = useAppStore((s) => (serverId ? s.tailscaleAuthUrls[serverId] : undefined));
+  // 用户是否显式发起了本节点登录（区分主核 always-emit 的 URL）——决定卡片是否进「连接中」态。
+  const loginInitiated = useAppStore((s) =>
+    serverId ? !!s.tailscaleLoginInitiated[serverId] : false
+  );
   const setTailscaleLoginState = useAppStore((s) => s.setTailscaleLoginState);
+  const setTailscaleAuthUrl = useAppStore((s) => s.setTailscaleAuthUrl);
+  const setTailscaleLoginInitiated = useAppStore((s) => s.setTailscaleLoginInitiated);
   // 当前主出口是否为本 TS 节点（selectedServerId 单一真值）：单例卡承载「设为出口/当前出口」——批3 把 TS 抽离
   // 列表后，这是登录后选 TS 作主出口的唯一入口（列表点击选中入口已随抽离丢失，否则登录了也用不上 TS 出口）。
   const selectedServerId = useAppStore((s) => s.config?.selectedServerId);
@@ -74,7 +90,19 @@ export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConne
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [connecting, setConnecting] = useState(false);
 
-  const state = deriveTsCardState(tsNode, loggedIn, hasAuthUrl);
+  // §H：首页「选择出口设备」导航进来 → 自动打开设置弹窗（TailscaleForm 内含 ExitNodeField），消费后清除一次性指令。
+  useEffect(() => {
+    if (autoOpenSettings) {
+      setShowKeyForm(false);
+      setSettingsOpen(true);
+      onAutoOpenConsumed?.();
+    }
+  }, [autoOpenSettings, onAutoOpenConsumed]);
+
+  // 登录进行中判据：用户显式发起 OR 该 TS 是当前选中出口（app 自动连接它=登录进行中，首页会弹登录）→ 卡片显「连接中」，
+  // 而非被 always-emit 的非活跃 URL 误判/漏判（修真机：首页弹登录时选中出口卡片曾显初始态）。
+  const loginActive = loginInitiated || isSelectedExit;
+  const state = deriveTsCardState(tsNode, loggedIn, hasAuthUrl, loginActive);
 
   // 设置弹窗里编辑（含填 Auth Key）→ 复用 TailscaleForm，统一走 saveServer（editingServer=现有 TS 节点）。
   // config 形状由 TailscaleForm 产出（{protocol:'tailscale', tailscaleSettings}），name 由现有节点带或默认。
@@ -101,7 +129,9 @@ export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConne
             protocol: 'tailscale',
             address: '',
             port: 0,
-            tailscaleSettings: { allowInternet: true, alwaysRouteSubnets: true },
+            // P0b：TS 的 allowInternet 由 exit_node 派生（meshAllowsInternet），此处不再硬编码 allowInternet:true
+            // （否则造出 allowInternet:true 但无 exit_node 的 S-b 态，谓词已忽略该字段但留着误导读代码者）。
+            tailscaleSettings: { alwaysRouteSubnets: true },
           } as Parameters<typeof saveServer>[0],
           undefined
         );
@@ -117,10 +147,14 @@ export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConne
 
   const handleCancel = async () => {
     if (!serverId) return;
+    // 点「取消」立即本地退出「连接中」态（乐观清）：主核路径 endpoint 在主核里、无瞬态核可杀，
+    // 若等 IPC 回执才清 UI，卡片会一直卡「连接中」（缺陷 2）。清 URL + initiated 双管，卡片当即回落「需登录」。
+    setTailscaleAuthUrl(serverId, '');
+    setTailscaleLoginInitiated(serverId, false);
     try {
       await api.server.tailscaleLoginCancel(serverId);
     } catch {
-      /* 取消失败不阻断：authUrl 会随核退出被清，UI 自然回落 */
+      /* 取消失败不阻断：UI 已乐观回落，瞬态核（若有）也会随核退出被清 */
     }
   };
 
@@ -195,7 +229,10 @@ export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConne
                   : state === 'key-ready'
                     ? t('servers.tsConnCardKeyReadyDesc', '代理启动即自动连接，无需登录')
                     : state === 'logging-in'
-                      ? t('servers.tsConnCardLoggingInDesc', '已在浏览器打开授权页，完成后自动连接')
+                      ? t(
+                          'servers.tsConnCardLoggingInDesc',
+                          '等待浏览器完成登录授权，可点「打开登录页」，授权后自动连接'
+                        )
                       : t('servers.tsConnCardIntro', '账号制组网：登录后本机即加入你的 tailnet')}
               </span>
               {/* 组网信息收进 ⓘ（与列表节点同款，hover 弹内网 IP/路由/出口节点/接受子网路由），卡片不被信息撑大。 */}
@@ -233,6 +270,13 @@ export function TailscaleConnectionCard({ tsNode, proxyRunning }: TailscaleConne
                 <Loader2 className="h-4 w-4 animate-spin" />
                 {t('servers.tsConnCardLoggingIn', '连接中…')}
               </span>
+              {/* 「打开登录页」：可靠重开当前授权页——主核路径不自动开浏览器、且核每会话一份 URL 取消后无帧回填，
+                  用户凭此随时重开完成登录（openTailscaleLogin 有缓存 URL 直开，无则回落 runTailscaleLogin 走 main 兜底）。 */}
+              {tsNode && (
+                <Button size="sm" onClick={() => openTailscaleLogin(tsNode, authUrl)}>
+                  {t('servers.tsConnCardOpenLogin', '打开登录页')}
+                </Button>
+              )}
               <Button size="sm" variant="outline" onClick={() => void handleCancel()}>
                 {t('servers.tsConnCardCancel', '取消')}
               </Button>

--- a/src/renderer/hooks/use-native-events.ts
+++ b/src/renderer/hooks/use-native-events.ts
@@ -60,6 +60,8 @@ interface NativeEventData {
   coreBaselineWarning: { current: string; bundled: string; kind: string };
   // 提权 helper proto < 期望（如属主根治 v6）：启动后主进程 emit → toast 引导升级（带「升级」action + 「不再提示」）。
   helperUpgradeable: { version: string };
+  // 缺陷1 登录期出口让位：选中 TS 出口未就绪→默认路由让位直连（engaged=true）/隧道 Running 后切回（engaged=false）。
+  meshLoginFallback: { engaged: boolean; serverName?: string };
 }
 
 type NativeEventListener<K extends keyof NativeEventData> = (data: NativeEventData[K]) => void;
@@ -117,6 +119,9 @@ export function useNativeEvent<K extends keyof NativeEventData>(
         break;
       case 'helperUpgradeable':
         unsubscribe = api.helper.onUpgradeable(callback as any);
+        break;
+      case 'meshLoginFallback':
+        unsubscribe = api.proxy.onMeshLoginFallback(callback as any);
         break;
       default:
         console.warn(`Unknown event: ${eventName}`);
@@ -253,9 +258,11 @@ function handleTailscaleAuth(data: NativeEventData['tailscaleAuth']) {
   // loggedIn=false）一律由 api STATUS（tailscaleStatus）驱动，此处不再据 AUTH_URL 反推 loggedIn=false。
   const idKey = data.serverId ?? data.nodeName;
   const url = data.authURL ?? data.url;
-  // 空 URL = 登录超时/失败信号（main 侧 armLoginTimeout 发）→ 清缓存退出「登录中」回「需登录」，不弹 toast。
+  // 空 URL = 登录超时/失败/取消/停核收尾信号 → 清缓存退出「登录中」回「需登录」，并 dismiss 那条 Infinity「需登录」
+  // toast（缺陷2：核已停时 tailscaleStatus 的离开-NeedsLogin dismiss 分支永不触发，仅清卡片不清 toast → 残留）。
   if (data.serverId && !url) {
     useAppStore.getState().setTailscaleAuthUrl(data.serverId, '');
+    toast.dismiss(tsAuthToastId(data.serverId));
     return;
   }
   // always-emit：无条件全量入表（transient 与主核两路径都存）→ 角标据此可点直开。serverId 缺失（旧主进程/
@@ -285,7 +292,8 @@ function handleTailscaleAuth(data: NativeEventData['tailscaleAuth']) {
 function handleTailscaleStatus(data: NativeEventData['tailscaleStatus']) {
   // sing-box 1.14 管理 API 真实态（取代 1.13 stateExists/stdout 启发式）：loggedIn（Running||Starting）即时驱动
   // 「需登录」角标；tailscaleIPs（self.tailscaleIPs）入 store 供节点卡「组网信息」popover 展示内网 IP。
-  // backendState/authURL 仅本地驱动登录 toast（不入 store）。
+  // backendState 仅本地驱动登录 toast（不入 store）；authURL 除驱动 toast 外，NeedsLogin 时【入 store】（缺陷4，下方），
+  // 是主核 always-emit 路径取消后恢复登录 URL 的可靠来源。
   useAppStore.getState().setTailscaleLoginState(data.serverId, data.loggedIn);
   // 内网 IP（self.tailscaleIPs）入 store，组网卡 popover 据此显示。
   useAppStore.getState().setTailscaleIps(data.serverId, data.tailscaleIPs || []);
@@ -294,6 +302,10 @@ function handleTailscaleStatus(data: NativeEventData['tailscaleStatus']) {
   // NeedsLogin 且核给出 authURL → 登录 toast（与瞬态核 AUTH_URL 共用 showTsLoginToast，固定 id 供翻 Running 时
   // dismiss/覆盖）。authURL 缺失则不弹（避免空 action）。
   if (data.backendState === 'NeedsLogin' && data.authURL) {
+    // 缺陷4：把 STATUS 携带的 authURL 入 store（主核 always-emit 唯一可靠 URL 来源）→「需登录」角标可点直开；
+    // 修「主核路径取消后 URL 不可恢复」死端（取消清了 store URL，此帧重填，角标恢复可用）。仅存 URL 不置 initiated，
+    // 故卡片不会因此误进「连接中」（loginInitiated 门控），只回「需登录」可点态。
+    useAppStore.getState().setTailscaleAuthUrl(data.serverId, data.authURL);
     const server = useAppStore.getState().config?.servers.find((s) => s.id === data.serverId);
     showTsLoginToast(data.serverId, server?.name ?? data.serverId, data.authURL);
   } else {
@@ -381,6 +393,30 @@ function handleHelperUpgradeable(_data: NativeEventData['helperUpgradeable']) {
   });
 }
 
+// 缺陷1 登录期出口让位提示（固定 id，engage/restore 互相 dismiss/覆盖）：engage→warning 8s 告知「登录期临时直连」；
+// restore→dismiss + （若带 serverName=真实切回出口）success 3s。stop/切出口触发的 engaged:false 无 serverName → 仅 dismiss。
+const meshLoginFallbackToastId = 'mesh-login-fallback';
+function handleMeshLoginFallback(data: NativeEventData['meshLoginFallback']) {
+  if (data.engaged) {
+    toast.warning(i18n.t('servers.meshLoginFallbackTitle', '组网登录期已临时直连'), {
+      id: meshLoginFallbackToastId,
+      description: i18n.t(
+        'servers.meshLoginFallbackDesc',
+        '所选 Tailscale 出口尚未连接，登录/授权期间流量暂走直连；连接成功后自动切回该出口。'
+      ),
+      duration: 8000,
+    });
+    return;
+  }
+  toast.dismiss(meshLoginFallbackToastId);
+  // 仅「真实切回出口」（带 serverName）弹成功提示；停核/切出口的复位无 serverName，只 dismiss 不打扰。
+  if (data.serverName) {
+    toast.success(i18n.t('servers.meshLoginFallbackRestored', { name: data.serverName }), {
+      duration: 3000,
+    });
+  }
+}
+
 /**
  * Hook to listen to all native events and update store
  */
@@ -400,6 +436,7 @@ export function useNativeEventListeners() {
   useNativeEvent('speedTestResult', handleSpeedTestResult);
   useNativeEvent('coreBaselineWarning', handleCoreBaselineWarning);
   useNativeEvent('helperUpgradeable', handleHelperUpgradeable);
+  useNativeEvent('meshLoginFallback', handleMeshLoginFallback);
 
   // L2 治本：挂载即主动拉一次 Tailscale 状态末帧 → 填 store（self IP + peers），不干等下一帧推送。
   // 根治「状态流 push-only-on-change、无心跳、渲染端错过那一帧即永久陈旧」（内网IP「尚未分配」/peers 拿不到）。

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -326,7 +326,10 @@
     "stopProxyFailed": "Failed to stop proxy",
     "speedTestDone": "Speed test complete",
     "speedTestSummary": "Tested {{count}} nodes · fastest {{name}} ({{ms}}ms)",
-    "speedTestNoResult": "Tested {{count}} nodes · all timed out"
+    "speedTestNoResult": "Tested {{count}} nodes · all timed out",
+    "tsExitNoDeviceWarn": "Set as exit, but no exit node selected — internet traffic still goes direct.",
+    "tsExitDeviceOfflineWarn": "The exit node is offline; internet may not route through Tailscale.",
+    "tsExitPickDevice": "Pick exit node"
   },
   "settings": {
     "nav": {
@@ -459,7 +462,9 @@
       "webrtcLeakOff": "Off",
       "webrtcLeakProxy": "Via proxy",
       "webrtcLeakBlock": "Block",
-      "webrtcLeakTunOnlyHint": "WebRTC leak protection only works in TUN mode. Switch to TUN mode to enable it."
+      "webrtcLeakTunOnlyHint": "WebRTC leak protection only works in TUN mode. Switch to TUN mode to enable it.",
+      "meshLoginFallback": "Fall back to direct during mesh login",
+      "meshLoginFallbackDesc": "When the selected Tailscale exit isn't connected yet, route traffic directly during login/authorization (so the auth page isn't sent to the not-yet-connected exit and deadlocks), then switch back to the exit once connected. Turn off to never go direct during login (authorization may fail instead)."
     },
     "proxyMode": {
       "systemProxyMode": "System Proxy Mode",
@@ -1104,7 +1109,7 @@
     "tsConnCardConnect": "Connect Tailscale",
     "tsConnCardUseAuthKey": "Use Auth Key",
     "tsConnCardLoggingIn": "Connecting…",
-    "tsConnCardLoggingInDesc": "Authorization page opened in your browser — connects automatically once done",
+    "tsConnCardLoggingInDesc": "Waiting for browser authorization — click Open login page if needed; connects automatically after you authorize.",
     "tsConnCardCancel": "Cancel",
     "tsConnCardConnected": "Connected",
     "tsConnCardLoggedInPast": "Logged in (last known)",
@@ -1171,7 +1176,11 @@
     "warpPlusLegacyHint": "This WARP node has no stored credentials (legacy) — to use WARP+, delete it and re-create.",
     "warpPlusApplied": "WARP+ applied",
     "warpPlusMaybeFree": "License submitted, but still free — check the license key.",
-    "warpPlusApplyFailed": "Failed to apply WARP+"
+    "warpPlusApplyFailed": "Failed to apply WARP+",
+    "meshLoginFallbackTitle": "Temporarily connecting directly (mesh login)",
+    "meshLoginFallbackDesc": "The selected Tailscale exit isn't connected yet, so traffic goes directly during login/authorization; it switches back to the exit automatically once connected.",
+    "meshLoginFallbackRestored": "Connected to {{name}}, routing switched back to this exit",
+    "tsConnCardOpenLogin": "Open login page"
   },
   "rules": {
     "ruleColumn": "Rule",

--- a/src/renderer/i18n/locales/fa.json
+++ b/src/renderer/i18n/locales/fa.json
@@ -326,7 +326,10 @@
     "stopProxyFailed": "توقف پروکسی ناموفق بود",
     "speedTestDone": "تست سرعت کامل شد",
     "speedTestSummary": "{{count}} گره · سریع‌ترین {{name}} ({{ms}}ms)",
-    "speedTestNoResult": "{{count}} گره · همه ناموفق"
+    "speedTestNoResult": "{{count}} گره · همه ناموفق",
+    "tsExitNoDeviceWarn": "به‌عنوان خروجی تنظیم شده، اما نود خروجی انتخاب نشده — ترافیک اینترنت همچنان مستقیم است.",
+    "tsExitDeviceOfflineWarn": "نود خروجی آفلاین است؛ ممکن است اینترنت از طریق Tailscale مسیردهی نشود.",
+    "tsExitPickDevice": "انتخاب نود خروجی"
   },
   "settings": {
     "nav": {
@@ -459,7 +462,9 @@
       "webrtcLeakOff": "خاموش",
       "webrtcLeakProxy": "از طریق پروکسی",
       "webrtcLeakBlock": "مسدود",
-      "webrtcLeakTunOnlyHint": "حفاظت در برابر نشت WebRTC فقط در حالت TUN کار می‌کند. برای فعال‌سازی به حالت TUN تغییر دهید."
+      "webrtcLeakTunOnlyHint": "حفاظت در برابر نشت WebRTC فقط در حالت TUN کار می‌کند. برای فعال‌سازی به حالت TUN تغییر دهید.",
+      "meshLoginFallback": "بازگشت به اتصال مستقیم هنگام ورود به Mesh",
+      "meshLoginFallbackDesc": "وقتی خروجی Tailscale انتخاب‌شده هنوز متصل نیست، در حین ورود/احراز هویت ترافیک مستقیم مسیردهی می‌شود (تا صفحه احراز هویت به خروجی متصل‌نشده هدایت نشود و قفل نکند) و پس از اتصال به همان خروجی بازمی‌گردد. برای اینکه هنگام ورود هرگز مستقیم نشود آن را خاموش کنید (در این صورت ممکن است احراز هویت شکست بخورد)."
     },
     "proxyMode": {
       "systemProxyMode": "حالت پروکسی سیستم",
@@ -1104,7 +1109,7 @@
     "tsConnCardConnect": "اتصال Tailscale",
     "tsConnCardUseAuthKey": "استفاده از Auth Key",
     "tsConnCardLoggingIn": "در حال اتصال…",
-    "tsConnCardLoggingInDesc": "صفحه مجوز در مرورگر باز شد — پس از تکمیل به‌طور خودکار متصل می‌شود",
+    "tsConnCardLoggingInDesc": "در انتظار احراز هویت در مرورگر — در صورت نیاز روی «باز کردن صفحه ورود» بزنید؛ پس از تأیید به‌طور خودکار متصل می‌شود.",
     "tsConnCardCancel": "لغو",
     "tsConnCardConnected": "متصل",
     "tsConnCardLoggedInPast": "وارد شده (آخرین وضعیت)",
@@ -1171,7 +1176,11 @@
     "warpPlusLegacyHint": "این نود WARP اعتبارنامه‌ای ذخیره ندارد (قدیمی) — برای WARP+ آن را حذف و دوباره بسازید.",
     "warpPlusApplied": "WARP+ اعمال شد",
     "warpPlusMaybeFree": "لایسنس ارسال شد، اما هنوز رایگان است — کلید لایسنس را بررسی کنید.",
-    "warpPlusApplyFailed": "اعمال WARP+ ناموفق بود"
+    "warpPlusApplyFailed": "اعمال WARP+ ناموفق بود",
+    "meshLoginFallbackTitle": "اتصال مستقیم موقت (ورود به Mesh)",
+    "meshLoginFallbackDesc": "خروجی Tailscale انتخاب‌شده هنوز متصل نیست، بنابراین در حین ورود/احراز هویت ترافیک مستقیم است؛ پس از اتصال به‌طور خودکار به خروجی بازمی‌گردد.",
+    "meshLoginFallbackRestored": "به «{{name}}» متصل شد، مسیردهی به این خروجی بازگشت",
+    "tsConnCardOpenLogin": "باز کردن صفحه ورود"
   },
   "rules": {
     "ruleColumn": "قانون",

--- a/src/renderer/i18n/locales/ru.json
+++ b/src/renderer/i18n/locales/ru.json
@@ -326,7 +326,10 @@
     "stopProxyFailed": "Не удалось остановить прокси",
     "speedTestDone": "Тест скорости завершён",
     "speedTestSummary": "Проверено: {{count}} · быстрейший {{name}} ({{ms}} мс)",
-    "speedTestNoResult": "Проверено: {{count}} · все недоступны"
+    "speedTestNoResult": "Проверено: {{count}} · все недоступны",
+    "tsExitNoDeviceWarn": "Назначен выходом, но выходной узел не выбран — интернет-трафик идёт напрямую.",
+    "tsExitDeviceOfflineWarn": "Выходной узел офлайн; интернет может не проходить через Tailscale.",
+    "tsExitPickDevice": "Выбрать выходной узел"
   },
   "settings": {
     "nav": {
@@ -459,7 +462,9 @@
       "webrtcLeakOff": "Выкл.",
       "webrtcLeakProxy": "Через прокси",
       "webrtcLeakBlock": "Блокировать",
-      "webrtcLeakTunOnlyHint": "Защита от утечек WebRTC работает только в режиме TUN. Переключитесь на режим TUN, чтобы включить её."
+      "webrtcLeakTunOnlyHint": "Защита от утечек WebRTC работает только в режиме TUN. Переключитесь на режим TUN, чтобы включить её.",
+      "meshLoginFallback": "Прямое подключение при входе в mesh",
+      "meshLoginFallbackDesc": "Когда выбранный выход Tailscale ещё не подключён, во время входа/авторизации трафик идёт напрямую (чтобы страница авторизации не отправлялась на неподключённый выход и не зависала), а после подключения переключается обратно на выход. Выключите, чтобы никогда не подключаться напрямую при входе (тогда авторизация может не пройти)."
     },
     "proxyMode": {
       "systemProxyMode": "Режим системного прокси",
@@ -1104,7 +1109,7 @@
     "tsConnCardConnect": "Подключить Tailscale",
     "tsConnCardUseAuthKey": "Использовать Auth Key",
     "tsConnCardLoggingIn": "Подключение…",
-    "tsConnCardLoggingInDesc": "Страница авторизации открыта в браузере — подключится автоматически после завершения",
+    "tsConnCardLoggingInDesc": "Ожидание авторизации в браузере — нажмите «Открыть страницу входа» при необходимости; подключится автоматически после авторизации.",
     "tsConnCardCancel": "Отмена",
     "tsConnCardConnected": "Подключено",
     "tsConnCardLoggedInPast": "Вход выполнен (последнее)",
@@ -1171,7 +1176,11 @@
     "warpPlusLegacyHint": "У этого узла WARP нет сохранённых учётных данных (устаревший) — для WARP+ удалите и создайте заново.",
     "warpPlusApplied": "WARP+ применён",
     "warpPlusMaybeFree": "Лицензия отправлена, но тариф всё ещё бесплатный — проверьте ключ.",
-    "warpPlusApplyFailed": "Не удалось применить WARP+"
+    "warpPlusApplyFailed": "Не удалось применить WARP+",
+    "meshLoginFallbackTitle": "Временное прямое подключение (вход в mesh)",
+    "meshLoginFallbackDesc": "Выбранный выход Tailscale ещё не подключён, поэтому во время входа/авторизации трафик идёт напрямую; после подключения он автоматически переключится на выход.",
+    "meshLoginFallbackRestored": "Подключено к «{{name}}», маршрутизация вернулась на этот выход",
+    "tsConnCardOpenLogin": "Открыть страницу входа"
   },
   "rules": {
     "ruleColumn": "Правило",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -326,7 +326,10 @@
     "stopProxyFailed": "停止代理失败",
     "speedTestDone": "测速完成",
     "speedTestSummary": "已测 {{count}} 个节点 · 最快 {{name}}（{{ms}}ms）",
-    "speedTestNoResult": "已测 {{count}} 个节点 · 均超时"
+    "speedTestNoResult": "已测 {{count}} 个节点 · 均超时",
+    "tsExitNoDeviceWarn": "已设为出口，但未选择出口设备，公网流量仍走直连。",
+    "tsExitDeviceOfflineWarn": "出口设备当前离线，公网可能无法经 Tailscale 出网。",
+    "tsExitPickDevice": "选择出口设备"
   },
   "settings": {
     "nav": {
@@ -459,7 +462,9 @@
       "webrtcLeakOff": "关闭",
       "webrtcLeakProxy": "走代理",
       "webrtcLeakBlock": "阻断",
-      "webrtcLeakTunOnlyHint": "WebRTC 防泄露仅在 TUN 模式生效，请切换到 TUN 模式后启用。"
+      "webrtcLeakTunOnlyHint": "WebRTC 防泄露仅在 TUN 模式生效，请切换到 TUN 模式后启用。",
+      "meshLoginFallback": "组网登录期出口让位",
+      "meshLoginFallbackDesc": "所选 Tailscale 出口尚未连接时，登录/授权期间默认路由临时走直连（避免授权页被导向未连上的出口而卡死），连接成功后自动切回该出口。关闭则登录期不直连（宁可授权失败也不产生直连流量）。"
     },
     "proxyMode": {
       "systemProxyMode": "系统代理模式",
@@ -1104,7 +1109,7 @@
     "tsConnCardConnect": "连接 Tailscale",
     "tsConnCardUseAuthKey": "用 Auth Key",
     "tsConnCardLoggingIn": "连接中…",
-    "tsConnCardLoggingInDesc": "已在浏览器打开授权页，完成后自动连接",
+    "tsConnCardLoggingInDesc": "等待浏览器完成登录授权，可点「打开登录页」，授权后自动连接",
     "tsConnCardCancel": "取消",
     "tsConnCardConnected": "已连接",
     "tsConnCardLoggedInPast": "已登录（上次）",
@@ -1171,7 +1176,11 @@
     "warpPlusLegacyHint": "此 WARP 节点缺少凭据（旧节点）——升级 WARP+ 需删除后重建。",
     "warpPlusApplied": "已升级 WARP+",
     "warpPlusMaybeFree": "license 已提交，但当前仍是免费版——请检查 license 是否有效。",
-    "warpPlusApplyFailed": "应用 WARP+ 失败"
+    "warpPlusApplyFailed": "应用 WARP+ 失败",
+    "meshLoginFallbackTitle": "组网登录期已临时直连",
+    "meshLoginFallbackDesc": "所选 Tailscale 出口尚未连接，登录/授权期间流量暂走直连；连接成功后自动切回该出口。",
+    "meshLoginFallbackRestored": "已连接「{{name}}」，已切回该出口",
+    "tsConnCardOpenLogin": "打开登录页"
   },
   "rules": {
     "ruleColumn": "规则",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -326,7 +326,10 @@
     "stopProxyFailed": "停止代理失敗",
     "speedTestDone": "測速完成",
     "speedTestSummary": "已測 {{count}} 個節點 · 最快 {{name}}（{{ms}}ms）",
-    "speedTestNoResult": "已測 {{count}} 個節點 · 均逾時"
+    "speedTestNoResult": "已測 {{count}} 個節點 · 均逾時",
+    "tsExitNoDeviceWarn": "已設為出口，但未選擇出口裝置，外網流量仍走直連。",
+    "tsExitDeviceOfflineWarn": "出口裝置目前離線，外網可能無法經 Tailscale 出網。",
+    "tsExitPickDevice": "選擇出口裝置"
   },
   "settings": {
     "nav": {
@@ -459,7 +462,9 @@
       "webrtcLeakOff": "關閉",
       "webrtcLeakProxy": "走代理",
       "webrtcLeakBlock": "阻斷",
-      "webrtcLeakTunOnlyHint": "WebRTC 防洩漏僅在 TUN 模式生效，請切換到 TUN 模式後啟用。"
+      "webrtcLeakTunOnlyHint": "WebRTC 防洩漏僅在 TUN 模式生效，請切換到 TUN 模式後啟用。",
+      "meshLoginFallback": "組網登入期出口讓位",
+      "meshLoginFallbackDesc": "所選 Tailscale 出口尚未連接時，登入/授權期間預設路由暫時走直連（避免授權頁被導向未連上的出口而卡死），連接成功後自動切回該出口。關閉則登入期不直連（寧可授權失敗也不產生直連流量）。"
     },
     "proxyMode": {
       "systemProxyMode": "系統代理模式",
@@ -1104,7 +1109,7 @@
     "tsConnCardConnect": "連接 Tailscale",
     "tsConnCardUseAuthKey": "用 Auth Key",
     "tsConnCardLoggingIn": "連接中…",
-    "tsConnCardLoggingInDesc": "已在瀏覽器開啟授權頁，完成後自動連接",
+    "tsConnCardLoggingInDesc": "等待瀏覽器完成登入授權，可點「開啟登入頁」，授權後自動連接",
     "tsConnCardCancel": "取消",
     "tsConnCardConnected": "已連接",
     "tsConnCardLoggedInPast": "已登入（上次）",
@@ -1171,7 +1176,11 @@
     "warpPlusLegacyHint": "此 WARP 節點缺少憑據（舊節點）——升級 WARP+ 需刪除後重建。",
     "warpPlusApplied": "已升級 WARP+",
     "warpPlusMaybeFree": "license 已提交，但目前仍是免費版——請檢查 license 是否有效。",
-    "warpPlusApplyFailed": "套用 WARP+ 失敗"
+    "warpPlusApplyFailed": "套用 WARP+ 失敗",
+    "meshLoginFallbackTitle": "組網登入期已暫時直連",
+    "meshLoginFallbackDesc": "所選 Tailscale 出口尚未連接，登入/授權期間流量暫走直連；連接成功後自動切回該出口。",
+    "meshLoginFallbackRestored": "已連接「{{name}}」，已切回該出口",
+    "tsConnCardOpenLogin": "開啟登入頁"
   },
   "rules": {
     "ruleColumn": "規則",

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -167,6 +167,16 @@ export const proxyApi = {
   },
 
   /**
+   * 监听「登录期出口让位」事件（缺陷1）：选中 TS 出口未就绪→默认路由让位直连（engaged=true）、隧道 Running 后
+   * 切回（engaged=false）。渲染端据此提示用户「登录期临时直连」。preload 通用 ipcRenderer.on 无 allowlist，无需改 preload。
+   */
+  onMeshLoginFallback(
+    listener: (data: { engaged: boolean; serverName?: string }) => void
+  ): () => void {
+    return ipcClient.on(IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK, listener);
+  },
+
+  /**
    * 监听 TUN 启动后的「无 marker 系统代理残留」提示（非 FlowZ 设的代理仍开着，可能干扰 TUN）。
    */
   onSystemProxyResidual(listener: (data: { proxy: string }) => void): () => void {
@@ -312,9 +322,11 @@ export const serverApi = {
    * Phase 2 按需登录：拉起瞬态登录核取交互登录 URL（主进程自动开浏览器 + 系统通知）。
    * started=false 时 reason 说明（alreadyLoggedIn / inMainCore / alreadyRunning），渲染端据此提示。
    */
-  async tailscaleLogin(
-    server: ServerConfig
-  ): Promise<{ started: boolean; reason?: 'alreadyLoggedIn' | 'inMainCore' | 'alreadyRunning' }> {
+  async tailscaleLogin(server: ServerConfig): Promise<{
+    started: boolean;
+    reason?: 'alreadyLoggedIn' | 'inMainCore' | 'alreadyRunning';
+    authUrl?: string; // inMainCore/alreadyRunning 时回传主核当前 authURL，渲染端可靠重开授权页（补取消后空窗）
+  }> {
     return ipcClient.invoke(IPC_CHANNELS.TAILSCALE_LOGIN, { server });
   },
 

--- a/src/renderer/lib/tailscale-login.ts
+++ b/src/renderer/lib/tailscale-login.ts
@@ -12,6 +12,7 @@
 import { toast } from 'sonner';
 import i18n from '../i18n';
 import { api } from '@/ipc';
+import { useAppStore } from '@/store/app-store';
 import type { ServerConfig } from '@/bridge/types';
 import { openExternal } from '../bridge/api-wrapper';
 import { safeHttpUrl } from '../../shared/url';
@@ -25,6 +26,8 @@ import { safeHttpUrl } from '../../shared/url';
 export function openTailscaleLogin(server: ServerConfig, authUrl: string | undefined): void {
   const safeUrl = authUrl ? safeHttpUrl(authUrl) : undefined;
   if (safeUrl) {
+    // 点「需登录」角标开缓存 URL = 用户显式发起登录 → 标记 initiated，卡片才进「连接中」态（回落分支已内置）。
+    useAppStore.getState().setTailscaleLoginInitiated(server.id, true);
     void openExternal(safeUrl);
     return;
   }
@@ -32,6 +35,9 @@ export function openTailscaleLogin(server: ServerConfig, authUrl: string | undef
 }
 
 export async function runTailscaleLogin(server: ServerConfig): Promise<void> {
+  // 用户显式发起登录（连接/需登录角标/表单立即登录共用此入口）→ 标记 initiated，卡片状态机才据此进「连接中」，
+  // 与主核 always-emit 的 AUTH_URL（非用户发起）区分开。
+  useAppStore.getState().setTailscaleLoginInitiated(server.id, true);
   try {
     const res = await api.server.tailscaleLogin(server);
     if (res.started) return; // 浏览器已开 + 系统通知 + 主进程推 toast，无需再 toast
@@ -40,13 +46,29 @@ export async function runTailscaleLogin(server: ServerConfig): Promise<void> {
         toast.info(i18n.t('servers.tsLoginAlready', { name: server.name }));
         break;
       case 'inMainCore':
-      case 'alreadyRunning':
-        toast.info(i18n.t('servers.tsLoginInProgress', { name: server.name }));
+      case 'alreadyRunning': {
+        // endpoint 已在运行主核（always-emit）或有在飞瞬态核 → 点「登录」应【重新打开】授权页，而非只弹"进行中"死路。
+        // 关键（真机实测 §F.3）：核每会话只生成一份 auth URL、不轮换，STATUS 事件驱动无 ticker → 取消清了 store URL 后
+        // 没有帧回填、空窗【无限期】。故优先用 main 回传的 live authURL（取自主核 STATUS 末帧缓存，取消也仍在），回落
+        // store 缓存。有则开浏览器 + 回填 store（角标恢复 + 卡片凭 hasAuthUrl 回「连接中」）；无（核刚起首帧未到）才提示。
+        const cachedUrl = useAppStore.getState().tailscaleAuthUrls[server.id];
+        const url = res.authUrl ?? cachedUrl;
+        const safe = url ? safeHttpUrl(url) : undefined;
+        if (safe) {
+          useAppStore.getState().setTailscaleAuthUrl(server.id, safe);
+          void openExternal(safe);
+        } else {
+          toast.info(i18n.t('servers.tsLoginInProgress', { name: server.name }));
+        }
         break;
+      }
       default:
         break;
     }
   } catch {
+    // F3：登录发起失败 → 回收 initiated，否则残留 initiated=true 会让后续主核 NeedsLogin 帧（缺陷4 填 URL）把卡片
+    // 无端推进「连接中」（浏览器从未打开）。非选中节点同样受影响（initiated 不依赖 isSelectedExit）。
+    useAppStore.getState().setTailscaleLoginInitiated(server.id, false);
     toast.error(i18n.t('servers.tsLoginFailed', { name: server.name }));
   }
 }

--- a/src/renderer/pages/server-page.tsx
+++ b/src/renderer/pages/server-page.tsx
@@ -182,6 +182,9 @@ export function ServerPage() {
     setIsDialogOpen(true);
   };
 
+  // §H：首页「选择出口设备」导航进来 → 落组网 tab + 一次性指令组网卡自动打开设置弹窗（选出口设备）。
+  const [tsAutoOpenSettings, setTsAutoOpenSettings] = useState(false);
+
   // 消费首页空状态跳服务器页时的意图：自动唤起对应对话框
   useEffect(() => {
     if (serverPageAction === 'add-server') {
@@ -191,6 +194,10 @@ export function ServerPage() {
     } else if (serverPageAction === 'add-sub') {
       setEditingSub(undefined);
       setIsSubDialogOpen(true);
+      setServerPageAction(null);
+    } else if (serverPageAction === 'ts-settings') {
+      setTabOverride('mesh'); // 兜底落组网 tab（TS=选中出口时 selectedGroupKey 本就 mesh，此处防未选态）
+      setTsAutoOpenSettings(true);
       setServerPageAction(null);
     }
   }, [serverPageAction, setServerPageAction]);
@@ -354,7 +361,12 @@ export function ServerPage() {
         <TabsContent value="mesh">
           <div className="space-y-4">
             <div ref={tailscaleCardRef}>
-              <TailscaleConnectionCard tsNode={tailscaleNode} proxyRunning={proxyRunning} />
+              <TailscaleConnectionCard
+                tsNode={tailscaleNode}
+                proxyRunning={proxyRunning}
+                autoOpenSettings={tsAutoOpenSettings}
+                onAutoOpenConsumed={() => setTsAutoOpenSettings(false)}
+              />
             </div>
             <MeshAccessEntry
               hasTailscale={!!tailscaleNode}

--- a/src/renderer/store/app-store.ts
+++ b/src/renderer/store/app-store.ts
@@ -55,8 +55,9 @@ interface ConnectionStatus {
 interface AppState {
   // UI State
   currentView: string;
-  // 首页空状态跳服务器页时的意图：'add-server' 唤起 ServerConfigDialog，'add-sub' 唤起订阅对话框（SubscriptionDialog），null 为无意图
-  serverPageAction: 'add-server' | 'add-sub' | null;
+  // 首页空状态跳服务器页时的意图：'add-server' 唤起 ServerConfigDialog，'add-sub' 唤起订阅对话框（SubscriptionDialog），
+  // 'ts-settings'（§H）落组网 tab + 自动打开 TS 设置弹窗（选出口设备），null 为无意图
+  serverPageAction: 'add-server' | 'add-sub' | 'ts-settings' | null;
   // 设置页子节（general/about/...）。提升到 store，供非设置页组件（如 naive 横幅「去更新」）跨页导航到指定节
   settingsSection: string;
   // F27：进入设置页前的来源视图，设置页「返回」按钮的导航目标（默认 home）
@@ -97,6 +98,12 @@ interface AppState {
   // 登录成功（setTailscaleLoginState(id,true)）时清该 serverId 的 URL，避免点角标开已失效的旧 URL。
   tailscaleAuthUrls: Record<string, string>;
 
+  // 用户是否【显式发起】了该 TS 节点的交互登录（serverId → initiated）。主核 always-emit AUTH_URL ≠ 用户在登录：
+  // 未选中/未就绪节点的 URL 也会持续入 tailscaleAuthUrls，若据此判「登录中」会把卡片误推进「连接中…已开浏览器」。
+  // 故卡片「logging-in」态须同时满足 initiated（用户点了登录/需登录角标）。登录成功、或收到空 URL（取消/超时/停核
+  // 收尾信号）、或用户点取消时清除。仅会话内存，不持久化（登录发起是瞬时交互态，重启即失效）。
+  tailscaleLoginInitiated: Record<string, boolean>;
+
   // Tailscale 节点内网 IP（serverId → tailnet IP 列表，100.x/fd7a:…）。1.14 api STATUS 流（self.tailscaleIPs）
   // 实时携带，由 setTailscaleIps 写入；供节点卡片「组网信息」popover 展示内网 IP，消「要登录控制台才看得到」黑盒。
   tailscaleIps: Record<string, string[]>;
@@ -119,7 +126,7 @@ interface AppState {
 
   // Actions
   setCurrentView: (view: string) => void;
-  setServerPageAction: (action: 'add-server' | 'add-sub' | null) => void;
+  setServerPageAction: (action: 'add-server' | 'add-sub' | 'ts-settings' | null) => void;
   setSettingsSection: (section: string) => void;
   /** 应用一批测速结果（serverId→latency）：合并 latencyMap + 为这些节点打 latencyTestedAt 时间戳（单一结果应用路径，会话内存态）。 */
   applyLatencyResults: (results: Record<string, number>) => void;
@@ -148,6 +155,8 @@ interface AppState {
   ) => void;
   // Tailscale 交互登录 URL 单条覆盖（serverId → 最新 AUTH_URL），由 EVENT_TAILSCALE_AUTH_URL 驱动。
   setTailscaleAuthUrl: (serverId: string, url: string) => void;
+  // 用户显式发起/退出该 TS 节点交互登录的标记（点登录/需登录角标置 true；点取消置 false）。
+  setTailscaleLoginInitiated: (serverId: string, initiated: boolean) => void;
   // Tailscale 内网 IP 单条覆盖（self.tailscaleIPs），由 EVENT_TAILSCALE_STATUS 驱动。
   setTailscaleIps: (serverId: string, ips: string[]) => void;
   // Tailscale 对端列表单条覆盖（serverId → peers），由 EVENT_TAILSCALE_STATUS / TAILSCALE_GET_STATUS 驱动。
@@ -188,6 +197,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   // 启动秒显：从 localStorage 缓存派生登录态初值（代理关时不再 spawn 瞬态核探针，见 use-tailscale-login-cache-store）。
   tailscaleLoginStates: loadTailscaleLoginStatesFromCache(),
   tailscaleAuthUrls: {},
+  tailscaleLoginInitiated: {},
   tailscaleIps: {},
   tailscalePeers: {},
   isPrivacyMode: false,
@@ -435,13 +445,20 @@ export const useAppStore = create<AppState>((set, get) => ({
   setTailscaleLoginState: (serverId, loggedIn, opts) => {
     set((s) => {
       const tailscaleLoginStates = { ...s.tailscaleLoginStates, [serverId]: loggedIn };
+      const patch: Partial<AppState> = { tailscaleLoginStates };
       // 登录成功后旧 AUTH_URL 失效：清掉该 serverId 的缓存 URL，避免点角标开过期登录页（无则原样返回引用）。
       if (loggedIn && s.tailscaleAuthUrls[serverId] !== undefined) {
         const tailscaleAuthUrls = { ...s.tailscaleAuthUrls };
         delete tailscaleAuthUrls[serverId];
-        return { tailscaleLoginStates, tailscaleAuthUrls };
+        patch.tailscaleAuthUrls = tailscaleAuthUrls;
       }
-      return { tailscaleLoginStates };
+      // 登录成功即退出「用户发起登录」态（下次的 always-emit URL 不应再让卡片显「连接中」）。
+      if (loggedIn && s.tailscaleLoginInitiated[serverId]) {
+        const tailscaleLoginInitiated = { ...s.tailscaleLoginInitiated };
+        delete tailscaleLoginInitiated[serverId];
+        patch.tailscaleLoginInitiated = tailscaleLoginInitiated;
+      }
+      return patch;
     });
     // 持久化登录态真值（STATUS 流 / 登出均经此）→ 代理关时下次启动秒显，免起核探针。
     // skipCache：state 文件存在性兜底的「乐观 true」不写缓存——缓存只存 STATUS 流真值（设计契约）；
@@ -453,15 +470,38 @@ export const useAppStore = create<AppState>((set, get) => ({
   setTailscaleAuthUrl: (serverId, url) => {
     set((s) => {
       if (!url) {
-        if (s.tailscaleAuthUrls[serverId] === undefined) return {};
-        const tailscaleAuthUrls = { ...s.tailscaleAuthUrls };
-        delete tailscaleAuthUrls[serverId];
-        return { tailscaleAuthUrls };
+        // 空 URL = 取消/超时/停核收尾信号：一并退出「用户发起登录」态（否则残留 initiated 会让下次
+        // always-emit 的 URL 又把卡片推回「连接中」）。
+        const clearInitiated = s.tailscaleLoginInitiated[serverId] === true;
+        if (s.tailscaleAuthUrls[serverId] === undefined && !clearInitiated) return {};
+        const patch: Partial<AppState> = {};
+        if (s.tailscaleAuthUrls[serverId] !== undefined) {
+          const tailscaleAuthUrls = { ...s.tailscaleAuthUrls };
+          delete tailscaleAuthUrls[serverId];
+          patch.tailscaleAuthUrls = tailscaleAuthUrls;
+        }
+        if (clearInitiated) {
+          const tailscaleLoginInitiated = { ...s.tailscaleLoginInitiated };
+          delete tailscaleLoginInitiated[serverId];
+          patch.tailscaleLoginInitiated = tailscaleLoginInitiated;
+        }
+        return patch;
       }
       // URL 未变则不重建表（always-emit 同一 URL 反复 emit 时省整表浅拷贝 + 无谓订阅者重渲染）。
       return s.tailscaleAuthUrls[serverId] === url
         ? {}
         : { tailscaleAuthUrls: { ...s.tailscaleAuthUrls, [serverId]: url } };
+    });
+  },
+  // 用户显式发起/退出交互登录标记（内容未变返 {} 免重渲染）。true=点登录/需登录角标；false=点取消。
+  setTailscaleLoginInitiated: (serverId, initiated) => {
+    set((s) => {
+      const current = s.tailscaleLoginInitiated[serverId] === true;
+      if (current === initiated) return {};
+      const tailscaleLoginInitiated = { ...s.tailscaleLoginInitiated };
+      if (initiated) tailscaleLoginInitiated[serverId] = true;
+      else delete tailscaleLoginInitiated[serverId];
+      return { tailscaleLoginInitiated };
     });
   },
   // 单条覆盖：EVENT_TAILSCALE_STATUS 即时更新该节点内网 IP（self.tailscaleIPs，纯单点写无并发竞态）。

--- a/src/shared/__tests__/endpoint-routes.test.ts
+++ b/src/shared/__tests__/endpoint-routes.test.ts
@@ -43,6 +43,9 @@ const ts = (routes?: string[], allowInternet?: boolean, reverseMesh?: boolean): 
     tailscaleSettings: {
       routes,
       ...(allowInternet === undefined ? {} : { allowInternet }),
+      // P0b：TS 的 allowInternet 现由 exit_node 派生。helper 的第 2 参语义（true=承载全隧道）在派生规则下靠同置一个
+      // exit_node 保持；false/缺省不置 exit_node（=不承载全隧道）。
+      ...(allowInternet ? { exitNode: '100.64.0.1' } : {}),
       ...(reverseMesh === undefined ? {} : { reverseMesh }),
     },
   }) as any;
@@ -87,12 +90,26 @@ describe('endpointForcedRouteCidrs', () => {
   });
 });
 
-describe('meshAllowsInternet（allowInternet 缺省 true，向后兼容）', () => {
+describe('meshAllowsInternet（WG 缺省 true；TS 由 exit_node 派生 P0b）', () => {
   it('WG 缺字段 → true', () => expect(meshAllowsInternet(wg())).toBe(true));
   it('WG allowInternet=true → true', () => expect(meshAllowsInternet(wg([], true))).toBe(true));
   it('WG allowInternet=false → false', () => expect(meshAllowsInternet(wg([], false))).toBe(false));
-  it('TS 缺字段 → true', () => expect(meshAllowsInternet(ts())).toBe(true));
-  it('TS allowInternet=false → false', () => expect(meshAllowsInternet(ts([], false))).toBe(false));
+  // TS：不信 allowInternet 存储 flag，只看 exit_node（治 S-b）。
+  it('TS 缺 exit_node → false（P0b：allowInternet 由 exit_node 派生，非缺省 true）', () =>
+    expect(meshAllowsInternet(ts())).toBe(false));
+  it('TS 有 exit_node → true', () =>
+    expect(meshAllowsInternet({ protocol: 'tailscale', tailscaleSettings: { exitNode: 'p' } } as any)).toBe(
+      true
+    ));
+  it('TS allowInternet=false → false（无 exit_node）', () =>
+    expect(meshAllowsInternet(ts([], false))).toBe(false));
+  it('[S-b] TS allowInternet=true 但无 exit_node → false（quick-join 硬编码不再误判承载全隧道）', () =>
+    expect(
+      meshAllowsInternet({
+        protocol: 'tailscale',
+        tailscaleSettings: { allowInternet: true },
+      } as any)
+    ).toBe(false));
   it('非组网协议 → 恒 true', () =>
     expect(meshAllowsInternet({ protocol: 'vless' } as any)).toBe(true));
 });

--- a/src/shared/__tests__/mesh-exit-route.test.ts
+++ b/src/shared/__tests__/mesh-exit-route.test.ts
@@ -56,8 +56,15 @@ describe('planMeshExitRoute（不依赖全局选中：exit-capable TS 即装，�
     expect(planMeshExitRoute(cfg([tsNode({ reverseMesh: false })], 'ts1'), false)).toBeNull();
   });
 
-  it('TS System 但无 exit_node(allowInternet=false) → null(不承载全隧道)', () => {
-    expect(planMeshExitRoute(cfg([tsNode({ allowInternet: false })], 'ts1'), false)).toBeNull();
+  it('[P0b] TS 有 exit_node 但存量 allowInternet=false → 仍装（allowInternet 谓词层已忽略，由 exit_node 派生）', () => {
+    expect(planMeshExitRoute(cfg([tsNode({ allowInternet: false })], 'ts1'), false)).toEqual({
+      iface: 'flowz-ts',
+      cidrs: ['0.0.0.0/0'],
+    });
+  });
+
+  it('[P0b] TS 无 exit_node → null（不承载全隧道；治 S-b 黑洞：quick-join allowInternet:true 无 exit_node 也走此）', () => {
+    expect(planMeshExitRoute(cfg([tsNode({ exitNode: undefined })], 'ts1'), false)).toBeNull();
   });
 
   it('TS System + allowInternet=true 但 exitNode 为空(旧/导入配置)→ null(无 exit peer,不装路由防黑洞)', () => {

--- a/src/shared/__tests__/mesh-login-fallback.test.ts
+++ b/src/shared/__tests__/mesh-login-fallback.test.ts
@@ -1,0 +1,49 @@
+/**
+ * meshLoginFallbackShouldEngage 纯谓词单测（缺陷1 登录期出口让位判定）。
+ * 覆盖：全条件满足→true；每个否决条件（关闭/direct 模式/已回退直连/非 TS/有 authKey/隧道已就绪）单独→false。
+ */
+import { meshLoginFallbackShouldEngage } from '../mesh-login-fallback';
+import type { MeshLoginFallbackInput } from '../mesh-login-fallback';
+
+/** 基线：选中未就绪的全隧道 TS 出口、开关开、非 direct 模式 → 应让位。 */
+function base(over: Partial<MeshLoginFallbackInput> = {}): MeshLoginFallbackInput {
+  return {
+    fallbackEnabled: true,
+    proxyModeDirect: false,
+    selectedExitFallsBackDirect: false,
+    selectedIsTailscale: true,
+    selectedHasAuthKey: false,
+    selectedTunnelReady: false,
+    ...over,
+  };
+}
+
+describe('meshLoginFallbackShouldEngage', () => {
+  it('全条件满足（选中未就绪 TS 出口 + 开关开 + 非 direct）→ true', () => {
+    expect(meshLoginFallbackShouldEngage(base())).toBe(true);
+  });
+
+  it('开关关闭（fallbackEnabled=false）→ false', () => {
+    expect(meshLoginFallbackShouldEngage(base({ fallbackEnabled: false }))).toBe(false);
+  });
+
+  it('direct 代理模式 → false（默认本就 direct，无「→代理」出口）', () => {
+    expect(meshLoginFallbackShouldEngage(base({ proxyModeDirect: true }))).toBe(false);
+  });
+
+  it('选中出口已回退直连（off-mesh / 仅子网段）→ false（final 已 direct，无死锁）', () => {
+    expect(meshLoginFallbackShouldEngage(base({ selectedExitFallsBackDirect: true }))).toBe(false);
+  });
+
+  it('选中出口非 Tailscale → false（无账号制交互登录死锁）', () => {
+    expect(meshLoginFallbackShouldEngage(base({ selectedIsTailscale: false }))).toBe(false);
+  });
+
+  it('TS 配了 authKey（静态凭据，无交互登录）→ false', () => {
+    expect(meshLoginFallbackShouldEngage(base({ selectedHasAuthKey: true }))).toBe(false);
+  });
+
+  it('隧道已就绪（Running）→ false（出口已可用，正常经代理）', () => {
+    expect(meshLoginFallbackShouldEngage(base({ selectedTunnelReady: true }))).toBe(false);
+  });
+});

--- a/src/shared/__tests__/tailscale-conn-state.test.ts
+++ b/src/shared/__tests__/tailscale-conn-state.test.ts
@@ -31,18 +31,27 @@ describe('deriveTsCardState', () => {
     expect(deriveTsCardState(tsNode('   '), undefined, false)).toBe('needs-login');
   });
 
-  it('交互型：有 authUrl 且未登录 → logging-in', () => {
-    expect(deriveTsCardState(tsNode(), undefined, true)).toBe('logging-in');
-    expect(deriveTsCardState(tsNode(), false, true)).toBe('logging-in');
+  it('交互型：登录进行中(loginActive=发起或选中出口) + 有 authUrl 且未登录 → logging-in', () => {
+    expect(deriveTsCardState(tsNode(), undefined, true, true)).toBe('logging-in');
+    expect(deriveTsCardState(tsNode(), false, true, true)).toBe('logging-in');
   });
 
-  it('交互型：loggedIn=true → connected（即使仍有 authUrl，登录成功优先）', () => {
+  it('交互型：有 authUrl 但登录未进行（loginActive=false，主核 always-emit 的非活跃 URL）→ needs-login', () => {
+    // loginActive 缺省 false：非选中且未手动发起的节点被主核 always-emit 的 URL 不应把卡片推进「连接中」（可点角标登录）。
+    expect(deriveTsCardState(tsNode(), undefined, true)).toBe('needs-login');
+    expect(deriveTsCardState(tsNode(), false, true)).toBe('needs-login');
+    expect(deriveTsCardState(tsNode(), false, true, false)).toBe('needs-login');
+  });
+
+  it('交互型：loggedIn=true → connected（即使仍有 authUrl + initiated，登录成功优先）', () => {
     expect(deriveTsCardState(tsNode(), true, false)).toBe('connected');
     expect(deriveTsCardState(tsNode(), true, true)).toBe('connected');
+    expect(deriveTsCardState(tsNode(), true, true, true)).toBe('connected');
   });
 
-  it('交互型：无 loggedIn 无 authUrl → needs-login', () => {
+  it('交互型：无 loggedIn 无 authUrl → needs-login（即便 initiated）', () => {
     expect(deriveTsCardState(tsNode(), undefined, false)).toBe('needs-login');
     expect(deriveTsCardState(tsNode(), false, false)).toBe('needs-login');
+    expect(deriveTsCardState(tsNode(), false, false, true)).toBe('needs-login');
   });
 });

--- a/src/shared/__tests__/tailscale-exit-warning.test.ts
+++ b/src/shared/__tests__/tailscale-exit-warning.test.ts
@@ -1,0 +1,145 @@
+/**
+ * deriveTsExitWarning 纯谓词单测（§H.2 全矩阵：协议 × proxyMode × loggedIn × exitNode × running × peer 三态）。
+ */
+import { deriveTsExitWarning } from '../tailscale-exit-warning';
+import type { TsExitWarningInput } from '../tailscale-exit-warning';
+import { meshSelectedExitFallsBackToDirect } from '../endpoint-routes';
+import type { ServerConfig, UserConfig } from '../types';
+import type { TailscaleStatusPeer } from '../tailscale-status';
+
+function tsNode(exitNode?: string): ServerConfig {
+  return {
+    id: 'ts1',
+    name: 'Tailscale',
+    protocol: 'tailscale',
+    address: '',
+    port: 0,
+    tailscaleSettings: exitNode === undefined ? {} : { exitNode },
+  } as ServerConfig;
+}
+function peer(over: Partial<TailscaleStatusPeer>): TailscaleStatusPeer {
+  return {
+    hostName: 'dev',
+    ip: '100.1.1.1',
+    online: true,
+    exitNode: false,
+    exitNodeOption: true,
+    active: false,
+    ...over,
+  };
+}
+
+/** 基线：选中 TS 出口、已登录、非 direct、代理运行、无 exit_node → no-exit-device。 */
+function base(over: Partial<TsExitWarningInput> = {}): TsExitWarningInput {
+  return {
+    selectedServer: tsNode(),
+    loggedIn: true,
+    proxyModeDirect: false,
+    proxyRunning: true,
+    peers: undefined,
+    ...over,
+  };
+}
+
+describe('deriveTsExitWarning', () => {
+  it('选中 TS + 登录 + 无 exit_node → no-exit-device（核心态，断开也成立）', () => {
+    expect(deriveTsExitWarning(base())).toBe('no-exit-device');
+    expect(deriveTsExitWarning(base({ proxyRunning: false }))).toBe('no-exit-device'); // 断开态也提示
+  });
+
+  it('[S-b] allowInternet=true 但无 exit_node → no-exit-device（按 exit_node 判、不信 allowInternet）', () => {
+    const s = { ...tsNode(), tailscaleSettings: { allowInternet: true } } as ServerConfig;
+    expect(deriveTsExitWarning(base({ selectedServer: s }))).toBe('no-exit-device');
+  });
+
+  it('未选中 TS（选中普通节点/直连哨兵/无）→ none', () => {
+    expect(deriveTsExitWarning(base({ selectedServer: undefined }))).toBe('none');
+    expect(
+      deriveTsExitWarning(base({ selectedServer: { protocol: 'vless' } as ServerConfig }))
+    ).toBe('none');
+  });
+
+  it('未登录 → none（登录/让位 UI own）', () => {
+    expect(deriveTsExitWarning(base({ loggedIn: false }))).toBe('none');
+  });
+
+  it('direct 模式 → none', () => {
+    expect(deriveTsExitWarning(base({ proxyModeDirect: true }))).toBe('none');
+  });
+
+  it('有 exit_node + 该设备 peer online → none', () => {
+    expect(
+      deriveTsExitWarning(
+        base({ selectedServer: tsNode('100.1.1.1'), peers: [peer({ online: true })] })
+      )
+    ).toBe('none');
+  });
+
+  it('有 exit_node + 该设备 peer offline + 代理运行 → exit-device-offline', () => {
+    expect(
+      deriveTsExitWarning(
+        base({
+          selectedServer: tsNode('100.1.1.1'),
+          peers: [peer({ ip: '100.1.1.1', online: false })],
+        })
+      )
+    ).toBe('exit-device-offline');
+  });
+
+  it('有 exit_node + peer offline 但代理未运行 → none（陈旧 snapshot 不误报 offline）', () => {
+    expect(
+      deriveTsExitWarning(
+        base({
+          selectedServer: tsNode('100.1.1.1'),
+          proxyRunning: false,
+          peers: [peer({ ip: '100.1.1.1', online: false })],
+        })
+      )
+    ).toBe('none');
+  });
+
+  it('有 exit_node 但值不匹配任何 peer（自定义值）→ none（无法判定不误报）', () => {
+    expect(
+      deriveTsExitWarning(base({ selectedServer: tsNode('custom-host'), peers: [peer({})] }))
+    ).toBe('none');
+  });
+
+  it('exit_node 按 hostName 匹配 offline → exit-device-offline', () => {
+    expect(
+      deriveTsExitWarning(
+        base({
+          selectedServer: tsNode('mybox'),
+          peers: [peer({ hostName: 'mybox', online: false })],
+        })
+      )
+    ).toBe('exit-device-offline');
+  });
+
+  // §H.5 F2：警示与路由严格镜像——`no-exit-device ⟺ meshSelectedExitFallsBackToDirect=true`（选中 TS、非 direct）。
+  // 两侧同源 `!exitNode` 派生，此跨谓词测试防将来单侧改口径而漂移。
+  describe('警示 ⟺ 路由回退 镜像（防漂移）', () => {
+    const cfg = (server: ServerConfig): UserConfig =>
+      ({
+        servers: [server],
+        selectedServerId: 'ts1',
+        proxyMode: 'global',
+      }) as unknown as UserConfig;
+    it('无 exit_node：警示=no-exit-device 且 路由 fallsBackToDirect=true', () => {
+      const s = tsNode(); // 无 exitNode
+      expect(deriveTsExitWarning(base({ selectedServer: s }))).toBe('no-exit-device');
+      expect(meshSelectedExitFallsBackToDirect(cfg(s))).toBe(true);
+    });
+    it('[S-b] allowInternet:true 但无 exit_node：两侧同判（警示 no-exit-device / 路由回退 direct）', () => {
+      const s = { ...tsNode(), tailscaleSettings: { allowInternet: true } } as ServerConfig;
+      expect(deriveTsExitWarning(base({ selectedServer: s }))).toBe('no-exit-device');
+      expect(meshSelectedExitFallsBackToDirect(cfg(s))).toBe(true);
+    });
+    it('有 exit_node：警示≠no-exit-device 且 路由 fallsBackToDirect=false', () => {
+      const s = tsNode('100.1.1.1');
+      expect(
+        deriveTsExitWarning(base({ selectedServer: s, peers: [peer({ online: true })] }))
+      ).toBe('none');
+      expect(meshSelectedExitFallsBackToDirect(cfg(s))).toBe(false);
+    });
+  });
+});

--- a/src/shared/endpoint-routes.ts
+++ b/src/shared/endpoint-routes.ts
@@ -76,7 +76,11 @@ export function endpointForcedRouteCidrs(server: ServerConfig): string[] {
 export function meshAllowsInternet(server: ServerConfig): boolean {
   const p = server.protocol?.toLowerCase();
   if (p === 'wireguard') return server.wireguardSettings?.allowInternet !== false;
-  if (p === 'tailscale') return server.tailscaleSettings?.allowInternet !== false;
+  // Tailscale：allowInternet 由 exit_node 派生（把表单单一真值 tailscale-form `allowInternet=!!exitNode` 下沉到谓词层，
+  // §H.5/P0b）。治 S-b：quick-join 硬编码 `allowInternet:true` 但无 exit_node 时不再误判「承载全隧道」→ 公网从「进
+  // tsnet 无出口的黑洞」变「回退 direct」（安全），且不为其装 OS 出口路由；与「无出口设备」警示语义严格镜像。
+  // 存量 tailscaleSettings.allowInternet 字段谓词层忽略（向后兼容、不迁移）。
+  if (p === 'tailscale') return !!server.tailscaleSettings?.exitNode?.trim();
   return true;
 }
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -161,6 +161,7 @@ export const IPC_CHANNELS = {
   EVENT_TAILSCALE_AUTH_URL: 'event:tailscaleAuthUrl', // Tailscale 节点需交互登录：核日志抓出的登录 URL（瞬态核路径）
   EVENT_TAILSCALE_STATUS: 'event:tailscaleStatus', // sing-box 1.14 管理 API 推送的 Tailscale 节点真实态（backendState/loggedIn/authURL/IP/过期）
   EVENT_TAILSCALE_STATE_CLEARED: 'event:tailscaleStateCleared', // 启动前属主归一删掉某节点 root 残留 state（登录态已失效）→ 渲染端清缓存，避免陈旧 loggedIn=true 与已清空 state 撕裂（payload={serverId}）
+  EVENT_MESH_LOGIN_FALLBACK: 'event:meshLoginFallback', // 缺陷1 登录期出口让位：选中 TS 出口未就绪→默认路由让位直连(engaged=true)/就绪后切回(engaged=false)，渲染端据此提示（payload={engaged,serverName?}）
   EVENT_SYSTEM_PROXY_RESIDUAL: 'event:systemProxyResidual', // TUN 启动后检测到无 marker 的系统代理残留（非 FlowZ 设的）→ 一次性提示
 
   // 界面语言不再经此反向同步：改走 config.language 单一真值源（主进程直接读 config，见 ConfigManager）。

--- a/src/shared/mesh-login-fallback.ts
+++ b/src/shared/mesh-login-fallback.ts
@@ -1,0 +1,45 @@
+/**
+ * 组网登录期「出口让位」判定（纯谓词，便于单测；单一真值防漂移）。
+ *
+ * 场景（缺陷 1）：选中出口为账号制 Tailscale 且承载全隧道时，proxy-selector.default = 该 TS endpoint。若隧道
+ * 尚未 Running（未登录/未授权/netmap 未同步），浏览器授权页与引导期控制平面流量被导向这个「尚未连上的出口」→
+ * 授权页打不开 → 授权永不完成 → 整条引导链死锁。治法：在隧道就绪前把默认路由临时让位 'direct'
+ * （hotSwitchSelector→direct，零重启，域名无关，TUN/系统代理统一），Running 后切回。
+ *
+ * 何时**不**让位：
+ *  - 用户关了该开关（meshLoginFallbackDirect===false）→ 宁可授权失败也不在引导期直连（无泄漏窗口）；
+ *  - direct 模式：默认本就 direct，无「→代理」出口，不适用；
+ *  - 选中出口已「回退直连」（off-mesh 或只承载子网段的组网节点，meshSelectedExitFallsBackToDirect）：final 已 →direct，
+ *    浏览器流量本就直连，无死锁；
+ *  - 选中非 Tailscale（如 WireGuard/普通代理）：不走账号制交互登录，无此死锁形态；
+ *  - authKey 形态 TS：静态凭据起核即认证，无交互登录死锁；
+ *  - 隧道已就绪（Running）：出口已可用，正常经代理，不让位。
+ */
+export interface MeshLoginFallbackInput {
+  /** 开关：config.meshLoginFallbackDirect !== false（默认开）。 */
+  fallbackEnabled: boolean;
+  /** 当前是否 direct 代理模式（default 本就 direct，不适用让位）。 */
+  proxyModeDirect: boolean;
+  /** 选中出口是否已「回退直连」（meshSelectedExitFallsBackToDirect：off-mesh / 仅子网段组网节点）。 */
+  selectedExitFallsBackDirect: boolean;
+  /** 选中出口是否为 Tailscale 协议。 */
+  selectedIsTailscale: boolean;
+  /** 选中 TS 是否配置了 authKey（静态凭据，无交互登录）。 */
+  selectedHasAuthKey: boolean;
+  /** 选中 TS 隧道是否已就绪（STATUS backendState=Running）。 */
+  selectedTunnelReady: boolean;
+}
+
+/**
+ * 是否应让默认路由让位直连（引导期）。全部条件与 default=proxy-selector→未连上 TS 出口这一死锁形态一一对应。
+ */
+export function meshLoginFallbackShouldEngage(input: MeshLoginFallbackInput): boolean {
+  return (
+    input.fallbackEnabled &&
+    !input.proxyModeDirect &&
+    !input.selectedExitFallsBackDirect &&
+    input.selectedIsTailscale &&
+    !input.selectedHasAuthKey &&
+    !input.selectedTunnelReady
+  );
+}

--- a/src/shared/tailscale-conn-state.ts
+++ b/src/shared/tailscale-conn-state.ts
@@ -21,13 +21,18 @@ export type TsCardState =
 export function deriveTsCardState(
   tsNode: ServerConfig | undefined,
   loggedIn: boolean | undefined,
-  hasAuthUrl: boolean
+  hasAuthUrl: boolean,
+  loginActive = false
 ): TsCardState {
   if (!tsNode) return 'no-node';
   // authKey 形态优先：静态凭据，起核即认证，不进登录态/检测态（与 WG 同质）。
   if (tsNode.tailscaleSettings?.authKey?.trim()) return 'key-ready';
-  // 交互登录：有 URL 且尚未登录成功 → 登录中（loggedIn 一旦转 true 即落 'connected'）。
-  if (hasAuthUrl && loggedIn !== true) return 'logging-in';
+  // 交互登录中：登录【正在进行】(loginActive) 且有 URL 且尚未登录成功。loginActive = 用户显式发起(loginInitiated)
+  // OR 该节点是当前选中出口（app 自动连接它=登录进行中，非被动 always-emit）。1.14 主核 always-emit 会为未选中/
+  // 未就绪节点持续 emit AUTH_URL——若仅凭 hasAuthUrl 判 'logging-in'，卡片会被这些非活跃 URL 误推进「连接中」。
+  // 故门控后：非选中且未手动发起时有 URL 只显 'needs-login'（可点角标登录）；选中出口自动连接 或 用户手点后进
+  // 'logging-in'（修真机：首页弹登录时选中出口卡片应显「连接中」而非初始态）。loggedIn 一旦转 true 即落 'connected'。
+  if (loginActive && hasAuthUrl && loggedIn !== true) return 'logging-in';
   if (loggedIn === true) return 'connected';
   return 'needs-login';
 }

--- a/src/shared/tailscale-exit-warning.ts
+++ b/src/shared/tailscale-exit-warning.ts
@@ -1,0 +1,45 @@
+/**
+ * 「Tailscale 出口名不副实」警示判定（纯函数，首页行内注脚用；§H）。
+ *
+ * 取代旧 §G「未选中就劝设为出口」（那是稳态噪音——用户显式选了别的出口/直连时反被劝）。这里只在【选中了 TS 当
+ * 全局出口、却出不了公网】时给有效提示：
+ *  - no-exit-device：选中 TS + 已登录 + 非 direct 模式 + 未配 exit_node → 公网并不经 TS（P0b 后回退 direct；S-b
+ *    的 quick-join allowInternet:true 无 exit_node 亦归此），提示「已设为出口但未选出口设备」。**按 exit_node 直判、
+ *    不信 allowInternet**（覆盖 S-b）。配置级问题，断开态也成立（截图 2 即断开）。
+ *  - exit-device-offline：选中 TS + 已登录 + 已配 exit_node + 代理运行 + 该 exit 设备 peer offline → 公网可能出不去。
+ *    仅代理运行时判（静态 snapshot 判 offline 会误报）。
+ *
+ * 未选中 TS / 未登录（含 NeedsLogin 让位期）/ direct 模式 / exit_node 为无法匹配的自定义值 → none（不误报，且与
+ * 出口让位 reconcileLoginFallback + 登录 toast/角标天然互斥：让位/登录 UI 在 loggedIn=false 期，本警示在 loggedIn 期）。
+ */
+import type { ServerConfig } from './types';
+import type { TailscaleStatusPeer } from './tailscale-status';
+
+export type TsExitWarning = 'none' | 'no-exit-device' | 'exit-device-offline';
+
+export interface TsExitWarningInput {
+  /** 当前选中的全局出口节点（config.selectedServerId 对应）。 */
+  selectedServer: ServerConfig | undefined;
+  /** 该出口的综合登录态（tailscaleLoginStates，缓存驱动，代理关时也有值）。 */
+  loggedIn: boolean;
+  /** 分流策略是否为全局直连（proxyMode==='direct'）。 */
+  proxyModeDirect: boolean;
+  /** 主核是否运行（peers 新鲜度门——offline 判定须实时 STATUS 流）。 */
+  proxyRunning: boolean;
+  /** 该 TS 的对端列表（store.tailscalePeers[id]）。 */
+  peers: TailscaleStatusPeer[] | undefined;
+}
+
+export function deriveTsExitWarning(i: TsExitWarningInput): TsExitWarning {
+  const s = i.selectedServer;
+  if (!s || s.protocol?.toLowerCase() !== 'tailscale') return 'none'; // 未选中 TS 出口 → 永不提示（§G 方向反转）
+  if (i.proxyModeDirect) return 'none'; // 显式全直连（与 meshSelectedExitFallsBackToDirect 同口径）
+  if (!i.loggedIn) return 'none'; // 未登录：需登录角标 / 登录 toast / 出口让位已 own，不叠加
+  const exitNode = s.tailscaleSettings?.exitNode?.trim();
+  if (!exitNode) return 'no-exit-device'; // 核心态：无 exit_node（S-a/S-b 统一，不信 allowInternet）→ 公网不经 TS
+  if (!i.proxyRunning) return 'none'; // offline 判定须新鲜 STATUS（陈旧 snapshot 会误报）
+  // exit_node 值与 peer 匹配（复用 exit-node-field 的 ip/hostName 口径）；匹配到且 offline → 警示，自定义值不匹配 → 不误报。
+  const peer = i.peers?.find((p) => p.ip === exitNode || p.hostName === exitNode);
+  if (peer && !peer.online) return 'exit-device-offline';
+  return 'none';
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -412,6 +412,10 @@ export interface UserConfig {
   privacyPassword?: string; // 隐私模式解锁密码
   autoSwitchNode?: boolean; // 节点故障时自动切换到可用节点
   interruptConnectionsOnSwitch?: boolean; // 切换节点时中断现有连接、强制在新节点重建（默认 false=优雅切换，现有连接保留至自然关闭）
+  // 组网登录期出口让位（默认开=undefined||true）：当选中出口为 Tailscale 且其隧道尚未 Running 时，默认路由临时让位
+  // 直连（hotSwitchSelector→direct，零重启），使浏览器授权页/引导期控制平面流量不被导向「尚未连上的 TS 出口」而死锁；
+  // 隧道 Running 后自动切回 TS 出口。关闭=false：宁可授权失败也不在引导期直连（无泄漏窗口）。见 shared/mesh-login-fallback。
+  meshLoginFallbackDirect?: boolean;
 
   // 窗口尺寸（仅在 rememberWindowSize 启用时使用）
   windowBounds?: { width: number; height: number };


### PR DESCRIPTION
## 问题
单个 Tailscale 节点作全局出口时，启动弹登录但浏览器打不开授权页——流量已被路由到尚未连通的 TS 出口，鸡生蛋死锁；取消 / 停 TUN 后登录卡死、再点无响应需手动退出。另外，选中 TS 当出口却未配 exit_node 时公网静默走直连、无有效提示（quick-join 的 `allowInternet:true` 无 exit_node 更会黑洞）。

## 改动

### 1. 登录期出口让位（reconcileLoginFallback）
选中 TS 出口且未就绪、`NeedsLogin` 时把 `proxy-selector` 让位到 `direct`（PUT 成功才置 flag、单飞、`Running`/切走/关开关时归位），授权页经直连可达；隧道 `Running` 后自动切回。零重启（`meshLoginFallbackDirect` 不进 `configGenerationNorm`）。4 驱动源（STATUS 帧 / switchMode 非重启腿 / 健康检查 / reassert）+ 自愈。

### 2. 登录会话统一 + UX
`startTailscaleLogin` 返回 live authURL（`tailscaleStatusCache`，主核 always-emit 唯一可靠来源）；取消恒广播空 URL、inMainCore 可重开；跨会话缓存失效清 authURL 防死链；`loginActive` 统一「需登录」角标 / 弹窗态。

### 3. 出口未配设备警示 + 路由收敛（含黑洞修复）
选中 TS 当出口、已登录、却未配 exit_node（公网静默走直连）时，首页「当前服务器」下拉正下方一行 warning 注脚提示并直达出口设备选择；出口设备离线亦提示。`meshAllowsInternet(TS)` 改由 exit_node 派生——治 quick-join `allowInternet:true` 无 exit_node 的黑洞（公网进 tsnet 无出口 → 改为回退 direct），与警示语义严格镜像。移除旧「未选中就劝设为出口」的稳态噪音引导。

## 验证
- gate：`tsc`（main + renderer）/ `eslint` / `jest` 全绿（本分支从 `main` 起、独立于其它在研工作，752 测试 / 51 套件绿）。
- 真机（Windows TUN + tailscale.com）：登录死锁解除；取消不回弹、再点可重开；无 exit_node 出口公网回退 direct（`route.final=direct`、curl 200，非黑洞）。
