### PR TITLE
chore(core): 随包 sing-box 内核升级至 1.14.0-alpha.46

### DIFF
--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,11 +1,11 @@
 {
-  "bundledCoreVersion": "1.14.0-alpha.45",
+  "bundledCoreVersion": "1.14.0-alpha.46",
   "cronetVersion": "v148.0.7778.96-1",
   "coreArchiveSha256": {
-    "linux": "a4c6c66dce8d636179193bce56db76f01ab953a2d1bdf65f15d2dfc2a07195c4",
-    "win": "7e1cbc218d0cef4a0168c89d7afc8cc95e9dd77ded3a49f9a02e1fad2ed7ba4a",
-    "mac-x64": "fc661d35f373dd930be7291173bebe30eb680502e60aca56a47b2dc6f77cfeb0",
-    "mac-arm64": "5d9e6027e12082227a88490deecfdca4147f6f6acc16cffe844d59fbf039b443"
+    "linux": "b86f5bd46c399cb230931e53029aa2f08d66957d042f15b5dd1efa49cc16a18a",
+    "win": "5d300c0d988a11320d2080667ac2945288795b0b31dad5d893884f212f95a18a",
+    "mac-x64": "e89f55e418cb56f6795b5ee75a234ed0a82344558cd51623618cee901a17a7f9",
+    "mac-arm64": "13527b5c2ca14ed23951a2a04a493f5e9971e699c9c97924607e1a9a1a70ba9e"
   },
   "cronetArchiveSha256": {
     "linux": "dc7293a929dffa695aae1a89555e7366158fa0a3f40bbe3012d445bc05c99672",


### PR DESCRIPTION
## 变更

`bundledCoreVersion` 1.14.0-alpha.45 → **1.14.0-alpha.46**，同步更新四平台 `coreArchiveSha256`（值取 SagerNet/sing-box 官方 release v1.14.0-alpha.46 的 asset digest）。

## 上游变更（无 breaking）

- rule-set `tag` 支持多 tag（`{tag}` 占位符）
- UDP NAT 新增可选字段 `udp_mapping` / `udp_filtering` / `udp_nat_max`（TUN/TProxy inbound）
- Fixes and improvements

两项新特性均为**新增可选字段**，FlowZ 现有 config 生成不涉及 → 不设即默认行为 → 向后兼容，无 schema 破坏。

## 验证

- `npm run fetch:core -- --force`：四平台压缩包全部下载并逐字节 sha256 校验通过（**4 ready, 0 failed**）
- linux 核 `sing-box version` 实测确认 **1.14.0-alpha.46**
- core-swap-gate / core-version-probe / version-handlers / neighbor 共 **74 单测全绿**；tsc 干净
- 仅改 `src/shared/core-manifest.json` 一个文件（核二进制构建时 fetch，不入库）

真机（mac/win runtime 冒烟）为条件项：无 breaking change，风险低，建议随 Package full 出包后在真机确认代理连通。