### PR TITLE
chore(core): 随包 sing-box 内核升级至 1.14.0-alpha.45

### DIFF
--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,11 +1,11 @@
 {
-  "bundledCoreVersion": "1.14.0-alpha.44",
+  "bundledCoreVersion": "1.14.0-alpha.45",
   "cronetVersion": "v148.0.7778.96-1",
   "coreArchiveSha256": {
-    "linux": "f94ced013079799b4ca10a89d9365bd88675a8ccd0ade19c7314caf7bd36611b",
-    "win": "9790599d1f3c3f5752683439b98829ff54b683c2f4746feb980796ea2dc196d7",
-    "mac-x64": "9b0e71baa9d0b0fe5a2770087444706d1cd3a4f1c8cdf6af4f8e6c11c080c959",
-    "mac-arm64": "2c15a4fc76b87254b6775df42b55b218dc0afae6d28e991278c64589673eb415"
+    "linux": "a4c6c66dce8d636179193bce56db76f01ab953a2d1bdf65f15d2dfc2a07195c4",
+    "win": "7e1cbc218d0cef4a0168c89d7afc8cc95e9dd77ded3a49f9a02e1fad2ed7ba4a",
+    "mac-x64": "fc661d35f373dd930be7291173bebe30eb680502e60aca56a47b2dc6f77cfeb0",
+    "mac-arm64": "5d9e6027e12082227a88490deecfdca4147f6f6acc16cffe844d59fbf039b443"
   },
   "cronetArchiveSha256": {
     "linux": "dc7293a929dffa695aae1a89555e7366158fa0a3f40bbe3012d445bc05c99672",


### PR DESCRIPTION
## 变更

随包 sing-box 内核 `1.14.0-alpha.44` → `1.14.0-alpha.45`。

- `src/shared/core-manifest.json`：`bundledCoreVersion` 升级，四平台 `coreArchiveSha256` 同步更新。
- 校验值取自 SagerNet/sing-box 官方 release `v1.14.0-alpha.45` 的 asset digest（`gh api repos/SagerNet/sing-box/releases/tags/v1.14.0-alpha.45 --jq '.assets[]|{name,digest}'`），与 `fetch-core.mjs` 的完整性 pin 契约一致。

内核二进制不入库（`resources/*/sing-box` 已 gitignore，打包时由 `npm run fetch:core` 现拉现打）。

## 验证

- `npm run fetch:core -- --force`：四平台压缩包全部下载并逐字节 sha256 校验通过（`4 ready, 0 failed`）。
- linux 核 `sing-box version` 确认为 `1.14.0-alpha.45`（tags 含 gvisor/quic/tailscale/naive 等，与既有一致）。
- `version-handlers-t10` / `core-swap-gate` / `version` / `core-build` / `neighbor` 共 122 单测全绿。
- 运行期 config schema 兼容性建议合并前真机 `sing-box check` 一次（alpha.44→45 单步 prerelease，schema 破坏概率低）。