### PR TITLE
fix(nsis): 修复 #314 引入的打包失败（uninstaller 单元 Var 未引用告警）

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -89,10 +89,17 @@
 ; + allowOnlyOneInstallerInstance.nsh:57），非 `p`/`P<>`。
 ; ================================================================
 
-Var flowzExistingDir   ; 已装 per-user 安装目录（"" = 未装 / 不启用 maintenance）
-Var flowzExistingVer   ; 已装版本号（仅 header 展示用）
-Var flowzRadioUpgrade  ; 「升级」单选控件句柄
-Var flowzRadioRemove   ; 「卸载」单选控件句柄
+; 仅 installer 编译单元声明：这 4 个 Var 只被 customInit/customWelcomePage 引用，而这两个宏
+; 只在 !ifndef BUILD_UNINSTALLER 分支插入（installer.nsi）。electron-builder 把本文件同时 include
+; 进 installer 与 uninstaller 两个编译单元；若顶层无条件声明，uninstaller 单元里它们声明却无处引用
+; → makensis warning 6001「not referenced or never set」→ electron-builder `warning treated as error`
+; → 打包失败。（preInit 用 $R0-$R2 通用寄存器、不碰这些 Var，两单元都插入亦无碍。）
+!ifndef BUILD_UNINSTALLER
+  Var flowzExistingDir   ; 已装 per-user 安装目录（"" = 未装 / 不启用 maintenance）
+  Var flowzExistingVer   ; 已装版本号（仅 header 展示用）
+  Var flowzRadioUpgrade  ; 「升级」单选控件句柄
+  Var flowzRadioRemove   ; 「卸载」单选控件句柄
+!endif
 
 ; 子实例侧：等待父安装器实例退出，规避 ALLOW_ONLY_ONE mutex 竞态。
 ; 此宏在 .onInit 的 mutex 检查之前展开（installer.nsi:56 < :73），是等待的唯一有效时机。


### PR DESCRIPTION
## 问题

#314 合并后，main 的 **Package**（full）与 **Release v4.2.8** 打包失败：

```
warning 6001: Variable "flowzExistingDir" not referenced or never set, wasting memory!
Error: warning treated as error
⨯ makensis.exe process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
```

## 根因

electron-builder 把 `build/installer.nsh` **同时 include 进 installer 与 uninstaller 两个编译单元**。#314 新增的 `flowzExistingDir` / `flowzExistingVer` / `flowzRadioUpgrade` / `flowzRadioRemove` 四个 `Var` 在顶层无条件声明，但只被 `customInit` / `customWelcomePage` 引用——而这两个宏仅在 `!ifndef BUILD_UNINSTALLER` 分支插入。于是 **uninstaller 编译单元里这四个 Var 声明却无处引用**，触发 makensis `warning 6001`，被 electron-builder 的 `warning treated as error` 升级为致命错误。

`preInit`（在 mutex 之前展开、两个编译单元都插入）只用 `$R0-$R2` 通用寄存器、不碰这些 Var，不受影响。

## 修复

用 `!ifndef BUILD_UNINSTALLER` 包住这四个 Var 声明（与 electron-builder 模板对 installer-only 变量的处置一致）。uninstaller 单元不再声明它们，warning 消除。

## 为什么 #314 的 PR CI 没拦住

PR 的 `Package` job 不编译 NSIS installer，只有 main push 的 `Package full` 与 Release 才实际跑 makensis 编译 `installer.nsh`。这个类别的问题在 PR 阶段 CI 结构性覆盖不到——只能靠 full package / 本地真实编译暴露。

> 建议合并后立即观察 main 的 Package/Release 是否恢复绿；本地正在用 electron-builder 真实编译 NSIS 复核，结果会补在评论。

Refs #312 #314
