### PR TITLE
fix: 提权死腿 / 托盘 i18n 漏迁 / GitHub 域名漂移 / 固定名 tmp

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -416,6 +416,20 @@ const MESSAGES = {
     ru: 'FlowZ — Подключено',
     fa: 'FlowZ — متصل',
   },
+  trayNoUpdateBody: {
+    'zh-CN': '当前已是最新版本',
+    'zh-TW': '目前已是最新版本',
+    'en-US': "You're on the latest version",
+    ru: 'У вас установлена последняя версия',
+    fa: 'شما از آخرین نسخه استفاده می‌کنید',
+  },
+  trayNoUpdateOk: {
+    'zh-CN': '确定',
+    'zh-TW': '確定',
+    'en-US': 'OK',
+    ru: 'ОК',
+    fa: 'تأیید',
+  },
 
   // —— 提权 helper 授权对话框（index.ts）：按钮 ——
   btnCancel: {

--- a/src/main/services/CoreUpdateService.ts
+++ b/src/main/services/CoreUpdateService.ts
@@ -29,7 +29,7 @@ import { CoreDownloader } from './core-downloader';
 import type { UpdateNetwork } from './UpdateNetwork';
 import coreManifest from '../../shared/core-manifest.json';
 import { IPC_CHANNELS } from '../../shared/ipc-channels';
-import { system32, powershellPath } from '../utils/win-system32';
+import { system32 } from '../utils/win-system32';
 
 export interface CoreUpdateCheckResult {
   hasUpdate: boolean;
@@ -1725,58 +1725,11 @@ export class CoreUpdateService {
    * 解决将文件写入 C:\Program Files (UAC 保护目录) 时的 EPERM 问题
    */
   private async copyFileElevatedWindows(src: string, dest: string): Promise<void> {
-    // delegate → PlatformPrivilegeService.copyFileElevated（T16 子 commit 1：PowerShell RunAs 逻辑原样保留，
-    // this.logManager.addLog → ctx.log）；未注入时保留原实现兜底。
-    if (this.privilegeService) return this.privilegeService.copyFileElevated(src, dest);
-    const { execSync } = require('child_process') as typeof import('child_process');
-
-    const escapedSrc = src.replace(/'/g, "''");
-    const escapedDest = dest.replace(/'/g, "''");
-
-    const destDir = path.dirname(dest);
-    if (!fs.existsSync(destDir)) {
-      fs.mkdirSync(destDir, { recursive: true });
+    // 恒经 PlatformPrivilegeService（index.ts 无条件注入）。旧内联 PowerShell RunAs 实现已删：它不可达，
+    // 且缺 service 侧的两处加固（脚本落盘随机名 + 不盲杀同名 sing-box 进程）——留着=误触发即复现已修 bug。
+    if (!this.privilegeService) {
+      throw new Error('privilegeService 未注入：copyFileElevatedWindows 不可用');
     }
-
-    try {
-      // First try a direct copy (works if app has write access)
-      fs.copyFileSync(src, dest);
-    } catch (directErr: any) {
-      if (directErr.code !== 'EPERM' && directErr.code !== 'EACCES' && directErr.code !== 'EBUSY') {
-        throw directErr;
-      }
-
-      this.logManager.addLog(
-        'info',
-        `Direct copy failed (${directErr.code}), attempting elevated PowerShell copy...`,
-        'CoreUpdateService'
-      );
-
-      // Fall back: use PowerShell with -Verb RunAs to elevate.
-      const scriptPath = path.join(app.getPath('temp'), `flowz-copy-${Date.now()}.ps1`);
-      // 使用 $ErrorActionPreference = 'Stop' 确保出错时非 0 退出
-      // 增加 Stop-Process 防御，防止因为 TUN 模式的高权限占用导致无法覆盖
-      fs.writeFileSync(
-        scriptPath,
-        `$ErrorActionPreference = 'Stop'\nStop-Process -Name "sing-box" -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 1\nCopy-Item -Path '${escapedSrc}' -Destination '${escapedDest}' -Force\n`
-      );
-
-      try {
-        // 使用 Start-Process -Verb RunAs 触发 UAC 提权并用 -Wait 阻塞直到完成
-        execSync(
-          `"${powershellPath()}" -Command "Start-Process '${powershellPath()}' -ArgumentList '-ExecutionPolicy Bypass -WindowStyle Hidden -File \\"${scriptPath}\\"' -Verb RunAs -Wait"`,
-          {
-            stdio: 'pipe',
-            timeout: 60000,
-          }
-        );
-      } finally {
-        try {
-          fs.unlinkSync(scriptPath);
-        } catch {
-          /* ignore */
-        }
-      }
-    }
+    return this.privilegeService.copyFileElevated(src, dest);
   }
 }

--- a/src/main/services/RuleResourceManager.ts
+++ b/src/main/services/RuleResourceManager.ts
@@ -7,8 +7,14 @@ import * as fs from 'fs/promises';
 import * as fssync from 'fs';
 import * as path from 'path';
 import { getRuleResourcesPath } from '../utils/paths';
+import { writeFileAtomic } from '../utils/atomic-write';
 import { MAX_GITHUB_JSON_BYTES } from '../utils/http-limits';
-import { applyGhProxy, ghMirrorUrl, normalizeGhProxyPrefix } from '../../shared/gh-proxy';
+import {
+  applyGhProxy,
+  ghMirrorUrl,
+  isGithubHost,
+  normalizeGhProxyPrefix,
+} from '../../shared/gh-proxy';
 import {
   mrdRawUrl,
   RULE_RESOURCE_CATALOG,
@@ -44,7 +50,6 @@ const IDLE_TIMEOUT_MS = 15_000;
 const OVERALL_TIMEOUT_MS = 120_000;
 const MAX_SIZE = 64 * 1024 * 1024;
 const POOL_SIZE = 3;
-const GITHUB_HOSTS = ['raw.githubusercontent.com', 'github.com'];
 
 type FetchResult =
   | { ok: true; buf: Buffer }
@@ -423,7 +428,7 @@ export class RuleResourceManager {
     const finalUrl = applyGhProxy(prefix, sourceUrl);
     let r = await this.fetchBuffer(finalUrl, onChunk);
     if (!r.ok && prefix) r = await this.fetchBuffer(sourceUrl, onChunk);
-    if (!r.ok && this.isGithub(sourceUrl)) {
+    if (!r.ok && isGithubHost(sourceUrl)) {
       r = await this.fetchBuffer(ghMirrorUrl(sourceUrl), onChunk);
     }
     if (!r.ok) return { ok: false, errorCode: r.errorCode };
@@ -432,14 +437,7 @@ export class RuleResourceManager {
       return { ok: false, errorCode: 'invalid_content' };
     }
     await fs.mkdir(path.dirname(destPath), { recursive: true });
-    const tmp = `${destPath}.download`;
-    try {
-      await fs.writeFile(tmp, r.buf);
-      await fs.rename(tmp, destPath);
-    } catch (e) {
-      await fs.unlink(tmp).catch(() => {}); // 清理半写 tmp，避免运行时/资源目录脏文件堆积
-      throw e;
-    }
+    await writeFileAtomic(destPath, r.buf);
     return { ok: true, size: r.buf.length };
   }
 
@@ -459,7 +457,7 @@ export class RuleResourceManager {
 
   /**
    * 更新内置 geo 规则集：从 SagerNet 源重下载到运行时目录（<userData>/rules）。
-   * 同名 tmp→rename 原子替换 → sing-box ≥1.10 fswatch 热重载，零重启零断流（条目已在非 direct 模式挂载）。
+   * 唯一后缀 tmp→rename 原子替换 → sing-box ≥1.10 fswatch 热重载，零重启零断流（条目已在非 direct 模式挂载）。
    */
   async updateBuiltin(
     tag: string,
@@ -538,9 +536,7 @@ export class RuleResourceManager {
       }
       const dest = path.join(getRuleSetRuntimeDir(), b.fileName);
       await fs.mkdir(path.dirname(dest), { recursive: true });
-      const tmp = `${dest}.reset`;
-      await fs.copyFile(src, tmp);
-      await fs.rename(tmp, dest);
+      await writeFileAtomic(dest, await fs.readFile(src));
       await this.setBuiltinUpdatedAt(tag, null); // 回到「出厂版」状态
       return { ok: true, id, name: b.tag, existedBefore: true };
     } catch (e) {
@@ -553,14 +549,6 @@ export class RuleResourceManager {
       };
     } finally {
       this.inflight.delete(id);
-    }
-  }
-
-  private isGithub(url: string): boolean {
-    try {
-      return GITHUB_HOSTS.includes(new URL(url).hostname);
-    } catch {
-      return false;
     }
   }
 
@@ -666,11 +654,13 @@ export class RuleResourceManager {
       if (items.length < 50) throw new Error('catalog too small');
       const fetchedAt = Date.now();
       await fs.mkdir(this.dir(), { recursive: true });
-      // 原子写：tmp → rename，与 .srs 落盘一致，防撕裂文件
-      const cachePath = this.catalogCachePath();
-      const tmp = `${cachePath}.tmp`;
-      await fs.writeFile(tmp, JSON.stringify({ schemaVersion: 1, fetchedAt, items }), 'utf-8');
-      await fs.rename(tmp, cachePath);
+      // 原子写（唯一后缀 tmp → rename）：本函数无 inflight 保护、IPC 层无去抖——当前唯一调用方靠按钮
+      // disabled 挡住连点，但那是 UI 侧的偶然防线；多窗口/未来非 UI 调用方即可并发写同一固定名 tmp 致
+      // 字节交错。唯一后缀让各 writer 写各自临时文件，不依赖调用方自律。
+      await writeFileAtomic(
+        this.catalogCachePath(),
+        JSON.stringify({ schemaVersion: 1, fetchedAt, items })
+      );
       this.catalogCache = { items, fetchedAt, source: 'remote' };
       return this.catalogCache;
     } catch (e) {

--- a/src/main/tray-actions.ts
+++ b/src/main/tray-actions.ts
@@ -211,9 +211,9 @@ export function buildTrayCallbacks(deps: TrayActionDeps) {
           const { dialog } = require('electron');
           dialog.showMessageBox(mainWindow, {
             type: 'info',
-            title: '检查更新',
-            message: '当前已是最新版本',
-            buttons: ['确定'],
+            title: mt('trayCheckUpdates'), // 复用打开本 dialog 的托盘菜单项文案，不另造近重复 key
+            message: mt('trayNoUpdateBody'),
+            buttons: [mt('trayNoUpdateOk')],
           });
         }
       }

--- a/src/shared/__tests__/gh-proxy.test.ts
+++ b/src/shared/__tests__/gh-proxy.test.ts
@@ -1,6 +1,41 @@
-import { ghMirrorUrl, applyGhProxy, normalizeGhProxyPrefix, GH_PROXY_PRESETS } from '../gh-proxy';
+import {
+  ghMirrorUrl,
+  applyGhProxy,
+  isGithubHost,
+  normalizeGhProxyPrefix,
+  GH_PROXY_PRESETS,
+} from '../gh-proxy';
 
 const GH = 'https://github.com/a/b/releases/download/v1/x.zip';
+
+// 域名表是「加速」与「镜像兜底」共用的单一真值。曾有消费方各持一份副本（RuleResourceManager 的 2 域
+// GITHUB_HOSTS vs 本表 5 域）→ 同一 URL 在第1级算 GitHub、第3级不算，三级兜底自相矛盾。
+// 本组断言逐个钉死 5 域 + 刻意排除项，任何漂移即红。
+describe('isGithubHost（域名表单一真值）', () => {
+  it.each([
+    'https://github.com/a/b',
+    'https://raw.githubusercontent.com/a/b/main/x.srs',
+    'https://objects.githubusercontent.com/gh-release-assets/1/2',
+    'https://gist.githubusercontent.com/u/id/raw/x',
+    'https://codeload.github.com/a/b/tar.gz/refs/heads/main',
+  ])('GitHub 家族域命中：%s', (url) => {
+    expect(isGithubHost(url)).toBe(true);
+  });
+
+  it('api.github.com 刻意不在表内（Trees API 刷新不走加速）', () => {
+    expect(isGithubHost('https://api.github.com/repos/a/b/git/trees/main')).toBe(false);
+  });
+
+  it('非 GitHub 域 → false', () => {
+    expect(isGithubHost('https://example.com/x.zip')).toBe(false);
+    expect(isGithubHost('https://notgithub.com/a')).toBe(false);
+  });
+
+  it('非法 URL → false（不抛）', () => {
+    expect(isGithubHost('not a url')).toBe(false);
+    expect(isGithubHost('')).toBe(false);
+  });
+});
 
 describe('ghMirrorUrl', () => {
   it('无 ghPrefix → 回落内置 preset[0]+url', () => {

--- a/src/shared/gh-proxy.ts
+++ b/src/shared/gh-proxy.ts
@@ -52,16 +52,25 @@ const GH_HOSTS = [
 ];
 
 /**
- * 拼接加速前缀 + 完整原 URL（同 gh-proxy 用法）。非前缀 / 非 GitHub 域 → 原样返回。
- * 注意：api.github.com 不在 GH_HOSTS（Trees API 刷新不走加速）。
+ * URL 是否属 GitHub 家族域（= 值得走镜像加速/兜底重试）。GH_HOSTS 的唯一消费入口：
+ * 消费方一律调本函数，禁止各自复制域名表——RuleResourceManager 曾有一份 2 域的本地副本，
+ * 与本表 5 域漂移，导致同一 URL 在「加速」时算 GitHub、在「镜像兜底」时不算，三级兜底自相矛盾。
+ * 注意：api.github.com **不在** GH_HOSTS（Trees API 刷新不走加速）。解析失败（非法 URL）→ false。
+ */
+export function isGithubHost(url: string): boolean {
+  try {
+    return GH_HOSTS.includes(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 拼接加速前缀 + 完整原 URL（同 gh-proxy 用法）。无前缀 / 非 GitHub 域 / 非法 URL → 原样返回。
  */
 export function applyGhProxy(prefix: string | undefined, url: string): string {
   if (!prefix) return url;
-  try {
-    if (!GH_HOSTS.includes(new URL(url).hostname)) return url;
-  } catch {
-    return url;
-  }
+  if (!isGithubHost(url)) return url;
   return prefix + url;
 }
 


### PR DESCRIPTION
一次全量代码审计（`src/` 13 万行 + helper/scripts）挖出的 4 处实质缺陷。三个 commit 按域分。纯逻辑改动，无 runtime 语义变更。

## 1. `fix(update)` 删 Windows 提权复制的不可达旧实现

`copyFileElevatedWindows` 在 delegate 到 `PlatformPrivilegeService` 之后，仍留 54 行旧 PowerShell RunAs 内联实现作「未注入时兜底」。但 `index.ts` **无条件**调 `setPrivilegeService` → 生产恒非 null → 该腿不可达。

**不是无害保险丝**：service 侧实现修了两处，旧腿都没有——

| | 旧腿（不可达） | service 侧（现役） |
|---|---|---|
| 脚本落盘 | `Date.now()` 可预测名 + 共享 temp | `randomBytes` + `wx` 独占创建 + privDir 0o700 |
| 进程终止 | `Stop-Process -Name "sing-box" -Force` **盲杀同名进程** | 按 `ExecutablePath` 定向终止 |

留着 = 一旦误触发即复现已修 bug。改纯 delegate，未注入**抛错**而非静默回落。

## 2. `fix(tray)` 检查更新的「已是最新」提示走 i18n

托盘「检查更新」无新版本时弹的 dialog 硬编码简体中文（标题/正文/按钮）。同文件其余分支、`index.ts` 全部 helper 对话框、`helper-handlers.ts` 卸载对话框**均已 i18n**，仅此一处遗漏 → 非中文用户看到纯中文框。

标题复用既有 `trayCheckUpdates`（正是打开本 dialog 的菜单项文案），不另造近重复 key。新增正文/按钮 2 个 key，5 语齐。

## 3. `fix(rules)` GitHub 域名判定收口单一谓词 + 落盘改唯一后缀原子写

**域名表漂移致镜像兜底漏判**：`RuleResourceManager` 自持 `GITHUB_HOSTS`（2 域）与 `shared/gh-proxy.ts` 的 `GH_HOSTS`（5 域）漂移，令 `fetchSrsToFile` 三级兜底自相矛盾：

```
1. applyGhProxy  → 按 5 域表：认定是 GitHub，加速
2. 失败 → 裸 URL 重试
3. 失败 → isGithub → 按 2 域表：不认，跳过镜像兜底   ← 同一 URL，结论相反
```

用户填 `codeload` / `gist` / `objects.githubusercontent.com` 直链时，加速失败后拿不到本该有的镜像重试。

改：导出 `isGithubHost()` 单一谓词，两处共用。**不导出域名数组**——那样消费方仍各自 `includes`，还会再漂。补测试逐个钉死 5 域 + `api.github.com` 刻意排除 + 非法 URL 不抛。

**固定名 tmp**：三处落盘（`.download`/`.reset`/`.tmp`）未用仓内既有的 `writeFileAtomic`（唯一随机后缀，其注释明说这正是它修的 bug 形态）。其中 `refreshCatalog` 无 inflight 保护、IPC 层无去抖，仅靠调用方按钮 `disabled` 挡并发——UI 侧的偶然防线。三处统一换用，消灭该形态以免被后续代码沿用。

## 验证

- `tsc --noEmit` = 0 · `eslint` = 0 · `jest` **228 套 3311 测全过**（较改前 +8，为新增域名表断言）
- 独立 review 一轮：零 High，2 Med + 2 Low + 2 Nit 全收
- 净变化 6 文件 / +72 / -89

## 说明

- 均为纯逻辑/文案改动，**不涉 runtime 语义**（窗口生命周期/IPC/内核），无需真机验证。
- 1 与 3 的死代码判定依据均已复核：`setPrivilegeService` 调用点在平坦作用域无平台守卫；`applyGhProxy` 重构后真值表逐字节等价（含非法 URL 分支）。