### PR TITLE
fix(servers): 修复导入节点编辑时传输协议丢失与端口无法清空

### DIFF
--- a/src/renderer/components/settings/shared/basic-fields.tsx
+++ b/src/renderer/components/settings/shared/basic-fields.tsx
@@ -76,9 +76,17 @@ export function PortField({
             value={field.value ?? ''}
             readOnly={readOnly}
             className={readOnly ? 'cursor-default opacity-70' : undefined}
-            onChange={(e) =>
-              field.onChange(e.target.value === '' ? undefined : parseInt(e.target.value, 10) || 0)
-            }
+            onChange={(e) => {
+              // 空串（退格删空）→ undefined，允许清空后重录；不用 `parseInt || 0`（0 触发 min(1) 校验挂、
+              // 且把「删到一位再退格」卡成 0 无法清空，issue #294）。非空按十进制解析，异常值 → undefined 不硬塞 0。
+              const raw = e.target.value;
+              if (raw === '') {
+                field.onChange(undefined);
+                return;
+              }
+              const n = Number.parseInt(raw, 10);
+              field.onChange(Number.isNaN(n) ? undefined : n);
+            }}
           />
           <FormMessage className="fld-err" />
         </div>

--- a/src/renderer/components/settings/trojan-form.tsx
+++ b/src/renderer/components/settings/trojan-form.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -67,35 +66,18 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
   const { t } = useTranslation();
   const trojanFormSchema = createTrojanSchema(t);
 
-  const form = useForm<TrojanFormValues>({
-    resolver: zodResolver(trojanFormSchema),
-    defaultValues: {
-      address: '',
-      port: 443,
-      password: '',
-      network: 'tcp',
-      security: 'tls',
-      tlsServerName: '',
-      tlsAllowInsecure: false,
-      tlsFingerprint: 'none',
-      tlsEngine: 'go',
-      alpn: '',
-      ...readTransportDefaults(),
-      ...echDefaults,
-      ...multiplexDefaults,
-      ...tlsSpoofDefaults,
-    },
-  });
+  // 标准化 security（转小写匹配 schema）。
+  const normalizeSecurity = (s: string | undefined): 'none' | 'tls' => {
+    const lower = (s || 'tls').toLowerCase();
+    return lower === 'none' ? 'none' : 'tls';
+  };
 
-  useEffect(() => {
+  // 同步 defaultValues（对齐 vless/vmess）：编辑态直接由 serverConfig 算初值，表单按 key={id} 挂载即正确。
+  // 不走挂载后 useEffect(form.reset)——radix Select 受控 value 被编程改写会触发伪 onValueChange 打回空态
+  // （传输显「选择传输协议」+ 保存 invalid input，issue #294）；同步初值让 Select 挂载即带正确值，结构性免疫。
+  const getDefaultValues = (): TrojanFormValues => {
     if (serverConfig && serverConfig.protocol?.toLowerCase() === 'trojan') {
-      // 标准化 network 和 security 值（转为全小写以匹配 schema）
-      const normalizeSecurity = (s: string | undefined): 'none' | 'tls' => {
-        const lower = (s || 'tls').toLowerCase();
-        return lower === 'none' ? 'none' : 'tls';
-      };
-
-      const formData = {
+      return {
         address: serverConfig.address || '',
         port: serverConfig.port || 443,
         password: serverConfig.password || '',
@@ -111,9 +93,29 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
         ...readMultiplexDefaults(serverConfig),
         ...readTlsSpoofDefault(serverConfig),
       };
-      form.reset(formData);
     }
-  }, [serverConfig, form]);
+    return {
+      address: '',
+      port: 443,
+      password: '',
+      network: 'tcp',
+      security: 'tls',
+      tlsServerName: '',
+      tlsAllowInsecure: false,
+      tlsFingerprint: 'none',
+      tlsEngine: 'go',
+      alpn: '',
+      ...readTransportDefaults(),
+      ...echDefaults,
+      ...multiplexDefaults,
+      ...tlsSpoofDefaults,
+    };
+  };
+
+  const form = useForm<TrojanFormValues>({
+    resolver: zodResolver(trojanFormSchema),
+    defaultValues: getDefaultValues(),
+  });
 
   const handleSubmit = async (values: TrojanFormValues) => {
     const network = values.network;

--- a/src/renderer/components/settings/trojan-form.tsx
+++ b/src/renderer/components/settings/trojan-form.tsx
@@ -85,7 +85,7 @@ export function TrojanForm({ serverConfig, onSubmit }: TrojanFormProps) {
         security: normalizeSecurity(serverConfig.security),
         tlsServerName: serverConfig.tlsSettings?.serverName || '',
         tlsAllowInsecure: serverConfig.tlsSettings?.allowInsecure || false,
-        tlsFingerprint: serverConfig.tlsSettings?.fingerprint || 'none',
+        tlsFingerprint: (serverConfig.tlsSettings?.fingerprint || 'none').toLowerCase(),
         tlsEngine: serverConfig.tlsSettings?.engine || 'go',
         alpn: serverConfig.tlsSettings?.alpn?.join(',') || '',
         ...readTransportDefaults(serverConfig),


### PR DESCRIPTION
## 问题（#294）

编辑链接导入的自建节点（如 trojan + tls + websocket）时：

1. **传输协议丢失**：节点列表正常显示 `ws`，但点「编辑」弹窗里「传输」下拉显示占位符「选择传输协议」，须手动重选一次 WebSocket 才能保存，否则报 `invalid input`。
2. **端口无法退格删空**：退格删到剩一位后无法继续删空，继续退格报 `invalid input`，只能全选后重新输入端口号。

## 根因（两处独立）

**Bug 1 — radix Select 受控 value 的 reset-race**
`trojan-form.tsx` 用挂载后 `useEffect(() => form.reset(formData))` 载入编辑数据。`@radix-ui/react-select` 的 `SelectContent` 懒挂 Portal，`form.reset` 编程改写受控 `value` 会触发一次伪 `onValueChange`，把刚 reset 的 `network` 打回空态 → 触发器显占位符（value 无匹配 item）+ 提交时 `z.enum` 收到空值报 `invalid input`。链路本身无误（导入正确写入 `network='ws'`，列表也据此显示），纯粹是 reset 之后被 radix 清空。

同仓 `exit-node-field` 曾因同一伪 `onValueChange` 迁离 radix Select，`mesh-fields` 加了 `interacted` 守卫——协议表单未覆盖。全 14 张表单中仅 trojan 走 `useEffect(form.reset)` 且传输/安全为常显受控 Select，故只有它中招；vless/vmess 等 9 张用同步 `defaultValues` 结构性免疫。

**Bug 2 — 端口 number 输入 `parseInt || 0`**
共享 `PortField` 的 `onChange` 用 `parseInt(e.target.value, 10) || 0`，清空/半删被压成 `0`，命中 `z.number().min(1)` 校验挂 → `invalid input`，且卡住无法删空。

## 修复

- **trojan-form.tsx**：移除挂载后 `useEffect(form.reset)`，改为同步 `getDefaultValues()` 喂 `useForm({ defaultValues })`（对齐 vless/vmess）。Select 挂载即带正确值，结构性消除 reset-race；覆盖 `network` + `security` 两个常显下拉。字段键与旧逻辑逐一对齐，无增删。
- **shared/basic-fields.tsx `PortField`**：`onChange` 去除 `|| 0`——空串归 `undefined`（允许退格删空后重录），异常值归 `undefined` 不再硬塞 0。修复全部 13 张使用 `PortField` 的协议表单。

## 验证

- `tsc --noEmit` 与 `eslint`（两文件）均 exit 0。
- 独立复审逐项通过：`getDefaultValues` 双分支字段键与 `HEAD` 逐一等价、无残留 `useEffect`、`onReset`/切换协议/订阅节点编辑路径行为不变、radix Select 挂载即显正确值、PortField 可清空。
- 待真机回归：导入 trojan+tls+ws → 编辑传输直接显 WebSocket 并可直接保存；任意节点端口可退格删空并重录保存。

Closes #294