### PR TITLE
tune(stats): aggregate rate-cap 2s→1s，提升拓扑更新跟手度（#242 后续）

### DIFF
--- a/src/main/workers/__tests__/stats-worker.test.ts
+++ b/src/main/workers/__tests__/stats-worker.test.ts
@@ -108,16 +108,16 @@ describe('stats-worker (batch2 数据面核心)', () => {
     expect(postsOf('aggregate')).toHaveLength(1);
   });
 
-  it('rate-cap：内容变但未过 AGG_MIN_INTERVAL_MS(2000) 不 post，过后才 post', () => {
+  it('rate-cap：内容变但未过 AGG_MIN_INTERVAL_MS(1000) 不 post，过后才 post', () => {
     send(CONNECT);
     fireConn([conn('a.com', 'P')]); // t0 首帧 post，lastSentAt=t0
     expect(postsOf('aggregate')).toHaveLength(1);
 
-    nowVal += 1000; // < 2000
+    nowVal += 500; // < 1000
     fireConn([conn('a.com', 'P'), conn('b.com', 'Q')]); // 内容变，但未过 cap → 不 post
     expect(postsOf('aggregate')).toHaveLength(1);
 
-    nowVal += 1500; // 累计 2500 ≥ 2000
+    nowVal += 600; // 累计 1100 ≥ 1000
     fireConn([conn('a.com', 'P'), conn('b.com', 'Q')]); // 仍与 lastSentSig 不同 → post
     expect(postsOf('aggregate')).toHaveLength(2);
   });

--- a/src/main/workers/stats-worker.ts
+++ b/src/main/workers/stats-worker.ts
@@ -24,9 +24,9 @@ import type { HostToWorkerMessage, WorkerToHostMessage } from '../services/Stats
 // utilityProcess 子进程的父端口（Electron 在子进程 process 上注入）。
 const parentPort = process.parentPort;
 
-// change-driven aggregate 的最小 post 间隔（batch2 §3.6）：内核帧 ~1s 到，签名变化且距上次 post ≥2s 才推——高 churn
-// 最坏 0.5 Hz；拓扑是计数图、落后 ≤2s 可接受，故无需额外 timer（帧本身即驱动）。
-const AGG_MIN_INTERVAL_MS = 2000;
+// change-driven aggregate 的最小 post 间隔（batch2 §3.6；#251 真机观测后 2s→1s 提升拓扑跟手度）：内核帧 ~1s 到，
+// 签名变化且距上次 post ≥1s 才推——高 churn 最坏 1 Hz；拓扑是计数图、落后 ≤1s 可接受，故无需额外 timer（帧本身即驱动）。
+const AGG_MIN_INTERVAL_MS = 1000;
 
 let apiClient: SingBoxApiClient | null = null;
 


### PR DESCRIPTION
## 背景
#242 batch2 的 change-driven aggregate rate-cap 原为 **2s**（内容变才推、高 churn 最坏 0.5Hz，杀掉旧 17Hz 全量推送=内存暴涨放大器）。#251 真机验证时观测到**活跃流量下拓扑更新偏钝**。

## 改动
一行调参 `AGG_MIN_INTERVAL_MS` 2000→1000 + 同步更新 rate-cap 单测时序 + 注释。连接集变化时拓扑最快 **1s** 反映（原 2s）；空载仍不更新（内容不变、change-driven 正确，非本改动能治）。

## 取舍
内存收益略减仍显著：Mac 真机 2s 时 aggregate 778→21（37×），1s 约 778→~40（~17×），远优于旧 17Hz；拓扑是计数图、落后 ≤1s 可接受。

## 测试
tsc 0 / eslint 0 / stats-worker 套件 24 passed（rate-cap 测试改 1000 时序）/ 全量 jest 2570 passed 0 failed。对 batch2/3/4 其余零改动。

Refs #242 #251