### PR TITLE
fix: 订阅导入节点缺失——传输层白名单补齐、未知传输统一拒绝、丢弃可见化

### DIFF
--- a/src/main/services/ClashSubscriptionParser.ts
+++ b/src/main/services/ClashSubscriptionParser.ts
@@ -188,6 +188,11 @@ function applyTransportAndTls(
     const edhn = str(wsOpts['early-data-header-name']);
     if (edhn) ws.earlyDataHeaderName = edhn;
     if (Object.keys(ws).length > 0) config.wsSettings = ws;
+    // mihomo 的 HTTPUpgrade 表达 = network:ws + ws-opts.v2ray-http-upgrade:true（无独立 network 值）。
+    // 不识别会导入成纯 ws——服务端等 HTTP Upgrade、客户端发 WS 帧的必死假节点（issue #263 同类）。
+    if (bool(wsOpts['v2ray-http-upgrade']) === true) {
+      config.network = 'httpupgrade';
+    }
   } else if (rawNet === 'grpc') {
     config.network = 'grpc';
     const grpcOpts = (p['grpc-opts'] as Record<string, unknown>) || {};
@@ -215,13 +220,21 @@ function applyTransportAndTls(
       if (single) httpSettings.host = [single];
     }
     if (Object.keys(httpSettings).length > 0) config.httpSettings = httpSettings;
+  } else if (rawNet && rawNet !== 'tcp') {
+    // xhttp/splithttp/kcp 等 sing-box 不支持的传输：静默落 tcp 会产出连不上的假节点，
+    // 整节点拒绝（mapNode catch 计 fail、聚合告警；与分享链/sing-box JSON 路径统一口径，issue #263）。
+    throw new Error(`不支持的传输层类型: ${rawNet}`);
   }
-  // 其余 network（缺省/tcp）不写，等价 tcp。
+  // 缺省/tcp 不写，等价 tcp。
 
   // —— TLS / Reality —— //
   const tlsEnabled = bool(p['tls']) === true || forceTls;
   const realityOpts = p['reality-opts'] as Record<string, unknown> | undefined;
   const hasReality = !!realityOpts && !!str(realityOpts['public-key']);
+  if (realityOpts && !hasReality) {
+    // 带 reality-opts 却缺 public-key：按普通 TLS 入库无法完成 Reality 握手（假节点），整节点拒绝。
+    throw new Error('reality-opts 缺少 public-key');
+  }
 
   if (tlsEnabled || hasReality) {
     config.security = hasReality ? 'reality' : 'tls';

--- a/src/main/services/ProtocolParser.ts
+++ b/src/main/services/ProtocolParser.ts
@@ -4,10 +4,10 @@
  */
 
 import { randomUUID } from 'crypto';
+import { isIPv6 } from 'net';
 import type {
   ServerConfig,
   Protocol,
-  Network,
   Security,
   TlsSettings,
   RealitySettings,
@@ -74,18 +74,19 @@ export class ProtocolParser implements IProtocolParser {
    * 解析协议 URL 为服务器配置
    */
   /**
-   * 预处理 SS URL，将裸 IPv6 地址（无方括号）转换为标准格式
+   * 预处理分享 URL，将裸 IPv6 地址（无方括号）转换为标准格式（全协议通用；无 '@' 时原样返回）。
    * 例: ss://user@2001:db8::1:8388?... → ss://user@[2001:db8::1]:8388?...
    */
-  private preprocessSsUrl(raw: string): string {
+  private preprocessBareIpv6(raw: string): string {
     const atIdx = raw.indexOf('@');
     if (atIdx === -1) return raw;
 
     const beforeAt = raw.substring(0, atIdx + 1);
     const afterAt = raw.substring(atIdx + 1);
 
-    // Split off query string / fragment so we only work on the host:port part
-    const qIdx = afterAt.search(/[?#]/);
+    // Split off path / query / fragment so we only work on the host:port part
+    // （SIP002 plugin 形态 `…:port/?plugin=…` 的 `/` 在 `?` 前是标准写法，不截断会使 hostPort 携 `/` 双判定皆失败）
+    const qIdx = afterAt.search(/[/?#]/);
     const hostPort = qIdx >= 0 ? afterAt.substring(0, qIdx) : afterAt;
     const suffix = qIdx >= 0 ? afterAt.substring(qIdx) : '';
 
@@ -97,9 +98,21 @@ export class ProtocolParser implements IProtocolParser {
     if (parts.length >= 4) {
       const lastColon = hostPort.lastIndexOf(':');
       const potentialPort = hostPort.substring(lastColon + 1);
-      if (/^\d+$/.test(potentialPort)) {
-        const ipv6Addr = hostPort.substring(0, lastColon);
-        return `${beforeAt}[${ipv6Addr}]:${potentialPort}${suffix}`;
+      const remainder = hostPort.substring(0, lastColon);
+      // 「地址 vs 地址:端口」文法固有歧义（2001:db8::1:8388 两种读法都合法），消解启发式：
+      //  1) 末段为 2-5 位十进制且 ≤65535 且余段是合法 IPv6 → 按 地址+端口 拆（分享链几乎恒带端口）。
+      //     单数字末段（如 ::1）按地址整段——真实代理端口不用 1-9，而地址末段 '1' 极常见。
+      //  2) 否则整段本身合法 IPv6（无端口形态）→ 只加括号，端口缺省交 parseBase（与域名无端口同语义）。
+      //  3) 两者皆非 → 原样返回，交 new URL 抛错（丢弃可见，不静默入库截断地址的假节点）。
+      if (
+        /^\d{2,5}$/.test(potentialPort) &&
+        parseInt(potentialPort, 10) <= 65535 &&
+        isIPv6(remainder)
+      ) {
+        return `${beforeAt}[${remainder}]:${potentialPort}${suffix}`;
+      }
+      if (isIPv6(hostPort)) {
+        return `${beforeAt}[${hostPort}]${suffix}`;
       }
     }
     return raw;
@@ -111,10 +124,9 @@ export class ProtocolParser implements IProtocolParser {
     }
 
     try {
-      // Preprocess SS URLs to handle bare IPv6 addresses
-      if (url.startsWith('ss://')) {
-        url = this.preprocessSsUrl(url);
-      }
+      // 裸 IPv6（无方括号）预处理泛化到全协议：原仅 ss:// 处理，vless/trojan/hy2 等裸 IPv6 链接
+      // 会在 new URL() 直接 throw 整节点丢（issue #263 调查项）。无 '@' 的形态（vmess base64）原样返回。
+      url = this.preprocessBareIpv6(url);
 
       const urlObj = new URL(url);
       let protocolStr = urlObj.protocol.replace(':', '');
@@ -222,10 +234,10 @@ export class ProtocolParser implements IProtocolParser {
       flow: params.get('flow') || undefined,
     };
 
-    // 解析传输层配置
-    const network = params.get('type') as Network | null;
+    // 解析传输层配置：归一化/白名单校验收口在 parseTransportSettings（内含 config.network 写入；
+    // 未知传输层（xhttp/splithttp/kcp 等 sing-box 不支持）throw 整节点拒绝，订阅逐行 catch 聚合告警）。
+    const network = params.get('type');
     if (network) {
-      config.network = network;
       this.parseTransportSettings(config, params, network);
     }
 
@@ -238,6 +250,10 @@ export class ProtocolParser implements IProtocolParser {
       }
       if (security === 'reality') {
         config.realitySettings = this.parseRealitySettings(params);
+        if (!config.realitySettings) {
+          // 缺 pbk 的 reality 节点无法握手（builder 不生成 reality tls 块 → 退化裸 TCP 假节点），整节点拒绝。
+          throw new Error('Reality 节点缺少 pbk（public key）参数');
+        }
       }
     }
 
@@ -261,10 +277,10 @@ export class ProtocolParser implements IProtocolParser {
       password,
     };
 
-    // 解析传输层配置
-    const network = params.get('type') as Network | null;
+    // 解析传输层配置：归一化/白名单校验收口在 parseTransportSettings（内含 config.network 写入；
+    // 未知传输层（xhttp/splithttp/kcp 等 sing-box 不支持）throw 整节点拒绝，订阅逐行 catch 聚合告警）。
+    const network = params.get('type');
     if (network) {
-      config.network = network;
       this.parseTransportSettings(config, params, network);
     }
 
@@ -277,6 +293,10 @@ export class ProtocolParser implements IProtocolParser {
     }
     if (security === 'reality') {
       config.realitySettings = this.parseRealitySettings(params);
+      if (!config.realitySettings) {
+        // 缺 pbk 的 reality 节点无法握手（builder 不生成 reality tls 块 → 退化裸 TCP 假节点），整节点拒绝。
+        throw new Error('Reality 节点缺少 pbk（public key）参数');
+      }
     }
 
     return config;
@@ -327,6 +347,16 @@ export class ProtocolParser implements IProtocolParser {
         type: 'salamander',
         password: obfsPassword,
       };
+    } else if (obfs === 'salamander') {
+      // 声明 salamander 即服务端强制混淆，缺 obfs-password 剥离后裸连必死（假节点）——
+      // 与 reality 缺 pbk 同判据（凭据残缺=整节点拒绝）。
+      throw new Error('Hysteria2 obfs=salamander 缺少 obfs-password');
+    } else if (obfs) {
+      // 非 salamander 值（sing-box hy2 无对应混淆类型/参数噪声）：剥离 + warn 留痕。
+      this.log(
+        'warn',
+        `Hysteria2 节点 "${name}" 的 obfs 参数（${obfs}）不受支持，已忽略混淆配置`
+      );
     }
 
     // 解析网络类型（tcp 或 udp）
@@ -472,6 +502,10 @@ export class ProtocolParser implements IProtocolParser {
       }
       if (security === 'reality') {
         config.realitySettings = this.parseRealitySettings(params);
+        if (!config.realitySettings) {
+          // 缺 pbk 的 reality 节点无法握手（builder 不生成 reality tls 块 → 退化裸 TCP 假节点），整节点拒绝。
+          throw new Error('Reality 节点缺少 pbk（public key）参数');
+        }
       }
     } else {
       // AnyTLS 默认就是 TLS
@@ -665,10 +699,10 @@ export class ProtocolParser implements IProtocolParser {
       password,
     };
 
-    // 解析传输层配置
-    const network = params.get('type') as Network | null;
+    // 解析传输层配置：归一化/白名单校验收口在 parseTransportSettings（内含 config.network 写入；
+    // 未知传输层（xhttp/splithttp/kcp 等 sing-box 不支持）throw 整节点拒绝，订阅逐行 catch 聚合告警）。
+    const network = params.get('type');
     if (network) {
-      config.network = network;
       this.parseTransportSettings(config, params, network);
     }
 
@@ -719,6 +753,13 @@ export class ProtocolParser implements IProtocolParser {
           path: vmessData.path || '/',
           headers: vmessData.host ? { Host: vmessData.host } : undefined,
         };
+      } else if (net === 'httpupgrade') {
+        // v2rayN 生态 net:"httpupgrade" 在野常见；sing-box 支持 vmess+httpupgrade，与 ws 同款 path/host 承载。
+        config.network = 'httpupgrade';
+        config.wsSettings = {
+          path: vmessData.path || '/',
+          headers: vmessData.host ? { Host: vmessData.host } : undefined,
+        };
       } else if (net === 'h2' || net === 'http') {
         config.network = 'http';
         config.httpSettings = {
@@ -730,8 +771,12 @@ export class ProtocolParser implements IProtocolParser {
         config.grpcSettings = {
           serviceName: vmessData.path || '',
         };
-      } else {
+      } else if (net === 'tcp' || net === 'raw' || net === 'none') {
         config.network = 'tcp';
+      } else {
+        // kcp/quic（V2Ray mKCP·QUIC 传输）/xhttp 等 sing-box 不支持——入库也连不上，
+        // 整节点拒绝（与 vless/trojan 统一口径，订阅逐行 catch 聚合告警）。
+        throw new Error(`不支持的传输层类型: ${net}`);
       }
 
       // 解析安全层
@@ -831,25 +876,41 @@ export class ProtocolParser implements IProtocolParser {
   }
 
   /**
-   * 解析传输层配置
+   * 解析传输层配置（vless/trojan/naive 共用）。接收原始 type 参数：小写归一 → 别名映射 → 写 config.network。
+   * 已知别名：h2→http（builder 兼容口径，见 generateTransportConfig）、raw/none→tcp（Xray 1.8.24+ 把 tcp
+   * 更名 raw，二者在野共存）。httpupgrade 复用 ws 形态的 path/host 承载（与 sing-box JSON 导入、outbound
+   * builder 同款，见 SubscriptionService.parseSingboxOutbounds / generateTransportConfig）。
+   * 未知值（xhttp/splithttp/kcp/quic 等 Xray 专属传输）sing-box 内核不支持——入库也连不上，整节点 throw
+   * 拒绝（订阅逐行 catch 聚合告警；消息保持「不支持的传输层类型」可检索，issue #263）。
    */
   private parseTransportSettings(
     config: ServerConfig,
     params: URLSearchParams,
-    network: Network
+    rawNetwork: string
   ): void {
+    const network = rawNetwork.toLowerCase();
     switch (network) {
       case 'ws':
+        config.network = 'ws';
+        config.wsSettings = this.parseWebSocketSettings(params);
+        break;
+      case 'httpupgrade':
+        config.network = 'httpupgrade';
         config.wsSettings = this.parseWebSocketSettings(params);
         break;
       case 'grpc':
+        config.network = 'grpc';
         config.grpcSettings = this.parseGrpcSettings(params);
         break;
+      case 'h2':
       case 'http':
+        config.network = 'http';
         config.httpSettings = this.parseHttpSettings(params);
         break;
       case 'tcp':
-        // TCP 不需要额外配置
+      case 'raw':
+      case 'none':
+        config.network = 'tcp'; // TCP 不需要额外配置
         break;
       default:
         throw new Error(`不支持的传输层类型: ${network}`);
@@ -1246,7 +1307,8 @@ export class ProtocolParser implements IProtocolParser {
       tls: config.security === 'tls' ? 'tls' : '',
     };
 
-    if (config.network === 'ws' && config.wsSettings) {
+    // httpupgrade 与 ws 同款 wsSettings 承载（parse 侧对称，见 parseVmess）——漏此臂会导出丢 path/Host。
+    if ((config.network === 'ws' || config.network === 'httpupgrade') && config.wsSettings) {
       vmessData.path = config.wsSettings.path || '/';
       vmessData.host = config.wsSettings.headers?.Host || '';
     } else if (config.network === 'http' && config.httpSettings) {
@@ -1320,8 +1382,8 @@ export class ProtocolParser implements IProtocolParser {
       params.set('type', config.network);
     }
 
-    // WebSocket 配置
-    if (config.network === 'ws' && config.wsSettings) {
+    // WebSocket / HTTPUpgrade 配置（httpupgrade 复用 ws 形态的 path/host 承载，见 parseTransportSettings）
+    if ((config.network === 'ws' || config.network === 'httpupgrade') && config.wsSettings) {
       if (config.wsSettings.path) {
         params.set('path', config.wsSettings.path);
       }

--- a/src/main/services/SubscriptionService.ts
+++ b/src/main/services/SubscriptionService.ts
@@ -97,6 +97,16 @@ type SingboxOutbound = {
   idle_session_check_interval?: string;
   idle_session_timeout?: string;
   min_idle_session?: number;
+  // ssh（private_key_path 属本机文件路径，跨设备订阅无意义，不收；其余 sing-box ssh outbound 字段全收）
+  user?: string;
+  private_key?: string;
+  private_key_passphrase?: string;
+  host_key?: string[];
+  host_key_algorithms?: string[];
+  client_version?: string;
+  cipher?: string[];
+  mac?: string[];
+  kex_algorithm?: string[];
   tls?: SingboxTls;
   transport?: SingboxTransport;
   multiplex?: SingboxMultiplex;
@@ -114,7 +124,11 @@ const SINGBOX_SUPPORTED_TYPES = new Set([
   'anytls',
   'socks',
   'http',
+  'ssh',
 ]);
+
+/** sing-box transport.type → ServerConfig.network 可承载的传输（其余 sing-box 不支持/FlowZ 无落点，整节点跳过）。 */
+const SINGBOX_SUPPORTED_TRANSPORTS = new Set(['ws', 'grpc', 'http', 'httpupgrade']);
 /** sing-box 非代理内部 outbound type（本地导入忽略，不作节点、不透传 custom）。 */
 const SINGBOX_INTERNAL_TYPES = new Set(['direct', 'block', 'dns', 'selector', 'urltest']);
 
@@ -182,7 +196,10 @@ export class SubscriptionService {
       s.sshSettings?.password ||
       s.wireguardSettings?.peerPublicKey ||
       '';
-    return `${(s.protocol || '').toLowerCase()}|${s.address}|${s.port}|${cred}`;
+    // network 维度：同 host:port:cred 但传输不同（tcp vs ws vs grpc）是不同节点，缺此维度会被误并静默吞节点。
+    // 指纹不持久化——reconcile 对新旧两侧用同一函数现算，归一化（h2→http/raw→tcp）对两侧等价，
+    // 存量节点 id / selectedServerId 不受本次加维度影响。
+    return `${(s.protocol || '').toLowerCase()}|${s.address}|${s.port}|${cred}|${(s.network || 'tcp').toLowerCase()}`;
   }
 
   /**
@@ -299,13 +316,33 @@ export class SubscriptionService {
     const servers: ServerConfig[] = [];
     const now = new Date().toISOString();
 
+    // 丢弃可见性（issue #263 调查项）：原三类 silent continue（不支持 type / 缺 server·port / 不支持 transport）
+    // 完全无日志——「8 进 4 出」用户无从察觉。聚合计数，函数尾统一 warn。
+    const skipByType = new Map<string, number>();
+    let missingFields = 0;
+    const skipByTransport = new Map<string, number>();
+
     for (const ob of outbounds) {
-      if (!SUPPORTED.has(ob.type)) continue;
+      if (!SUPPORTED.has(ob.type)) {
+        // direct/block/selector 等内部 outbound 是配置结构而非节点，不计入「丢弃」噪声。
+        if (!SINGBOX_INTERNAL_TYPES.has(ob.type)) {
+          skipByType.set(ob.type, (skipByType.get(ob.type) ?? 0) + 1);
+        }
+        continue;
+      }
       // 支持仅含 server_ports（端口跳跃、无 server_port）的 Hy2 节点：从首个范围的低位端口推导 port
       const effectivePort =
         ob.server_port ??
         (ob.server_ports?.[0] ? parseInt(ob.server_ports[0].split(':')[0], 10) : undefined);
-      if (!ob.server || !effectivePort) continue;
+      if (!ob.server || !effectivePort) {
+        missingFields++;
+        continue;
+      }
+      // 不支持的 transport（quic 等）：入库会静默降级裸 TCP 产假节点，整节点跳过（与分享链/Clash 路径统一口径）。
+      if (ob.transport?.type && !SINGBOX_SUPPORTED_TRANSPORTS.has(ob.transport.type)) {
+        skipByTransport.set(ob.transport.type, (skipByTransport.get(ob.transport.type) ?? 0) + 1);
+        continue;
+      }
 
       try {
         const base: Partial<ServerConfig> = {
@@ -346,7 +383,7 @@ export class SubscriptionService {
         // Transport
         if (ob.transport?.type) {
           const t = ob.transport;
-          const netType = t.type as 'ws' | 'grpc' | 'http' | 'httpupgrade' | 'tcp';
+          const netType = t.type as 'ws' | 'grpc' | 'http' | 'httpupgrade';
           base.network = netType;
           if (netType === 'ws') {
             // 与 httpupgrade 对齐：transport.host 折叠进 Host header（部分配置把 ws Host 放在 t.host），
@@ -484,6 +521,29 @@ export class SubscriptionService {
             username: ob.username,
             password: ob.password,
           });
+        } else if (ob.type === 'ssh') {
+          // ssh：与 Clash 路径（ClashSubscriptionParser mapNode ssh 分支）对齐的落点；
+          // private_key_path 是本机文件路径、跨设备订阅无意义，刻意不映射。
+          const ssh: NonNullable<ServerConfig['sshSettings']> = {};
+          if (ob.user) ssh.user = ob.user;
+          if (ob.password) ssh.password = ob.password;
+          if (ob.private_key) ssh.privateKey = ob.private_key;
+          if (ob.private_key_passphrase) ssh.privateKeyPassphrase = ob.private_key_passphrase;
+          if (ob.host_key && ob.host_key.length > 0) ssh.hostKey = ob.host_key;
+          if (ob.host_key_algorithms && ob.host_key_algorithms.length > 0)
+            ssh.hostKeyAlgorithms = ob.host_key_algorithms;
+          if (ob.client_version) ssh.clientVersion = ob.client_version;
+          // 算法协商覆盖（对接老/特定 SSH 服务端）：丢弃会静默退回默认算法集、连不上且无从排查。
+          if (ob.cipher && ob.cipher.length > 0) ssh.cipher = ob.cipher;
+          if (ob.mac && ob.mac.length > 0) ssh.mac = ob.mac;
+          if (ob.kex_algorithm && ob.kex_algorithm.length > 0) ssh.kexAlgorithm = ob.kex_algorithm;
+          servers.push({
+            ...(base as ServerConfig),
+            protocol: 'ssh',
+            network: 'tcp',
+            security: 'none',
+            sshSettings: Object.keys(ssh).length > 0 ? ssh : undefined,
+          });
         }
       } catch (e: any) {
         this.logManager.addLog(
@@ -492,6 +552,21 @@ export class SubscriptionService {
           'Subscription'
         );
       }
+    }
+    if (skipByType.size > 0) {
+      const detail = [...skipByType.entries()].map(([t, c]) => `${t}(${c})`).join(', ');
+      this.logManager.addLog('warn', `跳过不支持的 outbound 类型: ${detail}`, 'Subscription');
+    }
+    if (skipByTransport.size > 0) {
+      const detail = [...skipByTransport.entries()].map(([t, c]) => `${t}(${c})`).join(', ');
+      this.logManager.addLog('warn', `跳过不支持的传输层类型: ${detail}`, 'Subscription');
+    }
+    if (missingFields > 0) {
+      this.logManager.addLog(
+        'warn',
+        `跳过 ${missingFields} 个缺 server/port 的 outbound`,
+        'Subscription'
+      );
     }
     return servers;
   }
@@ -743,10 +818,18 @@ export class SubscriptionService {
       }
     }
 
-    const lines = decodedContent.split(/\r?\n/).filter((line) => line.trim().length > 0);
+    // trim 每行（与 parseLocalContent 口径一致）：前导空白的合法链接否则被 startsWith 误判「不支持 scheme」。
+    const lines = decodedContent
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
     const servers: ServerConfig[] = [];
     const now = new Date().toISOString();
 
+    // 丢弃可见性（issue #263）：逐行 warn 之外聚合两类丢弃计数——①scheme 不受支持的行（原完全静默）
+    // ②解析失败的行（原只有散落 warn）——最终 info 一并给出，用户不翻告警也能看出「导入不全」。
+    let failedLines = 0;
+    const unsupportedSchemes = new Map<string, number>();
     for (const line of lines) {
       if (this.protocolParser.isSupported(line)) {
         try {
@@ -756,9 +839,21 @@ export class SubscriptionService {
           server.updatedAt = now;
           servers.push(server);
         } catch (e: any) {
+          failedLines++;
           this.logManager.addLog('warn', `解析订阅中的节点失败: ${e.message}`, 'Subscription');
         }
+      } else if (line.includes('://')) {
+        const scheme = line.split('://')[0].trim().toLowerCase();
+        unsupportedSchemes.set(scheme, (unsupportedSchemes.get(scheme) ?? 0) + 1);
       }
+    }
+    if (unsupportedSchemes.size > 0) {
+      const detail = [...unsupportedSchemes.entries()].map(([s, c]) => `${s}(${c})`).join(', ');
+      this.logManager.addLog(
+        'warn',
+        `跳过不支持的协议链接: ${detail}`,
+        'Subscription'
+      );
     }
 
     if (servers.length === 0) {
@@ -774,7 +869,12 @@ export class SubscriptionService {
       }
       return { servers: [] };
     }
-    this.logManager.addLog('info', `成功从订阅解析了 ${servers.length} 个节点`, 'Subscription');
+    const skippedTotal = failedLines + [...unsupportedSchemes.values()].reduce((a, b) => a + b, 0);
+    this.logManager.addLog(
+      'info',
+      `成功从订阅解析了 ${servers.length} 个节点${skippedTotal > 0 ? `（另有 ${skippedTotal} 条被跳过/失败，详见上方告警）` : ''}`,
+      'Subscription'
+    );
     return { servers };
   }
 

--- a/src/main/services/__tests__/ClashSubscriptionParser.test.ts
+++ b/src/main/services/__tests__/ClashSubscriptionParser.test.ts
@@ -1290,3 +1290,97 @@ describe('LOW-4 override skip-cert-verify:false 也覆盖（赋值语义）', ()
     expect(servers[0].tlsSettings?.allowInsecure).toBe(true);
   });
 });
+
+// ── issue #263：Clash 路径与分享链/sing-box JSON 统一「不支持传输拒节点」口径 + reality 完整性 ──
+describe('传输层白名单 + reality 完整性（issue #263 统一口径）', () => {
+  const NOW = '2026-07-07T00:00:00.000Z';
+
+  it('vless network=xhttp → fail 计数 + 聚合告警，不入库', () => {
+    const r = parseClashProxies(
+      [{ name: 'x', type: 'vless', server: 'a.com', port: 443, uuid: 'u', network: 'xhttp' }],
+      'sub',
+      NOW
+    );
+    expect(r.servers).toHaveLength(0);
+    expect(r.failed).toBe(1);
+    expect(r.warnings.join('\n')).toMatch(/不支持的传输层类型: xhttp/);
+  });
+
+  it('network 缺省/tcp 正常入库（不受白名单影响）', () => {
+    const r = parseClashProxies(
+      [
+        { name: 'a', type: 'vless', server: 'a.com', port: 443, uuid: 'u' },
+        { name: 'b', type: 'vless', server: 'a.com', port: 444, uuid: 'u', network: 'tcp' },
+      ],
+      'sub',
+      NOW
+    );
+    expect(r.servers).toHaveLength(2);
+    expect(r.failed).toBe(0);
+  });
+
+  it('reality-opts 缺 public-key → fail（防按普通 TLS 入库成假节点）', () => {
+    const r = parseClashProxies(
+      [
+        {
+          name: 'r',
+          type: 'vless',
+          server: 'a.com',
+          port: 443,
+          uuid: 'u',
+          tls: true,
+          'reality-opts': { 'short-id': '01ab' },
+        },
+      ],
+      'sub',
+      NOW
+    );
+    expect(r.servers).toHaveLength(0);
+    expect(r.failed).toBe(1);
+    expect(r.warnings.join('\n')).toMatch(/public-key/);
+  });
+});
+
+describe('mihomo HTTPUpgrade 表达（network:ws + v2ray-http-upgrade）', () => {
+  const NOW = '2026-07-07T00:00:00.000Z';
+
+  it('ws-opts.v2ray-http-upgrade:true → network=httpupgrade（settings 落点不变）', () => {
+    const { servers } = parseClashProxies(
+      [
+        {
+          name: 'hu',
+          type: 'vless',
+          server: 'a.com',
+          port: 443,
+          uuid: 'u',
+          network: 'ws',
+          'ws-opts': { path: '/up', headers: { Host: 'h.com' }, 'v2ray-http-upgrade': true },
+        },
+      ],
+      'sub',
+      NOW
+    );
+    expect(servers).toHaveLength(1);
+    expect(servers[0].network).toBe('httpupgrade');
+    expect(servers[0].wsSettings).toEqual({ path: '/up', headers: { Host: 'h.com' } });
+  });
+
+  it('普通 ws（无 flag）→ 仍 ws', () => {
+    const { servers } = parseClashProxies(
+      [
+        {
+          name: 'ws',
+          type: 'vless',
+          server: 'a.com',
+          port: 443,
+          uuid: 'u',
+          network: 'ws',
+          'ws-opts': { path: '/ws' },
+        },
+      ],
+      'sub',
+      NOW
+    );
+    expect(servers[0].network).toBe('ws');
+  });
+});

--- a/src/main/services/__tests__/SubscriptionService.test.ts
+++ b/src/main/services/__tests__/SubscriptionService.test.ts
@@ -587,3 +587,172 @@ describe('parseLocalContent — 本地导入（不联网）', () => {
     await expect(svc.parseLocalContent(huge)).rejects.toThrow(/过大/);
   });
 });
+
+// ── issue #263 补丁组：丢弃可见性聚合 / 指纹传输维度 / sing-box ssh 映射 ──
+describe('issue #263 — 聚合可见性 / 指纹传输维度 / ssh 映射', () => {
+  const CTX = { allowProviders: true, viaProxy: false, userAgent: 'ua' };
+
+  it('URL-list：不支持 scheme 聚合 warn + 结果 info 带跳过计数', async () => {
+    const log = new FakeLog();
+    const svc = newService(log);
+    const content = [
+      'vless://uuid-1@a.com:443?encryption=none#ok',
+      'ssr://AAAA',
+      'ssr://BBBB',
+      'juicity://CCCC',
+    ].join('\n');
+    const r = await (svc as any).parseSubscriptionContent(content, 'sub-x', CTX);
+    expect(r.servers).toHaveLength(1);
+    const warns = log.entries
+      .filter((e) => e.level === 'warn')
+      .map((e) => e.message)
+      .join('\n');
+    expect(warns).toMatch(/跳过不支持的协议链接/);
+    expect(warns).toMatch(/ssr\(2\)/);
+    expect(warns).toMatch(/juicity\(1\)/);
+    const infos = log.entries
+      .filter((e) => e.level === 'info')
+      .map((e) => e.message)
+      .join('\n');
+    expect(infos).toMatch(/另有 3 条被跳过\/失败/);
+  });
+
+  it('URL-list：xhttp 节点 fail 计入结果 info（issue #263 主症状可见化）', async () => {
+    const log = new FakeLog();
+    const svc = newService(log);
+    const content = [
+      'anytls://pw@a.com:443#any',
+      'vless://uuid-1@a.com:443?type=xhttp#dead',
+    ].join('\n');
+    const r = await (svc as any).parseSubscriptionContent(content, 'sub-x', CTX);
+    expect(r.servers).toHaveLength(1);
+    expect(r.servers[0].protocol).toBe('anytls');
+    const warns = log.entries
+      .filter((e) => e.level === 'warn')
+      .map((e) => e.message)
+      .join('\n');
+    expect(warns).toMatch(/不支持的传输层类型: xhttp/);
+    const infos = log.entries
+      .filter((e) => e.level === 'info')
+      .map((e) => e.message)
+      .join('\n');
+    expect(infos).toMatch(/另有 1 条被跳过\/失败/);
+  });
+
+  it('sing-box outbounds：type/transport/缺字段三类跳过聚合 warn；internal 类型不计噪声', () => {
+    const log = new FakeLog();
+    const svc = newService(log);
+    const obs = [
+      { type: 'vless', tag: 'ok', server: 'a.com', server_port: 443, uuid: 'u' },
+      { type: 'wireguard', tag: 'wg', server: 'a.com', server_port: 51820 },
+      { type: 'vless', tag: 'noport', server: 'a.com', uuid: 'u' },
+      { type: 'vless', tag: 'quic', server: 'a.com', server_port: 443, uuid: 'u', transport: { type: 'quic' } },
+      { type: 'direct', tag: 'direct' },
+      { type: 'selector', tag: 'sel', outbounds: [] },
+    ];
+    const servers = (svc as any).parseSingboxOutbounds(obs, 'sub-x');
+    expect(servers).toHaveLength(1);
+    expect(servers[0].name).toBe('ok');
+    const warns = log.entries
+      .filter((e) => e.level === 'warn')
+      .map((e) => e.message)
+      .join('\n');
+    expect(warns).toMatch(/跳过不支持的 outbound 类型: wireguard\(1\)/);
+    expect(warns).toMatch(/跳过不支持的传输层类型: quic\(1\)/);
+    expect(warns).toMatch(/跳过 1 个缺 server\/port 的 outbound/);
+    expect(warns).not.toMatch(/direct|selector/);
+  });
+
+  it('sing-box ssh outbound → 一等映射（与 Clash 路径同落点；private_key_path 刻意不收）', () => {
+    const log = new FakeLog();
+    const svc = newService(log);
+    const servers = (svc as any).parseSingboxOutbounds(
+      [
+        {
+          type: 'ssh',
+          tag: 's1',
+          server: 'a.com',
+          server_port: 22,
+          user: 'root',
+          password: 'pw',
+          private_key: 'PEM',
+          private_key_passphrase: 'pp',
+          host_key: ['ssh-ed25519 AAAA'],
+          host_key_algorithms: ['ssh-ed25519'],
+          client_version: 'SSH-2.0-x',
+        },
+      ],
+      'sub-x'
+    );
+    expect(servers).toHaveLength(1);
+    expect(servers[0].protocol).toBe('ssh');
+    expect(servers[0].sshSettings).toEqual({
+      user: 'root',
+      password: 'pw',
+      privateKey: 'PEM',
+      privateKeyPassphrase: 'pp',
+      hostKey: ['ssh-ed25519 AAAA'],
+      hostKeyAlgorithms: ['ssh-ed25519'],
+      clientVersion: 'SSH-2.0-x',
+    });
+  });
+
+  it('serverFingerprint 含传输维度：同 host:port:cred 不同 network 不再误并；缺省归一 tcp', () => {
+    const base = {
+      id: 'i',
+      name: 'n',
+      protocol: 'vless',
+      address: 'a.com',
+      port: 443,
+      uuid: 'u',
+    } as unknown as ServerConfig;
+    const ws = { ...base, network: 'ws' } as ServerConfig;
+    const grpc = { ...base, network: 'grpc' } as ServerConfig;
+    expect(SubscriptionService.serverFingerprint(ws)).not.toBe(
+      SubscriptionService.serverFingerprint(grpc)
+    );
+    expect(SubscriptionService.serverFingerprint(base)).toMatch(/\|tcp$/);
+  });
+});
+
+describe('issue #263 review 补测 — ssh 算法字段 / 行首空白', () => {
+  it('ssh outbound cipher/mac/kex_algorithm → sshSettings 对应落点（不静默丢协商配置）', () => {
+    const log = new FakeLog();
+    const svc = newService(log);
+    const servers = (svc as any).parseSingboxOutbounds(
+      [
+        {
+          type: 'ssh',
+          tag: 's',
+          server: 'a.com',
+          server_port: 22,
+          user: 'root',
+          password: 'pw',
+          cipher: ['aes128-gcm@openssh.com'],
+          mac: ['hmac-sha2-256'],
+          kex_algorithm: ['curve25519-sha256'],
+        },
+      ],
+      'sub-x'
+    );
+    expect(servers[0].sshSettings).toMatchObject({
+      cipher: ['aes128-gcm@openssh.com'],
+      mac: ['hmac-sha2-256'],
+      kexAlgorithm: ['curve25519-sha256'],
+    });
+  });
+
+  it('URL-list 行首空白的合法链接正常解析，不误计「不支持 scheme」', async () => {
+    const log = new FakeLog();
+    const svc = newService(log);
+    const content = '  vless://uuid-1@a.com:443?encryption=none#ok  \n\t trojan://pw@b.com:443#t';
+    const r = await (svc as any).parseSubscriptionContent(content, 'sub-x', {
+      allowProviders: true,
+      viaProxy: false,
+      userAgent: 'ua',
+    });
+    expect(r.servers).toHaveLength(2);
+    const warns = log.entries.filter((e) => e.level === 'warn');
+    expect(warns.find((w) => w.message.includes('跳过不支持的协议链接'))).toBeUndefined();
+  });
+});

--- a/src/main/services/__tests__/protocol-parser.test.ts
+++ b/src/main/services/__tests__/protocol-parser.test.ts
@@ -719,3 +719,146 @@ describe('VMess insecure 单向丢弃（parse 侧特征：generate 不回写，�
     expect(parser.parseUrl(url).tlsSettings?.allowInsecure).toBe(true);
   });
 });
+
+// ── issue #263：传输层归一化/白名单 + 裸 IPv6 泛化 + reality 完整性 + hy2 obfs 剥离告警 ──
+describe('传输层归一化与白名单（issue #263）', () => {
+  it('vless type=httpupgrade → network=httpupgrade + wsSettings 承载 path/host', () => {
+    const c = parser.parseUrl(
+      'vless://uuid-1@a.com:443?encryption=none&type=httpupgrade&path=%2Fup&host=cdn.example.com&security=tls&sni=a.com#n'
+    );
+    expect(c.network).toBe('httpupgrade');
+    expect(c.wsSettings?.path).toBe('/up');
+    expect(c.wsSettings?.headers?.Host).toBe('cdn.example.com');
+  });
+
+  it('往返不动点 httpupgrade（generate 回写 path/host）', () => {
+    expectRoundTripStable(
+      'vless://uuid-1@a.com:443?encryption=none&type=httpupgrade&path=%2Fup&host=cdn.example.com&security=tls&sni=a.com&fp=chrome#n'
+    );
+  });
+
+  it('vless type=h2 → network=http（builder 兼容口径）', () => {
+    const c = parser.parseUrl(
+      'vless://uuid-1@a.com:443?encryption=none&type=h2&path=%2Fh2&host=h.example.com#n'
+    );
+    expect(c.network).toBe('http');
+    expect(c.httpSettings?.path).toBe('/h2');
+  });
+
+  it('type 大小写不敏感 + raw/none 归一 tcp（Xray 1.8.24+ 别名）', () => {
+    expect(parser.parseUrl('vless://u@a.com:443?type=RAW#n').network).toBe('tcp');
+    expect(parser.parseUrl('vless://u@a.com:443?type=none#n').network).toBe('tcp');
+    expect(parser.parseUrl('vless://u@a.com:443?type=WS&path=%2Fp#n').network).toBe('ws');
+  });
+
+  it('vless/trojan type=xhttp|splithttp|kcp（sing-box 不支持）→ 整节点拒绝且消息可检索', () => {
+    expect(() => parser.parseUrl('vless://u@a.com:443?type=xhttp#n')).toThrow(
+      /不支持的传输层类型: xhttp/
+    );
+    expect(() => parser.parseUrl('trojan://pw@a.com:443?type=splithttp#n')).toThrow(
+      /不支持的传输层类型: splithttp/
+    );
+    expect(() => parser.parseUrl('vless://u@a.com:443?type=kcp#n')).toThrow(
+      /不支持的传输层类型: kcp/
+    );
+  });
+
+  it('vmess net 未知（kcp/quic）→ 拒绝；net=raw → tcp（与 vless/trojan 统一口径）', () => {
+    const vmessUrl = (net: string) =>
+      'vmess://' +
+      Buffer.from(
+        JSON.stringify({ v: '2', ps: 'V', add: 'x.com', port: '443', id: 'uid', net })
+      ).toString('base64');
+    expect(() => parser.parseUrl(vmessUrl('kcp'))).toThrow(/不支持的传输层类型: kcp/);
+    expect(() => parser.parseUrl(vmessUrl('quic'))).toThrow(/不支持的传输层类型: quic/);
+    expect(parser.parseUrl(vmessUrl('raw')).network).toBe('tcp');
+  });
+
+  it('裸 IPv6（无方括号）泛化到 vless/trojan（原仅 ss://）', () => {
+    const v = parser.parseUrl('vless://uuid-1@2001:db8::1:443?encryption=none#v6');
+    expect(v.address).toBe('2001:db8::1');
+    expect(v.port).toBe(443);
+    const t = parser.parseUrl('trojan://pw@2001:db8::2:8443#t6');
+    expect(t.address).toBe('2001:db8::2');
+    expect(t.port).toBe(8443);
+  });
+
+  it('reality 缺 pbk → 整节点拒绝（vless/trojan；防裸 TCP 假节点入库）', () => {
+    expect(() => parser.parseUrl('vless://u@a.com:443?security=reality&sid=ab#n')).toThrow(/pbk/);
+    expect(() => parser.parseUrl('trojan://pw@a.com:443?security=reality#n')).toThrow(/pbk/);
+  });
+
+  it('hy2 obfs 非 salamander → 剥离混淆不拒节点；salamander 缺 obfs-password → 拒（强制混淆裸连必死）', () => {
+    const c = parser.parseUrl('hysteria2://pw@a.com:443?obfs=faketype&obfs-password=x#n');
+    expect(c.hysteria2Settings?.obfs).toBeUndefined();
+    expect(() => parser.parseUrl('hysteria2://pw@a.com:443?obfs=salamander#n')).toThrow(
+      /缺少 obfs-password/
+    );
+  });
+
+  it('vmess net=httpupgrade → 一等承载（v2rayN 在野形态，sing-box 支持）', () => {
+    const url =
+      'vmess://' +
+      Buffer.from(
+        JSON.stringify({
+          v: '2',
+          ps: 'V',
+          add: 'x.com',
+          port: '443',
+          id: 'uid',
+          net: 'httpupgrade',
+          path: '/up',
+          host: 'h.com',
+        })
+      ).toString('base64');
+    const c = parser.parseUrl(url);
+    expect(c.network).toBe('httpupgrade');
+    expect(c.wsSettings).toEqual({ path: '/up', headers: { Host: 'h.com' } });
+  });
+
+  it('裸 IPv6 无端口 → 整段加括号不截地址（端口缺省 443，与域名无端口同语义）', () => {
+    const c = parser.parseUrl('vless://uuid-1@2001:db8::1?encryption=none#v6np');
+    expect(c.address).toBe('2001:db8::1');
+    expect(c.port).toBe(443);
+  });
+});
+
+// ── 复审轮2 补测：vmess httpupgrade 往返对称 / SIP002 裸 IPv6 + plugin ──
+describe('复审轮2 边界', () => {
+  it('vmess httpupgrade 往返不动点（generate 回写 path/host，不退化空值）', () => {
+    const url =
+      'vmess://' +
+      Buffer.from(
+        JSON.stringify({
+          v: '2',
+          ps: 'VHU',
+          add: 'x.com',
+          port: '443',
+          id: 'uid',
+          aid: '0',
+          scy: 'auto',
+          net: 'httpupgrade',
+          path: '/up',
+          host: 'cdn.example.com',
+          tls: 'tls',
+          sni: 's.com',
+          fp: 'chrome',
+        })
+      ).toString('base64');
+    const first = parser.parseUrl(url);
+    expect(first.wsSettings).toEqual({ path: '/up', headers: { Host: 'cdn.example.com' } });
+    const second = parser.parseUrl(parser.generateUrl(first));
+    expect(second.network).toBe('httpupgrade');
+    expect(second.wsSettings).toEqual({ path: '/up', headers: { Host: 'cdn.example.com' } });
+  });
+
+  it('SIP002 裸 IPv6 + /?plugin= 形态：/ 前截断 hostPort，端口拆分不受破坏', () => {
+    const b64 = Buffer.from('aes-128-gcm:pw').toString('base64');
+    const c = parser.parseUrl(
+      `ss://${b64}@2001:db8::1:8388/?plugin=obfs-local%3Bobfs%3Dhttp#ss-v6-plugin`
+    );
+    expect(c.address).toBe('2001:db8::1');
+    expect(c.port).toBe(8388);
+    expect(c.shadowsocksSettings?.plugin).toBe('obfs-local');
+  });
+});


### PR DESCRIPTION
## 问题

机场订阅同时含 vless 与 anytls 节点时，FlowZ 只导入 anytls，vless 全部缺失且无任何提示。

Closes #263

## 根因

分享链解析器的传输层白名单只认 tcp/ws/grpc/http，未知值整节点丢弃：

- `httpupgrade` 属实现遗漏——Network 类型联合、sing-box JSON 导入、outbound 构建三处均已支持，唯 URI 解析漏 case；
- 机场近年把 vless 迁往 xhttp/splithttp（Xray 专属传输，sing-box 内核无对应能力），这类节点被静默丢弃；anytls 链接无 type 参数故幸存。

## 修复

- 分享链 type 白名单补 httpupgrade（vless/trojan/naive/vmess），h2→http、raw/none→tcp（Xray 1.8.24+ 别名），小写归一
- mihomo 的 HTTPUpgrade 表达（`network: ws` + `ws-opts.v2ray-http-upgrade: true`）识别为 httpupgrade
- 未知传输（xhttp/splithttp/kcp 等内核不支持）三条导入路径（URI / Clash / sing-box JSON）统一整节点拒绝——原 Clash/JSON 路静默降级裸 TCP，产出连不上的假节点
- 丢弃可见化：URI 不支持 scheme 聚合告警、sing-box 路径三类静默跳过聚合告警、结果日志带跳过计数
- 裸 IPv6 预处理泛化到全协议（原仅 ss://），地址/端口文法歧义按启发式消解（末段 2-5 位十进制且余段合法才拆端口）
- reality 缺 pbk、hy2 salamander 缺 obfs-password 整节点拒绝（防假节点入库）
- 节点指纹加传输维度（同 host:port:凭据不同传输不再误并；指纹不持久化，存量节点 id 不受影响）
- sing-box JSON 路径补 ssh 映射（含 cipher/mac/kex_algorithm 算法协商字段）

## 测试

- jest 4 套 221 tests 全绿（新增 30+ 用例：传输归一矩阵、往返不动点、聚合计数、IPv6 边界、SIP002 plugin）
- tsc main/renderer 双绿
- 独立 review 三轮收敛全绿

## 升级后用户侧

vless 节点若仍缺失，日志会给出聚合告警；搜「不支持的传输层类型」——若为 xhttp/splithttp，属 sing-box 内核无该传输能力，需服务端提供 ws/tcp/httpupgrade 形态节点。
