### PR TITLE
fix(fakeip): v6 假段改 2001:2::/48 治 Chrome LNA 拦截 + 核 start/stop 刷 OS DNS 缓存

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -11,7 +11,8 @@
 // 协议（每行以 \n 结尾，路径整行传递 → 容忍含空格的路径，如 "Application Support/FlowZ"）：
 //
 //	行1: <token>
-//	行2: <command>           ping | version | start | stop | status
+//	行2: <command>           ping | version | start | stop | status | cleanup | freeport | install-core |
+//	                         route-add | route-del | default-restore | flush-dns
 //	start 追加: 行3=<cfg> 行4=<log，可空> 行5=<fwd: 0|1> 行6=<父appPID，可选；缺失/空=不启父死看护（兼容旧客户端）>
 //
 // 仅依赖 Go 标准库（无第三方依赖，便于交叉编译与审计）。
@@ -63,7 +64,13 @@ import (
 //
 //	善后误删、停核 unsetRoutes 不回填 → Mac 停核后断网。app 侧在停核后检测全局 default 缺失则经本命令 `route add
 //	-inet default <gw>` 补回（best-effort）。proto<8 无此命令 → 回 ERR unknown，断网安全网失效但 TUN 正常。
-const protoVersion = "8"
+//
+// v9：加 flush-dns 命令——root 依次执行 dscacheutil -flushcache 与 killall -HUP mDNSResponder，两层系统 DNS
+//
+//	缓存全清（用户级 dscacheutil 无权 HUP mDNSResponder，清不到其 unicast cache）。核 start/stop 后由 app 侧
+//	best-effort 调用；dscacheutil 成功而 HUP 失败回 OK flushed-partial（app 不降级，用户级重复无益）；
+//	proto<9 无此命令 → 回 ERR unknown，app 降级用户级 dscacheutil。
+const protoVersion = "9"
 
 var (
 	singboxBin string // 安装时锁定的 sing-box 路径
@@ -368,6 +375,21 @@ func handle(conn net.Conn) {
 		}
 		_ = exec.Command("/sbin/route", "-n", "add", "-inet", "default", gw).Run()
 		fmt.Fprintln(conn, "OK default-restore")
+	case "flush-dns":
+		// proto v9：root 刷系统 DNS 缓存——dscacheutil 清 Directory Services 缓存 + HUP mDNSResponder 清 unicast
+		// resolver 缓存（用户级 dscacheutil 无权 HUP，清不到后者）。app 在核 start/stop 后 best-effort 调用，
+		// 清掉「系统解析器受控/还原」边界另一侧的陈旧记录（如 TUN+FakeIP 会话缓存的假 IP 骑跨到直连态）。
+		// 两命令均瞬时完成、无参数注入面。dscacheutil 失败回 ERR（app 降级用户级 dscacheutil 有意义）；
+		// dscacheutil 成功而 HUP 失败回 OK flushed-partial（app 不降级——用户级同样无权 HUP，重复无益）。
+		if out, err := exec.Command("/usr/bin/dscacheutil", "-flushcache").CombinedOutput(); err != nil {
+			fmt.Fprintf(conn, "ERR dscacheutil %v %s\n", err, strings.TrimSpace(string(out)))
+			break
+		}
+		if out, err := exec.Command("/usr/bin/killall", "-HUP", "mDNSResponder").CombinedOutput(); err != nil {
+			fmt.Fprintf(conn, "OK flushed-partial killall-hup %v %s\n", err, strings.TrimSpace(string(out)))
+			break
+		}
+		fmt.Fprintln(conn, "OK flushed")
 	case "freeport":
 		// 按端口（root lsof）定位 LISTEN 持有者：是 sing-box 才 kill -9，否则回报占用者名字（不杀）。
 		// 彻底摆脱 app 侧 cmdline 匹配，覆盖「外部 / 旧 app 路径 / 改过 singboxBin 路径」的 9090 占用者（L2）。

--- a/src/main/__tests__/safe-redirect-fetch.test.ts
+++ b/src/main/__tests__/safe-redirect-fetch.test.ts
@@ -24,7 +24,7 @@ function makeResp(status: number, location?: string): FakeResp {
 const PUBLIC = [{ address: '93.184.216.34' }];
 const INTERNAL = [{ address: '10.0.0.5' }];
 const META = [{ address: '169.254.169.254' }];
-const FAKEIP6 = [{ address: '2001:db8::57' }]; // FlowZ FakeIP（IPv6 2001:db8::/32 公网文档段）：isFlowzFakeIp 豁免、Chrome LNA 判 public
+const FAKEIP6 = [{ address: '2001:2::57' }]; // FlowZ FakeIP（IPv6 2001:2::/48 benchmarking 保留段）：isFlowzFakeIp 豁免、Chrome LNA 判 public
 const REAL_ULA6 = [{ address: 'fc00::57' }]; // 真实 ULA（fc00::/7）：isPrivateIp 判内网、非 FakeIP，直连不豁免
 
 const base = {
@@ -177,7 +177,7 @@ describe('safeRedirectFetch', () => {
     );
   });
 
-  it('exemptFakeIp=true → 豁免 FlowZ FakeIP（IPv6 2001:db8::/32，经代理出口）', async () => {
+  it('exemptFakeIp=true → 豁免 FlowZ FakeIP（IPv6 2001:2::/48，经代理出口）', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(makeResp(200));
     const lookup = jest.fn().mockResolvedValue(FAKEIP6);
     const r = await safeRedirectFetch<FakeResp>({

--- a/src/main/services/HelperManager.ts
+++ b/src/main/services/HelperManager.ts
@@ -37,8 +37,9 @@ const SOCKET_PATH = `${SYSTEM_SUPPORT}/helper.sock`;
  *  MIN_USABLE ≤ proto < EXPECTED → upgradeable（旧版仍能 TUN，仅温和提示可升级、不强制重装）；proto < MIN_USABLE 才 needsRepair。
  *  v3=SIGTERM 收割 child；v4=freeport；v5=install-core（root 写受保护目录持久化内核 + 哈希校验防 TOCTOU）；
  *  v6=chownRuntimeDirs（root 跑的 sing-box 退出后归还 tailscale/dashboard/ui 属主给登录用户，根治跨提权态属主冲突）；
- *  v7=route-add/route-del（出口托管 ifscope 拆半默认路由）；v8=default-restore（停核补回被 EEXIST 善后误删的全局 default）。 */
-const EXPECTED_PROTO = '8';
+ *  v7=route-add/route-del（出口托管 ifscope 拆半默认路由）；v8=default-restore（停核补回被 EEXIST 善后误删的全局 default）；
+ *  v9=flush-dns（root 刷系统 DNS 缓存：dscacheutil + HUP mDNSResponder 两层全清）。 */
+const EXPECTED_PROTO = '9';
 const MIN_USABLE_PROTO = 4;
 /** launchctl 加载态探测缓存 TTL：getStatus 被首页/设置页高频轮询，避免每次都 spawn launchctl。 */
 const LOADED_PROBE_TTL_MS = 10_000;
@@ -359,6 +360,20 @@ export class HelperManager implements IPrivilegedHelper {
   async restoreDefaultRoute(gateway: string): Promise<{ ok: boolean; error?: string }> {
     try {
       const resp = await this.sendCommand(['default-restore', gateway], 5000);
+      return resp.startsWith('OK') ? { ok: true } : { ok: false, error: resp.trim() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  /** 经 helper(root, v9) 刷系统 DNS 缓存（dscacheutil + killall -HUP mDNSResponder，两层全清）。
+   *  dscacheutil 成功而 HUP 失败时 helper 回 `OK flushed-partial <原因>` → {ok:true, partial:应答原文}（不降级：
+   *  用户级同样无权 HUP，重复无益；partial 供调用方降格 warn 留痕）；proto<9 旧 helper 回 ERR unknown →
+   *  {ok:false}，调用方（os-dns-flush）降级用户级 dscacheutil。 */
+  async flushDns(): Promise<{ ok: boolean; partial?: string; error?: string }> {
+    try {
+      const resp = await this.sendCommand(['flush-dns'], 5000);
+      if (resp.startsWith('OK flushed-partial')) return { ok: true, partial: resp.trim() };
       return resp.startsWith('OK') ? { ok: true } : { ok: false, error: resp.trim() };
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : String(e) };

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -30,6 +30,7 @@ import { PlatformPrivilegeService } from './PlatformPrivilegeService';
 import { type ISystemProxyManager, SystemProxyBase } from './SystemProxyManager';
 import { type ISystemDnsManager } from './SystemDnsManager';
 import { DnsInterfaceWatcher, shouldReconcileDns } from './DnsInterfaceWatcher';
+import { flushOsDnsCache } from './os-dns-flush';
 import { localProxyPort, controlApiPort } from '../../shared/proxy-ports';
 import { effectiveBypassLan } from '../../shared/system-proxy-bypass';
 import { resolveTunStack } from '../../shared/tun-stack';
@@ -1005,6 +1006,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       );
     }
 
+    // 核已成功起动、DNS 接管状态已收口 → best-effort 刷 OS DNS 缓存（fire-and-forget，不阻塞启动；让位
+    // CoreStartSupersededError 与失败路径在更早处已抛、到不了这里）。清掉接管边界前系统解析器缓存的陈旧记录
+    // （典型：直连态缓存的真实/错族 IP 在 TUN+FakeIP 态继续被命中 → 绕过 hijack-dns 反查）。**有意全模式触发**：
+    // 非 TUN/非接管（systemProxy/manual）亦刷——上一会话可能是 TUN+FakeIP（假 IP 仍在 OS 缓存），且直连态自身的
+    // 陈旧记录同样受益。
+    this.flushOsDnsCacheBestEffort('start');
+
     // sing-box 1.14 管理 API：核起后连 api service 订阅 Tailscale 状态（断线重连，随主核生命周期）。
     if (this.hasManagementApi()) {
       this.tailscaleApiClient?.stop();
@@ -1217,6 +1225,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     if (!this.singboxProcess && !this.singboxPid) {
       // 崩溃/外部死亡后停核：主核已不在，文末那条 restore 会被本早退跳过。若 system WG 全隧道用裸 0/0 删了 en0 全局
       // 默认路由而 sing-tun unsetRoutes 未回填，在此补回（restore 自身幂等 + savedDefaultGateway 门控，无关场景 no-op）。
+      // 有意取舍：本早退路径**不刷 OS DNS 缓存**（文末 flushOsDnsCacheBestEffort 同被跳过）——① 崩溃残留的假 IP
+      // 随 DNS TTL 过期自愈，且下次 start 成功尾部必补刷；② 若挪进本分支，每次冷启动的内部 stop 腿（无核可停）
+      // 都会空刷 + 记日志，常态噪声换罕见崩溃场景的边际收益不划算。
       await this.restoreDefaultRouteIfMissing();
       return;
     }
@@ -1240,6 +1251,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // macOS 停核断网安全网（补回腿）：放在最后——sing-box 已完全退出（sing-tun unsetRoutes 已跑），此刻若检测全局
     // default 缺失即补回起核前快照的网关。best-effort、绝不抛，不扰动上方已调试好的拆除时序。非 macOS no-op。
     await this.restoreDefaultRouteIfMissing();
+    // 停核收尾 → best-effort 刷 OS DNS 缓存（fire-and-forget，绝不阻塞停止；restoreDns 由用户停止前置的
+    // ensureSystemProxyCleared → ensureSystemDnsRestored 收口，先于本方法）。清掉 TUN+FakeIP 会话期系统解析器
+    // 缓存的假 IP——停核后仍命中会致直连态撞不可达的假地址。重启经 stop+start 各刷一次，可接受、不去抖。
+    this.flushOsDnsCacheBestEffort('stop');
   }
 
   /**
@@ -5288,6 +5303,31 @@ exit 0
     } finally {
       this.clearingSystemDns = false;
     }
+  }
+
+  /**
+   * best-effort 刷 OS 级 DNS 缓存（fire-and-forget，绝不抛、不阻塞生命周期）：核 start 成功尾部 / stopInner 尾部
+   * 各一次，清掉「系统解析器受控/还原」边界另一侧的陈旧缓存（典型：TUN+FakeIP 会话期缓存的假 IP 停核后仍被命中）。
+   * darwin 优先 root helper（v9 flush-dns，两层缓存全清；flushDns 是具体方法非 IPrivilegedHelper 接口成员，
+   * 与 installCore 同惯例 cast），helper 未装/旧 proto 由 os-dns-flush 降级用户级 dscacheutil。
+   */
+  private flushOsDnsCacheBestEffort(context: 'start' | 'stop'): void {
+    const helperFlushDns =
+      process.platform === 'darwin'
+        ? // 返回类型从 flushDns() 推断（含 partial 字段），签名演进自动跟随、不留漂移面。
+          () => {
+            // darwin helperManager 恒为 HelperManager（与 teardownForQuit 同惯例）；未装时 socket ENOENT 快速失败
+            // → {ok:false} → os-dns-flush 走用户级降级，无额外延迟、不弹框。
+            this.helperManager ??= new HelperManager();
+            return (this.helperManager as HelperManager).flushDns();
+          }
+        : null;
+    void flushOsDnsCache({
+      helperFlushDns,
+      log: (level, message) => this.logToManager(level, `[dns-flush:${context}] ${message}`),
+    }).catch(() => {
+      /* flushOsDnsCache 契约永不 reject；兜实现漂移 */
+    });
   }
 
   /**

--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -807,7 +807,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
         {
           "inet4_range": "198.18.0.0/15",
-          "inet6_range": "2001:db8::/32",
+          "inet6_range": "2001:2::/48",
           "tag": "fakeip",
           "type": "fakeip",
         },

--- a/src/main/services/__tests__/dns-resolver.test.ts
+++ b/src/main/services/__tests__/dns-resolver.test.ts
@@ -313,12 +313,13 @@ describe('§B：enableIPv6 收敛 AAAA（IPv4-only 节点防 ERR_CONNECTION_CLOS
     expect(fakeip(cfg)?.inet6_range).toBeUndefined();
   });
 
-  it('enableIPv6=true → strategy=prefer_ipv4 + fakeip 带 inet6_range=2001:db8::/32（公网文档段，避开 Chrome LNA）', () => {
+  it('enableIPv6=true → strategy=prefer_ipv4 + fakeip 带 inet6_range=2001:2::/48（benchmarking 保留段，Chrome LNA 判 public）', () => {
     const v6cfg = { ...tunFx.config, enableIPv6: true } as AnyCfg;
     const cfg = new ProxyManager().generateSingBoxConfig(v6cfg) as AnyCfg;
     expect(cfg.dns.strategy).toBe('prefer_ipv4');
-    // 公网文档段（非旧 ULA fc00::/18）：浏览器 Chrome Local Network Access 判 public、不拦 public 页面取该段子资源。
-    expect(fakeip(cfg)?.inet6_range).toBe('2001:db8::/32');
+    // RFC 5180 benchmarking 段不在 Chromium LNA 的 NonPublicAddressSpaceMap → 判 public，与 v4 假段同空间；
+    // 文档段 2001:db8::/32 在表内判 local，会触发 LNA 整批拦截，不可用。详见 shared/fakeip-filter。
+    expect(fakeip(cfg)?.inet6_range).toBe('2001:2::/48');
   });
 });
 

--- a/src/main/services/__tests__/os-dns-flush.test.ts
+++ b/src/main/services/__tests__/os-dns-flush.test.ts
@@ -1,0 +1,73 @@
+/**
+ * flushOsDnsCache 单测（node env，依赖全注入）：darwin helper 成功（不降级）/ helper 失败（降级用户级
+ * dscacheutil）/ win32 / linux / exec 抛错不外抛——覆盖三平台分支 + 不变量「永不 reject」。
+ */
+import { flushOsDnsCache } from '../os-dns-flush';
+
+describe('flushOsDnsCache', () => {
+  it('darwin：helper flush-dns 成功 → 不降级（exec 不被调用）', async () => {
+    const exec = jest.fn();
+    const helper = jest.fn().mockResolvedValue({ ok: true });
+    const log = jest.fn();
+    await flushOsDnsCache({ platform: 'darwin', exec, helperFlushDns: helper, log });
+    expect(helper).toHaveBeenCalledTimes(1);
+    expect(exec).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('info', expect.stringContaining('helper root'));
+  });
+
+  it('darwin：helper partial（dscacheutil 成功、仅 HUP 失败）→ 不降级（exec 不被调），warn 留痕含详情', async () => {
+    const exec = jest.fn();
+    const helper = jest
+      .fn()
+      .mockResolvedValue({ ok: true, partial: 'OK flushed-partial killall-hup exit status 1' });
+    const log = jest.fn();
+    await flushOsDnsCache({ platform: 'darwin', exec, helperFlushDns: helper, log });
+    expect(exec).not.toHaveBeenCalled(); // 用户级同样无权 HUP，重复降级无益
+    expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('killall-hup'));
+  });
+
+  it('darwin：helper 失败（旧 proto 回 ERR unknown）→ 降级用户级 dscacheutil', async () => {
+    const exec = jest.fn().mockResolvedValue(undefined);
+    const helper = jest.fn().mockResolvedValue({ ok: false, error: 'ERR unknown' });
+    const log = jest.fn();
+    await flushOsDnsCache({ platform: 'darwin', exec, helperFlushDns: helper, log });
+    expect(exec).toHaveBeenCalledWith('/usr/bin/dscacheutil', ['-flushcache'], expect.any(Number));
+    expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('降级'));
+  });
+
+  it('darwin：无 helper（null，未装/非 TUN 场景）→ 直接用户级 dscacheutil', async () => {
+    const exec = jest.fn().mockResolvedValue(undefined);
+    await flushOsDnsCache({ platform: 'darwin', exec, helperFlushDns: null });
+    expect(exec).toHaveBeenCalledWith('/usr/bin/dscacheutil', ['-flushcache'], expect.any(Number));
+  });
+
+  it('darwin：helper reject（契约防御）→ 仍降级、不外抛', async () => {
+    const exec = jest.fn().mockResolvedValue(undefined);
+    const helper = jest.fn().mockRejectedValue(new Error('socket boom'));
+    await expect(
+      flushOsDnsCache({ platform: 'darwin', exec, helperFlushDns: helper })
+    ).resolves.toBeUndefined();
+    expect(exec).toHaveBeenCalledWith('/usr/bin/dscacheutil', ['-flushcache'], expect.any(Number));
+  });
+
+  it('win32：ipconfig /flushdns（无需提权，不碰 helper）', async () => {
+    const exec = jest.fn().mockResolvedValue(undefined);
+    const helper = jest.fn();
+    await flushOsDnsCache({ platform: 'win32', exec, helperFlushDns: helper });
+    expect(exec).toHaveBeenCalledWith('ipconfig', ['/flushdns'], expect.any(Number));
+    expect(helper).not.toHaveBeenCalled();
+  });
+
+  it('linux：resolvectl flush-caches', async () => {
+    const exec = jest.fn().mockResolvedValue(undefined);
+    await flushOsDnsCache({ platform: 'linux', exec });
+    expect(exec).toHaveBeenCalledWith('resolvectl', ['flush-caches'], expect.any(Number));
+  });
+
+  it('exec 抛错（如无 systemd-resolved）→ 永不 reject，仅 warn', async () => {
+    const exec = jest.fn().mockRejectedValue(new Error('ENOENT'));
+    const log = jest.fn();
+    await expect(flushOsDnsCache({ platform: 'linux', exec, log })).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('ENOENT'));
+  });
+});

--- a/src/main/services/os-dns-flush.ts
+++ b/src/main/services/os-dns-flush.ts
@@ -1,0 +1,89 @@
+/**
+ * OS 级 DNS 缓存刷新（best-effort）。
+ *
+ * 动机：核 start/stop 跨越「系统解析器受控/还原」边界时，OS 缓存里可能残留边界另一侧的记录
+ * （典型：TUN+FakeIP 会话期缓存的假 IP 停核后仍被命中 → 直连态拿假 IP 撞墙；反向同理）。
+ * 由 ProxyManager 在核 start 成功尾部 / stop 尾部 fire-and-forget 调用。
+ *
+ * 不变量：
+ *  - 永不 reject（任何失败仅 log warn）——刷缓存是增益项，绝不阻塞/拖垮代理生命周期；
+ *  - 每个外部命令 3s 硬超时（defaultExec 内置；注入 exec 时超时由注入方按 timeoutMs 参数落实）；helper 路径的
+ *    超时由 HelperManager.sendCommand（5s）另行落实，不经本模块的 exec；
+ *  - 依赖（exec / platform / helper / log）全部可注入，便于三平台 mock 单测（模块自身零 Electron 依赖）。
+ *
+ * 平台行为：
+ *  - darwin：优先注入的 root helper flush-dns（dscacheutil + killall -HUP mDNSResponder，两层缓存全清）；
+ *    helper 不可用/旧 proto（<9 回 ERR unknown）→ 降级用户级 `dscacheutil -flushcache`——无权 HUP
+ *    mDNSResponder，对其 unicast cache 无保证、仅尽力。
+ *  - win32：`ipconfig /flushdns`（无需提权）。
+ *  - linux：`resolvectl flush-caches`（无 systemd-resolved 的发行版命令缺失/失败 → 仅日志）。
+ *  - 其余平台：no-op。
+ */
+import { execFile } from 'child_process';
+
+/** 单个外部命令的硬超时：刷缓存命令均为瞬时操作，3s 未归即视为异常（防挂起命令拖住 fire-and-forget 链）。 */
+const EXEC_TIMEOUT_MS = 3000;
+
+export interface OsDnsFlushDeps {
+  /** 平台判定（默认 process.platform）。 */
+  platform?: NodeJS.Platform;
+  /** 外部命令执行器（默认 execFile 包装，带 timeoutMs 硬超时；非零退出/超时/spawn 失败 → reject）。 */
+  exec?: (file: string, args: string[], timeoutMs: number) => Promise<void>;
+  /** macOS root helper 的 flush-dns 通道（HelperManager.flushDns）；缺省/null=不可用，直接走用户级降级。
+   *  ok:true + partial=helper 应答原文（dscacheutil 成功、仅 HUP mDNSResponder 失败）→ 不降级、warn 留痕。 */
+  helperFlushDns?: (() => Promise<{ ok: boolean; partial?: string; error?: string }>) | null;
+  /** 日志（默认静默）。 */
+  log?: (level: 'info' | 'warn', message: string) => void;
+}
+
+function defaultExec(file: string, args: string[], timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { timeout: timeoutMs }, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+/** 刷 OS 级 DNS 缓存。语义见文件头：best-effort、永不 reject。 */
+export async function flushOsDnsCache(deps: OsDnsFlushDeps = {}): Promise<void> {
+  const platform = deps.platform ?? process.platform;
+  const exec = deps.exec ?? defaultExec;
+  const log = deps.log ?? ((): void => {});
+  try {
+    if (platform === 'darwin') {
+      if (deps.helperFlushDns) {
+        // helper 契约上永不 reject（HelperManager.flushDns 异常收敛为 ok:false）；.catch 兜实现漂移，保证降级腿可达。
+        const r = await deps
+          .helperFlushDns()
+          .catch((e): { ok: boolean; partial?: string; error?: string } => ({
+            ok: false,
+            error: e instanceof Error ? e.message : String(e),
+          }));
+        if (r.ok) {
+          if (r.partial) {
+            // partial：dscacheutil 已成功、仅 HUP mDNSResponder 失败——不降级（用户级同样无权 HUP，重复无益），
+            // 降格 warn 留痕便于诊断。
+            log('warn', `已刷新系统 DNS 缓存（helper root，partial：${r.partial}）`);
+          } else {
+            log('info', '已刷新系统 DNS 缓存（helper root：dscacheutil + HUP mDNSResponder）');
+          }
+          return;
+        }
+        log('warn', `helper flush-dns 不可用（${r.error ?? '未知'}），降级用户级 dscacheutil`);
+      }
+      // 用户级降级：无权 HUP mDNSResponder → 对其 unicast cache 无保证，仅尽力。
+      await exec('/usr/bin/dscacheutil', ['-flushcache'], EXEC_TIMEOUT_MS);
+      log(
+        'info',
+        '已刷新系统 DNS 缓存（用户级 dscacheutil，对 mDNSResponder unicast cache 无保证）'
+      );
+    } else if (platform === 'win32') {
+      await exec('ipconfig', ['/flushdns'], EXEC_TIMEOUT_MS);
+      log('info', '已刷新系统 DNS 缓存（ipconfig /flushdns）');
+    } else if (platform === 'linux') {
+      await exec('resolvectl', ['flush-caches'], EXEC_TIMEOUT_MS);
+      log('info', '已刷新系统 DNS 缓存（resolvectl flush-caches）');
+    }
+  } catch (e) {
+    // 不变量：永不 reject。命令缺失（如无 systemd-resolved）/超时/非零退出 → 仅记 warn。
+    log('warn', `刷新系统 DNS 缓存失败（忽略）: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}

--- a/src/main/services/singbox-dns-builder.ts
+++ b/src/main/services/singbox-dns-builder.ts
@@ -210,10 +210,11 @@ export function buildDnsConfig(
       // §B：开 IPv6 才给 FakeIP 分配 v6 段（双栈外观：客户端拿到假 AAAA、可用 v6 路径连本机 TUN）；关 IPv6 则不分配
       //   → fakeip 对 AAAA 无段可分配即返空（真机实测：无需改规则 query_type），配合下方 strategy=ipv4_only 客户端纯 v4，
       //   杜绝"双栈站 + 节点无 v6"时浏览器试 v6 失败致 ERR_CONNECTION_CLOSED。
-      // v6 段取公网文档段 2001:db8::/32（非旧 ULA fc00::/18）：浏览器 Chrome Local Network Access 把 ULA(fc00::/7) 判 private、
-      //   拦截 public 页面取该段子资源(net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS，YouTube 图片/字体批量失败)；2001:db8::/32
-      //   在全局单播内判 public、不触发该拦截。假 IP 仅本机占位、真实连接由出口节点反查域名后建立，假 v4/假 v6 对可达性无差别。
-      //   详见 shared/fakeip-filter。
+      // v6 段取 2001:2::/48（RFC 5180 benchmarking，IANA 永久保留、全网不可路由）：Chromium LNA 地址空间表
+      //   （ip_address_space_util.cc 的 NonPublicAddressSpaceMap）把文档段 2001:db8::/32 与 ULA(fc00::/7) 都判 local、
+      //   benchmarking 段不在表内=public → 与 v4 假段 198.18/15 同为 public，同页面两族假 IP 不地址空间分裂，public
+      //   initiator 取假 v6 子资源不触发 net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS 整批拦截。假 IP 仅本机占位、
+      //   真实连接由出口节点反查域名后建立，假 v4/假 v6 对可达性无差别。详见 shared/fakeip-filter。
       ...(config.enableIPv6 ? { inet6_range: FAKEIP_INET6_RANGE } : {}),
     });
   }

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -630,7 +630,7 @@ export function buildRouteConfig(
     // 与 mesh force-route 块一致：空数组不发射规则（用户把 bypassLANList 编辑成只剩域名时 cidrs 为空，
     // 避免 `ip_cidr:[]` 空规则；域名直连仍由下方 geosite-private 兜底）。
     // FakeIP 护栏：剔除与 fakeip 假 IP 段相交的旁路条目，否则假 IP 被当私网直连→绕过 fakeip 反查→服务端收不到域名。
-    // 现 fakeip v4=198.18/15(私网外)、v6=2001:db8::/32(全局单播文档段) 均与 LAN 旁路(含 fc00::/7 ULA、私网 v4)天然不相交，
+    // 现 fakeip v4=198.18/15(私网外)、v6=2001:2::/48(RFC 5180 benchmarking 保留段) 均与 LAN 旁路(含 fc00::/7 ULA、私网 v4)天然不相交，
     // 护栏对默认清单退化为 no-op；保留以防用户自定义清单或未来改动再撞（曾因 fakeip v6=fc00::/18 被旁路 fc00::/7 吃掉撞墙）。
     const fakeipRanges = usesFakeIp(config)
       ? [FAKEIP_INET4_RANGE, ...(config.enableIPv6 ? [FAKEIP_INET6_RANGE] : [])]

--- a/src/shared/__tests__/ip.test.ts
+++ b/src/shared/__tests__/ip.test.ts
@@ -95,21 +95,21 @@ describe('cidrsOverlap / cidrOverlapsAny — 家族感知(v4+v6)', () => {
 });
 
 describe('partitionCidrsByOverlap + FakeIP 段护栏不变量', () => {
-  it('剔除与 fakeip 段相交的旁路条目（v4 198.18/15 + v6 2001:db8::/32）', () => {
-    const ranges = [FAKEIP_INET4_RANGE, FAKEIP_INET6_RANGE]; // [198.18.0.0/15, 2001:db8::/32]
+  it('剔除与 fakeip 段相交的旁路条目（v4 198.18/15 + v6 2001:2::/48）', () => {
+    const ranges = [FAKEIP_INET4_RANGE, FAKEIP_INET6_RANGE]; // [198.18.0.0/15, 2001:2::/48]
     const r = partitionCidrsByOverlap(
-      ['10.0.0.0/8', 'fc00::/7', '2001:db8:1::/48', '198.18.0.0/16'],
+      ['10.0.0.0/8', 'fc00::/7', '2001:2:0:1::/64', '198.18.0.0/16'],
       ranges
     );
-    // fc00::/7（ULA 旁路）现与 fakeip 公网假段不相交 → 保留；2001:db8 子段命中 v6 假段、198.18/16 命中 v4 假段 → 剔除
-    expect(r.overlapping.sort()).toEqual(['198.18.0.0/16', '2001:db8:1::/48'].sort());
+    // fc00::/7（ULA 旁路）与 fakeip 假段不相交 → 保留；2001:2 子段命中 v6 假段、198.18/16 命中 v4 假段 → 剔除
+    expect(r.overlapping.sort()).toEqual(['198.18.0.0/16', '2001:2:0:1::/64'].sort());
     expect(r.disjoint).toEqual(['10.0.0.0/8', 'fc00::/7']);
   });
   it('ranges 空 → 全保留（不启 fakeip 时不剔）', () => {
     expect(partitionCidrsByOverlap(['fc00::/7'], []).disjoint).toEqual(['fc00::/7']);
   });
-  // 回归不变量：默认旁路清单 CIDR 必须与 fakeip 段全不相交（旁路含完整 ULA fc00::/7，fakeip v6 在公网文档段 2001:db8::/32，
-  // 二者不相交；防未来把 fakeip 段改回 ULA 私网段再撞墙）。
+  // 回归不变量：默认旁路清单 CIDR 必须与 fakeip 段全不相交（旁路含完整 ULA fc00::/7，fakeip v6 在 benchmarking
+  // 保留段 2001:2::/48，二者不相交；防未来把 fakeip 段改回 ULA 私网段再撞墙）。
   it('DEFAULT_BYPASS_LAN 与 FakeIP 段零相交（v4+v6 永久免疫同类撞墙）', () => {
     const ranges = [FAKEIP_INET4_RANGE, FAKEIP_INET6_RANGE];
     const { overlapping } = partitionCidrsByOverlap(

--- a/src/shared/__tests__/ssrf-guard.test.ts
+++ b/src/shared/__tests__/ssrf-guard.test.ts
@@ -117,8 +117,8 @@ describe('assertHostAllowed — DNS rebinding 防护（注入 lookup）', () => 
     );
   });
 
-  it('域名解析到 FakeIP（2001:db8::/32）+ exemptFakeIp=true（经代理）→ 放行（核按域名重解析真实）', async () => {
-    const v6 = async () => [{ address: '2001:db8::57' }];
+  it('域名解析到 FakeIP（2001:2::/48）+ exemptFakeIp=true（经代理）→ 放行（核按域名重解析真实）', async () => {
+    const v6 = async () => [{ address: '2001:2::57' }];
     await expect(
       assertHostAllowed(new URL('https://subscribe.example.com/sub'), v6, true)
     ).resolves.toBeUndefined();
@@ -148,27 +148,28 @@ describe('assertHostAllowed — DNS rebinding 防护（注入 lookup）', () => 
     ).rejects.toThrow(/已拒绝/);
   });
 
-  it('FakeIP（2001:db8）+ 真内网 混合 + exemptFakeIp=true → 拒（豁免假段但真内网仍命中）', async () => {
-    const lookup = async () => [{ address: '2001:db8::57' }, { address: '10.0.0.5' }];
+  it('FakeIP（2001:2）+ 真内网 混合 + exemptFakeIp=true → 拒（豁免假段但真内网仍命中）', async () => {
+    const lookup = async () => [{ address: '2001:2::57' }, { address: '10.0.0.5' }];
     await expect(
       assertHostAllowed(new URL('https://mixed2.example.com/'), lookup, true)
     ).rejects.toThrow(/已拒绝/);
   });
 });
 
-describe('isFlowzFakeIp — FlowZ FakeIP 假段（198.18.0.0/15 + 2001:db8::/32）', () => {
-  it('FakeIP v4（198.18/15）+ v6（2001:db8::/32）→ true', () => {
+describe('isFlowzFakeIp — FlowZ FakeIP 假段（198.18.0.0/15 + 2001:2::/48）', () => {
+  it('FakeIP v4（198.18/15）+ v6（2001:2::/48）→ true', () => {
     expect(isFlowzFakeIp('198.18.0.1')).toBe(true);
     expect(isFlowzFakeIp('198.19.255.255')).toBe(true);
-    expect(isFlowzFakeIp('2001:db8::57')).toBe(true);
-    expect(isFlowzFakeIp('2001:db8:ffff:ffff::1')).toBe(true); // /32 内
+    expect(isFlowzFakeIp('2001:2::57')).toBe(true);
+    expect(isFlowzFakeIp('2001:2:0:ffff::1')).toBe(true); // /48 内（第 4 组任意值仍在段内）
   });
 
   it('FakeIP 段外（真内网 / 真 ULA / link-local / 公网）→ false（豁免不放过真内网）', () => {
     expect(isFlowzFakeIp('198.17.0.1')).toBe(false); // 198.18/15 下界外
     expect(isFlowzFakeIp('198.20.0.1')).toBe(false); // 上界外
-    expect(isFlowzFakeIp('2001:db9::1')).toBe(false); // 超 2001:db8::/32 上界
-    expect(isFlowzFakeIp('2001:db7::1')).toBe(false); // 下界外
+    expect(isFlowzFakeIp('2001:2:1::1')).toBe(false); // 超 2001:2::/48 上界（第 3 组非 0）
+    expect(isFlowzFakeIp('2001:1::1')).toBe(false); // 下界外
+    expect(isFlowzFakeIp('2001:db8::57')).toBe(false); // RFC 3849 文档段：已非 FlowZ 假段（Chromium LNA 判 local）
     expect(isFlowzFakeIp('fc00::57')).toBe(false); // 真实 ULA（已不再是假段）
     expect(isFlowzFakeIp('fd00::1')).toBe(false); // 真实 ULA（fd00::/8）
     expect(isFlowzFakeIp('fe80::1')).toBe(false); // link-local
@@ -180,6 +181,6 @@ describe('isFlowzFakeIp — FlowZ FakeIP 假段（198.18.0.0/15 + 2001:db8::/32�
   // 不因「假段改了、识别没同步」而静默失效（旧硬编码 0x2001/0x0db8 无此保证，是冗余豁免分支唯一仍生效的回归护栏）。
   it('由常量派生：识别段基址跟随 FAKEIP_INET*_RANGE，不漂移', () => {
     expect(isFlowzFakeIp(FAKEIP_INET4_RANGE.split('/')[0])).toBe(true); // 段基址 198.18.0.0
-    expect(isFlowzFakeIp(FAKEIP_INET6_RANGE.replace(/\/\d+$/, '') + '1')).toBe(true); // 2001:db8::1
+    expect(isFlowzFakeIp(FAKEIP_INET6_RANGE.replace(/\/\d+$/, '') + '1')).toBe(true); // 2001:2::1
   });
 });

--- a/src/shared/fakeip-filter.ts
+++ b/src/shared/fakeip-filter.ts
@@ -41,11 +41,26 @@ export const DEFAULT_FAKEIP_FILTER_DOMAINS = [
 
 /**
  * FakeIP 假 IP 段（单一真值）：dns-builder 分配给 fakeip server；旁路/force-route 护栏据此排除，防假 IP 被当私网直连。
- * - v4 `198.18.0.0/15`：RFC 2544 基准段，刻意在私网空间之外（不与任何 LAN 旁路 v4 段相交），浏览器 Chrome LNA 判为 public。
- * - v6 `2001:db8::/32`：RFC 3849 文档保留段，在全局单播 2000::/3 内——浏览器 Chrome Local Network Access 判为 **public**，
- *   故 https 公网页面取该段子资源不被当「public→private 降级」拦截（旧 fc00::/18 在 ULA=private，会触发
- *   net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS，YouTube 图片/字体等跨源资源加载失败）。文档段永不路由公网、
- *   不与真实目标撞 IP，TUN 抓 v6 后照样反查域名喂代理。与 LAN 旁路 fc00::/7(ULA) 不相交，护栏对其退化为 no-op。
+ *
+ * 选段硬约束——两族假段必须被 Chrome Local Network Access（LNA）同判 public：
+ * Chromium 按 `services/network/public/cpp/ip_address_space_util.cc` 的 NonPublicAddressSpaceMap 分类地址空间
+ * （已核对 149.0.7827.200 / 150.0.7871.46 / main 三版一致）：v6 侧 `2001:db8::/32`、`3fff::/20`（RFC 3849/9637
+ * 文档段）、`fc00::/7`、`fe80::/10`、`fec0::/10` → kLocal；**不在表内 = kPublic**。该映射 2025-09-01 由
+ * "[LNA] Add additional IP address space mappings"（WICG/local-network-access#15）加入。若两族假段地址空间分裂
+ * （如 v4 public + v6 local），任一 public initiator（骑真实 IP / v4 假 IP 的文档或 Service Worker）取 local
+ * 假 IP 子资源即被整批拦截："Permission was denied for this request to access the `local` address space" /
+ * net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS（YouTube 真机复现：HAR 证实文档骑 v6 假 IP、跨域子资源
+ * 100% 被拦）。两族统一为 public 后，fake 世界与真实互联网同属 public 空间，LNA 结构性不触发，且对过渡残留
+ * （陈旧 SW/连接池/DNS 缓存里的 public initiator）免疫。
+ *
+ * - v4 `198.18.0.0/15`：RFC 2544 基准测试段，刻意在私网空间之外（不与任何 LAN 旁路 v4 段相交）；
+ *   不在 NonPublicAddressSpaceMap → kPublic。
+ * - v6 `2001:2::/48`：RFC 5180 IPv6 benchmarking 段，IANA 永久保留、全网不可路由 → 不与真实主机撞 IP；
+ *   不在 NonPublicAddressSpaceMap → kPublic。文档段 2001:db8::/32 不可用——它在表内判 kLocal（见上）。
+ *   与 LAN 旁路 fc00::/7(ULA) 不相交，护栏对其退化为 no-op；TUN 抓 v6 后照样反查域名喂代理。
+ *
+ * 假设登记：若未来 Chromium 把 benchmarking 段（198.18.0.0/15 / 2001:2::/48）也收进 local 表（其加文档段的
+ * 「完备性」理由同样适用于它们），本选段需重估。
  */
 export const FAKEIP_INET4_RANGE = '198.18.0.0/15';
-export const FAKEIP_INET6_RANGE = '2001:db8::/32';
+export const FAKEIP_INET6_RANGE = '2001:2::/48';

--- a/src/shared/ip.ts
+++ b/src/shared/ip.ts
@@ -103,7 +103,7 @@ export function cidrOverlapsAny(target: string, candidates: string[]): boolean {
 
 /**
  * 把 cidrs 按"与 ranges 任一相交"分两组（v4+v6）。FakeIP 护栏用：剔除会吃掉假 IP 段（198.18.0.0/15 ·
- * 2001:db8::/32）的旁路/私网直连条目，防假 IP 被当私网直连、绕过 fakeip 反查致服务端收不到域名（v6 撞墙根因）。
+ * 2001:2::/48）的旁路/私网直连条目，防假 IP 被当私网直连、绕过 fakeip 反查致服务端收不到域名（v6 撞墙根因）。
  */
 export function partitionCidrsByOverlap(
   cidrs: string[],

--- a/src/shared/ssrf-guard.ts
+++ b/src/shared/ssrf-guard.ts
@@ -67,7 +67,7 @@ export function isPrivateIp(ip: string): boolean {
 }
 
 /**
- * 是否 FlowZ FakeIP 假地址（FAKEIP_INET4_RANGE=198.18.0.0/15 / FAKEIP_INET6_RANGE=2001:db8::/32）。
+ * 是否 FlowZ FakeIP 假地址（FAKEIP_INET4_RANGE=198.18.0.0/15 / FAKEIP_INET6_RANGE=2001:2::/48）。
  * TUN+FakeIP 下系统 DNS 解析公网订阅域名会返回假 IP；它不是真内网——核连接时按域名反查真实解析。
  * **由 fakeip-filter 常量派生（单一真值）**：裸 IP 视为 /32(v4)·/128(v6) 与假段做家族感知交集，改 FAKEIP_INET*_RANGE
  * 本判定自动跟随、不漂移（旧版手抄 0x2001/0x0db8 是双真值——改回私网段忘同步即静默撞墙）。

--- a/src/shared/system-proxy-bypass.ts
+++ b/src/shared/system-proxy-bypass.ts
@@ -23,7 +23,7 @@ export const DEFAULT_BYPASS_LAN: readonly string[] = [
   '224.0.0.0/4', // 组播
   '233.252.0.0/24', // MCAST-TEST-NET
   '240.0.0.0/4', // 保留
-  'fc00::/7', // IPv6 ULA 全段（FakeIP 假 v6 已移至公网文档段 2001:db8::/32、不再占 ULA，故覆盖完整 /7；护栏校验两者零相交）
+  'fc00::/7', // IPv6 ULA 全段（FakeIP 假 v6 在 benchmarking 保留段 2001:2::/48、不占 ULA，故覆盖完整 /7；护栏校验两者零相交）
   'fe80::/10', // IPv6 link-local
   // 本地 / mDNS
   'localhost',


### PR DESCRIPTION
## 问题

TUN + 全局 IPv6 下访问 YouTube 等站，跨域静态资源（i.ytimg / yt3.ggpht / fonts.googleapis / gstatic）批量失败，控制台报 `Permission was denied for this request to access the 'local' address space` / `net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`。表现为时好时坏：刷新、清浏览器缓存、或关闭 IPv6（保留 FakeIP）后恢复。

## 根因

Chrome 的 Local Network Access（LNA）按 Chromium `services/network/public/cpp/ip_address_space_util.cc` 的 `NonPublicAddressSpaceMap` 分类地址空间（已核对 149.0.7827.200 / 150.0.7871.46 / main 三版一致）：

| 段 | FlowZ 用途 | Chrome 分类 |
|---|---|---|
| `198.18.0.0/15` | FakeIP v4 | 不在表内 = **kPublic** |
| `2001:db8::/32` | FakeIP v6（旧） | RFC 3849 文档段，在表内 = **kLocal** |

该文档段映射由 Chromium 2025-09-01 的 "[LNA] Add additional IP address space mappings"（WICG/local-network-access#15）加入——晚于当初选 2001:db8 的判断，使其"判 public"的前提自那时起即不成立。

两族假段地址空间分裂后，同一页面里 v4 假 IP 的连接被判 public、v6 假 IP 的被判 local。LNA 要求"较公网的 initiator → 较本地的目标"必须显式许可，于是任一 public initiator（骑真实 IP / v4 假 IP / 陈旧连接池的文档或 Service Worker）取 v6 假 IP 子资源即被整批拦截。这解释了全部现象：刷新使 SW 重新骑上 v6 假 IP 统一为 local 而放行、清缓存使全世界重建于 fake 而统一 local、关 IPv6 使全部落 v4 假 IP 统一为 public 而结构性不触发。HAR 实证：文档骑 `[2001:db8::26]`，跨域子资源 100% 被拦。

## 主修

FakeIP v6 段 `2001:db8::/32` → **`2001:2::/48`**（RFC 5180 IPv6 benchmarking，IANA 永久保留、全网不可路由、不在 Chromium LNA 表内 = kPublic）。与 v4 假段 `198.18.0.0/15` 同判 public，fake 世界与真实互联网统一为 public 空间，LNA 结构性不触发，**且对过渡残留（陈旧 SW / 连接池 / DNS 缓存里的 public initiator）免疫**——这是不选"回退统一 local"的原因：统一 local 对 public 残留 initiator 天然脆弱，正是本次事故形态。

不选统一 local（回 fc00::/18）：对过渡场景脆弱。
选统一 public（2001:2::/48）：结构性免疫，但依赖 Chromium 未来不把 benchmarking 段收进 local 表——已在常量注释登记该假设。

`FAKEIP_INET6_RANGE` 为单一真值，dns/route/inbounds builder 与 ssrf-guard/isFlowzFakeIp 全部派生跟随。

## 辅修

核 start 成功 / stop 尾部 best-effort 刷 OS DNS 缓存（fire-and-forget、永不阻塞生命周期、永不 reject），清掉跨越"系统解析器受控/还原"边界后另一侧的陈旧缓存（典型：TUN+FakeIP 会话缓存的假 IP 停核后仍被命中）。

- darwin：优先 root helper（proto 8→9 新增 `flush-dns`：`dscacheutil -flushcache` + `killall -HUP mDNSResponder` 两层全清）；旧 helper（proto 8）经 upgradeable 温和提示、仍可用，降级用户级 `dscacheutil`。
- win32：`ipconfig /flushdns`；linux：`resolvectl flush-caches`。

辅修属卫生措施，缩短真实/错族 IP 残留窗口；单独做它无法根治症状（够不到 SW 上持久化的地址空间分类），故主修才是根治。

## 验证

- gate 全绿：`go vet`/`gofmt`、`tsc`（main+renderer）、`jest`（2353 用例 / 37 快照）、`eslint`/`prettier`。
- 独立 review 四轮，零 Low/Nit 全绿。
- 真机（macOS，Chrome 149）：live 配置 `inet6_range=2001:2::/48`；`dig i.ytimg.com AAAA` → `2001:2::25`、`www.youtube.com AAAA` → `2001:2::24`；TUN 模式连通正常。