### PR TITLE
fix(ui): 连接/日志页高度棘轮改用 container h-full(替代 contain:size 回归)

### DIFF
--- a/src/renderer/components/layout/main-layout.tsx
+++ b/src/renderer/components/layout/main-layout.tsx
@@ -17,6 +17,11 @@ const isMac = window.electron?.platform === 'darwin';
 const isWindows = window.electron?.platform === 'win32';
 const isLinux = !isMac && !isWindows; // Linux frameless → 右上自绘窗口控制按钮（替代系统 titleBarOverlay）
 
+// hero 页（单卡填满 + 卡内滚动）：.container 用 h-full（height:100%，对定高 scroller 解析）而非 min-h-full。
+// min-h-full 是 height:auto，内容 intrinsic 高经 flex-basis:0 链成为地板 → 卡片缩不回、卡内 overflow-y 失效（高度棘轮）。
+// h-full 让 .container 高与内容解耦、纯视口驱动、双向跟窗；卡 min-height 地板超视口时溢出并入页级 scroller 兜底滚动。
+const HERO_VIEWS = new Set(['connections', 'logs']);
+
 export function MainLayout({
   currentView,
   onViewChange,
@@ -53,8 +58,13 @@ export function MainLayout({
         )}
         {/* 内容区滚动，状态栏固定在卡片底部（flex-none）——全页常驻实心底栏。 */}
         <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto app-region-no-drag">
-          {/* min-h-full + flex-col：hero 页（home/conns/logs）flex-fill 填满至底栏（保 pb-6 等距）；滚动页自然增长。 */}
-          <div className="container mx-auto flex min-h-full max-w-[1400px] flex-col px-6 pb-6">
+          {/* hero 页（conns/logs）用 h-full 断高度棘轮（见上 HERO_VIEWS 注）；其余页 min-h-full 自然增长。
+              home 保 min-h-full：拓扑卡已由 connection-topology 的 [contain:size] 单独定高，不进 hero 集合（最小 blast radius）。 */}
+          <div
+            className={`container mx-auto flex ${
+              HERO_VIEWS.has(currentView) ? 'h-full' : 'min-h-full'
+            } max-w-[1400px] flex-col px-6 pb-6`}
+          >
             {children}
           </div>
         </div>

--- a/src/renderer/conduit.css
+++ b/src/renderer/conduit.css
@@ -1190,9 +1190,7 @@
 
 /* 表卡：flex 列 → 滚动区 flex:1 自身滚动 + 截断脚注常驻底部 */
 .conns-card { flex: 1; min-height: 400px; display: flex; flex-direction: column; overflow: hidden; padding: 0; }
-/* contain:size 断「高度棘轮」：否则表格内容 intrinsic 高经 flex-basis:0 链传进 main-layout .container(min-h-full auto)
-   使卡片长到全内容高、缩窗不回缩、overflow-y 因卡高非 definite 而失效（低行数掩盖，高行数暴露，同拓扑）。 */
-.conns-scroll { flex: 1; overflow-x: auto; overflow-y: auto; contain: size; }
+.conns-scroll { flex: 1; overflow-x: auto; overflow-y: auto; }
 .ctbl { width: 100%; min-width: 1000px; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
 /* 表头：hairline 下衬 · sticky · 排序 active 用 teal(唯一) */
 .ctbl thead th { position: sticky; top: 0; z-index: 2; text-align: left; background: hsl(var(--surface)); color: hsl(var(--fg-faint)); font-size: 10.5px; font-weight: 640; letter-spacing: 0.04em; text-transform: uppercase; white-space: nowrap; padding: 9px 12px; border-bottom: 1px solid hsl(var(--hair)); user-select: none; }
@@ -1316,14 +1314,14 @@
   .ld-diag-act { display: flex; gap: 8px; flex: none; }
 
   /* 实时日志查看器：bar/foot hairline 分区，stream 自身滚动 */
-  .log-viewer { flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden; padding: 0; }
+  /* min-height 地板（对齐 .conns-card 400px 语义）：诊断卡展开+矮窗时 viewer 止步 280px、超出走页级滚动，而非把日志流挤成窄条塌缩。 */
+  .log-viewer { flex: 1; min-height: 280px; display: flex; flex-direction: column; overflow: hidden; padding: 0; }
   .lv-bar { display: flex; align-items: center; gap: 8px; padding: 12px 14px; border-bottom: 1px solid hsl(var(--hair)); }
   .lv-search { position: relative; flex: 1; }
   .lv-search .input { padding-left: 32px; }
   .lv-search-ic { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); width: 15px; height: 15px; color: hsl(var(--fg-faint)); pointer-events: none; }
 
-  /* contain:size 断高度棘轮（同 .conns-scroll）：日志多时否则卡片长到全内容高、缩窗不回缩。 */
-  .lv-stream { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; contain: size; padding: 8px 6px; font-size: 12px; line-height: 1.5; scrollbar-width: thin; }
+  .lv-stream { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: 8px 6px; font-size: 12px; line-height: 1.5; scrollbar-width: thin; }
   .lv-stream:focus-visible { outline: none; box-shadow: inset 0 0 0 2px hsl(var(--ring) / 0.5); }
   .lg { display: grid; grid-template-columns: 104px 58px 1fr; gap: 0 10px; align-items: baseline; padding: 2px 8px; border-radius: 5px; }
   .lg:hover { background: hsl(var(--surface-2) / 0.7); }


### PR DESCRIPTION
## 问题
#273 在 `.conns-scroll`/`.lv-stream` 上加 `contain:size` 引入回归:拖动窗口(高/宽)时内嵌内容(表格/日志行)不再跟随缩放。

## 根因
main-layout 的 `.container` 用 `min-h-full`(`height:auto`),内容 intrinsic 高经 `flex-basis:0` 链上传成为地板 → 卡片缩不回、卡内 `overflow-y` 失效(高度棘轮)。`min-h-0` 救不了它——`.container` 是普通 block 非 flex item。

## 修复(根因位置)
- hero 视图(connections/logs)的 `.container` 改用 `h-full`(`height:100%`,对定高 scroller 解析)→ 卡高与内容解耦、纯视口驱动、**双向跟窗**;卡 `min-height` 地板超视口时溢出并入页级 scroller 兜底滚动。
- `.conns-scroll`/`.lv-stream` 回退 `contain:size`(CSS 复原)。
- home 保持 `min-h-full`(拓扑卡由 `connection-topology` 的 `[contain:size]` 单独定高,最小 blast radius)。
- `.log-viewer` 加 `min-height:280px` 地板(对齐 `.conns-card` 400px 语义):诊断卡展开+矮窗时 viewer 止步 280px、超出走页级滚动,而非把日志流挤成窄条塌缩。

## 验证
真机 macOS arm64 双向拖动:窗口缩放正常、内嵌内容跟随(陈先生真机确认)。tsc + eslint 绿。