### PR TITLE
feat(update): 更新提醒弹窗直达本版本 changelog + 去内联发布说明

### DIFF
--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -15,12 +15,7 @@ import type {
   UpdatePopupAction,
   UpdatePopupLabels,
 } from '../../shared/types/update';
-import {
-  UPDATE_POPUP_WIDTH,
-  popupHeightFor,
-  popupPosition,
-  previewReleaseNotes,
-} from './update-popup-layout';
+import { UPDATE_POPUP_WIDTH, popupHeightFor, popupPosition } from './update-popup-layout';
 import { APP_USER_AGENT } from '../../shared/constants';
 import { MAX_GITHUB_JSON_BYTES } from '../utils/http-limits';
 import { getUserDataPath } from '../utils/paths';
@@ -471,8 +466,18 @@ export class UpdateService {
     this.logManager.addLog('info', `已跳过版本: ${version}`, 'UpdateService');
   }
 
-  openReleasesPage(): void {
-    shell.openExternal(`https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases`);
+  /**
+   * 打开 GitHub releases 页。传 version（发布 tag，如 v4.2.7）→ 直达该版本的 changelog 页
+   * （/releases/tag/<tag>），精确定位本次更新说明；不传 → 泛列表页（About「查看所有版本」等无版本上下文入口）。
+   */
+  openReleasesPage(version?: string): void {
+    const base = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases`;
+    if (version) {
+      const tag = version.startsWith('v') ? version : `v${version}`;
+      shell.openExternal(`${base}/tag/${encodeURIComponent(tag)}`);
+    } else {
+      shell.openExternal(base);
+    }
   }
 
   /**
@@ -492,7 +497,6 @@ export class UpdateService {
       theme: this.resolvedTheme(),
       version: updateInfo.version,
       currentVersion: `v${app.getVersion()}`,
-      notes: previewReleaseNotes(updateInfo.releaseNotes || ''),
       labels: this.popupLabels(),
     });
 
@@ -681,7 +685,8 @@ export class UpdateService {
     if (!this.updatePopupWindow || this.updatePopupWindow.isDestroyed()) return;
     if (event.sender !== this.updatePopupWindow.webContents) return; // 只认本弹窗
     if (action === 'viewLog') {
-      this.openReleasesPage(); // 打开 releases，弹窗保留在 remind 态（不 resolve）
+      // 直达本次更新版本的 changelog 页（currentUpdateInfo 在 showUpdateDialog 设）；弹窗保留在 remind 态（不 resolve）。
+      this.openReleasesPage(this.currentUpdateInfo?.version);
       return;
     }
     if (action === 'cancel') {

--- a/src/main/services/__tests__/update-popup-layout.test.ts
+++ b/src/main/services/__tests__/update-popup-layout.test.ts
@@ -1,20 +1,15 @@
 /**
- * 更新弹窗纯布局逻辑单测（无 electron 依赖）：态→高度、平台→角落定位、发布说明预览截断。
+ * 更新弹窗纯布局逻辑单测（无 electron 依赖）：态→高度、平台→角落定位。
  */
-import {
-  UPDATE_POPUP_WIDTH,
-  popupHeightFor,
-  popupPosition,
-  previewReleaseNotes,
-} from '../update-popup-layout';
+import { UPDATE_POPUP_WIDTH, popupHeightFor, popupPosition } from '../update-popup-layout';
 
 describe('popupHeightFor', () => {
   it('四态各有确定高度，remind 最高、progress/done 同高', () => {
-    expect(popupHeightFor('remind')).toBe(184);
+    expect(popupHeightFor('remind')).toBe(160);
     expect(popupHeightFor('error')).toBe(152);
     expect(popupHeightFor('progress')).toBe(116);
     expect(popupHeightFor('done')).toBe(116);
-    // remind 承载动作+说明 → 应高于 progress
+    // remind 承载动作+链接（无内联更新说明）→ 仍高于 progress
     expect(popupHeightFor('remind')).toBeGreaterThan(popupHeightFor('progress'));
   });
 });
@@ -55,37 +50,5 @@ describe('popupPosition', () => {
     expect(p.x).toBe(Math.round(1000.5 - W - 8));
     expect(Number.isInteger(p.x)).toBe(true);
     expect(Number.isInteger(p.y)).toBe(true);
-  });
-});
-
-describe('previewReleaseNotes', () => {
-  it('空/undefined → 空串', () => {
-    expect(previewReleaseNotes('')).toBe('');
-    expect(previewReleaseNotes(undefined as unknown as string)).toBe('');
-  });
-
-  it('按行截前 maxLines 行', () => {
-    const raw = 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8';
-    expect(previewReleaseNotes(raw, 3)).toBe('l1\nl2\nl3');
-  });
-
-  it('超 maxChars 截断补省略号', () => {
-    const raw = 'x'.repeat(500);
-    const out = previewReleaseNotes(raw, 6, 100);
-    expect(out.endsWith('…')).toBe(true);
-    expect(out.length).toBeLessThanOrEqual(101);
-  });
-
-  it('去首尾空白', () => {
-    expect(previewReleaseNotes('  hi  \n\n', 6)).toBe('hi');
-  });
-
-  it('不在 surrogate pair 中间截断（末尾无孤立 high surrogate）', () => {
-    // '🚀' = 2 code units；构造边界恰落在 emoji 中间的场景。
-    const raw = `${'a'.repeat(99)}🚀tail`;
-    const out = previewReleaseNotes(raw, 6, 100); // 第 100 个 code unit = 🚀 的 high surrogate
-    const last = out.charCodeAt(out.length - 2); // 末字符是 '…'，看其前一字符
-    expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
-    expect(out.endsWith('…')).toBe(true);
   });
 });

--- a/src/main/services/__tests__/update-service-popup.test.ts
+++ b/src/main/services/__tests__/update-service-popup.test.ts
@@ -10,7 +10,7 @@ const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-updsvc-test-'));
 
 jest.mock('electron', () => ({
   app: { getPath: () => TMP, getVersion: () => '1.0.0', isPackaged: false, getAppPath: () => TMP },
-  shell: {},
+  shell: { openExternal: jest.fn() },
   // 可实例化的 BrowserWindow 桩：让 createUpdatePopup 走完新建路径，暴露 webContents.send 以断言初始态下发。
   BrowserWindow: class {
     webContents = { setWindowOpenHandler: () => {}, on: () => {}, send: jest.fn() };
@@ -33,10 +33,12 @@ jest.mock('electron', () => ({
   Notification: class {},
 }));
 
+import { shell } from 'electron';
 import { UpdateService } from '../UpdateService';
 import { setMainLanguage, mt } from '../../i18n';
 
 const log = { addLog: () => {} } as any;
+const openExternal = shell.openExternal as unknown as jest.Mock;
 
 describe('UpdateService.showUpdateDialog 并发流互斥闸门', () => {
   it('已有活跃弹窗 → 直接返回 later，不新建弹窗（Med-1：防覆盖 resolver / 双下载）', async () => {
@@ -60,6 +62,34 @@ describe('UpdateService.createUpdatePopup 新建窗口路径下发初始状态�
     expect(svc.lastPopupState).toEqual(state);
     // 同步向 renderer 下发一次当前态（页面 onState 晚注册时由 did-finish-load 兜底重放同一 lastPopupState）。
     expect(win.webContents.send).toHaveBeenCalledWith(expect.anything(), state);
+  });
+});
+
+describe('UpdateService.openReleasesPage 直达本版本 changelog', () => {
+  const svc = new UpdateService(log) as any;
+  const RELEASES = 'https://github.com/dododook/FlowZ/releases';
+  beforeEach(() => openExternal.mockClear());
+
+  it('传 version（带 v 前缀）→ 直达该版本 tag 页', () => {
+    svc.openReleasesPage('v4.2.7');
+    expect(openExternal).toHaveBeenCalledWith(`${RELEASES}/tag/v4.2.7`);
+  });
+
+  it('version 缺 v 前缀 → 自动补 v 再定位', () => {
+    svc.openReleasesPage('4.2.7');
+    expect(openExternal).toHaveBeenCalledWith(`${RELEASES}/tag/v4.2.7`);
+  });
+
+  it('不传 version → 泛 releases 列表页（无版本上下文入口）', () => {
+    svc.openReleasesPage();
+    expect(openExternal).toHaveBeenCalledWith(RELEASES);
+  });
+
+  it('viewLog 动作用 currentUpdateInfo.version 直达本次更新的 changelog', () => {
+    svc.currentUpdateInfo = { version: 'v3.1.0' };
+    svc.updatePopupWindow = { webContents: {}, isDestroyed: () => false };
+    svc.onPopupAction({ sender: svc.updatePopupWindow.webContents }, 'viewLog');
+    expect(openExternal).toHaveBeenCalledWith(`${RELEASES}/tag/v3.1.0`);
   });
 });
 

--- a/src/main/services/update-popup-layout.ts
+++ b/src/main/services/update-popup-layout.ts
@@ -12,13 +12,16 @@ export const UPDATE_POPUP_WIDTH = 380;
 
 /**
  * 各态窗口内容高度（px，内容驱动的固定值）：
- * remind 最高（图标+标题+当前版本+2 行说明+动作行+文字链）；error 含 2 行错误文本+动作行；
- * progress/done 仅图标行+进度条+计数行。实现期可按真机微调，纯函数便于随规格演进钉测试。
+ * remind（图标+标题+当前版本+动作行+文字链，无内联说明）；error 含 2 行错误文本+动作行；
+ * progress/done 仅图标行+进度条+计数行。纯函数便于随规格演进钉测试。
+ * headroom 约定：固定值在 Linux 自然内容高之上留 ~15px 余量（progress/done 实测 ~15.5、error ~30），
+ * 吸收 Win/Mac CJK 字体（PingFang/微软雅黑 vs Noto）行高差异——宁多留（margin-top:auto 吸成极小内部
+ * 间距、不可见）不裁切（overflow:hidden 会切底部行）。remind 自然高 146.5(Linux/Xvfb 实测)→160。
  */
 export function popupHeightFor(phase: UpdatePopupPhase): number {
   switch (phase) {
     case 'remind':
-      return 184;
+      return 160;
     case 'error':
       return 152;
     case 'progress':
@@ -49,18 +52,4 @@ export function popupPosition(
   const y =
     platform === 'darwin' ? workArea.y + inset : workArea.y + workArea.height - height - inset;
   return { x: Math.round(x), y: Math.round(y) };
-}
-
-/**
- * 发布说明预览：取前 maxLines 行、总长截 maxChars 字符（超出补省略号），去尾空白。
- * GitHub releaseNotes 可能很长/含 markdown——弹窗只展示概要，完整日志走「查看更新日志」外链。
- */
-export function previewReleaseNotes(raw: string, maxLines = 6, maxChars = 400): string {
-  const lines = (raw || '').split('\n').slice(0, maxLines).join('\n').trim();
-  if (lines.length <= maxChars) return lines;
-  let cut = lines.slice(0, maxChars);
-  // 防在 surrogate pair 中间截断（末字符为孤立 high surrogate → 渲染 �）：多退一个 code unit。
-  const lastCode = cut.charCodeAt(cut.length - 1);
-  if (lastCode >= 0xd800 && lastCode <= 0xdbff) cut = cut.slice(0, -1);
-  return `${cut.trimEnd()}…`;
 }

--- a/src/renderer/update-popup/main.ts
+++ b/src/renderer/update-popup/main.ts
@@ -34,7 +34,7 @@ let current: UpdatePopupState | null = null;
 // 入场动画只播一次：仅首个全量 render 给 .upop 加 .enter（相变重建的 .upop 不带 → 不重播）。
 let firstRender = true;
 
-/** HTML 转义：version/notes/errorText 可能含 GitHub 侧内容，注入 innerHTML 前一律转义（防 XSS）。 */
+/** HTML 转义：version/errorText 可能含 GitHub 侧内容，注入 innerHTML 前一律转义（防 XSS）。 */
 function esc(s: string): string {
   return s.replace(/[&<>"']/g, (c) =>
     c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;'
@@ -81,7 +81,6 @@ function render(s: UpdatePopupState): void {
         <button class="upop-x" type="button" data-act="later" aria-label="${esc(L.later)}">${ICON_X}</button>
       </div>
       ${s.currentVersion ? `<div class="upop-sub">${esc(L.currentPrefix)} ${esc(s.currentVersion)}</div>` : ''}
-      ${s.notes ? `<div class="upop-notes">${esc(s.notes)}</div>` : ''}
       <div class="upop-acts">
         <button class="btn flow sm" type="button" data-act="update">${esc(L.update)}</button>
         <button class="btn ghost sm" type="button" data-act="later">${esc(L.later)}</button>

--- a/src/shared/types/update.ts
+++ b/src/shared/types/update.ts
@@ -88,8 +88,6 @@ export interface UpdatePopupState {
   version: string;
   /** remind：当前运行版本（如 v1.2.0）。 */
   currentVersion?: string;
-  /** remind：发布说明预览（已截断）。 */
-  notes?: string;
   /** progress/done：百分比 0-100。 */
   percentage?: number;
   /** progress：字节计数文本（如 "28.6 MB / 45.3 MB"）。 */


### PR DESCRIPTION
## 背景

更新提醒弹窗（remind 态）此前内联展示发布说明预览，但 CSS `-webkit-line-clamp: 2` 只显 2 行——实际就是 `## What's Changed` + 一行，看着像「不显示更新日志」。且底部「查看更新日志」按钮只打开 GitHub `/releases` **泛列表页**，不定位本次更新的版本。

## 变更

按需求「弹窗只保留版本提示、不内联更新内容；加按钮直达 changelog」：

- **弹窗只留版本提示**：新版本号 pill + 「当前 vX.Y.Z」副行，移除内联发布说明。
- **按钮直达本版本 changelog**：`openReleasesPage(version?)` 传 tag → `/releases/tag/<tag>` 精确定位本次更新说明，缺省 → 泛列表页（About 等无版本上下文入口）；`viewLog` 动作用 `currentUpdateInfo.version`。tag 补 `v` 前缀 + `encodeURIComponent`。
- **连带清理**：删 `UpdatePopupState.notes` 字段、弹窗 notes 渲染分支、及其唯一消费者 `previewReleaseNotes` 工具与其单测（去内联说明后彻底无引用）。
- **高度收窄**：remind 弹窗 `184 → 160`（宽 380 不变）。

## 高度 & 三平台

`184` 系带 2 行内联说明时的值；去说明后 Xvfb + Electron `capturePage` **实测**四态自然内容高与既有 fixed 值的 headroom：

| 态 | 自然高(Linux) | fixed | headroom |
|----|----|----|----|
| remind | 146.5 | **160** | ~13.5 |
| error | 121.8 | 152 | ~30 |
| progress | 100.5 | 116 | ~15.5 |
| done | 100.0 | 116 | ~16 |

remind 取 160 而非贴边的 147，是对齐既有约定的 ~15px headroom，用于吸收 **Win/Mac CJK 字体**（PingFang SC / 微软雅黑 vs Linux Noto）的行高差异。方向上宁多留不裁切：`.upop-acts { margin-top:auto }` 把余量吸成动作行上方极小内部间距（不可见），而 `.upop { overflow:hidden }` 一旦高度不足会切掉底部「跳过此版本 / 查看更新日志」链接行。

> 注：自然高在本机 Linux/Xvfb 实测；Win/Mac 未直接跑（此环境无法起）。13.5px 余量 ≈ 每行 2.7px×5 行，足够覆盖 CJK 行高常见差异，且与已跨平台出厂的 progress/done/error 同约定。

## 测试

- 新增 `openReleasesPage` 四例：版本直达 `/tag/v4.2.7`、缺 `v` 自动补全、缺省泛列表、`viewLog` 经 `currentUpdateInfo.version` 直达。**变异验证**：篡改实现丢 `/tag/` 路径后三条版本用例转红、泛列表例保持绿。
- `update-popup-layout` 高度断言 `184 → 160`。
- `update-service` / `update-popup` / `window-reference-refresh` / `core-update-scheduler` 等 7 套共 86 单测全绿；`tsc --noEmit` 全项目 + 改动文件 `eslint` 干净。