### PR TITLE
fix(ui): 连接/日志页 hero 卡高度棘轮根治(contain:size)

### DIFF
--- a/src/renderer/conduit.css
+++ b/src/renderer/conduit.css
@@ -1190,7 +1190,9 @@
 
 /* 表卡：flex 列 → 滚动区 flex:1 自身滚动 + 截断脚注常驻底部 */
 .conns-card { flex: 1; min-height: 400px; display: flex; flex-direction: column; overflow: hidden; padding: 0; }
-.conns-scroll { flex: 1; overflow-x: auto; overflow-y: auto; }
+/* contain:size 断「高度棘轮」：否则表格内容 intrinsic 高经 flex-basis:0 链传进 main-layout .container(min-h-full auto)
+   使卡片长到全内容高、缩窗不回缩、overflow-y 因卡高非 definite 而失效（低行数掩盖，高行数暴露，同拓扑）。 */
+.conns-scroll { flex: 1; overflow-x: auto; overflow-y: auto; contain: size; }
 .ctbl { width: 100%; min-width: 1000px; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
 /* 表头：hairline 下衬 · sticky · 排序 active 用 teal(唯一) */
 .ctbl thead th { position: sticky; top: 0; z-index: 2; text-align: left; background: hsl(var(--surface)); color: hsl(var(--fg-faint)); font-size: 10.5px; font-weight: 640; letter-spacing: 0.04em; text-transform: uppercase; white-space: nowrap; padding: 9px 12px; border-bottom: 1px solid hsl(var(--hair)); user-select: none; }
@@ -1320,7 +1322,8 @@
   .lv-search .input { padding-left: 32px; }
   .lv-search-ic { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); width: 15px; height: 15px; color: hsl(var(--fg-faint)); pointer-events: none; }
 
-  .lv-stream { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: 8px 6px; font-size: 12px; line-height: 1.5; scrollbar-width: thin; }
+  /* contain:size 断高度棘轮（同 .conns-scroll）：日志多时否则卡片长到全内容高、缩窗不回缩。 */
+  .lv-stream { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; contain: size; padding: 8px 6px; font-size: 12px; line-height: 1.5; scrollbar-width: thin; }
   .lv-stream:focus-visible { outline: none; box-shadow: inset 0 0 0 2px hsl(var(--ring) / 0.5); }
   .lg { display: grid; grid-template-columns: 104px 58px 1fr; gap: 0 10px; align-items: baseline; padding: 2px 8px; border-radius: 5px; }
   .lg:hover { background: hsl(var(--surface-2) / 0.7); }


### PR DESCRIPTION
拓扑高度棘轮(#272)的同构:连接/日志 hero 填充卡同样内容撑高、缩窗不回缩(overflow-y 因卡高非 definite 失效,低行数掩盖高行数暴露;连接页 sim 200 行实测 cardH 9386px)。`.conns-scroll`/`.lv-stream` 加 `contain:size` 断棘轮→视口驱动+内部滚动(真机验:cardH 9386→709)。充分梳理确认同构仅此三处 hero 卡,弹窗因 max-h-[92vh] definite 安全。