### PR TITLE
chore(core): bump sing-box 内核到 1.14.0-alpha.41

### DIFF
--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,11 +1,11 @@
 {
-  "bundledCoreVersion": "1.14.0-alpha.40",
+  "bundledCoreVersion": "1.14.0-alpha.41",
   "cronetVersion": "v148.0.7778.96-1",
   "coreArchiveSha256": {
-    "linux": "dc44780a1e0afff257f866f330d08c66615772000ade73eae35832ac59db1a37",
-    "win": "2a5fde9db7dfc94ebf9cc74d669038fcccafa7b759dcbcf354f6b538e7c68a90",
-    "mac-x64": "09fa25f22aceac251fc7e274da6f472ff2923239731851e8e63761aa0aec4ddf",
-    "mac-arm64": "131fc6e7547ed425f5c2ee5e95e1b7941756345fef9a29be92055bfa622e24ff"
+    "linux": "475c10fa2f0fcfd39ad1d849de40484ce779ee1737ef6b77c080de4dca43b025",
+    "win": "b7d694076ffa76f9a9ba3d8d06900ab3cd46c7812a17405b5115d50a937cea45",
+    "mac-x64": "dfe077115a322adbabba4ce291a2bd2d92e8740b234d9d2f041f42fe6da17766",
+    "mac-arm64": "020083d1c048ed997c38cacbc3240ecd360d53723f5a86b75015231f069aaab6"
   },
   "cronetArchiveSha256": {
     "linux": "dc7293a929dffa695aae1a89555e7366158fa0a3f40bbe3012d445bc05c99672",


### PR DESCRIPTION
## 变更

sing-box 内核基线 `1.14.0-alpha.40` → `1.14.0-alpha.41`。

`core-manifest.json` 改两处：`bundledCoreVersion` + 四平台 `coreArchiveSha256`（linux/win/mac-x64/mac-arm64），值取自官方 release asset digest。

## 验证

- `npm run fetch:core -- --force`：四平台核全部下载成功，压缩包 sha256 与 manifest 一致
- Linux 核实测 `sing-box version 1.14.0-alpha.41`（go1.25.11）
- gate 绿：`core-build` / `core-version-probe-serial` / `core-swap-gate` / `core-reseed-{atomic,windows,linux-helper}` 全过（75 passed）
- alpha.41 为干净官方 token（无 fork 后缀），`comparableCoreVersion` / `compareSemver` 无 quirk 风险；硬地板 `coreVersionAtLeast(1,14)` 满足

尚未做 Win/Mac 真机起核 smoke，建议发版前补一次。

## 说明：alpha.41 新特性与本仓关系

alpha.41 具名新特性均属 `bridge` outbound + hysteria2 `realm` 的 P2P/mesh 子系统：

- windows bridge（经 WinDivert，需管理员）
- bridge 支持 `preferred_by`
- hy2 `realm.ip_version`
- hy2 `realm.port_mapping`（UPnP/NAT-PMP）

本仓作标准订阅代理客户端，hysteria2 走标准 outbound、组网走 Tailscale/WireGuard/WARP，均不涉及 bridge/realm，故 config-builder 无需改动。本次升级仅为跟进 alpha 线 bug fixes。
