### PR TITLE
fix: 测速中断提示副行跨订阅黏死 (#308)

### DIFF
--- a/src/renderer/components/settings/__tests__/speed-test-toast.test.ts
+++ b/src/renderer/components/settings/__tests__/speed-test-toast.test.ts
@@ -3,7 +3,7 @@
  * 去重并集节点进度（union 去重、result serverId 去重）、全部结束一次 success/error、批次间隔离、归零退订。
  */
 jest.mock('sonner', () => ({
-  toast: { loading: jest.fn(), success: jest.fn(), error: jest.fn() },
+  toast: { loading: jest.fn(), success: jest.fn(), error: jest.fn(), warning: jest.fn() },
 }));
 
 let resultCb: ((d: { serverId: string; latency: number }) => void) | null = null;
@@ -42,6 +42,7 @@ beforeEach(() => {
   (toast.loading as jest.Mock).mockClear();
   (toast.success as jest.Mock).mockClear();
   (toast.error as jest.Mock).mockClear();
+  (toast.warning as jest.Mock).mockClear();
 });
 
 describe('聚合测速 toast 协调器（去重并集节点进度）', () => {
@@ -110,5 +111,29 @@ describe('聚合测速 toast 协调器（去重并集节点进度）', () => {
     result('x');
     endAggSpeedTest(false);
     expect(toast.success).toHaveBeenCalledWith('DONE', ID); // 批2 成功，不受批1失败污染
+  });
+
+  it('回归 #308：中断批写了副行 description，下批 loading 必须显式带 description:undefined 清副行', () => {
+    const richLabels = {
+      ...labels,
+      interruptedSummary: (tested: number, total: number) => `已完成 ${tested}/${total} 节点`,
+    };
+    // 批1：中断收尾 → warning 带副行 description（sonner 会把它写到 TOAST_ID 上）
+    beginAggSpeedTest(['a', 'b'], richLabels);
+    result('a');
+    endAggSpeedTest(false, undefined, 'interrupted');
+    expect(toast.warning).toHaveBeenCalledWith('INTERRUPTED', {
+      id: 'speedtest-aggregate',
+      description: '已完成 1/2 节点',
+    });
+    // 批2：换订阅重测 → loading 调用必须显式携带 description key（值 undefined），
+    // 否则 sonner 浅合并保留批1 的副行，跨订阅黏死（#308）。
+    beginAggSpeedTest(['x'], richLabels);
+    const calls = (toast.loading as jest.Mock).mock.calls;
+    const lastLoading = calls[calls.length - 1];
+    expect(lastLoading[0]).toBe('RUN:0/1');
+    // hasOwnProperty 直查：key 必须在场（toEqual/toHaveBeenCalledWith 会忽略 undefined 属性，抓不到本 bug）。
+    expect(Object.prototype.hasOwnProperty.call(lastLoading[1], 'description')).toBe(true);
+    expect(lastLoading[1].description).toBeUndefined();
   });
 });

--- a/src/renderer/components/settings/speed-test-toast.ts
+++ b/src/renderer/components/settings/speed-test-toast.ts
@@ -47,7 +47,10 @@ let unsubResult: (() => void) | null = null;
 
 function render(): void {
   if (!labels || active === 0) return;
-  toast.loading(labels.running(tested.size, union.size), { id: TOAST_ID });
+  // description: undefined 是必需的显式清空——sonner 按 id 更新 toast 走浅合并（{...旧, ...新}），
+  // 不带的字段保留旧值。若上一批以 interrupted/skipped 收尾写过副行 description，loading 态
+  // （duration:Infinity 不自动消失）会一直残留那行「已完成 x/y 节点」并跨订阅黏死（#308）。
+  toast.loading(labels.running(tested.size, union.size), { id: TOAST_ID, description: undefined });
 }
 
 /** 一次测速开始：serverIds 并入 union、引用计数++；首个订阅 per-node result 事件累计已测唯一节点。 */


### PR DESCRIPTION
## 问题

订阅测速未完整跑完（核跃迁/崩溃打断）时，聚合 toast 弹出中断提示，副行「已完成 x/y 节点，其余保留原值」。此后**换其他订阅重新测速，该副行一直残留、跨订阅黏死**——主行节点数（如 29/49、10/44、0/24）在动，副行却冻结在上一次的 20/35。见 #308 截图。

## 根因

`src/renderer/components/settings/speed-test-toast.ts` 的 `render()` 更新 loading toast 时只传 `{ id: TOAST_ID }`、不带 `description`。sonner 2.x 按 id 更新 toast 走**浅合并**（`{ ...旧toast, ...新data }`，见 sonner `Observer.create`），新 data 未带的字段保留旧值。上一批以 `interrupted`/`skipped` 收尾时 `endAggSpeedTest` 经 `toast.warning(..., { description })` 把副行写到了 `TOAST_ID` 上；loading 态 `duration: Infinity` 不自动消失，于是后续每次 `render()` 都合并在这条残留副行之上，永不清除。

## 修复

`render()` 显式传 `description: undefined` 覆盖清空。loading 进行态本就不该带副行，语义也正确。单点修复即够：`beginAggSpeedTest` 恒先 `render()`（清干净基线），`endAggSpeedTest` 三分支各自显式设/不设 description 均落在干净基线上。

## 测试

- 新增回归单测：中断批写副行后，下批 loading 断言携带 `description` key 且值为 `undefined`（用 `hasOwnProperty` 直查——`toHaveBeenCalledWith` 会忽略 `undefined` 属性，抓不到本 bug）。
- 变异验证：去掉 `description: undefined` 后仅该回归用例转红、其余 5 例保持绿，确认测试有牙。
- `speed-test-toast` 全 6 例通过；`tsc --noEmit` 全项目干净；两文件 `eslint` 干净。

Closes #308