### PR TITLE
docs(macos): DMG 内附首次打开引导（ad-hoc 签名 Gatekeeper 提示）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,10 @@ jobs:
             TEMP_DIR=$(mktemp -d)
             cp -R "$APP_PATH" "$TEMP_DIR/"
             ln -s /Applications "$TEMP_DIR/Applications"
+            # ad-hoc 签名（无付费 Developer ID/公证）→ 从下载的 DMG 拖出的 app 带 quarantine，
+            # macOS 首次打开报「已损坏，应移到废纸篓」，且右键→打开无效、须 xattr -cr。
+            # DMG 内附首次打开引导（中英），教用户清除隔离属性。文件名带序号让它排在 app 前、更显眼。
+            cp "build/macos-dmg-open-guide.txt" "$TEMP_DIR/0 首次打开必读 READ ME FIRST.txt"
             hdiutil create -volname "FlowZ ${VERSION} (${ARCH})" \
               -srcfolder "$TEMP_DIR" \
               -ov -format UDZO \

--- a/build/macos-dmg-open-guide.txt
+++ b/build/macos-dmg-open-guide.txt
@@ -1,0 +1,45 @@
+════════════════════════════════════════════════════════════
+  首次打开 FlowZ 提示「已损坏」？这是正常现象，按下面三步即可
+════════════════════════════════════════════════════════════
+
+若 macOS 提示：
+    「"FlowZ.app" 已损坏，无法打开。您应该将它移到废纸篓。」
+
+这是因为本应用未使用付费的 Apple 开发者签名（成本原因），
+并非文件损坏，也不是病毒。按以下步骤即可正常使用：
+
+  1. 先把 FlowZ 拖到左侧的「应用程序 (Applications)」文件夹
+
+  2. 打开「终端 (Terminal)」，粘贴并回车运行这一行命令：
+
+         xattr -cr /Applications/FlowZ.app
+
+  3. 之后正常双击打开 FlowZ 即可（此命令只需执行一次）
+
+  注意：对「已损坏」这个提示，「右键 →打开」是无效的，
+        必须用上面的终端命令清除隔离属性。
+
+
+────────────────────────────────────────────────────────────
+  Getting "damaged and can't be opened" on first launch?
+────────────────────────────────────────────────────────────
+
+If macOS says:
+    "FlowZ.app is damaged and can't be opened. You should move
+     it to the Trash."
+
+This is because the app is not signed with a paid Apple Developer
+certificate. It is NOT malware and the file is NOT corrupted.
+To use it:
+
+  1. Drag FlowZ into the Applications folder (on the left)
+
+  2. Open Terminal, then paste and run this single line:
+
+         xattr -cr /Applications/FlowZ.app
+
+  3. Double-click FlowZ to open it normally (run the command once)
+
+  Note: "Right-click → Open" does NOT work for the "damaged"
+        message — you must use the Terminal command above to
+        clear the quarantine attribute.


### PR DESCRIPTION
## 问题

macOS 包为 ad-hoc 签名（`codesign --force --deep --sign -`，无付费 Developer ID / 公证）。用户从浏览器下载 DMG → OS 打 `com.apple.quarantine` → 拖出的 app 继承 → Gatekeeper 判定 **ad-hoc + quarantine + 未公证** = 「"FlowZ.app" 已损坏，无法打开，应将它移到废纸篓」。

关键：此提示（"damaged"）**「右键→打开」无效**（那只对"无法验证开发者"有效），必须 `xattr -cr` 清除隔离属性才能打开。普通用户不知道，直接以为软件坏了。

## 修复（过渡止血）

DMG 内附一份中英文首次打开引导 `build/macos-dmg-open-guide.txt`，教用户拖入 Applications 后运行：

```
xattr -cr /Applications/FlowZ.app
```

文件名带序号 `0` 让它在 Finder 里排到 FlowZ.app 前、更显眼。

## 为什么不是自动修复

打包侧无法在 app 首次打开前自动清 quarantine——quarantine 是用户**下载时** OS 加的，而 app 被 Gatekeeper 拦住根本没启动，app 内逻辑跑不了；DMG 内放 .command 脚本同样带 quarantine 被拦。所以只能引导用户手动清。

## 根治方向（另行评估）

Developer ID + 公证（Apple Developer $99/年）是唯一零用户操作的解：下载拖入即开，顺带根治 ad-hoc 的 TCC 逐版重置 / Keychain ACL / 登录项等债。本 PR 是拿到证书前的过渡。

## 验证

release.yml YAML 校验通过。**DMG 实际产出需下次 release 的 CI（macOS runner + hdiutil）验证**：挂载 DMG 确认说明文件在、文件名中文正常显示、排在 app 前。本地 Linux 无法跑 hdiutil。