### PR TITLE
fix(window): 关窗保活 + 冷重建 hydrating skeleton 根治关窗重开卡顿/状态错乱（#251）

### DIFF
--- a/src/main/__tests__/window-close-policy.test.ts
+++ b/src/main/__tests__/window-close-policy.test.ts
@@ -21,3 +21,26 @@ describe('shouldQuitOnAllWindowsClosed', () => {
     expect(shouldQuitOnAllWindowsClosed('linux', true, false)).toBe(true);
   });
 });
+
+// #251 revert-to-hide：close 处理器 shouldQuit=true → destroy+退出；false → window.hide() 保活。
+// 锁定「keepAlive == !shouldQuitOnAllWindowsClosed」映射（复用既有 policy 函数、零新判定），四象限全覆盖。
+describe('关窗保活映射（keepAlive == !shouldQuitOnAllWindowsClosed）', () => {
+  const cases: Array<[NodeJS.Platform, boolean, boolean, boolean]> = [
+    // [platform, minimizeToTray, hasTray, expectKeepAlive(=hide)]
+    ['darwin', true, true, true], // macOS 恒保活（hide）
+    ['darwin', false, false, true], // macOS 无视设置恒保活
+    ['win32', true, true, true], // 有托盘 + minimizeToTray → 保活
+    ['linux', true, true, true],
+    ['win32', false, true, false], // minimizeToTray=false → 真退出（destroy）
+    ['linux', false, false, false],
+    ['win32', true, false, false], // 托盘创建失败兜底 → 退出
+    ['linux', true, false, false],
+  ];
+  it.each(cases)(
+    '%s minimizeToTray=%s hasTray=%s → keepAlive=%s',
+    (platform, minimizeToTray, hasTray, keepAlive) => {
+      const shouldQuit = shouldQuitOnAllWindowsClosed(platform, minimizeToTray, hasTray);
+      expect(!shouldQuit).toBe(keepAlive);
+    }
+  );
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -633,6 +633,9 @@ function getPreferredSystemLanguagesSafe(): string[] {
 }
 
 async function createWindow(forceShow = false) {
+  // Part C：冷重建计时锚点（createWindow 入口 → presentWindow 首次 show）。量化 discard/首唤重建死区，
+  // 为将来「优化重建」提供数据。hide→show 走 showWindow 不经本函数 → 天然不计时（保活路径无死区）。
+  const createT0 = Date.now();
   // macOS 需要设置应用菜单以启用 Cmd+C/V/X/A 等快捷键
   if (process.platform === 'darwin') {
     const template: Electron.MenuItemConstructorOptions[] = [
@@ -870,6 +873,8 @@ async function createWindow(forceShow = false) {
       if (wantShow || (!cfg.silentStart && !isHiddenArg && !isMacHidden)) {
         mainWindow?.show();
         logManager.addLog('info', 'Main window shown', 'Main');
+        // Part C：本次 createWindow 从入口到首帧呈现的耗时（冷重建/首启）。app.log 随诊断导出自然带出。
+        logManager.addLog('info', `[window-recreate-timing] ${Date.now() - createT0}ms`, 'Main');
         logStartupTimingOnce();
       } else {
         logManager.addLog('info', 'Main window kept hidden (Silent Start)', 'Main');
@@ -917,9 +922,10 @@ async function createWindow(forceShow = false) {
     logManager.addLog('error', `Window failed to load: ${errorDescription} (${errorCode})`, 'Main');
   });
 
-  // macOS：Cmd+H（app.hide()）系统级隐藏时摘 Dock 图标（仅驻留菜单栏，不占 Dock / Cmd-Tab），重新显示时
-  // 恢复。关闭窗口现在统一走 destroy（不再 hide），由模块级 browser-window-created 的 'closed' 监听器摘
-  // Dock 图标，不经本分支。经 activation policy 状态机（见 hideDockIfMenubarOnly/restoreDockPresence）。
+  // macOS：Cmd+H（app.hide()）系统级隐藏、或关窗保活档（minimizeToTray）走 window.hide() 时摘 Dock 图标（仅驻留
+  // 菜单栏，不占 Dock / Cmd-Tab），重新显示时恢复。两条路径都触发 'hide' → 本钩子摘 Dock；仅真退出档（shouldQuit）
+  // 走 destroy，由模块级 browser-window-created 的 'closed' 监听器摘。经 activation policy 状态机（见
+  // hideDockIfMenubarOnly/restoreDockPresence）。
   if (process.platform === 'darwin') {
     mainWindow.on('hide', () => {
       // 经 accessory + app.hide() 摘 Dock 图标（机制与 macOS 限制见 hideDockIfMenubarOnly）。
@@ -931,10 +937,11 @@ async function createWindow(forceShow = false) {
     });
   }
 
-  // 处理窗口关闭事件：统一销毁渲染进程释放内存（不再区分平台/minimizeToTray 去 hide 保活——隐藏态
-  // 长期占满渲染进程内存正是 issue #242 的放大器之一，关窗是明确的"暂时不需要看"信号，没有理由继续
-  // 保活）。是否常驻托盘 vs 彻底退出，在销毁的这一刻就算好存进 pendingQuitOnAllClosed，供 window-all-closed
-  // 消费（而非等它触发时才判断——那时可能已经隔了很久、配置或托盘状态都可能变过）。
+  // 处理窗口关闭事件：默认保活（隐藏到托盘，reopen=show() 即显，恢复 4.1.8 语义）——batch2/3/4 后隐藏态
+  // 推送归零、水位死平（异常增长有 renderer-memory watchdog 兜底），无需靠关窗销毁渲染进程重置水位（d6ae203
+  // 的收益在这三批落地后已冗余，代价是 100% reopen 冷重建，见 #251）。仅当 shouldQuitOnAllWindowsClosed
+  // （minimizeToTray=false / 无托盘非 mac）才 destroy + 退出（避免无窗口无托盘的僵尸进程）；是否退出在销毁的
+  // 这一刻就算好存进 pendingQuitOnAllClosed（仅 destroy 分支写），供 window-all-closed 消费。
   mainWindow.on('close', (event) => {
     const window = mainWindow;
     if (!window || window.isDestroyed()) return;
@@ -945,12 +952,22 @@ async function createWindow(forceShow = false) {
 
     event.preventDefault();
     const minimizeToTray = configManager.get<boolean>('minimizeToTray') ?? true;
-    pendingQuitOnAllClosed = shouldQuitOnAllWindowsClosed(
+    const shouldQuit = shouldQuitOnAllWindowsClosed(
       process.platform,
       minimizeToTray,
       !!trayManager?.hasTray()
     );
-    releaseWindowMemory({ window, logManager, reason: 'close' });
+    if (shouldQuit) {
+      // minimizeToTray=false / 无托盘非 mac → 销毁渲染进程 + 退出。pendingQuitOnAllClosed 仅在此 destroy 分支
+      // 就地写入，供随后 window-all-closed 消费最后一次值（无陈旧读：每条 destroy 路径销毁前都重算）。
+      pendingQuitOnAllClosed = true;
+      releaseWindowMemory({ window, logManager, reason: 'close' });
+    } else {
+      // 保活：隐藏到托盘，reopen 走 show() 即显（无冷重建死区）。'hide' 事件由上方 macOS 钩子消费摘 Dock；
+      // hide 不减窗口计数、不触发 window-all-closed，故 pendingQuitOnAllClosed 保持不动（Fable 复审坐实安全）。
+      window.hide();
+      logManager.addLog('info', 'Window hidden to tray', 'Main');
+    }
   });
 
   mainWindow.on('closed', () => {

--- a/src/renderer/pages/home-page-skeleton.tsx
+++ b/src/renderer/pages/home-page-skeleton.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { PageHeader } from '@/components/page-header';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * 首页冷重建骨架（#251）：store 未 hydrate（config===null）期的统一占位——silent 首唤 / watchdog discard 后 reopen
+ * 等冷重建路径下，避免各卡把「尚未加载」渲成「确定错误态」（尤其 ProxyControlCard `if(!config) return null` 致两列
+ * grid 右列塌陷 / 布局塌方，比错文本扎眼一个量级）。config 到达（HomePage 的门放行）即整体切真实卡。
+ *
+ * 形似真 home 布局（PageHeader 真渲 + 两列等高卡 + 网络信息卡 + 拓扑卡）→ 防 hydrate 时 CLS 跳动。
+ * 复用 `animate-pulse bg-muted`（network-info-card.tsx 先例，项目无 ui/skeleton 原语）。
+ * 纯展示：零 store / 零 localStorage / 零凭据 / 零缓存（不用旧态冒充当前，骨架诚实说「还没好」）。
+ */
+function Bar({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-muted ${className}`} />;
+}
+
+export function HomePageSkeleton() {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-6">
+      {/* PageHeader 不依赖 config → 真渲，与真实首屏一致 */}
+      <PageHeader title={t('home.pageTitle')} description={t('home.pageDesc')} />
+
+      {/* 连接状态卡 + 代理控制卡：两列等高（grid 默认 stretch），内容量对称防高差 */}
+      <div className="grid gap-6 min-[900px]:grid-cols-2">
+        {[0, 1].map((i) => (
+          <Card key={i}>
+            <CardHeader>
+              <Bar className="h-6 w-32" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Bar className="h-4 w-full" />
+              <Bar className="h-4 w-full" />
+              <Bar className="h-4 w-2/3" />
+              <Bar className="h-9 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 网络信息卡：导流脊 + 双出口 IP 网格 + 遥测行 */}
+      <Card>
+        <CardHeader>
+          <Bar className="h-6 w-32" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Bar className="h-6 w-full" />
+          <div className="grid grid-cols-2 gap-4">
+            <Bar className="h-12 w-full" />
+            <Bar className="h-12 w-full" />
+          </div>
+          <Bar className="h-4 w-2/3" />
+        </CardContent>
+      </Card>
+
+      {/* 连接拓扑卡：图表区 */}
+      <Card>
+        <CardHeader>
+          <Bar className="h-6 w-32" />
+        </CardHeader>
+        <CardContent>
+          <Bar className="h-40 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/renderer/pages/home-page.tsx
+++ b/src/renderer/pages/home-page.tsx
@@ -3,10 +3,21 @@ import { ProxyControlCard } from '@/components/home/proxy-control-card';
 import { NetworkInfoCard } from '@/components/home/network-info-card';
 import { ConnectionTopology } from '@/components/home/connection-topology';
 import { PageHeader } from '@/components/page-header';
+import { useAppStore } from '@/store/app-store';
+import { HomePageSkeleton } from './home-page-skeleton';
 import { useTranslation } from 'react-i18next';
 
 export function HomePage() {
   const { t } = useTranslation();
+  const config = useAppStore((s) => s.config);
+
+  // #251 冷重建（silent 首唤 / watchdog discard 后 reopen）：store 未 hydrate 时 config===null，直接渲统一骨架，
+  // 避免 ProxyControlCard(`if(!config) return null`) 致两列 grid 塌陷 + 各卡渲「确定错误态」。**单条件 config**
+  // （不入 connectionStatus——refreshConnectionStatus catch 不 set，首次 IPC 失败会永久卡骨架）；config 无 set-null
+  // 路径 →「null==未 hydrate」判据可靠。config 到达即整体切真实卡（ConnectionTopology 此刻才挂载订阅 aggregate，
+  // 冷重建首屏本不该空订阅，正协同非回归）。
+  if (!config) return <HomePageSkeleton />;
+
   return (
     <div className="space-y-6">
       <PageHeader title={t('home.pageTitle')} description={t('home.pageDesc')} />


### PR DESCRIPTION
## 背景

4.1.9 提交 d6ae203「关窗统一销毁渲染进程」（issue #242 的粗暴缓解）致 #251：关窗后重开动画卡顿 + store 未 hydrate 时**代理控制卡整卡消失/状态错乱**（截图坐实：21 活动连接在跑、流量正常，UI 却显示「未知/暂无服务器配置/未连接」+ 代理控制卡不见——`proxy-control-card.tsx if(!config) return null` 致两列 grid 塌陷）。用户退回 4.1.8。

本 PR 外科式治本，**保留 d6ae203 其余四块**（pendingQuit 时序修 / setMainWindow 刷新 / 静默懒建窗 / 语言真值源归位），只改关窗销毁分支 + 补冷重建骨架。

## 改动

- **Part A 关窗 revert-to-hide**（`index.ts` close 处理器）：`shouldQuit ? destroy+退出 : window.hide()`，`keepAlive == !shouldQuitOnAllWindowsClosed`（复用既有 policy 函数、零新判定）。常见路径（minimizeToTray=true+托盘 / macOS）hide 保活 → reopen `show()` 即显、渲染进程不销毁、所有卡完整、状态正确。Dock 摘除靠既有 `on('hide')→hideDockIfMenubarOnly` 钩子**零补码**；`pendingQuitOnAllClosed` 仅 destroy 分支写（hide 不触发 window-all-closed，无陈旧读）；minimizeToTray=false / 无托盘非 mac → destroy+退出（无僵尸）。
- **Part B 统一 hydrating skeleton**（`home-page.tsx` + 新 `home-page-skeleton.tsx`）：`config===null` → 渲骨架，兜冷重建（silent 首唤 / watchdog discard）的 store 未 hydrate 期，一次消除三症状（ProxyControl 塌陷 + 无配置 + 未知）。**单条件 config**（不入 connectionStatus——refreshConnectionStatus catch 不 set，首次 IPC 失败会永久卡骨架）；**零 store / 零 localStorage / 零凭据 / 零缓存**；形似真布局（`animate-pulse bg-muted`）防 CLS。
- **Part C** `[window-recreate-timing]` 计时日志入 app.log（量化残留冷重建路径重建耗时；纯日志、不动诊断注册面）。

## 测试

- 单测：window-close-policy +8 例（`keepAlive==!shouldQuit` 四象限映射）。Part B 是表现层 null-gate + 静态骨架无可抽分支逻辑、repo 无 jsdom/RTL 设施，靠 tsc 类型收窄 + 真机。
- gate：tsc(main+renderer) 0 error、eslint 0 error、全量 jest **2578 passed / 0 failed**、**§14 回归清单 10 套件逐一 PASS**（batch1-4 无回归）。
- **隔离性**：仅 4 文件；StatsWorkerHost/StatsSubscriptionRegistry/stats-worker/renderer-memory-watchdog/use-stats-topic/connections-aggregate/诊断段 **零 diff**。hide-on-close 使 hidden 长活窗成常态 → 激活 #242 batch4 内存 watchdog 原本近死代码的 discard 分支（设计意图达成，非冲突）。
- **Win 真机冒烟**：字节校验一致、app.log 干净启动无崩溃、`[window-recreate-timing] 654ms` 落盘（Part C 确认）。

## 治本边界（Fable 评估）

**#251 错态维度完整闭环**——三症状全消、常见路径（关窗重开）零卡零错。**已知取舍（保留）**：silent 首唤 / watchdog discard 残留冷重建路径的 1-3s 黑屏死区（renderer spawn+parse+mount，物理在 loadConfig 前）骨架兜不掉——消它的唯一治本是回滚静默懒建窗（renderer 常驻），代价 silentStart 用户后台 +250MB（逆 #242）；权衡后保留懒建（silent 首唤每天一次、骨架诚实反馈、reporter 主诉关窗重开 Part A 全解）。

## 待真机交互验证（合入前，桌面手动）

Windows：关窗→重开秒显 + minimizeToTray=false 真退出无僵尸 + silent 首唤见骨架不塌陷。macOS：关窗 hide→重开 + Dock 摘除/恢复 + Cmd+H 不回归。

Fixes #251
