### PR TITLE
fix(update): 修 remind 弹窗白屏挂死窗（新建路径未下发初始状态）

### DIFF
--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -647,6 +647,9 @@ export class UpdateService {
 
     this.updatePopupWindow = win;
     this.registerPopupActionListener();
+    // 下发初始状态：写 lastPopupState 供 did-finish-load 重放（页面 onState 监听晚于此 send 时兜底）。
+    // 缺此行则 remind 态 lastPopupState 恒 null → did-finish-load 不重放 → 页面永空 → 白卡片挂死窗（#300）。
+    this.sendPopupState(state);
     return win;
   }
 

--- a/src/main/services/__tests__/update-service-popup.test.ts
+++ b/src/main/services/__tests__/update-service-popup.test.ts
@@ -11,7 +11,22 @@ const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-updsvc-test-'));
 jest.mock('electron', () => ({
   app: { getPath: () => TMP, getVersion: () => '1.0.0', isPackaged: false, getAppPath: () => TMP },
   shell: {},
-  BrowserWindow: class {},
+  // 可实例化的 BrowserWindow 桩：让 createUpdatePopup 走完新建路径，暴露 webContents.send 以断言初始态下发。
+  BrowserWindow: class {
+    webContents = { setWindowOpenHandler: () => {}, on: () => {}, send: jest.fn() };
+    loadFile = () => Promise.resolve();
+    loadURL = () => Promise.resolve();
+    setMenu = () => {};
+    once = () => {};
+    on = () => {};
+    isDestroyed = () => false;
+    setContentSize = () => {};
+    setPosition = () => {};
+    close = () => {};
+  },
+  nativeTheme: { shouldUseDarkColors: false },
+  screen: { getPrimaryDisplay: () => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }) },
+  ipcMain: { on: () => {} },
   dialog: { showMessageBox: jest.fn() },
   net: {},
   session: {},
@@ -32,6 +47,19 @@ describe('UpdateService.showUpdateDialog 并发流互斥闸门', () => {
     );
     // 断言未触碰弹窗创建（updatePopupWindow 仍是注入的假窗，未被替换）
     expect(typeof svc.updatePopupWindow.isDestroyed).toBe('function');
+  });
+});
+
+describe('UpdateService.createUpdatePopup 新建窗口路径下发初始状态（#300 回归）', () => {
+  const state = { phase: 'remind' as const, theme: 'light' as const, version: 'v2.0.0' };
+
+  it('新建弹窗后 seed lastPopupState 并向 renderer 下发（防 did-finish-load 无态可重放 → 白卡片挂死窗）', () => {
+    const svc = new UpdateService(log) as any;
+    const win = svc.createUpdatePopup(state);
+    // lastPopupState 必须被写入：否则 did-finish-load 重放条件恒 false，remind 态永不渲染。
+    expect(svc.lastPopupState).toEqual(state);
+    // 同步向 renderer 下发一次当前态（页面 onState 晚注册时由 did-finish-load 兜底重放同一 lastPopupState）。
+    expect(win.webContents.send).toHaveBeenCalledWith(expect.anything(), state);
   });
 });
 


### PR DESCRIPTION
Closes #300

## 症状
开启代理后屏幕角落出现一块 frameless + alwaysOnTop 的纯色底卡片（浅色主题白、深色主题深灰），无按钮、无法点击、Esc 失效、不在任务栏，只能 Cmd+Q 完全退出才消失，重启再开代理复现。

## 根因
`createUpdatePopup` 的**新建窗口路径从不下发初始状态**：`did-finish-load` 回调只重放 `this.lastPopupState`，而该字段仅在 `sendPopupState` 内写入。remind 态走新建路径时从不调 `sendPopupState` → `lastPopupState` 恒 `null` → 渲染端 `onState` 永不触发 → 页面 `#update-root` 永远为空 → 用户看到的就是 BrowserWindow 的主题化实色底。

- 无按钮：页面无 DOM。
- Esc 失效：`update-popup/main.ts` 的 keydown 被 `!current` 短路（从未收到状态）。
- 无法关闭：frameless + skipTaskbar + alwaysOnTop，无 OS 手段；`showUpdateDialog` 互斥闸门让后续检查静默返 `later`，无自愈。

**为何仅 remind 态**：progress/done/error 态由下载循环持续调 `sendPopupState`（首次即写入 `lastPopupState` 供重放），不受影响；remind 是唯一入口态，恰好被杀。

**回归来源**：PR #292 的 review 加固把「首次加载后 `once` 下发初始状态」替换成「崩溃后重放 `lastPopupState`」，但新建路径从不 seed `lastPopupState`。随 v4.2.3 起全平台全主题 100% 必现，v4.2.4 发布后才有新版本触发。

**为何开代理后触发**：更新检查依赖代理才够得到 GitHub（大陆直连不通），并非代理事件本身触发弹窗。

## 修复
`createUpdatePopup` 末尾补一行 `this.sendPopupState(state)`，seed `lastPopupState` 供 `did-finish-load` 兜底重放；复用分支（顶部已自带 `sendPopupState` 后 early-return）语义不变。

## 测试
- 新增回归单测：钉「新建窗口路径首个 `did-finish-load` 必须有状态可发」（seed `lastPopupState` + 向 renderer `send`）。撤掉修复行即转红，已验证。
- Gate 全绿：`tsc -p tsconfig.main.json` = 0、`eslint` = 0、`jest` 全量 224 套 3269 测全过。

## 待真机验证（Xvfb/真机各一次）
remind 四态流转 + Esc/× + 角落定位——弹窗创建属 runtime 语义项，单测覆盖纯逻辑分支。