### PR TITLE
fix(speedtest): 覆盖感知并发编排,杜绝多入口子集测速静默漏测/错测

### DIFF
--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -53,9 +53,11 @@ export class SpeedTestService {
    */
   private buildOutboundFn?: (server: ServerConfig, tag: string) => Record<string, unknown> | null;
 
-  /** 进行中的测速 Promise：双入口（UI/托盘）并发时复用同一次测速，避免起两个临时 sing-box（端口/资源冲突）。
-   *  第二个调用方等待同一份最终结果（不收流式 onResult，末尾 results 同步覆盖即可）。 */
+  /** 进行中的测速 Promise + 其覆盖的节点 id 集：多入口并发（首页/托盘/页级全部/本组/单节点，各传不同 serverIds
+   *  子集）时按「覆盖」编排——新请求 ⊆ 在飞集 → 复用同一次（零重跑、避免双临时 sing-box 端口冲突）；未覆盖 → 串行链
+   *  在其后（不同分组/单节点/子集先-全量后 各自被完整测到，永不并发双 sing-box、无静默漏测）。 */
   private currentTest: Promise<Map<string, number | null>> | null = null;
+  private currentTestIds: Set<string> | null = null;
 
   constructor(
     logManager: LogManager,
@@ -83,17 +85,33 @@ export class SpeedTestService {
     if (testable.length === 0) {
       return new Map();
     }
-    // 双入口（UI/托盘）并发复用同一次测速，避免起两个临时 sing-box（端口/资源冲突）。
-    // second caller 拿同一份 final results，但其 onResult/onProgress 不触发（流式只由 first caller 驱动）；
-    // 可接受：数据最终正确，且 EVENT_SPEED_TEST_RESULT/PROGRESS 是 IPC broadcast，second caller 的 renderer
-    // 订阅仍能收到 first caller 推的事件（latencyMap/进度照常更新）。
-    if (this.currentTest) return this.currentTest;
-    this.currentTest = this.doTestAllServers(testable, onResult, onProgress, testUrl).finally(
-      () => {
+    // 并发编排（多入口各传不同子集）：按「在飞测速是否覆盖本次请求」决定复用 or 串行。
+    const inFlight = this.currentTest;
+    const inFlightIds = this.currentTestIds;
+    const requestIds = new Set(testable.map((s) => s.id));
+    if (inFlight && inFlightIds && [...requestIds].every((id) => inFlightIds.has(id))) {
+      // 覆盖态（在飞集 ⊇ 本次请求）：复用同一次测速，零重跑。second caller 拿同一份 final results，其 onResult/
+      // onProgress 不驱动（流式只由 first caller），但 EVENT_SPEED_TEST_RESULT/PROGRESS 是 IPC broadcast，
+      // 本 caller 的 renderer 仍收得到（latencyMap/进度照常更新）。
+      return inFlight;
+    }
+    // 未覆盖（不同分组 / 单节点先-全量后 / 子集先-全量后）：串行链在在飞测速之后跑——永不并发双临时 sing-box
+    // （端口/资源冲突），且本次请求的节点集用**自身** set 完整测到（杜绝旧「无条件复用」导致的静默漏测/错测）。
+    const run = inFlight
+      ? inFlight
+          .catch(() => {}) // 吞前一次异常，仅为串行不断链（本次独立、不受前次成败影响）
+          .then(() => this.doTestAllServers(testable, onResult, onProgress, testUrl))
+      : this.doTestAllServers(testable, onResult, onProgress, testUrl);
+    this.currentTest = run;
+    this.currentTestIds = requestIds;
+    void run.finally(() => {
+      // 仅当仍是最新一次（其后无更晚的串行链接）才清空，避免清掉排队中的下一次。
+      if (this.currentTest === run) {
         this.currentTest = null;
+        this.currentTestIds = null;
       }
-    );
-    return this.currentTest;
+    });
+    return run;
   }
 
   private async doTestAllServers(

--- a/src/main/services/__tests__/speed-test-coalesce.test.ts
+++ b/src/main/services/__tests__/speed-test-coalesce.test.ts
@@ -1,0 +1,109 @@
+/**
+ * SpeedTestService.testAllServers 覆盖感知并发编排单测（纯逻辑，doTestAllServers 打桩，无网络/无 sing-box）。
+ * 多入口并发（首页/托盘/页级全部/本组/单节点各传不同 serverIds 子集）：
+ *   覆盖态（在飞集 ⊇ 请求）→ 复用同一次、零重跑；未覆盖 → 串行链在其后、各自用自身 set 完整测到（杜绝静默漏测/错测）。
+ */
+import { SpeedTestService } from '../SpeedTestService';
+
+const mockLog = { addLog: () => {} } as unknown as ConstructorParameters<
+  typeof SpeedTestService
+>[0];
+const srv = (id: string) => ({ id, protocol: 'vmess', address: '1.2.3.4', port: 1 }) as never;
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeSvc() {
+  const svc = new SpeedTestService(mockLog);
+  const calls: string[][] = [];
+  const deferreds: Array<(m: Map<string, number | null>) => void> = [];
+  // 打桩私有 doTestAllServers：记录每次实际测的 id 集 + 交出 resolve 手柄以精确编排时序。
+  (svc as unknown as { doTestAllServers: unknown }).doTestAllServers = (
+    servers: Array<{ id: string }>
+  ) => {
+    calls.push(servers.map((s) => s.id));
+    return new Promise<Map<string, number | null>>((resolve) => deferreds.push(resolve));
+  };
+  return { svc, calls, deferreds };
+}
+
+describe('SpeedTestService.testAllServers 覆盖感知并发编排', () => {
+  it('覆盖态复用：子集请求撞全量在飞 → 只跑一次，两者拿同一份结果', async () => {
+    const { svc, calls, deferreds } = makeSvc();
+    const pAll = svc.testAllServers([srv('a'), srv('b'), srv('c')]);
+    const pSub = svc.testAllServers([srv('b')]); // b ⊆ {a,b,c}
+    expect(calls.length).toBe(1); // 复用，未起第二次临时 sing-box
+    deferreds[0](
+      new Map([
+        ['a', 10],
+        ['b', 20],
+        ['c', 30],
+      ])
+    );
+    const all = await pAll;
+    const sub = await pSub;
+    expect(all).toEqual(
+      new Map([
+        ['a', 10],
+        ['b', 20],
+        ['c', 30],
+      ])
+    );
+    expect(sub).toBe(all); // 同一份 Map 引用
+  });
+
+  it('未覆盖串行：不同分组连续 → 串行两跑，B 用自身 set、拿自身结果（非 A 的）', async () => {
+    const { svc, calls, deferreds } = makeSvc();
+    const pA = svc.testAllServers([srv('a1'), srv('a2')]);
+    const pB = svc.testAllServers([srv('b1')]); // b1 ⊄ {a1,a2}
+    expect(calls.length).toBe(1); // B 排队，A 独占（不并发双 sing-box）
+    deferreds[0](
+      new Map([
+        ['a1', 10],
+        ['a2', 20],
+      ])
+    );
+    await pA;
+    await flush(); // 串行链推进到 B
+    expect(calls.length).toBe(2); // A 完 → B 起
+    expect(calls[1]).toEqual(['b1']); // B 用自身 set（非复用 A 的 {a1,a2}）
+    deferreds[1](new Map([['b1', 30]]));
+    expect(await pB).toEqual(new Map([['b1', 30]])); // B 拿自身结果，杜绝旧「无条件复用→拿 A 结果」错测
+  });
+
+  it('子集先-全量后：串行，全量测自身全集（旧实现只会拿到 {a}、静默漏测 b/c）', async () => {
+    const { svc, calls, deferreds } = makeSvc();
+    const pSub = svc.testAllServers([srv('a')]);
+    const pAll = svc.testAllServers([srv('a'), srv('b'), srv('c')]); // ⊄ {a}
+    expect(calls.length).toBe(1);
+    deferreds[0](new Map([['a', 10]]));
+    await pSub;
+    await flush();
+    expect(calls.length).toBe(2);
+    expect(calls[1].slice().sort()).toEqual(['a', 'b', 'c']); // 全量测全集，非只 a
+    deferreds[1](
+      new Map([
+        ['a', 11],
+        ['b', 20],
+        ['c', 30],
+      ])
+    );
+    expect(await pAll).toEqual(
+      new Map([
+        ['a', 11],
+        ['b', 20],
+        ['c', 30],
+      ])
+    );
+  });
+
+  it('串行链结束后归零：可再次立即发起全新测速（非排队）', async () => {
+    const { svc, calls, deferreds } = makeSvc();
+    const p1 = svc.testAllServers([srv('a')]);
+    deferreds[0](new Map([['a', 10]]));
+    await p1;
+    await flush();
+    const p2 = svc.testAllServers([srv('a')]); // 无在飞 → 立即跑
+    expect(calls.length).toBe(2);
+    deferreds[1](new Map([['a', 12]]));
+    expect(await p2).toEqual(new Map([['a', 12]]));
+  });
+});

--- a/src/renderer/components/home/connection-control-card.tsx
+++ b/src/renderer/components/home/connection-control-card.tsx
@@ -127,8 +127,8 @@ export function ConnectionControlCard() {
   const selectedServer = servers.find((s) => s.id === selectedServerId);
   const isDirect = isDirectSelection(selectedServerId);
 
-  // 就地全量测速（复用服务器页 hook：isSpeedTestable 过滤 + 三态 + toast，结果经全局 latencyMap 回流下拉）。
-  const { isTestingSpeed, speedProgress, handleSpeedTest } = useSpeedTest(servers);
+  // 就地全量测速（复用服务器页 hook：isSpeedTestable 过滤 + 聚合 toast，结果经全局 latencyMap 回流下拉）。
+  const { isTestingSpeed, handleSpeedTest } = useSpeedTest(servers);
 
   // config 是接管方式持久化真值；优先它，避免启动时 connectionStatus 未刷新而默认 systemProxy 盖掉已存的 tun。
   const proxyModeType = config?.proxyModeType || connectionStatus?.proxyModeType || 'systemProxy';
@@ -288,10 +288,7 @@ export function ConnectionControlCard() {
         ? startDisabledReason || t('home.startProxy')
         : t('home.startProxy');
 
-  const speedTitle =
-    isTestingSpeed && speedProgress
-      ? `${speedProgress.tested}/${speedProgress.total}`
-      : t('servers.speedTestGroup');
+  const speedTitle = isTestingSpeed ? t('servers.speedTesting') : t('servers.speedTestGroup');
 
   const isEmptyState = servers.length === 0 && !isDirect;
 

--- a/src/renderer/components/settings/__tests__/speed-test-toast.test.ts
+++ b/src/renderer/components/settings/__tests__/speed-test-toast.test.ts
@@ -1,0 +1,77 @@
+/**
+ * 聚合测速 toast 协调器单测（纯逻辑，mock sonner）：多入口/多组并发测速收敛为单个 toast——
+ * 引用计数首个→loading、仍在跑显剩余组数、全部结束一次 success/error、批次间失败态隔离。
+ */
+jest.mock('sonner', () => ({
+  toast: { loading: jest.fn(), success: jest.fn(), error: jest.fn() },
+}));
+import { toast } from 'sonner';
+import {
+  beginAggSpeedTest,
+  endAggSpeedTest,
+  __resetAggSpeedTestForTest,
+} from '../speed-test-toast';
+
+const labels = {
+  start: 'START',
+  running: (n: number) => `RUN:${n}`,
+  done: 'DONE',
+  fail: 'FAIL',
+};
+const ID = { id: 'speedtest-aggregate' };
+
+beforeEach(() => {
+  __resetAggSpeedTestForTest();
+  (toast.loading as jest.Mock).mockClear();
+  (toast.success as jest.Mock).mockClear();
+  (toast.error as jest.Mock).mockClear();
+});
+
+describe('聚合测速 toast 协调器', () => {
+  it('单组：begin→loading(start)，end→success(done)，同一固定 id', () => {
+    beginAggSpeedTest(labels);
+    expect(toast.loading).toHaveBeenCalledWith('START', ID);
+    endAggSpeedTest(false);
+    expect(toast.success).toHaveBeenCalledWith('DONE', ID);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('多组并发：第二个 begin 显剩余组数、只一个 toast，全部结束才 success', () => {
+    beginAggSpeedTest(labels); // active 1
+    beginAggSpeedTest(labels); // active 2
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:2', ID);
+    endAggSpeedTest(false); // active 1 → 仍 loading（剩余组数）
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:1', ID);
+    expect(toast.success).not.toHaveBeenCalled();
+    endAggSpeedTest(false); // active 0 → success（仅一次）
+    expect(toast.success).toHaveBeenCalledWith('DONE', ID);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('任一失败：归零弹 error（带描述），不弹 success', () => {
+    beginAggSpeedTest(labels);
+    beginAggSpeedTest(labels);
+    endAggSpeedTest(true, 'boom'); // 记本批失败
+    endAggSpeedTest(false); // 归零
+    expect(toast.error).toHaveBeenCalledWith('FAIL', {
+      id: 'speedtest-aggregate',
+      description: 'boom',
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('批次隔离：上批失败不污染下批', () => {
+    beginAggSpeedTest(labels);
+    endAggSpeedTest(true, 'e1'); // 批1 失败
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    beginAggSpeedTest(labels); // 批2
+    endAggSpeedTest(false); // 批2 成功
+    expect(toast.success).toHaveBeenCalledWith('DONE', ID);
+  });
+
+  it('end 多于 begin：计数不为负、无 labels 时 no-op（不误弹）', () => {
+    endAggSpeedTest(false); // 无在飞、labels 已复位 → no-op
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/settings/__tests__/speed-test-toast.test.ts
+++ b/src/renderer/components/settings/__tests__/speed-test-toast.test.ts
@@ -1,10 +1,24 @@
 /**
- * 聚合测速 toast 协调器单测（纯逻辑，mock sonner）：多入口/多组并发测速收敛为单个 toast——
- * 引用计数首个→loading、仍在跑显剩余组数、全部结束一次 success/error、批次间失败态隔离。
+ * 聚合测速 toast 协调器单测（纯逻辑，mock sonner + api.onSpeedTestResult）：多入口/多组并发测速收敛为单个 toast——
+ * 去重并集节点进度（union 去重、result serverId 去重）、全部结束一次 success/error、批次间隔离、归零退订。
  */
 jest.mock('sonner', () => ({
   toast: { loading: jest.fn(), success: jest.fn(), error: jest.fn() },
 }));
+
+let resultCb: ((d: { serverId: string; latency: number }) => void) | null = null;
+const unsubResult = jest.fn();
+jest.mock('../../../ipc/api-client', () => ({
+  api: {
+    server: {
+      onSpeedTestResult: (cb: (d: { serverId: string; latency: number }) => void) => {
+        resultCb = cb;
+        return unsubResult;
+      },
+    },
+  },
+}));
+
 import { toast } from 'sonner';
 import {
   beginAggSpeedTest,
@@ -13,46 +27,70 @@ import {
 } from '../speed-test-toast';
 
 const labels = {
-  start: 'START',
-  running: (n: number) => `RUN:${n}`,
+  running: (tested: number, total: number) => `RUN:${tested}/${total}`,
   done: 'DONE',
   fail: 'FAIL',
 };
 const ID = { id: 'speedtest-aggregate' };
+const result = (serverId: string) => resultCb?.({ serverId, latency: 10 });
 
 beforeEach(() => {
   __resetAggSpeedTestForTest();
+  resultCb = null;
+  unsubResult.mockClear();
   (toast.loading as jest.Mock).mockClear();
   (toast.success as jest.Mock).mockClear();
   (toast.error as jest.Mock).mockClear();
 });
 
-describe('聚合测速 toast 协调器', () => {
-  it('单组：begin→loading(start)，end→success(done)，同一固定 id', () => {
-    beginAggSpeedTest(labels);
-    expect(toast.loading).toHaveBeenCalledWith('START', ID);
+describe('聚合测速 toast 协调器（去重并集节点进度）', () => {
+  it('单次：begin(3 节点)→loading 0/3，每 result 递增，end→success + 退订', () => {
+    beginAggSpeedTest(['a', 'b', 'c'], labels);
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:0/3', ID);
+    result('a');
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:1/3', ID);
+    result('b');
+    result('c');
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:3/3', ID);
     endAggSpeedTest(false);
     expect(toast.success).toHaveBeenCalledWith('DONE', ID);
-    expect(toast.error).not.toHaveBeenCalled();
+    expect(unsubResult).toHaveBeenCalledTimes(1);
   });
 
-  it('多组并发：第二个 begin 显剩余组数、只一个 toast，全部结束才 success', () => {
-    beginAggSpeedTest(labels); // active 1
-    beginAggSpeedTest(labels); // active 2
-    expect(toast.loading).toHaveBeenLastCalledWith('RUN:2', ID);
-    endAggSpeedTest(false); // active 1 → 仍 loading（剩余组数）
-    expect(toast.loading).toHaveBeenLastCalledWith('RUN:1', ID);
+  it('并集去重：本组[a,b,c] + 单节点[b] → total=3（b 不重复），同 serverId 二测不重复计', () => {
+    beginAggSpeedTest(['a', 'b', 'c'], labels);
+    beginAggSpeedTest(['b'], labels); // b ⊆ 已有 → 并集仍 3
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:0/3', ID);
+    result('a');
+    result('b');
+    result('b'); // b 二测：tested 去重仍 2
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:2/3', ID);
+    endAggSpeedTest(false); // active 2→1，仍 loading
     expect(toast.success).not.toHaveBeenCalled();
-    endAggSpeedTest(false); // active 0 → success（仅一次）
+    result('c');
+    endAggSpeedTest(false); // active 0 → success
     expect(toast.success).toHaveBeenCalledWith('DONE', ID);
-    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('本组A + 全部：并集=全部总数（A 被吞），非 2+4', () => {
+    beginAggSpeedTest(['a', 'b'], labels); // 本组 A(2)
+    beginAggSpeedTest(['a', 'b', 'c', 'd'], labels); // 全部(4，含 A)
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:0/4', ID);
+    result('a');
+    result('b');
+    result('c');
+    result('d');
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:4/4', ID);
+    endAggSpeedTest(false);
+    endAggSpeedTest(false);
+    expect(toast.success).toHaveBeenCalledWith('DONE', ID);
   });
 
   it('任一失败：归零弹 error（带描述），不弹 success', () => {
-    beginAggSpeedTest(labels);
-    beginAggSpeedTest(labels);
-    endAggSpeedTest(true, 'boom'); // 记本批失败
-    endAggSpeedTest(false); // 归零
+    beginAggSpeedTest(['a'], labels);
+    beginAggSpeedTest(['b'], labels);
+    endAggSpeedTest(true, 'boom');
+    endAggSpeedTest(false);
     expect(toast.error).toHaveBeenCalledWith('FAIL', {
       id: 'speedtest-aggregate',
       description: 'boom',
@@ -60,18 +98,16 @@ describe('聚合测速 toast 协调器', () => {
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  it('批次隔离：上批失败不污染下批', () => {
-    beginAggSpeedTest(labels);
-    endAggSpeedTest(true, 'e1'); // 批1 失败
+  it('批次隔离 + 复位：上批失败/已测不污染下批，归零退订', () => {
+    beginAggSpeedTest(['a', 'b'], labels);
+    result('a');
+    endAggSpeedTest(true, 'e1'); // 批1 归零（失败）
     expect(toast.error).toHaveBeenCalledTimes(1);
-    beginAggSpeedTest(labels); // 批2
-    endAggSpeedTest(false); // 批2 成功
-    expect(toast.success).toHaveBeenCalledWith('DONE', ID);
-  });
-
-  it('end 多于 begin：计数不为负、无 labels 时 no-op（不误弹）', () => {
-    endAggSpeedTest(false); // 无在飞、labels 已复位 → no-op
-    expect(toast.success).not.toHaveBeenCalled();
-    expect(toast.error).not.toHaveBeenCalled();
+    expect(unsubResult).toHaveBeenCalledTimes(1);
+    beginAggSpeedTest(['x'], labels); // 批2：union/tested/anyFailed 全复位
+    expect(toast.loading).toHaveBeenLastCalledWith('RUN:0/1', ID); // total=1（非承接批1的 2）
+    result('x');
+    endAggSpeedTest(false);
+    expect(toast.success).toHaveBeenCalledWith('DONE', ID); // 批2 成功，不受批1失败污染
   });
 });

--- a/src/renderer/components/settings/server-list-helpers.ts
+++ b/src/renderer/components/settings/server-list-helpers.ts
@@ -67,7 +67,7 @@ export const getCountryCode = (name: string): string | null => {
   // russia 含 us、berlin 含 in、montreal 含 tr、sweden 含 de、madrid 含 id 等；
   // 同时兼容 "US01" / "HK-02" 等写法。中文名/城市/旗帜 emoji 足够独特，仍按子串匹配。
   if (/香港|🇭🇰|hong kong|(?<![a-z])hk(?![a-z])/.test(lowerName)) return 'hk';
-  if (/台湾|🇹🇼|台北|新北|(?<![a-z])(?:tw|taiwan)(?![a-z])/.test(lowerName)) return 'cn';
+  if (/台湾|🇹🇼|台北|新北|(?<![a-z])(?:tw|taiwan)(?![a-z])/.test(lowerName)) return 'tw';
   if (/日本|🇯🇵|东京|大阪|(?<![a-z])(?:jp|japan)(?![a-z])/.test(lowerName)) return 'jp';
   if (/新加坡|🇸🇬|狮城|(?<![a-z])(?:sg|singapore)(?![a-z])/.test(lowerName)) return 'sg';
   if (/美国|🇺🇸|洛杉矶|硅谷|西雅图|(?<![a-z])(?:us|usa|america)(?![a-z])/.test(lowerName))

--- a/src/renderer/components/settings/server-list.tsx
+++ b/src/renderer/components/settings/server-list.tsx
@@ -83,13 +83,8 @@ export function ServerList({
   const { t } = useTranslation();
 
   // 测速态 + handler（hook 下沉，纯逻辑）
-  const {
-    isTestingSpeed,
-    speedProgress,
-    testingServerIds,
-    handleSpeedTest,
-    handleSingleSpeedTest,
-  } = useSpeedTest(servers);
+  const { isTestingSpeed, testingServerIds, handleSpeedTest, handleSingleSpeedTest } =
+    useSpeedTest(servers);
 
   // 搜索 / 过滤 / 排序态 + 派生列表（hook 下沉，纯逻辑）
   const {
@@ -390,11 +385,7 @@ export function ServerList({
           disabled={isTestingSpeed}
         >
           <Zap className={isTestingSpeed ? 'animate-pulse fill-current/20' : ''} />
-          {isTestingSpeed
-            ? speedProgress
-              ? `${t('servers.speedTesting')} ${speedProgress.tested}/${speedProgress.total}`
-              : t('servers.speedTesting')
-            : t('servers.speedTestGroup')}
+          {isTestingSpeed ? t('servers.speedTesting') : t('servers.speedTestGroup')}
         </button>
 
         {/* 多选 */}

--- a/src/renderer/components/settings/speed-test-toast.ts
+++ b/src/renderer/components/settings/speed-test-toast.ts
@@ -1,0 +1,70 @@
+/**
+ * 聚合测速 toast 协调器（跨 useSpeedTest 实例共享的模块级单例）。
+ *
+ * 动机：多入口/多组并发测速（首页全部 / 页级全部 / 各组本组 / 快速连点不同分组）时，若每次 handleSpeedTest 各自
+ * 弹独立 loading→success toast，会堆叠出 N 个「开始测速」+ N 个「测速完成」。此处用**引用计数 + 固定 toast id**
+ * 收敛为一个 toast：首个开始弹 loading，仍有在跑则更新剩余组数文案，全部结束再弹一次 success/error。
+ *
+ * 保留「排队多组」能力（不走禁用全部按钮的捷径）：并发/排队的每组测速都各自 begin/end，聚合 toast 反映总体进度。
+ * 纯逻辑、不依赖 i18n（文案由调用方传入），便于单测。
+ */
+import { toast } from 'sonner';
+
+const TOAST_ID = 'speedtest-aggregate';
+
+/** 聚合 toast 文案（调用方按当前语言解析后传入；running 依剩余组数动态生成）。 */
+export interface AggSpeedToastLabels {
+  /** 仅一组在跑：开始测速。 */
+  start: string;
+  /** 多组并发/排队：n 组测速中。 */
+  running: (n: number) => string;
+  /** 全部结束、无失败：测速完成。 */
+  done: string;
+  /** 全部结束、有失败：测速失败。 */
+  fail: string;
+}
+
+// 模块级共享态：active=在跑+排队的测速次数；anyFailed/lastError 累计本批失败信息（active 归零时消费）。
+let active = 0;
+let anyFailed = false;
+let lastError: string | undefined;
+let labels: AggSpeedToastLabels | null = null;
+
+/** 一次测速开始：引用计数++，首个弹 loading，多组则更新剩余组数文案。 */
+export function beginAggSpeedTest(l: AggSpeedToastLabels): void {
+  labels = l;
+  if (active === 0) {
+    // 新一批：清空上一批的失败累计。
+    anyFailed = false;
+    lastError = undefined;
+  }
+  active += 1;
+  toast.loading(active > 1 ? l.running(active) : l.start, { id: TOAST_ID });
+}
+
+/** 一次测速结束：引用计数--，归零则按 anyFailed 弹一次 success/error；否则更新剩余组数、保持 loading。 */
+export function endAggSpeedTest(failed: boolean, error?: string): void {
+  if (failed) {
+    anyFailed = true;
+    lastError = error ?? lastError;
+  }
+  active = Math.max(0, active - 1);
+  const l = labels;
+  if (!l) return;
+  if (active === 0) {
+    if (anyFailed) toast.error(l.fail, { id: TOAST_ID, description: lastError });
+    else toast.success(l.done, { id: TOAST_ID });
+    labels = null;
+  } else {
+    // 仍有在跑/排队：保持同一 toast、更新剩余组数（保留排队可见性）。
+    toast.loading(l.running(active), { id: TOAST_ID });
+  }
+}
+
+/** 仅供单测复位模块级态（生产不用）。 */
+export function __resetAggSpeedTestForTest(): void {
+  active = 0;
+  anyFailed = false;
+  lastError = undefined;
+  labels = null;
+}

--- a/src/renderer/components/settings/speed-test-toast.ts
+++ b/src/renderer/components/settings/speed-test-toast.ts
@@ -1,64 +1,84 @@
 /**
  * 聚合测速 toast 协调器（跨 useSpeedTest 实例共享的模块级单例）。
  *
- * 动机：多入口/多组并发测速（首页全部 / 页级全部 / 各组本组 / 快速连点不同分组）时，若每次 handleSpeedTest 各自
- * 弹独立 loading→success toast，会堆叠出 N 个「开始测速」+ N 个「测速完成」。此处用**引用计数 + 固定 toast id**
- * 收敛为一个 toast：首个开始弹 loading，仍有在跑则更新剩余组数文案，全部结束再弹一次 success/error。
+ * 动机：多入口/多组并发测速（首页全部 / 页级全部 / 各组本组 / 单节点⚡ / 快速连点）时，若每次各自弹独立
+ * loading→success toast 会堆叠。此处用**引用计数 + 固定 toast id + 去重并集节点进度**收敛为一个 toast：
+ * 首个开始订阅 per-node result 事件，以「已测唯一节点 / 全部请求节点并集」显进度，全部结束再弹一次 success/error。
  *
- * 保留「排队多组」能力（不走禁用全部按钮的捷径）：并发/排队的每组测速都各自 begin/end，聚合 toast 反映总体进度。
- * 纯逻辑、不依赖 i18n（文案由调用方传入），便于单测。
+ * 去重并集：各次测速的 serverIds 并入 union（重叠/子集不重复计——如「本组 A 再点全部」并集=全部；coalesce B⊆A
+ * 并集=A）；已测节点按 result 事件 serverId 入 Set 去重（节点被二测不重复计）。天然处理 本组×本组 / 本组×全部 /
+ * coalesce / 托盘并发。保留排队多组能力（不禁按钮），纯以 toast 反映总体进度。
  */
 import { toast } from 'sonner';
+// 相对路径（非 @/ 别名）：jest 无 @/ moduleNameMapper，别名会致本模块单测无法解析/mock。
+import { api } from '../../ipc/api-client';
 
 const TOAST_ID = 'speedtest-aggregate';
 
-/** 聚合 toast 文案（调用方按当前语言解析后传入；running 依剩余组数动态生成）。 */
+/** 聚合 toast 文案（调用方按当前语言解析后传入；running 依已测/并集节点数动态生成）。 */
 export interface AggSpeedToastLabels {
-  /** 仅一组在跑：开始测速。 */
-  start: string;
-  /** 多组并发/排队：n 组测速中。 */
-  running: (n: number) => string;
-  /** 全部结束、无失败：测速完成。 */
+  /** 进行中：已测 tested / 并集 total 节点。 */
+  running: (tested: number, total: number) => string;
+  /** 全部结束、无失败。 */
   done: string;
-  /** 全部结束、有失败：测速失败。 */
+  /** 全部结束、有失败。 */
   fail: string;
 }
 
-// 模块级共享态：active=在跑+排队的测速次数；anyFailed/lastError 累计本批失败信息（active 归零时消费）。
+// 模块级共享态：active=在跑+排队的测速次数；union=全部请求节点并集（去重）；tested=已测唯一节点（result 去重）。
 let active = 0;
 let anyFailed = false;
 let lastError: string | undefined;
 let labels: AggSpeedToastLabels | null = null;
+const union = new Set<string>();
+const tested = new Set<string>();
+let unsubResult: (() => void) | null = null;
 
-/** 一次测速开始：引用计数++，首个弹 loading，多组则更新剩余组数文案。 */
-export function beginAggSpeedTest(l: AggSpeedToastLabels): void {
-  labels = l;
-  if (active === 0) {
-    // 新一批：清空上一批的失败累计。
-    anyFailed = false;
-    lastError = undefined;
-  }
-  active += 1;
-  toast.loading(active > 1 ? l.running(active) : l.start, { id: TOAST_ID });
+function render(): void {
+  if (!labels || active === 0) return;
+  toast.loading(labels.running(tested.size, union.size), { id: TOAST_ID });
 }
 
-/** 一次测速结束：引用计数--，归零则按 anyFailed 弹一次 success/error；否则更新剩余组数、保持 loading。 */
+/** 一次测速开始：serverIds 并入 union、引用计数++；首个订阅 per-node result 事件累计已测唯一节点。 */
+export function beginAggSpeedTest(serverIds: string[], l: AggSpeedToastLabels): void {
+  labels = l;
+  if (active === 0) {
+    anyFailed = false;
+    lastError = undefined;
+    union.clear();
+    tested.clear();
+    // 首个测速：订阅 result 事件（每测完一个节点回 serverId），去重累计已测唯一节点。
+    unsubResult = api.server.onSpeedTestResult(({ serverId }) => {
+      tested.add(serverId);
+      render();
+    });
+  }
+  active += 1;
+  for (const id of serverIds) union.add(id);
+  render();
+}
+
+/** 一次测速结束：引用计数--；归零则一次 success/error + 复位并退订，否则更新进度、保持 loading。 */
 export function endAggSpeedTest(failed: boolean, error?: string): void {
   if (failed) {
     anyFailed = true;
     lastError = error ?? lastError;
   }
   active = Math.max(0, active - 1);
-  const l = labels;
-  if (!l) return;
-  if (active === 0) {
-    if (anyFailed) toast.error(l.fail, { id: TOAST_ID, description: lastError });
-    else toast.success(l.done, { id: TOAST_ID });
-    labels = null;
-  } else {
-    // 仍有在跑/排队：保持同一 toast、更新剩余组数（保留排队可见性）。
-    toast.loading(l.running(active), { id: TOAST_ID });
+  if (active > 0) {
+    render();
+    return;
   }
+  // 全部结束：一次 success/error + 复位 + 退订。
+  if (labels) {
+    if (anyFailed) toast.error(labels.fail, { id: TOAST_ID, description: lastError });
+    else toast.success(labels.done, { id: TOAST_ID });
+  }
+  labels = null;
+  union.clear();
+  tested.clear();
+  unsubResult?.();
+  unsubResult = null;
 }
 
 /** 仅供单测复位模块级态（生产不用）。 */
@@ -67,4 +87,8 @@ export function __resetAggSpeedTestForTest(): void {
   anyFailed = false;
   lastError = undefined;
   labels = null;
+  union.clear();
+  tested.clear();
+  unsubResult?.();
+  unsubResult = null;
 }

--- a/src/renderer/components/settings/use-speed-test.ts
+++ b/src/renderer/components/settings/use-speed-test.ts
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { api } from '@/ipc/api-client';
 import { useAppStore } from '@/store/app-store';
 import { isSpeedTestable } from '../../../shared/endpoint-routes';
+import { beginAggSpeedTest, endAggSpeedTest } from './speed-test-toast';
 import type { ServerConfigWithId } from './server-list-helpers';
 
 export function useSpeedTest(servers: ServerConfigWithId[]) {
@@ -37,19 +38,23 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
     const unsubscribeProgress = api.server.onSpeedTestProgress(({ tested, ok, total }) => {
       setSpeedProgress({ tested, ok, total });
     });
-    // 进度 toast 捕获 id：完成/失败原地替换「开始测速」（声明在 try 外供 catch 引用）。
-    const speedToastId = toast.loading(t('servers.speedTestStart'));
+    // 聚合 toast（跨入口/多组并发只弹一个：首个开始→loading、仍有在跑显剩余组数、全部结束→success/error 一次，
+    // 不堆叠；保留排队多组能力，见 speed-test-toast）。
+    beginAggSpeedTest({
+      start: t('servers.speedTestStart'),
+      running: (n) =>
+        t('servers.speedTestingCount', { count: n, defaultValue: '测速中 · {{count}} 组' }),
+      done: t('servers.speedTestDone'),
+      fail: t('servers.speedTestFail'),
+    });
     try {
       const results = await api.server.speedTest(serverIdsToTest);
       // 末尾兜底同步（确保最终结果一致，兜底事件丢失）；函数式合并保留未测节点的历史延迟。
       applyLatencyResults(results);
-      toast.success(t('servers.speedTestDone'), { id: speedToastId });
+      endAggSpeedTest(false);
       // 不再自动排序（保留用户排序偏好，测速只更新延迟值）
     } catch (error) {
-      toast.error(t('servers.speedTestFail'), {
-        id: speedToastId,
-        description: error instanceof Error ? error.message : String(error),
-      });
+      endAggSpeedTest(true, error instanceof Error ? error.message : String(error));
     } finally {
       unsubscribeProgress();
       setIsTestingSpeed(false);

--- a/src/renderer/components/settings/use-speed-test.ts
+++ b/src/renderer/components/settings/use-speed-test.ts
@@ -1,8 +1,7 @@
 /**
  * 节点测速 hook —— 从 server-list.tsx 下沉（审计 §1 Tier-1，纯逻辑零 JSX）。
- * 封 isTestingSpeed/speedProgress/testingServerIds 三态 + 全量/单节点两个 handler。
- * 测速事件订阅在 handleSpeedTest 内声明（try 外），catch/finally 路径均 unsubscribe（防 listener 泄漏，
- * 与原 god-component 行为逐字一致——无独立 useEffect 生命周期，订阅随 handler 起止）。
+ * 封 isTestingSpeed/testingServerIds 两态 + 全量/单节点两个 handler。进度/结果 toast 移交
+ * speed-test-toast 聚合协调器（跨入口/多组去重并集节点进度、单一 toast），按钮仅显「测速中」二态。
  */
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -17,12 +16,19 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
   const applyLatencyResults = useAppStore((state) => state.applyLatencyResults);
   const { t } = useTranslation();
   const [isTestingSpeed, setIsTestingSpeed] = useState(false);
-  const [speedProgress, setSpeedProgress] = useState<{
-    tested: number;
-    ok: number;
-    total: number;
-  } | null>(null);
   const [testingServerIds, setTestingServerIds] = useState<Set<string>>(new Set());
+
+  // 聚合 toast 文案（进度由 speed-test-toast 协调器按已测/并集节点数动态渲染）。
+  const aggLabels = {
+    running: (tested: number, total: number) =>
+      t('servers.speedTestingNodes', {
+        tested,
+        total,
+        defaultValue: '测速中 · {{tested}}/{{total}} 节点',
+      }),
+    done: t('servers.speedTestDone'),
+    fail: t('servers.speedTestFail'),
+  };
 
   const handleSpeedTest = async () => {
     // 排除不可测节点（Tailscale / 自定义 endpoint / reverseMesh）：与 ⚡ 禁用、后端 null 分支同口径
@@ -33,20 +39,8 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
       return;
     }
     setIsTestingSpeed(true);
-    // per-node 结果监听已上移到 use-native-events 顶层持久 hook（托盘/UI 两入口共用，写全局 latencyMap，跨页不丢）；
-    // 此处仅订阅进度（页面局部进度条）+ 末尾兜底同步。订阅声明在 try 外，确保 catch/finally 都能 unsubscribe。
-    const unsubscribeProgress = api.server.onSpeedTestProgress(({ tested, ok, total }) => {
-      setSpeedProgress({ tested, ok, total });
-    });
-    // 聚合 toast（跨入口/多组并发只弹一个：首个开始→loading、仍有在跑显剩余组数、全部结束→success/error 一次，
-    // 不堆叠；保留排队多组能力，见 speed-test-toast）。
-    beginAggSpeedTest({
-      start: t('servers.speedTestStart'),
-      running: (n) =>
-        t('servers.speedTestingCount', { count: n, defaultValue: '测速中 · {{count}} 组' }),
-      done: t('servers.speedTestDone'),
-      fail: t('servers.speedTestFail'),
-    });
+    // 进度/结果移交聚合 toast 协调器（订 result 事件、去重并集节点进度）；按钮仅「测速中」，不再各自弹 toast。
+    beginAggSpeedTest(serverIdsToTest, aggLabels);
     try {
       const results = await api.server.speedTest(serverIdsToTest);
       // 末尾兜底同步（确保最终结果一致，兜底事件丢失）；函数式合并保留未测节点的历史延迟。
@@ -56,9 +50,7 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
     } catch (error) {
       endAggSpeedTest(true, error instanceof Error ? error.message : String(error));
     } finally {
-      unsubscribeProgress();
       setIsTestingSpeed(false);
-      setSpeedProgress(null);
     }
   };
 
@@ -69,19 +61,15 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
       s.add(serverId);
       return s;
     });
+    // 单节点也并入聚合 toast（连点多个节点不堆叠终端 toast）；行内 spinner 仍由 testingServerIds 驱动。
+    beginAggSpeedTest([serverId], aggLabels);
     try {
       const results = await api.server.speedTest([serverId]);
-
       // Update only this specific node's latency in the store（函数式合并，避免 stale 覆盖）
       applyLatencyResults(results);
-
-      if (results[serverId] !== undefined) {
-        toast.success(t('servers.speedTestDone'));
-      }
+      endAggSpeedTest(false);
     } catch (error) {
-      toast.error(t('servers.speedTestFail'), {
-        description: error instanceof Error ? error.message : String(error),
-      });
+      endAggSpeedTest(true, error instanceof Error ? error.message : String(error));
     } finally {
       setTestingServerIds((prev) => {
         const s = new Set(prev);
@@ -93,7 +81,6 @@ export function useSpeedTest(servers: ServerConfigWithId[]) {
 
   return {
     isTestingSpeed,
-    speedProgress,
     testingServerIds,
     handleSpeedTest,
     handleSingleSpeedTest,

--- a/src/renderer/conduit.css
+++ b/src/renderer/conduit.css
@@ -342,7 +342,8 @@
   .nd-card.pick { border-color: hsl(var(--flow) / 0.5); background: hsl(var(--flow-weak) / 0.55); }
 
   /* 国旗水印（淡） */
-  .nd-flag { position: absolute; right: -8px; top: -12px; font-size: 66px; line-height: 1;
+  /* 国旗水印置右下角：避让首行右侧的 SpeedBadge 延迟徽标（原右上重叠遮挡测速结果，用户反馈）。 */
+  .nd-flag { position: absolute; right: -8px; bottom: -12px; font-size: 66px; line-height: 1;
     opacity: 0.08; filter: grayscale(0.15); pointer-events: none; user-select: none; }
   .dark .nd-flag { opacity: 0.11; }
 

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -1150,7 +1150,8 @@
     "meshTsManageSub": "Settings · Log out / Switch account",
     "meshTsKeyReadySub": "Settings · Delete",
     "meshTsAddSub": "Interactive login / AuthKey",
-    "meshTsEntryTitle": "Tailscale mesh access and account management"
+    "meshTsEntryTitle": "Tailscale mesh access and account management",
+    "speedTestingCount": "Testing · {{count}} groups"
   },
   "rules": {
     "ruleColumn": "Rule",

--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -1151,7 +1151,7 @@
     "meshTsKeyReadySub": "Settings · Delete",
     "meshTsAddSub": "Interactive login / AuthKey",
     "meshTsEntryTitle": "Tailscale mesh access and account management",
-    "speedTestingCount": "Testing · {{count}} groups"
+    "speedTestingNodes": "Testing · {{tested}}/{{total}} nodes"
   },
   "rules": {
     "ruleColumn": "Rule",

--- a/src/renderer/i18n/locales/fa.json
+++ b/src/renderer/i18n/locales/fa.json
@@ -1150,7 +1150,8 @@
     "meshTsManageSub": "تنظیمات · خروج / تعویض حساب",
     "meshTsKeyReadySub": "تنظیمات · حذف",
     "meshTsAddSub": "ورود تعاملی / AuthKey",
-    "meshTsEntryTitle": "دسترسی به شبکهٔ Tailscale و مدیریت حساب"
+    "meshTsEntryTitle": "دسترسی به شبکهٔ Tailscale و مدیریت حساب",
+    "speedTestingCount": "در حال تست · {{count}} گروه"
   },
   "rules": {
     "ruleColumn": "قانون",

--- a/src/renderer/i18n/locales/fa.json
+++ b/src/renderer/i18n/locales/fa.json
@@ -1151,7 +1151,7 @@
     "meshTsKeyReadySub": "تنظیمات · حذف",
     "meshTsAddSub": "ورود تعاملی / AuthKey",
     "meshTsEntryTitle": "دسترسی به شبکهٔ Tailscale و مدیریت حساب",
-    "speedTestingCount": "در حال تست · {{count}} گروه"
+    "speedTestingNodes": "در حال تست · {{tested}}/{{total}} گره"
   },
   "rules": {
     "ruleColumn": "قانون",

--- a/src/renderer/i18n/locales/ru.json
+++ b/src/renderer/i18n/locales/ru.json
@@ -1150,7 +1150,8 @@
     "meshTsManageSub": "Настройки · выход / смена аккаунта",
     "meshTsKeyReadySub": "Настройки · удаление",
     "meshTsAddSub": "Интерактивный вход / AuthKey",
-    "meshTsEntryTitle": "Подключение к сети Tailscale и управление аккаунтом"
+    "meshTsEntryTitle": "Подключение к сети Tailscale и управление аккаунтом",
+    "speedTestingCount": "Тест · {{count}} гр."
   },
   "rules": {
     "ruleColumn": "Правило",

--- a/src/renderer/i18n/locales/ru.json
+++ b/src/renderer/i18n/locales/ru.json
@@ -1151,7 +1151,7 @@
     "meshTsKeyReadySub": "Настройки · удаление",
     "meshTsAddSub": "Интерактивный вход / AuthKey",
     "meshTsEntryTitle": "Подключение к сети Tailscale и управление аккаунтом",
-    "speedTestingCount": "Тест · {{count}} гр."
+    "speedTestingNodes": "Тест · {{tested}}/{{total}} узлов"
   },
   "rules": {
     "ruleColumn": "Правило",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1150,7 +1150,8 @@
     "meshTsManageSub": "设置 · 登出 / 切换账户",
     "meshTsKeyReadySub": "设置 · 删除",
     "meshTsAddSub": "交互登录 / AuthKey",
-    "meshTsEntryTitle": "Tailscale 组网接入与账户管理"
+    "meshTsEntryTitle": "Tailscale 组网接入与账户管理",
+    "speedTestingCount": "测速中 · {{count}} 组"
   },
   "rules": {
     "ruleColumn": "规则",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1151,7 +1151,7 @@
     "meshTsKeyReadySub": "设置 · 删除",
     "meshTsAddSub": "交互登录 / AuthKey",
     "meshTsEntryTitle": "Tailscale 组网接入与账户管理",
-    "speedTestingCount": "测速中 · {{count}} 组"
+    "speedTestingNodes": "测速中 · {{tested}}/{{total}} 节点"
   },
   "rules": {
     "ruleColumn": "规则",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -1150,7 +1150,8 @@
     "meshTsManageSub": "設定 · 登出 / 切換帳戶",
     "meshTsKeyReadySub": "設定 · 刪除",
     "meshTsAddSub": "互動登入 / AuthKey",
-    "meshTsEntryTitle": "Tailscale 組網接入與帳戶管理"
+    "meshTsEntryTitle": "Tailscale 組網接入與帳戶管理",
+    "speedTestingCount": "測速中 · {{count}} 組"
   },
   "rules": {
     "ruleColumn": "規則",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -1151,7 +1151,7 @@
     "meshTsKeyReadySub": "設定 · 刪除",
     "meshTsAddSub": "互動登入 / AuthKey",
     "meshTsEntryTitle": "Tailscale 組網接入與帳戶管理",
-    "speedTestingCount": "測速中 · {{count}} 組"
+    "speedTestingNodes": "測速中 · {{tested}}/{{total}} 節點"
   },
   "rules": {
     "ruleColumn": "規則",

--- a/src/renderer/pages/server-page.tsx
+++ b/src/renderer/pages/server-page.tsx
@@ -247,11 +247,7 @@ export function ServerPage() {
             disabled={allSpeed.isTestingSpeed}
           >
             <Zap className={allSpeed.isTestingSpeed ? 'animate-pulse fill-current/20' : ''} />
-            {allSpeed.isTestingSpeed
-              ? allSpeed.speedProgress
-                ? `${t('servers.speedTesting')} ${allSpeed.speedProgress.tested}/${allSpeed.speedProgress.total}`
-                : t('servers.speedTesting')
-              : t('servers.speedTestAll')}
+            {allSpeed.isTestingSpeed ? t('servers.speedTesting') : t('servers.speedTestAll')}
           </button>
           {/* 添加下拉（CSS-only :focus-within 弹出，与工具栏协议/排序下拉同范式） */}
           <div className="nd-dd">


### PR DESCRIPTION
## 根因
`SpeedTestService.currentTest` 单飞按「是否存在」**无条件复用**,不看在飞测速是否覆盖本次请求的 `serverIds`。注释假设「双入口都全量、同一 set」——被 per-group 本组测速(子集)/单节点⚡/子集先-全量后 打破。

穷举(入口 × 分组):
| 场景 | 旧行为 | 判 |
|---|---|---|
| 全部测速 多入口并发(首页/托盘/页级) | coalesce 同一次 | ✓ |
| 同分组本组测速重复点 | 按钮 disabled 挡 | ✓ |
| 全部 → 本组(子集) | 本组 ⊆ 全部,coalesce | ✓ |
| **本组/单节点 → 全部** | 全部撞子集 currentTest → 只测子集、**其余静默漏测** | ✗ |
| **不同分组连续点**(A 跑时点 B) | B 撞 A → **B 拿 A 的节点结果、B 自己从未测** | ✗ |

## 修复(覆盖感知 coalesce + 串行链)
`currentTest` 旁记 `currentTestIds`(在飞节点集)。新请求 S:
- `S ⊆ 在飞集` → 复用同一次(零重跑、避免双临时 sing-box 端口冲突)
- 否则 → **串行链**在在飞测速之后、用**自身 set** 完整测到(不同分组/子集先-全量后 各自被测、永不并发双 sing-box、无漏测/错测)

不采「打断旧测速」:无 AbortController,中途 teardown 临时 sing-box + 释放探针端口本身有 race,比串行更糟。

## 测试
新增 `speed-test-coalesce.test.ts`(桩 `doTestAllServers`):覆盖复用 / 未覆盖串行(B 用自身 set 拿自身结果)/ 子集先-全量后(全量测全集)/ 归零 4 例。gate tsc + eslint + jest 2895 绿。真机待验:快速切 tab + 测速中点他组/全部。