### PR TITLE
feat: 手动双击安装器时给已安装用户升级/卸载选择 (#312)

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -49,3 +49,139 @@
     RMDir /r "$APPDATA\flowz"
   ${endif}
 !macroend
+
+; ================================================================
+; #312 后续：已安装 + 手动双击 setup.exe 的 maintenance mode。
+;
+; 诉求：用户绕过 app 内更新器、手动双击新版 setup.exe 时（该路径无 --updated，
+; ${isUpdated} 恒假），当前行为 = 显示目录页（可改路径，能装出第二个目录）+ 旧
+; 卸载器跑 WinShell::UninstShortcut 取消任务栏固定（#312 在内置更新器修复后剩余
+; 的唯一 pin 丢失面）。改为：已安装时首页给「升级 / 卸载」二选一。
+;
+;   升级 → 以 `--updated /currentuser` 重启自身 = 与内置更新器（fix #312 的
+;          update-install-script.ts --updated）**同一链路**：skipPageIfUpdated
+;          跳过目录页（= 锁死目录，杜绝第二个安装目录）、keep-shortcuts 链路保住
+;          任务栏 pin、旧卸载器走 ${isUpdated} 分支跳过下方 customUnInstall
+;          （helper 服务不断流、无 UAC、用户数据不动）。
+;   卸载 → 启动已装的 Uninstall.exe（无 --updated = 真卸载语义：清 pin/helper
+;          服务/用户数据，走下方 customUnInstall 的 ${ifNot} ${isUpdated} 块，
+;          正确且与既有钩子零冲突）。
+;
+; 首装（检测不到已装）与内置更新器（--updated）两条路径均在 PRE 里 Abort → 零接触。
+; 静默 /S 不带参数 + 页面回调 silent 下不执行 → 天然绕过。portable.nsi 无这些
+; 插桩点 → 零影响。
+;
+; ---- mutex 竞态防护（升级分支 relaunch 的唯一工程难点）----
+; ALLOW_ONLY_ONE_INSTALLER_INSTANCE（installer.nsi:73/76）在 .onInit 里建命名
+; mutex（allowOnlyOneInstallerInstance.nsh:14），handle 用 `?e` 只压 GetLastError、
+; 从未存储 → 无法主动释放，只能随进程退出由内核回收。升级分支的 relaunch 只能发生
+; 在页面 Leave（用户点「升级」后），此时父实例 mutex 已持有 → 子实例直接 CreateMutex
+; 会撞 ERROR_ALREADY_EXISTS 被 Abort（且父窗口已销毁，FindWindow 前台化也无效，
+; 表现为「点了升级后再无任何窗口」）。
+; 解法：relaunch 带 /flowz-wait-pid=<父PID>；子实例的 preInit（installer.nsi:56，
+; **早于** :73 的 mutex 检查）里 WaitForSingleObject 等父进程退出（典型 <200ms，
+; 上限 10s 兜底）→ 走到 mutex 检查时父 mutex 已回收 → 干净拿到。等的是「父句柄
+; signaled」这个事实，非猜测时长；全程安装器自身代码，无 cmd/ping 外部进程链。
+; 降级安全：参数缺失/PID 无效/OpenProcess 失败 → 跳过等待；超时 → 走原 mutex 检查
+; （最坏 = 现状 Abort，不更劣）。
+;
+; System::Call 惯用法照模板：handle 用 `i` 类型接、`!= 0` 判定（getProcessInfo.nsh:118
+; + allowOnlyOneInstallerInstance.nsh:57），非 `p`/`P<>`。
+; ================================================================
+
+Var flowzExistingDir   ; 已装 per-user 安装目录（"" = 未装 / 不启用 maintenance）
+Var flowzExistingVer   ; 已装版本号（仅 header 展示用）
+Var flowzRadioUpgrade  ; 「升级」单选控件句柄
+Var flowzRadioRemove   ; 「卸载」单选控件句柄
+
+; 子实例侧：等待父安装器实例退出，规避 ALLOW_ONLY_ONE mutex 竞态。
+; 此宏在 .onInit 的 mutex 检查之前展开（installer.nsi:56 < :73），是等待的唯一有效时机。
+!macro preInit
+  Push $R0
+  Push $R1
+  Push $R2
+  ${GetParameters} $R0
+  ClearErrors
+  ${GetOptions} $R0 "/flowz-wait-pid=" $R1
+  ${IfNot} ${Errors}
+  ${AndIf} $R1 != ""
+    ; OpenProcess(SYNCHRONIZE=0x00100000=1048576, bInheritHandle=0, pid) → handle（i 接，0=失败）
+    System::Call 'kernel32::OpenProcess(i 1048576, i 0, i $R1) i .R2'
+    ${If} $R2 != 0
+      ; 父进程退出即 signaled，立即返回；父若卡死则 10s 上限兜底后继续（走原 mutex 检查）
+      System::Call 'kernel32::WaitForSingleObject(i $R2, i 10000)'
+      System::Call 'kernel32::CloseHandle(i $R2)'
+    ${EndIf}
+  ${EndIf}
+  Pop $R2
+  Pop $R1
+  Pop $R0
+!macroend
+
+; 检测本机已安装（在 initMultiUser + SetRegView 64 之后展开，installer.nsi:80）。
+; 自读注册表，不依赖模板内部变量（$perUserInstallationFolder 等非稳定 API）。
+!macro customInit
+  ReadRegStr $flowzExistingDir HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation
+  ReadRegStr $flowzExistingVer HKCU "${UNINSTALL_REGISTRY_KEY}" DisplayVersion
+  ; 闸门 1：存在 per-machine（HKLM）安装（历史 /allusers 装出）→ 不启用，回默认流程，不恶化现状
+  ReadRegStr $R0 HKLM "${INSTALL_REGISTRY_KEY}" InstallLocation
+  ${If} $R0 != ""
+    StrCpy $flowzExistingDir ""
+  ${EndIf}
+  ; 闸门 2：注册表残留但主程序已不存在 → 当首装（避免对已删安装弹升级/卸载）
+  ${If} $flowzExistingDir != ""
+    ${IfNot} ${FileExists} "$flowzExistingDir\${APP_EXECUTABLE_FILENAME}"
+      StrCpy $flowzExistingDir ""
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+; 已安装时的首页「升级 / 卸载」。原生 Page custom（非 MUI_PAGE_CUSTOMFUNCTION define
+; 机制）→ 与目录页的 skipPageIfUpdated PRE 槽零冲突。插在页序列第一位（assistedInstaller.nsh:9）。
+!macro customWelcomePage
+  Page custom flowzMaintenancePre flowzMaintenanceLeave
+
+  Function flowzMaintenancePre
+    ${If} ${isUpdated}             ; 内置更新器 / 我们自己的升级 relaunch：不介入
+      Abort
+    ${EndIf}
+    ${If} $flowzExistingDir == ""  ; 未安装（或被闸门置空）：首装流程零改变
+      Abort
+    ${EndIf}
+
+    ; 文案暂用英文字面量（PR 评审时如需随 $LANGUAGE 本地化再换 LangString）
+    !insertmacro MUI_HEADER_TEXT "FlowZ $flowzExistingVer is already installed" "Choose an operation"
+    nsDialogs::Create 1018
+    Pop $0
+    ${NSD_CreateLabel} 0u 0u 300u 20u "Existing installation: $flowzExistingDir"
+    Pop $0
+    ${NSD_CreateRadioButton} 10u 34u 285u 12u "Upgrade to ${VERSION} (keeps settings and taskbar pin)"
+    Pop $flowzRadioUpgrade
+    ${NSD_CreateRadioButton} 10u 52u 285u 12u "Uninstall FlowZ"
+    Pop $flowzRadioRemove
+    ${NSD_Check} $flowzRadioUpgrade   ; 默认选「升级」
+    nsDialogs::Show
+  FunctionEnd
+
+  Function flowzMaintenanceLeave
+    ${NSD_GetState} $flowzRadioRemove $0
+    ${If} $0 == ${BST_CHECKED}
+      ; —— 卸载：启动已装卸载器。不传 --updated//S → 真卸载 GUI（走下方 customUnInstall
+      ;    的 ${ifNot} ${isUpdated} 清理块）。Uninstall.exe 的 un.onInit 无 mutex 检查
+      ;    （uninstaller.nsh），无竞态。
+      ReadRegStr $R0 HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString
+      ${If} $R0 != ""
+        Exec '$R0'                  ; 值形如 "<dir>\Uninstall FlowZ.exe" /currentuser（已含引号）
+      ${EndIf}
+      SetErrorLevel 0
+      Quit
+    ${EndIf}
+    ; —— 升级：以内置更新器同款参数重启自身。--updated → 跳目录页(锁死目录)+keep-shortcuts
+    ;    (保 pin)+旧卸载器跳过 customUnInstall；/currentuser → 跳「为谁安装」页；
+    ;    /flowz-wait-pid → 子实例 preInit 等本进程退出后再抢 mutex。
+    System::Call 'kernel32::GetCurrentProcessId() i .r0'
+    Exec '"$EXEPATH" /currentuser --updated /flowz-wait-pid=$0'
+    SetErrorLevel 0
+    Quit
+  FunctionEnd
+!macroend


### PR DESCRIPTION
## 背景

#312 的 pin 修复（#313）覆盖**内置更新器**路径。用户若绕过 app 内更新、手动双击从 release 下载的新版 `setup.exe`，该路径没有 `--updated`：

- 显示目录页、可改路径 → 能装出**第二个安装目录**；
- `$isTryToKeepShortcuts` 仍为 `false` → 旧卸载器照样 `WinShell::UninstShortcut` → **任务栏 pin 照丢**（与目录改没改无关）。

这是 #313 之后手动路径残留的最后一个 pin 丢失面。本 PR 让**已安装**用户手动双击时，首页直接给「升级 / 卸载」二选一（传统安装器的 maintenance mode）。

## 行为

`build/installer.nsh` 追加三个宏（electron-builder NSIS 官方扩展点，均 `!ifmacrodef` 可选宏）：

- **`customInit`**：自读 `HKCU InstallLocation` + `DisplayVersion` 检测已装（不依赖模板内部变量）。两道保守闸门：存在 per-machine（HKLM）安装 → 不启用回默认流程；注册表残留但主程序已删 → 当首装。
- **`customWelcomePage`**：`Page custom`，页序列第一位。
  - PRE：`${isUpdated}`（更新器 / 本 PR 的升级 relaunch）或未安装 → `Abort`（**首装与 app 内更新两条路径零接触**）。
  - 已安装 → nsDialogs 显示「Upgrade / Uninstall」。
  - **升级** → `Exec '"$EXEPATH" /currentuser --updated /flowz-wait-pid=<PID>'`：以内置更新器同款参数重启自身，复用 `skipPageIfUpdated`（跳目录页 = 锁定安装位置）+ `keep-shortcuts`（保任务栏 pin）+ 旧卸载器走 `${isUpdated}` 分支跳过 `customUnInstall`（helper 服务不断流、无 UAC、用户数据不动）。
  - **卸载** → `Exec` 已装 `UninstallString`（无 `--updated` = 真卸载语义，走既有 `customUnInstall` 清理块）。
- **`preInit`**：见下方竞态防护。

首装、app 内更新、静默 `/S`、portable 均不受影响。

## mutex 竞态防护

升级分支 relaunch 与 `ALLOW_ONLY_ONE_INSTALLER_INSTANCE`（`.onInit` 里建命名 mutex）有竞态：relaunch 只能发生在页面 Leave，此时父实例 mutex 已持有，且该 mutex 的 handle 用 `?e` 只压 `GetLastError`、从未存储 → **无法主动释放**，只能随进程退出由内核回收。子实例直接抢会撞 `ERROR_ALREADY_EXISTS` 被 Abort（父窗口已销毁，连 `FindWindow` 前台化都无效 → 表现为「点了升级后再无窗口」）。

解法：relaunch 带 `/flowz-wait-pid=<父PID>`；子实例在 **`preInit`**（`installer.nsi` 里 `.onInit` 的 mutex 检查**之前**展开）里 `OpenProcess(SYNCHRONIZE)` + `WaitForSingleObject(≤10s)` 等父进程退出 → 父 mutex 已回收后再抢，确定性规避。降级安全：参数缺失 / PID 无效 / `OpenProcess` 失败 → 跳过等待；超时 → 走原 mutex 检查（最坏 = 现状）。

附带：子实例带 `--updated`，若 FlowZ 正在运行会走 `_CHECK_APP_RUNNING` 的静默优雅关闭分支，比手动双击弹 "app is running" 体验更好。

## ⚠️ 尚未真机验证

本改动为 NSIS 脚本，**无法在 CI/Linux 编译**（需 Windows + makensis）。已完成的是逐行核对每个 define / 宏插入点 / `System::Call` 惯用法的模板源码依据 + 结构平衡静态检查。**合并前需 Windows 真机跑以下清单**：

| # | 场景 | 通过判据 |
|---|---|---|
| 1 | 干净首装 | 无 maintenance 页；目录页照常可改 |
| 2 | 已装态双击 | 首页即「Upgrade/Uninstall」，显示旧版本+目录 |
| 3 | 选 Upgrade | ≤1s 新实例直接 instfiles→finish；目录不变；**桌面/任务栏 pin 保留**；`sc query FlowZHelper` 在跑；全程无 UAC |
| 4 | **竞态专项**：场景 3 连跑 10 次 + 慢速 VM 5 次 | 15/15 正常进 instfiles（失败样态 = 点 Upgrade 后无窗口） |
| 5 | 选 Uninstall | 服务删除（恰一次 UAC）、`%APPDATA%\flowz` 删、pin 清、注册表清 |
| 6 | app 内更新回归 | 无 maintenance 页，pin 保留 |
| 7 | 静默 `/S` | 无任何页，直接升级成功 |
| 8 | FlowZ 运行中选 Upgrade | 静默关闭 app 后继续，不弹 "app is running" |
| 9 | `/allusers` HKLM 安装 + 双击 | 无 maintenance 页（闸门 1） |
| 10 | portable 冒烟 | 打包 + 运行正常 |
| 11 | 残留检查 | `%TEMP%` 无 `ns*.tmp` 残留 |

Refs #312
