### PR TITLE
refactor(settings): 高级页重排——内核管理置顶、数据备份置末

### DIFF
--- a/src/renderer/components/settings/advanced-settings.tsx
+++ b/src/renderer/components/settings/advanced-settings.tsx
@@ -5,18 +5,16 @@ import { CoreManagementCard } from './core-management-card';
 import { SingboxDashboardSection } from './singbox-dashboard-section';
 
 /**
- * 设置「高级」节：数据备份 + sing-box 官方面板（opt-in 逃生舱）+ 系统运维。
- * 内核管理从「关于」迁入（C9/M3：破坏性运维不藏在只读关于页）；日志/诊断在「日志」页；clash API/终端在「网络」节。
+ * 设置「高级」节：内核管理（置顶）+ sing-box 官方面板（opt-in 逃生舱）+ 数据备份（末位）。
+ * 内核管理从「关于」迁入（C9/M3：破坏性运维不藏在只读关于页）并置顶（高频运维入口，不埋在底部）；
+ * 数据备份置末（低频）；日志/诊断在「日志」页；clash API/终端在「网络」节。
  */
 export function AdvancedSettings() {
   return (
     <div className="space-y-6">
-      {/* 数据备份与恢复 */}
-      <Card>
-        <CardContent className="pt-6">
-          <BackupRestoreSection />
-        </CardContent>
-      </Card>
+      {/* 系统运维：内核管理（含回滚/重置出厂/完全卸载）。置顶——高频运维入口，不埋在底部。 */}
+      <CoreVersionBanner />
+      <CoreManagementCard />
 
       {/* sing-box 官方面板（opt-in）：高级用户/调试逃生舱，开关 + 打开按钮 */}
       <Card>
@@ -25,9 +23,12 @@ export function AdvancedSettings() {
         </CardContent>
       </Card>
 
-      {/* 系统运维：内核管理（含回滚/重置出厂/完全卸载）。从「关于」迁入。 */}
-      <CoreVersionBanner />
-      <CoreManagementCard />
+      {/* 数据备份与恢复 —— 末位 */}
+      <Card>
+        <CardContent className="pt-6">
+          <BackupRestoreSection />
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## 改动
设置「高级」页三块重排顺序:
- **内核管理**(CoreVersionBanner 版本/更新 + CoreManagementCard 回滚/重置出厂/卸载)——高频运维入口,从底部**移到首位**。
- **sing-box 官方面板**——居中。
- **数据备份**(低频)——**移到末位**。

顺序:内核管理 → sing-box 面板 → 数据备份。

## 说明
纯 JSX 重排,无逻辑/组件改动。内核管理仍留「高级」(尊重既有 C9/M3 决策:回滚/重置/卸载等破坏性运维不进只读「关于」页);本次只调页内顺序、不跨页迁移。

## 测试
tsc 0 / eslint 0。纯展示重排、无可测逻辑。