### PR TITLE
fix(speedtest): 端点节点目标穿隧道解析,消除国内 DNS geo 偏差致 WARP/WG 测速超时

### DIFF
--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -303,14 +303,23 @@ export class SpeedTestService {
     // 解析测速端点（一次，预热+正式共用）；非法 testUrl 经 resolveSpeedTestTarget 回落默认 generate_204。
     const target = resolveSpeedTestTarget(testUrl);
 
+    // 端点节点（WG/WARP，L3）目标域名必被 sing-box 本地解析 → 需 exit-DNS(穿隧道) + local-DNS(兜底) 双形态入站，
+    // 故对端点多分配一个「local 兜底口」。isEndpointProtocol 键控（非硬编码 wireguard），未来端点类型自动覆盖。
+    const isEndpoint = (u: { outbound: Record<string, unknown> }) =>
+      isEndpointProtocol(u.outbound.type as string);
+    const endpointUsable = usable.filter(isEndpoint);
     try {
-      // 1. 为可用节点分配 HTTP 代理端口
-      const ports = await this.findFreePorts(usable.length);
-      const serverPortMap = new Map<string, number>(); // serverId → HTTP proxy port
+      // 1. 分配 HTTP 代理端口：前 usable.length 个=各节点 exit 形态口；其后 endpointUsable.length 个=端点 local 兜底口。
+      const ports = await this.findFreePorts(usable.length + endpointUsable.length);
+      const serverPortMap = new Map<string, number>(); // serverId → exit 形态 HTTP proxy port
       usable.forEach((u, idx) => serverPortMap.set(u.server.id, ports[idx]));
+      const endpointLocalPortMap = new Map<string, number>(); // 端点 serverId → local-DNS 兜底口
+      endpointUsable.forEach((u, idx) =>
+        endpointLocalPortMap.set(u.server.id, ports[usable.length + idx])
+      );
 
-      // 2. 生成临时 sing-box 配置（每节点独立 HTTP 入站 → 该节点出站）
-      const config = this.generateProxyTestConfig(usable, serverPortMap);
+      // 2. 生成临时 sing-box 配置（每节点独立 HTTP 入站 → 该节点出站；端点额外 local 兜底入站 + 穿隧道 DNS）
+      const config = this.generateProxyTestConfig(usable, serverPortMap, endpointLocalPortMap);
 
       // 3. 写入临时配置文件
       const userDataPath = getUserDataPath();
@@ -364,12 +373,45 @@ export class SpeedTestService {
       //    预热轮。并发上限避免大订阅 N 路握手同时打出→请求风暴假超时；小订阅(≤上限)等价全并行。
       //    每测完一个节点立即回调 onResult（UI 流式显示），不等队列。
       await this.runWithLimit(usable, SpeedTestService.PROXY_TEST_CONCURRENCY, async (u) => {
-        const port = serverPortMap.get(u.server.id)!;
-        const { latency, reason } = await this.measureViaTunnel(
-          port,
-          SpeedTestService.MEASURE_TIMEOUT_MS,
-          target
-        );
+        let latency: number | null;
+        let reason: string | undefined;
+        if (isEndpoint(u)) {
+          // 端点双测（两路并行、总耗时 ≤ MEASURE_TIMEOUT_MS）：exit-DNS 形态（目标经隧道解析、geo 正确）优先，
+          // 失败才回落 local-DNS 形态（dns-direct 兜底，救国内出口 WG）。exit 优先而非先到先得——local 本机解析
+          // 几乎恒先到（0-7ms vs 隧道 80-100ms），先到先得会白改（恒选 geo 错的 local）。
+          const exitP = this.measureViaTunnel(
+            serverPortMap.get(u.server.id)!,
+            SpeedTestService.MEASURE_TIMEOUT_MS,
+            target
+          );
+          const localP = this.measureViaTunnel(
+            endpointLocalPortMap.get(u.server.id)!,
+            SpeedTestService.MEASURE_TIMEOUT_MS,
+            target
+          );
+          const exit = await exitP;
+          if (exit.latency !== null) {
+            void localP.catch(() => {}); // exit 命中：local 探测跑完即弃，吞异常防悬挂
+            latency = exit.latency;
+          } else {
+            const local = await localP;
+            if (local.latency !== null) {
+              latency = local.latency;
+              this.logManager.addLog('info', `${u.server.name} 测速回落 local-DNS`, 'SpeedTest');
+            } else {
+              latency = null;
+              reason = `exit:${exit.reason ?? '?'}|local:${local.reason ?? '?'}`;
+            }
+          }
+        } else {
+          const r = await this.measureViaTunnel(
+            serverPortMap.get(u.server.id)!,
+            SpeedTestService.MEASURE_TIMEOUT_MS,
+            target
+          );
+          latency = r.latency;
+          reason = r.reason;
+        }
         results.set(u.server.id, latency);
         if (latency === null) noteFail(reason ?? 'unknown'); // ③ 记失败模式
         report(u.server.id, latency);
@@ -418,43 +460,82 @@ export class SpeedTestService {
    */
   private generateProxyTestConfig(
     usable: { server: ServerConfig; tag: string; outbound: Record<string, unknown> }[],
-    serverPortMap: Map<string, number>
+    serverPortMap: Map<string, number>,
+    endpointLocalPortMap: Map<string, number>
   ): Record<string, unknown> {
     const inbounds: Record<string, unknown>[] = [];
     const outbounds: Record<string, unknown>[] = [];
     const endpoints: Record<string, unknown>[] = [];
     const routeRules: Record<string, unknown>[] = [];
+    // 仅解析节点 server 地址的国内 DNS（见下「两类解析不变量」）；端点另加穿隧道 DNS（dns-exit-<id8>）。
+    const dnsServers: Record<string, unknown>[] = [
+      { tag: 'dns-direct', type: 'udp', server: '223.5.5.5', server_port: 53 },
+    ];
+    const dnsRules: Record<string, unknown>[] = [];
 
     for (const { server, tag, outbound } of usable) {
       const port = serverPortMap.get(server.id);
       if (!port) continue;
-      const inboundTag = `http-in-${server.id.slice(0, 8)}`;
+      const id8 = server.id.slice(0, 8);
+      const inboundTag = `http-in-${id8}`;
       inbounds.push({ type: 'http', tag: inboundTag, listen: '127.0.0.1', listen_port: port });
-      // endpoint（WireGuard/Tailscale）进 endpoints[]，普通协议进 outbounds[]；route 规则均按 tag 指向（一致）。
-      // 按单一真值 isEndpointProtocol 判 type（非硬编码 'wireguard'），未来新增 endpoint 类型自动归位、不误进 outbounds。
+      routeRules.push({ inbound: [inboundTag], action: 'route', outbound: tag });
+      // endpoint（WireGuard/WARP/未来 TS）进 endpoints[]，普通协议进 outbounds[]；route 均按 tag 指向。
+      // 按单一真值 isEndpointProtocol 判 type（非硬编码 'wireguard'），未来端点类型自动归位。
       if (isEndpointProtocol(outbound.type as string)) {
         endpoints.push(outbound);
+        // 端点是 L3（运 IP 包、不认域名）→ sing-box 强制**本地解析**目标域名（wireguard/endpoint.go 空 QueryOptions，
+        // 过 dns.rules + default）。默认 dns-direct(223.5.5.5 国内 DNS) 解出国内 geo 镜像 IP、境外出口回连中国 → 超时/失真。
+        // 故：exit 形态入站（http-in-<id8>）的目标解析用「穿本节点隧道」的 1.1.1.1（anycast 由出口就近应答 → geo 正确）；
+        // 另起 local 形态入站（http-in-l-<id8>，无 dns.rule → 回落 dns-direct）作兜底——救国内出口 WG（穿隧道查 1.1.1.1
+        // 会 anycast 落境外、答案在墙内不可达）。两形态经 inbound 键控 dns.rule 精确分流（dns router 保留连接 InboundContext）。
+        const localPort = endpointLocalPortMap.get(server.id);
+        if (localPort) {
+          const localInboundTag = `http-in-l-${id8}`;
+          inbounds.push({
+            type: 'http',
+            tag: localInboundTag,
+            listen: '127.0.0.1',
+            listen_port: localPort,
+          });
+          routeRules.push({ inbound: [localInboundTag], action: 'route', outbound: tag });
+        }
+        const exitDnsTag = `dns-exit-${id8}`;
+        dnsServers.push({
+          tag: exitDnsTag,
+          type: 'udp',
+          server: '1.1.1.1',
+          server_port: 53,
+          detour: tag, // 查询穿本端点隧道 → anycast 由出口就近应答
+        });
+        // WG localAddress 含 v6 → prefer_ipv4（避免 v6 优先落不可达）；纯 v4 → ipv4_only（消 v6 解析噪声）。
+        const hasV6 = !!server.wireguardSettings?.localAddress?.some((a) => a.includes(':'));
+        dnsRules.push({
+          inbound: [inboundTag], // 仅 exit 形态入站的目标解析走穿隧道 DNS；local 形态回落 dns-direct
+          action: 'route',
+          server: exitDnsTag,
+          strategy: hasV6 ? 'prefer_ipv4' : 'ipv4_only',
+          disable_cache: true, // 多端点并测出口 geo 答案各异，禁缓存防互污染（cache 按 question 全局共享）
+        });
       } else {
         outbounds.push(outbound); // 预构造的出站（tag 已为 out-<id8>）
       }
-      routeRules.push({ inbound: [inboundTag], action: 'route', outbound: tag });
     }
 
     // 必须有 direct 出站（sing-box 启动要求）
     outbounds.push({ type: 'direct', tag: 'direct' });
 
-    // ① 解析不变量（issue #154，localhost 实验确证，见 docs/design/speedtest-remote-resolve-154.md）：
-    //   测速【目标域名】（如 www.gstatic.com）由【每个被测节点的出口】远程解析——sing-box 把域名 ATYP=domain
-    //   透传给代理出站，**不经本机 AliDNS**。dns-direct/default_domain_resolver 仅用于解析【节点 server 地址】
-    //   （域名 server 节点需要；IP-server 节点不触发）。这一不变量使端点选择与「任播/国内镜像/geo 调度」全脱钩
-    //   （故默认得以用非任播的 gstatic），且各节点量到的是自身真实路径、无「解析点≠出口」错配。
-    //   ⚠️ 勿在此引入 sniff / outbound.domain_strategy / 针对目标的本地解析——会把目标解析拉回本机、破坏该不变量。
+    // 两类解析不变量（issue #154 + 2026-07 端点修正，真机 debug 确证）：
+    //  · 代理出站（vless/vmess/trojan/hy2/tuic/ss/snell/anytls/naive/ssh…）：目标域名以 ATYP=domain **透传给出口远程
+    //    解析**，不经本机 dns-direct（代理 dialer 只拨 server 地址、destination 进协议头）。各节点量到自身真实路径。
+    //    ⚠️ 勿引入 sniff / outbound.domain_strategy / 针对目标的本地解析——会破坏此不变量。
+    //  · 端点（WG/WARP…L3）：**必本地解析**目标（内核强制）。故上方用 inbound 键控 dns.rule 把 exit 形态目标解析压到
+    //    穿隧道 1.1.1.1（geo 正确），local 形态回落 dns-direct（国内出口兜底）；default_domain_resolver 仍解节点 server 地址。
+    const dns: Record<string, unknown> = { servers: dnsServers };
+    if (dnsRules.length > 0) dns.rules = dnsRules; // 仅有端点节点时下发；纯代理配置零变化
     const config: Record<string, unknown> = {
       log: { level: 'warn' },
-      dns: {
-        // sing-box 1.13+ 要求显式 type；仅解析节点 server 地址（见上「解析不变量」），不解析测速目标。
-        servers: [{ tag: 'dns-direct', type: 'udp', server: '223.5.5.5', server_port: 53 }],
-      },
+      dns,
       inbounds,
       outbounds,
       route: {
@@ -463,7 +544,7 @@ export class SpeedTestService {
         default_domain_resolver: 'dns-direct',
       },
     };
-    if (endpoints.length > 0) config.endpoints = endpoints; // WireGuard 测速：顶层 endpoints[]
+    if (endpoints.length > 0) config.endpoints = endpoints; // 端点测速：顶层 endpoints[]
     return config;
   }
 

--- a/src/main/services/__tests__/speed-test-endpoint-dns.test.ts
+++ b/src/main/services/__tests__/speed-test-endpoint-dns.test.ts
@@ -1,0 +1,91 @@
+/**
+ * 测速临时 config 的「端点目标解析」单测（纯 config 生成，无网络）。
+ * 端点(WG/WARP)是 L3、目标域名必被本地解析：默认 dns-direct(国内 DNS)会解出国内 geo IP、境外出口回连中国 → 超时/失真。
+ * 修复:exit 形态入站的目标解析穿隧道走 1.1.1.1(geo 正确)+ local 形态入站回落 dns-direct(救国内出口 WG),inbound 键控。
+ * 验:端点双入站/双 route、穿隧道 dns server(detour)、inbound 键控 dns.rule(disable_cache/strategy)、纯代理零变化。
+ */
+import { SpeedTestService } from '../SpeedTestService';
+
+const mockLog = { addLog: () => {} } as unknown as ConstructorParameters<
+  typeof SpeedTestService
+>[0];
+
+type Usable = { server: Record<string, unknown>; tag: string; outbound: Record<string, unknown> };
+function gen(usable: Usable[], exitPorts: number[], localPorts: Record<string, number>) {
+  const svc = new SpeedTestService(mockLog) as unknown as {
+    generateProxyTestConfig: (
+      u: Usable[],
+      exit: Map<string, number>,
+      local: Map<string, number>
+    ) => Record<string, any>;
+  };
+  const serverPortMap = new Map(usable.map((u, i) => [u.server.id as string, exitPorts[i]]));
+  const endpointLocalPortMap = new Map(Object.entries(localPorts));
+  return svc.generateProxyTestConfig(usable, serverPortMap, endpointLocalPortMap);
+}
+const wg = (id: string, localAddress: string[]): Usable => ({
+  server: { id, name: 'WARP', protocol: 'wireguard', wireguardSettings: { localAddress } },
+  tag: `out-${id.slice(0, 8)}`,
+  outbound: { type: 'wireguard', tag: `out-${id.slice(0, 8)}` },
+});
+const vless = (id: string): Usable => ({
+  server: { id, name: 'HK', protocol: 'vless' },
+  tag: `out-${id.slice(0, 8)}`,
+  outbound: { type: 'vless', tag: `out-${id.slice(0, 8)}`, uuid: 'x' },
+});
+
+describe('测速临时 config:端点目标解析穿隧道 + local 兜底', () => {
+  it('WG 端点:双入站 + 穿隧道 dns server(detour) + inbound 键控 dns.rule(disable_cache/ipv4_only)', () => {
+    const cfg = gen([wg('wgnode01', ['172.16.0.2/32'])], [21001], { wgnode01: 21002 });
+    const inTags = cfg.inbounds.map((i: any) => i.tag);
+    expect(inTags).toContain('http-in-wgnode01'); // exit 形态
+    expect(inTags).toContain('http-in-l-wgnode01'); // local 兜底形态
+    expect(cfg.endpoints).toHaveLength(1); // WG 进 endpoints[]
+    // 两入站都指向同一端点 tag
+    expect(cfg.route.rules.filter((r: any) => r.outbound === 'out-wgnode01')).toHaveLength(2);
+    // 穿隧道 DNS server(detour 指向本端点 tag)
+    expect(cfg.dns.servers.find((s: any) => s.tag === 'dns-exit-wgnode01')).toMatchObject({
+      server: '1.1.1.1',
+      detour: 'out-wgnode01',
+    });
+    // inbound 键控 dns.rule:仅 exit 形态、禁缓存、v4-only(无 v6 localAddress)
+    expect(cfg.dns.rules).toEqual([
+      {
+        inbound: ['http-in-wgnode01'],
+        action: 'route',
+        server: 'dns-exit-wgnode01',
+        strategy: 'ipv4_only',
+        disable_cache: true,
+      },
+    ]);
+  });
+
+  it('WG localAddress 含 v6 → strategy prefer_ipv4', () => {
+    const cfg = gen([wg('wgnodv61', ['172.16.0.2/32', '2606:4700::1/128'])], [21001], {
+      wgnodv61: 21002,
+    });
+    expect(cfg.dns.rules[0].strategy).toBe('prefer_ipv4');
+  });
+
+  it('纯代理配置:无 dns.rules、单入站、无 endpoints、进 outbounds', () => {
+    const cfg = gen([vless('vlessn01')], [21001], {});
+    expect(cfg.dns.rules).toBeUndefined();
+    expect(cfg.inbounds).toHaveLength(1);
+    expect(cfg.inbounds[0].tag).toBe('http-in-vlessn01');
+    expect(cfg.endpoints).toBeUndefined();
+    expect(cfg.outbounds.some((o: any) => o.tag === 'out-vlessn01')).toBe(true);
+  });
+
+  it('混合:代理条目零变化(单入站/无 dns.rule),仅端点有 dns.rule + 双入站', () => {
+    const cfg = gen([vless('vlessn01'), wg('wgnode01', ['172.16.0.2/32'])], [21001, 21003], {
+      wgnode01: 21004,
+    });
+    expect(cfg.dns.rules.map((r: any) => r.inbound[0])).toEqual(['http-in-wgnode01']); // 只端点有 dns.rule
+    expect(cfg.inbounds.find((i: any) => i.tag === 'http-in-vlessn01').listen_port).toBe(21001);
+    expect(cfg.inbounds.map((i: any) => i.tag).sort()).toEqual([
+      'http-in-l-wgnode01',
+      'http-in-vlessn01',
+      'http-in-wgnode01',
+    ]);
+  });
+});


### PR DESCRIPTION
## 根因(Mac 真机 debug 坐实)
测速临时 config 对**端点(WG/WARP,L3)**:sing-box 强制本地解析目标域名(gstatic)→ 经 `default_domain_resolver: dns-direct`(**223.5.5.5 国内 DNS**)→ 国内 geo 镜像 IP(180.163.x)→ **境外 WARP 出口回连中国 → 超时**(000/12s,时灵时死)。

**代理节点无此问题**:目标 `ATYP=domain` 透传给出口**远程解析**(「解析不变量」成立、延迟真实)——真机 vless+reality debug + sing-box 源码双证。旧注释把代理语义误推到全类型;对端点从不成立。

## 修复(isEndpointProtocol 键控)
端点**双形态测速**:
- **exit 形态入站**:目标解析经 `inbound` 键控 `dns.rule` 定向到「穿本节点隧道」的 1.1.1.1(anycast 出口就近应答 → geo 正确),**优先**
- **local 形态入站**:回落 `dns-direct`(救**国内出口 WG**——穿隧道查 1.1.1.1 会 anycast 落境外、墙内不可达)
- 双测并行(≤8s)、**exit 优先而非先到先得**(local 本机解析恒先到);`disable_cache`(多端点并测防互污染)
- **代理节点路径零改动**;outbound builder 零改(endpoint `domain_resolver` 只管 peer 地址、改它 peer 解析死锁 FATAL,已反证)

## 真机验证
修复后 WARP:exit 形态 gstatic→`142.251.24.94`(Google edge)→**204/0.56s**(修复前超时);local 形态→180.163.x 国内镜像(国内出口兜底路径)。

## Tailscale
同型 bias,本修复自动覆盖(isEndpointProtocol);但**维持排除**——冷启动 2-10s > 8s 预算 / 双会话冲突 / DERP 期延迟无意义。

Fable 深度调研设计。单测 4 例(双入站/穿隧道 dns/inbound 键控 rule/纯代理零变化)。gate tsc+eslint+jest 2904 绿。