### PR TITLE
test(update): 修 Windows CI —— core-swap-gate 注入 privilegeService stub

### DIFF
--- a/src/main/services/__tests__/core-swap-gate.test.ts
+++ b/src/main/services/__tests__/core-swap-gate.test.ts
@@ -198,6 +198,14 @@ describe('T2：CoreUpdateService 4 写核路径 setCoreSwapInProgress try/finall
     svc.setProxyManager(proxy);
     svc.setConfigProvider(() => Promise.resolve({ autoUpdateCore: true } as any));
     svc.setEventSender(() => {});
+    // rollbackCore 在 win32 分支经 privilegeService.copyFileElevated 写核（生产由 index.ts 无条件注入）；
+    // 非 win32 分支直接 fs.copyFileSync。注入等价 stub（复刻 service 首步 copyFileSync），使 copySpy 计数
+    // 与 'disk full' 抛错传播在 windows/linux/mac runner 上一致。
+    svc.setPrivilegeService({
+      copyFileElevated: async (src: string, dest: string) => {
+        require('fs').copyFileSync(src, dest);
+      },
+    } as any);
     return svc;
   }
 


### PR DESCRIPTION
## 背景：#305 合入时漏了这个修复

#305 的 CI 在 **windows-latest 上是红的**（macOS 绿）。我推了修复 commit 到分支，但 GitHub 侧**跨 fork PR 的 head 未同步**（fork 分支已是 `c159be9`，PR head 始终停在 `80b66a7`），结果 #305 以不含修复的版本合入 → **main 当前 Windows CI 红**。

本 PR 把那个 commit 补上（cherry-pick，内容与当时一致）。

## 症状

`src/main/services/__tests__/core-swap-gate.test.ts` T2 的两条 `rollbackCore` 用例，仅 windows runner：

```
Expected substring: "disk full"
Received message:   "privilegeService 未注入：copyFileElevatedWindows 不可用"
```

## 根因

#305 删掉了 `copyFileElevatedWindows` 的不可达旧腿（内联 PowerShell RunAs），改为纯 delegate 到 `privilegeService.copyFileElevated`。而 `rollbackCore` 是分平台的：

```ts
if (process.platform === 'win32') {
  await this.copyFileElevatedWindows(backupPath, currentPath);  // ← 经 privilegeService
} else {
  fs.copyFileSync(backupPath, currentPath);                      // ← 测试的 copySpy 直接命中
}
```

T2 的 `makeSvc` 不注入 `privilegeService`。Linux/macOS runner 走 else 分支 → `copySpy` 照常捕获 → 绿；Windows runner 上 `process.platform === 'win32'` 为真（无需 mock），走 delegate → 撞「未注入」抛错。

**旧腿此前在 Windows 上恰好承担了「测试里的 `fs.copyFileSync` 入口」** —— 它在生产不可达（`index.ts` 无条件调 `setPrivilegeService`），但在未注入的测试里可达。

## 为什么不恢复旧腿

生产恒注入，旧腿仍是死代码；且它缺 service 侧两处加固（脚本落盘随机名防 TOCTOU、按 `ExecutablePath` 定向终止而非盲杀同名 sing-box）。恢复=把已修 bug 放回来。

改测试侧：注入等价 stub，复刻 service 首步 `fs.copyFileSync`，使 `copySpy` 计数与 `'disk full'` 抛错传播在三平台 runner 上一致。仅改 T2 工厂（T3/T4 不走该分支，Windows 上本就绿）。

## 验证

强制 `process.platform='win32'` 的测试副本上：

| | 结果 |
|---|---|
| 无本修复 | **精确复现 CI 两处失败**（同样的 Expected/Received） |
| 有本修复 | 25/25 通过 |

全量：`tsc` = 0 · `jest` 228 套 3311 测绿。

## 教训

本地/Linux gate 全绿不代表跨平台绿。`process.platform` 分支在 Linux 上「看着没人走」是错觉——windows runner 上它是真的。涉及平台分支的改动，需在目标平台语义下验证（本次用强制 platform 的副本 + 负向验证坐实）。