### PR TITLE
fix: 更新后任务栏固定/托盘位置丢失 (#312)

### DIFF
--- a/src/main/services/TrayManager.ts
+++ b/src/main/services/TrayManager.ts
@@ -35,6 +35,22 @@ const PROTOCOL_SHORT: Record<string, string> = {
   hysteria2: 'Hy2',
 };
 
+/**
+ * macOS 托盘位置持久化标识（#312）。Electron 的 `new Tray(image, guid)` 在 darwin 上经
+ * `electron_api_tray.cc` 的 `SetAutoSaveName(guid.AsLowercaseString())` 落到 NSStatusItem.autosaveName
+ * （`tray_icon_cocoa.mm` 的 `TrayIcon::Create(guid)` 本身忽略 guid，只实现 SetAutoSaveName），系统据此把
+ * 菜单栏位置存进本 app 的 preferences domain（键 `NSStatusItem Preferred Position <guid>`）；
+ * 不传则 AppKit 自动选名，位置不跨启动保留（electron#47838）。
+ * 格式须为合法 UUID：`guid_converter.h` 走 `base::Uuid::ParseCaseInsensitive` + `is_valid`，非法则 `Tray::New`
+ * 抛 "Invalid GUID format" → 被 createTray 的 try/catch 吞掉 → **托盘静默消失**（比丢位置严重）。
+ *
+ * **一次性生成后永久写死，跨版本不得变更**——改了等于换 autosaveName，用户已拖好的位置会丢。
+ * **仅 darwin 传**：Electron 文档明确警告 Windows 上未签名 exe 的 GUID 会与 exe 路径永久绑定，路径一变托盘
+ * 创建即失败；FlowZ 无 Authenticode 签名且 portable 形态每版换文件名（见 update-install-script.ts 便携态注释）
+ * → win32 传 guid 会直接弄坏 portable 更新后的托盘。Linux 忽略此参数。
+ */
+const MACOS_TRAY_GUID = 'ba2b1484-56c4-430d-a3a9-18e6cc3f45dd';
+
 export type TrayIconState = 'idle' | 'connected' | 'connecting';
 
 export interface TrayMenuData {
@@ -148,7 +164,8 @@ export class TrayManager implements ITrayManager {
     try {
       const icon = this.loadTrayIcon('idle');
 
-      this.tray = new Tray(icon);
+      // darwin 传 guid（= NSStatusItem.autosaveName）保住用户拖放的菜单栏位置；win32/linux 必须不传，见 MACOS_TRAY_GUID。
+      this.tray = process.platform === 'darwin' ? new Tray(icon, MACOS_TRAY_GUID) : new Tray(icon);
       this.tray.setToolTip('FlowZ');
 
       // 托盘点击行为：

--- a/src/main/services/__tests__/tray-manager-guid.test.ts
+++ b/src/main/services/__tests__/tray-manager-guid.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #312：托盘 guid 的平台分派。
+ *
+ * darwin 必须传固定 guid —— Electron 在 darwin 上把它赋给 NSStatusItem.autosaveName，系统据此把用户拖放的
+ * 菜单栏位置存进本 app 的 preferences domain；不传则位置不跨启动保留（electron#47838），每次更新后图标回到默认位。
+ *
+ * win32 必须**不**传 —— Electron 文档明示未签名 exe 的 GUID 与 exe 路径永久绑定，路径变则托盘创建失败；
+ * FlowZ 无 Authenticode 签名且 portable 形态每版换文件名 → 传了会弄坏 portable 更新后的托盘。这条是本次改动
+ * 最危险的逃逸面（传错了在 Linux/mac 上一切正常、只在 Windows portable 真机炸），故单独钉死。
+ */
+const trayCtorArgs: unknown[][] = [];
+
+jest.mock('electron', () => ({
+  app: { getLocale: () => 'zh-CN', getPreferredSystemLanguages: () => ['zh-Hans-CN'] },
+  BrowserWindow: class {},
+  Tray: class {
+    constructor(...args: unknown[]) {
+      trayCtorArgs.push(args);
+    }
+    setToolTip = jest.fn();
+    setImage = jest.fn();
+    setContextMenu = jest.fn();
+    destroy = jest.fn();
+    on = jest.fn();
+  },
+  Menu: { buildFromTemplate: () => ({}) },
+  nativeImage: {
+    createFromPath: () => ({ resize: () => ({}), isEmpty: () => false }),
+    createFromDataURL: () => ({}),
+  },
+}));
+
+// loadTrayIcon 经 ResourceManager 取图标路径（真实实现依赖打包态的 app 路径，测试态拿不到）。
+// 给一个不存在的路径 → 走 createDefaultTrayIcon 分支，与本测关注的 guid 分派无关。
+jest.mock('../ResourceManager', () => ({
+  resourceManager: { getTrayIconPath: () => '/nonexistent/flowz-tray-icon.png' },
+}));
+
+import { TrayManager } from '../TrayManager';
+
+const makeLogger = () => ({ addLog: jest.fn(), clearLogs: jest.fn() }) as any;
+
+/** UUID v4 形态；Electron 对非 UUID 的 guid 抛 "Invalid GUID format"。 */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function createTrayOn(platform: NodeJS.Platform): unknown[] {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    trayCtorArgs.length = 0;
+    new TrayManager(null, makeLogger()).createTray();
+    expect(trayCtorArgs).toHaveLength(1);
+    return trayCtorArgs[0];
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+}
+
+describe('TrayManager 托盘 guid 平台分派（#312）', () => {
+  it('darwin：传 guid，且为合法 UUID（= NSStatusItem.autosaveName，保住菜单栏位置）', () => {
+    const args = createTrayOn('darwin');
+    expect(args).toHaveLength(2);
+    expect(typeof args[1]).toBe('string');
+    expect(args[1]).toMatch(UUID_RE);
+  });
+
+  it('win32：绝不传 guid（未签名 exe 的 GUID 绑死 exe 路径，portable 换名后托盘创建即失败）', () => {
+    expect(createTrayOn('win32')).toHaveLength(1);
+  });
+
+  it('linux：不传 guid（该参数在 Linux 无意义）', () => {
+    expect(createTrayOn('linux')).toHaveLength(1);
+  });
+
+  // 钉死字面量而非「跨调用自比」——后者是同进程内常量自比、恒真，守不住任何常量替换：
+  // 换成另一个合法 UUID（或 crypto.randomUUID()，模块级 const 进程内同样稳定）时全绿，
+  // 而用户菜单栏位置已全丢。这是本次改动唯一真实的长期逃逸面（重构手滑即触发）。
+  // 钉死后「改 guid」必须同时改本测试 → 强制过一次有意识决策。
+  it('guid 恒为该字面量（跨版本不得变更；改动=换 autosaveName=用户已拖好的位置全丢）', () => {
+    expect(createTrayOn('darwin')[1]).toBe('ba2b1484-56c4-430d-a3a9-18e6cc3f45dd');
+  });
+});

--- a/src/main/services/__tests__/update-install-script.test.ts
+++ b/src/main/services/__tests__/update-install-script.test.ts
@@ -56,12 +56,32 @@ describe('buildWindowsUpdateVbs', () => {
     expect(s).toContain('oldExe = "D:\\\\Apps\\\\FlowZ.exe"');
   });
 
-  it('NSIS 态：跑下载的 setup、无 CopyFile（原行为）', () => {
+  it('NSIS 态：跑下载的 setup 且带 --updated、无 CopyFile', () => {
     const s = buildWindowsUpdateVbs({ installerPath: tmp, portableTarget: null });
+    // VBS 展开后为:  WshShell.Run "<setup 绝对路径>" --updated, 1, False
     expect(s).toContain(
-      'WshShell.Run """C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-4.1.7-win-x64-portable.exe"""'
+      'WshShell.Run """C:\\\\Users\\\\u\\\\AppData\\\\Local\\\\Temp\\\\FlowZ-4.1.7-win-x64-portable.exe"" --updated", 1, False'
     );
     expect(s).not.toContain('fso.CopyFile');
+  });
+
+  // #312：缺 --updated → NSIS ${isUpdated} 为假 → 旧卸载器 WinShell::UninstShortcut 取消任务栏固定。
+  // 钉死「参数在 VBS 里位于闭合引号之外」——写成 """...--updated""" 会被当成路径的一部分传给 ShellExecute，
+  // 静默退化回丢 pin 的旧行为且无任何报错。
+  it('NSIS 态：--updated 在 VBS 字符串闭合引号之外（不得混进 exe 路径）', () => {
+    const s = buildWindowsUpdateVbs({ installerPath: 'C:\\T\\s.exe', portableTarget: null });
+    expect(s).toContain('WshShell.Run """C:\\\\T\\\\s.exe"" --updated", 1, False');
+    expect(s).not.toContain('--updated"""');
+    expect(s).not.toContain('s.exe --updated');
+  });
+
+  it('便携态不得带 --updated（无 NSIS 安装器，参数会被当文件名）', () => {
+    const s = buildWindowsUpdateVbs({
+      installerPath: tmp,
+      portableTarget: 'D:\\Apps\\FlowZ-4.1.5-win-x64-portable.exe',
+      portableNewPath: 'D:\\Apps\\FlowZ-4.1.7-win-x64-portable.exe',
+    });
+    expect(s).not.toContain('--updated');
   });
 });
 

--- a/src/main/services/update-install-script.ts
+++ b/src/main/services/update-install-script.ts
@@ -108,11 +108,29 @@ export function buildWindowsUpdateVbs(opts: {
       'fso.DeleteFile WScript.ScriptFullName, True',
     ].join('\r\n');
   }
-  // NSIS 安装态：与旧 installUpdate 逐字等价（运行 setup + 删自身）。NSIS 据注册表记住的目录原位升级、不动 %APPDATA% data。
+  // NSIS 安装态：运行 setup + 删自身。NSIS 据注册表记住的目录原位升级、不动 %APPDATA% data。
+  //
+  // `--updated` 不可省（#312 任务栏固定每次更新丢失的根因）：NSIS 的 ${isUpdated} 谓词 = 「命令行含 --updated」
+  // （StdUtils.TestParameter，见 app-builder-lib templates/nsis/include/*.nsh）。本项目设了
+  // allowToChangeInstallationDirectory → installUtil.nsh 的 setIsTryToKeepShortcuts 在 ${ifNot} ${isUpdated}
+  // 时把 $isTryToKeepShortcuts 置 false → 新安装器不给旧版卸载器传 --keep-shortcuts → 旧卸载器执行
+  // WinShell::UninstShortcut（= IStartMenuPinnedList::RemoveFromList）**显式取消任务栏固定**；随后安装段只重建
+  // 桌面/开始菜单快捷方式，故症状是「唯独任务栏 pin 每次更新丢」。Windows 无程序化重新固定的 API，删了只能手动加回。
+  // **滞后一版生效**：本 VBS 由「当前运行的旧版 app」生成 → 升级到含本修复的那一版时，跑脚本的仍是不带
+  // --updated 的旧版，pin 仍会丢最后一次；自本版 → 下一版起才保住。（旧版卸载器本身支持 --keep-shortcuts，
+  // 缺的只是旧版 VBS 不传 --updated。）release note 需写明，否则会收到「升级到修复版还是丢了」的无效反馈。
+  //
+  // 附带行为变化两条：
+  // ① 激活 skipPageIfUpdated → 更新时跳过欢迎/目录页（已装机不再问安装目录，杜绝装出第二个目录）。
+  // ② $keepShortcuts=true 后 addStartMenuLink/addDesktopLink（installer.nsh:189-243）不再无条件重建快捷方式
+  //    → 用户手动删掉的桌面/开始菜单快捷方式，更新后不再被重建（FlowZ createDesktopShortcut:true 非 "always"、
+  //    无 RECREATE define）。此为 electron-updater 生态标准语义，算改进。注意上文第 6 环描述的「安装段重建
+  //    快捷方式」是**修复前**的行为，勿与此处混读。
+  // 与 electron-updater 官方行为一致（NsisUpdater.ts 恒传 ["--updated"]）。
   return [
     'WScript.Sleep 2000',
     'Set WshShell = CreateObject("WScript.Shell")',
-    `WshShell.Run """${src}""", 1, False`,
+    `WshShell.Run """${src}"" --updated", 1, False`,
     'Set fso = CreateObject("Scripting.FileSystemObject")',
     'fso.DeleteFile WScript.ScriptFullName, True',
   ].join('\r\n');


### PR DESCRIPTION
## 问题

issue #312：每次更新后图标从任务栏取消固定（报告者 Windows 11）。排查发现这个 issue 实际包含两个平台两套互不相关的机制。

## Windows：任务栏 pin 每次更新丢失

FlowZ 内置更新器启动新版 NSIS 安装器时**未传 `--updated`**。electron-builder 的 NSIS 安装器覆盖安装时会运行旧版本卸载器，是否保留快捷方式由 `--keep-shortcuts` 链路控制：

- `${isUpdated}` 谓词 = 命令行含 `--updated`（`StdUtils.TestParameter`）。
- 本项目 `allowToChangeInstallationDirectory: true` → `installUtil.nsh` 的 `setIsTryToKeepShortcuts` 在 `${ifNot} ${isUpdated}` 时把 `$isTryToKeepShortcuts` 置 `false` → 新安装器不给旧卸载器传 `--keep-shortcuts`。
- 旧卸载器 `${ifNot} ${isKeepShortcuts}` 命中 → `WinShell::UninstShortcut`（即 `IStartMenuPinnedList::RemoveFromList`）**显式取消任务栏固定**；随后安装段只重建桌面/开始菜单快捷方式 → 症状为「唯独任务栏 pin 每次更新丢」。

与代码签名无关。修复：更新脚本传 `--updated`（与 electron-updater 官方 `NsisUpdater.ts` 恒传一致），同时激活 `skipPageIfUpdated` 跳过更新时的目录页。

> ⚠️ **滞后一版生效**：执行更新脚本的仍是旧版程序，升级到本版的那一次仍会丢一次固定，从再下一次更新起不再丢。无法绕过（旧版卸载器本身支持 `--keep-shortcuts`，缺的只是旧版脚本不传 `--updated`）。

## macOS：菜单栏托盘图标位置每次更新后重置

`TrayManager.createTray()` 的 `new Tray(icon)` 未传第二参数 `guid`。Electron 在 darwin 上经 `electron_api_tray.cc` 的 `SetAutoSaveName(guid.AsLowercaseString())` 把它落到 `NSStatusItem.autosaveName`，系统据此把菜单栏位置存进 app 的 preferences domain；不传则位置不跨启动保留（electron/electron#47838 正是修这个）。

修复：darwin 传写死 UUID 作为 guid。

- **win32 绝不传**：Electron 文档明确未签名 exe 的 GUID 与 exe 路径永久绑定、路径变则托盘创建失败；FlowZ 无 Authenticode 签名且 portable 每版换文件名。
- **Linux 忽略此参数**。
- guid 一次性写死、跨版本不得变更（改动 = 换 autosaveName = 用户已拖好的位置丢失），已用钉死字面量的单测强制。

> macOS 位置持久化按 bundle identifier 索引、不消费代码签名，与之前推测的 ad-hoc 签名无关。首个修复版上线后位置键从旧自动名迁到 guid 名（一次性，无真实回归——改动前本就不持久）。

## 测试

- 新增 `tray-manager-guid.test.ts`：darwin 传合法 UUID guid / win32 不传 / linux 不传 / guid 钉死字面量。
- `update-install-script.test.ts` 补 NSIS 分支 `--updated` 断言（参数在闭合引号之外、便携态不带）。
- 变异验证 10 条全部被断言杀死（`--updated` 侧 4 + guid 侧 6，含「换另一合法 UUID」「randomUUID」两条真实逃逸面）。
- `tsc`（main + renderer）0 error；全量 `jest` 229 suites / 3339 passed；改动文件 `eslint` 干净。

## 未覆盖

- **真机未验**：Windows 走一次内置更新验 pin 保持 / macOS 拖好位置后更新验位置保持——本地无 Win/mac 真机。
- **便携版**、**手动双击安装包升级**是另外两条独立路径。手动双击路径的 maintenance mode 方案单独提 PR。

Closes #312
