### PR TITLE
fix(tun): verify TUN interface up before marking ready (win32)

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -115,12 +115,23 @@ import {
   sampleProcessRssMb,
   type MemoryTimelineFrame,
 } from './process-sampler';
-import { probeWinTunAdapterPresent, waitForAdapterReleased } from './win-tun-adapter';
+import {
+  probeWinTunAdapterPresent,
+  waitForAdapterReleased,
+  probeWinTunAdapterPresence,
+  waitForAdapterPresent,
+  recordAdapterPresence,
+  isPersistentTunFailure,
+  type AdapterPresence,
+  type TunAdapterObservation,
+} from './win-tun-adapter';
 import {
   probeTcpReachable,
   waitForCoreReady,
+  startMessageIsNonRetryable,
   CoreStartRetryError,
   CoreStartSupersededError,
+  CoreStartTunPersistentError,
 } from './core-readiness';
 import coreManifest from '../../shared/core-manifest.json';
 
@@ -526,6 +537,19 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private static readonly CORE_READY_POLL_MS = 500;
   // 管理 API 可连探测（默认 TCP 直连）；注入式便于单测替换桩。
   private coreReadyProbe: (host: string, port: number) => Promise<boolean> = probeTcpReachable;
+
+  // issue #324：正向 TUN 就绪验证（仅 win32+TUN）。就绪窗内并行观测自家 wintun 适配器是否出现，落 sticky 标志——
+  //   死后验尸不可靠（适配器随进程句柄消失），故必须窗口内观测。就绪后 grace 内仍未见 = 本腿失败（硬闸，拒假连接）。
+  private adapterPresenceProbe: (name: string) => Promise<AdapterPresence> =
+    probeWinTunAdapterPresence;
+  // 就绪窗/grace 内的适配器观测轮询间隔（1s）。就绪窗 ≤12s → ≤~12 次 PS spawn；见到即停观测省 spawn。真机项 #2 校准。
+  private static readonly TUN_READY_OBSERVE_POLL_MS = 1000;
+  // 就绪（API 绑定）后再给适配器出现的 grace 上限（8s）：适配器晚于 API bind 出现属正常时序，避免误杀 #159/#176 瞬态。真机项 #2 校准。
+  private static readonly TUN_READY_GRACE_TIMEOUT_MS = 8000;
+  // issue #324 分类 tracker（start-scoped，win32+TUN 时于 startInternal 置对象、否则 null）。跨所有重试腿 sticky 累计观测：
+  //   adapterEverSeen=任一腿曾见适配器（→ 瞬态释放竞态族）；probeEverConclusive=探测链路曾给出 clean present/absent
+  //   （排除杀软拦 PS 的全 unknown 误判）。预算耗尽 && !adapterEverSeen && probeEverConclusive → 持续性 TUN 失败终态。
+  private tunReadyObservation: TunAdapterObservation | null = null;
   // issue #176 诊断计数：本次启动经几次「就绪重试」才成功（runStartWithRetry 累计）。>0 = 起核慢（多因 Windows
   // 重启争用下 wintun 适配器未及时释放），与「核崩溃自动重启」（restartCount/AUTO_RESTARTING）是不同轴，纳入诊断
   // 区分「核崩」vs「争用慢起」。每次 startInternal 复位。
@@ -846,6 +870,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     const startGen = this.lifecycleGeneration;
     let readyRetries = 0; // 本次启动累计的就绪重试次数（onRetry 自增），成功后落 lastStartReadyRetries 供诊断。
     this.lastStartReadyRetries = 0;
+    // issue #324：仅 win32+TUN 开正向适配器观测 tracker（否则 null → 全链路 no-op，macOS/Linux/非 TUN 零改动）。
+    //   start-scoped、跨所有重试腿 sticky——故置于 runStartWithRetry 之前、每次 start 一个新对象。
+    this.tunReadyObservation =
+      process.platform === 'win32' && isTunMode
+        ? { adapterEverSeen: false, probeEverConclusive: false }
+        : null;
 
     // 5. 启动 sing-box 进程（issue #159 的 wintun 适配器释放门控已下沉至 startSingBoxProcess 顶部，覆盖每次重试腿 + helper/UAC 两支路）
     // 双 TUN 竞态（mesh redesign R3）：system_interface（reverseMesh）节点在 TUN 模式下会建第二张内核 TUN。
@@ -866,6 +896,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           if (error instanceof CoreStartSupersededError) {
             return false;
           }
+          // issue #324：CoreStartTunPersistentError 的「不重试」是**结构性**的——它仅由 maybeToTunPersistentError 在
+          //   runStartWithRetry() reject 之后（startInternal catch 收口）生成，直达 start() catch，**永不经 retry()**，
+          //   故 shouldRetry 见不到它，无需在此加 instanceof 守卫（避免留测不到的防御死路径，YAGNI）。
           // 启动 gate 备用腿（补 check 盲区）：run 阶段 `dependency[X] not found` FATAL（detour/selector 幽灵
           // tag）→ 允许重试一次（onRetry 会解析 tag、pruneTagsClosure 修正重写盘），refFixAttempted 闸保证只修一次。
           if (/dependency\[(.+?)\] not found/i.test(error.message)) {
@@ -875,23 +908,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           if (this.isCronetLibError(error.message)) {
             return false;
           }
-          // 只对特定错误进行重试
-          const message = error.message.toLowerCase();
-
-          // 不重试的错误类型
-          const nonRetryableErrors = [
-            '找不到',
-            '权限',
-            'permission',
-            'enoent',
-            'eacces',
-            'eperm',
-            '配置文件格式错误',
-            'invalid config',
-          ];
-
-          // 如果是不可重试的错误，直接失败
-          if (nonRetryableErrors.some((pattern) => message.includes(pattern))) {
+          // 不重试的错误类型（权限/找不到/坏配置）：判据下沉 core-readiness.startMessageIsNonRetryable（单测守卫，
+          //   保证 issue #324 A1/A3 新增文案不被词表误命中而变不可重试，review Low#5）。
+          if (startMessageIsNonRetryable(error.message)) {
             return false;
           }
 
@@ -999,7 +1018,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           throw err;
         }
       } else {
-        throw err;
+        // issue #324：起核重试预算耗尽的收口——win32+TUN 且全程未见适配器（探测可用）→ 转持续性 TUN 失败终态诊断，
+        //   停「正在自动重试」误导；其余（含瞬态族/探测全 unknown/非 TUN）原样上抛。见 maybeToTunPersistentError。
+        throw this.maybeToTunPersistentError(err);
       }
     }
 
@@ -4469,6 +4490,29 @@ exit 0
     const port = this.tailscaleApiPort;
     if (!port) return; // 无管理 API 端口 → 不阻断
     const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+    // issue #324：仅 win32+TUN 开正向适配器观测（tunReadyObservation 非 null 即已由 startInternal 判定 win32+TUN）。
+    //   在就绪等待窗内并行探自家 wintun 适配器是否出现，sticky 落 tracker——即便本腿随后进程死（验尸不可靠），也已知
+    //   「本次 start 是否曾见适配器」。见到即停观测省 spawn。macOS/Linux/非 TUN：obs=null → 全程 no-op、零改动。
+    const obs = this.tunReadyObservation;
+    const adapterName = obs ? resolveWinTunInterfaceName(this.currentConfig as UserConfig) : '';
+    let observing = obs !== null;
+    const recordPresence = (p: AdapterPresence): void => {
+      if (obs) recordAdapterPresence(obs, p); // sticky monotonic 累计（纯函数，单测覆盖）
+    };
+    const observerDone: Promise<void> = observing
+      ? (async () => {
+          while (observing && !obs!.adapterEverSeen) {
+            const p = await this.adapterPresenceProbe(adapterName).catch(
+              () => 'unknown' as AdapterPresence
+            );
+            recordPresence(p);
+            if (!observing || obs!.adapterEverSeen) break;
+            await sleep(ProxyManager.TUN_READY_OBSERVE_POLL_MS);
+          }
+        })()
+      : Promise.resolve();
+
     const outcome = await waitForCoreReady(
       { timeoutMs: ProxyManager.CORE_READY_TIMEOUT_MS, pollMs: ProxyManager.CORE_READY_POLL_MS },
       {
@@ -4478,19 +4522,102 @@ exit 0
         isSuperseded: () => this.lifecycleGeneration !== startGen,
       }
     ).catch(() => 'timeout' as const);
-    if (outcome === 'ready') return;
-    // issue #176：被接管 → 静默让位，绝不 stopCore（接管方拥有拆核权，避免抢放适配器）。由 start() 包装吞掉。
+    observing = false; // 停就绪窗观测，等其 drain（在途 sleep 至多 1s；若卡在在途 probe，Get-NetAdapter 的 execFile timeout 4s 封顶）
+    await observerDone.catch(() => {});
+
+    // issue #176：被接管 → 静默让位，绝不 stopCore（接管方拥有拆核权，避免抢放适配器）。由 start() 包装吞掉。优先于一切。
     if (outcome === 'superseded') {
       throw new CoreStartSupersededError();
     }
+
+    if (outcome === 'ready') {
+      // issue #324 A1 正向硬闸（win32+TUN）：API 已绑但需验**本腿**自家 TUN 适配器真的建起。
+      //   review Med#2：**每腿独立验证**、不吃跨腿 sticky `adapterEverSeen`——前腿见过（可能是 #159 残留同名旧适配器）
+      //   不代表本腿的 TUN 已建，靠 sticky 免检会让假连接从门下漏过；sticky 仅供 A2/A3 分类。适配器真在时首轮 ~200ms 即早退，成本可忽略。
+      if (!obs) return; // 非 win32+TUN → 无正向门
+      const res = await waitForAdapterPresent(
+        adapterName,
+        {
+          timeoutMs: ProxyManager.TUN_READY_GRACE_TIMEOUT_MS,
+          pollMs: ProxyManager.TUN_READY_OBSERVE_POLL_MS,
+        },
+        // review High#1：grace 轮询注入 isSuperseded（镜像 waitForCoreReady）——被接管即让位，绝不 stopCore/发 started。
+        {
+          probe: (n) => this.adapterPresenceProbe(n),
+          sleep,
+          isSuperseded: () => this.lifecycleGeneration !== startGen,
+        }
+      ).catch(() => ({ outcome: 'unknown', polls: 0 }) as const);
+      // issue #176 High#1：grace 窗内被更新的 start/stop 接管 → 静默让位，**绝不 stopCore**（接管方拥有拆核权，避免抢放
+      //   适配器加剧风暴），也不对已被接管的腿发幻影 started。由 start() 包装吞掉（镜像上方 outcome==='superseded'）。
+      if (res.outcome === 'superseded') {
+        throw new CoreStartSupersededError();
+      }
+      if (res.outcome === 'present') {
+        recordPresence('present');
+        return;
+      }
+      if (res.outcome === 'unknown') {
+        // 探测链路全程 unknown（杀软拦 PS 等）→ fail-open 放行，绝不据此判失败（对齐 #159 反向门 fail-open 纪律）。
+        this.logToManager(
+          'warn',
+          `Windows TUN 适配器 ${adapterName} 存在性无法确认（探测失败），fail-open 继续`
+        );
+        return;
+      }
+      // res.outcome === 'absent-timeout'：探测可用但适配器确证未出现 → 硬闸失败本腿。停掉半死核（API 通但无 TUN =
+      //   假连接，比失败更糟），抛 CoreStartRetryError 交 retry；预算耗尽后由 maybeToTunPersistentError 升为终态诊断。
+      recordPresence('absent');
+      await this.helperManager?.stopCore().catch(() => {});
+      throw new CoreStartRetryError(
+        `sing-box 已就绪但 TUN 适配器 ${adapterName} 未建立，正在自动重试`
+      );
+    }
+
     // 失败：尽力停掉这个起不来的核（best-effort，其 wintun 适配器随即开始释放，给 retry 让路），再抛 CoreStartRetryError
     // ——startSingBoxProcess 的 helper catch 会透传它给 runStartWithRetry 静默重起（而非误判 helper 启动失败弹 UAC/osascript）。
     await this.helperManager?.stopCore().catch(() => {});
     if (outcome === 'dead') {
+      // issue #324 A3：dead 分支文案细分——win32+TUN 且探测可用（probeEverConclusive）却全程未见适配器 → 疑 wintun 被拦/
+      //   驱动异常（非瞬态释放竞态）。否则（曾见适配器=瞬态，或探测全 unknown 无从判定）保持原「TUN 初始化未完成」文案。
+      if (obs && isPersistentTunFailure(obs)) {
+        throw new CoreStartRetryError(
+          'sing-box 启动期退出（TUN 适配器从未创建，疑 wintun 被拦/驱动异常），正在自动重试'
+        );
+      }
       throw new CoreStartRetryError('sing-box 启动期退出（TUN 初始化未完成），正在自动重试');
     }
     // issue #176：软化文案——「未绑定」多因 Windows 重启争用下 wintun 适配器未及时释放致起核慢，非真失败。
     throw new CoreStartRetryError('sing-box 起核较慢（管理接口尚未就绪），正在自动重试');
+  }
+
+  /**
+   * issue #324 A2：起核重试预算耗尽后的持续性 TUN 失败终态转化。仅 win32+TUN（tunReadyObservation 非 null）且原错误
+   *   为可重试的 CoreStartRetryError 时判定；跨所有重试腿 sticky 观测：
+   *   - 曾见适配器（adapterEverSeen）→ 瞬态释放竞态族（#159/#176），保持原错误（照旧终态但不改语义）。
+   *   - 探测链路全程未给 clean 结论（!probeEverConclusive，全 unknown=杀软拦 PS）→ fail-open 保持瞬态，绝不误判终态。
+   *   - 探测可用且全程未见适配器 → 持续性 TUN init 失败：emit 结构化诊断（TUN_INIT_PERSISTENT）+ 转 CoreStartTunPersistentError。
+   * 不碰 retry 循环语义（blast radius 最小）；瞬态场景重试预算原封不动。
+   */
+  private maybeToTunPersistentError(err: unknown): unknown {
+    const obs = this.tunReadyObservation;
+    if (!obs) return err; // 非 win32+TUN → 原样（obs 仅 win32+TUN 时非 null）
+    if (!(err instanceof CoreStartRetryError)) return err; // 仅转化可重试的起核错误
+    // 曾出现 → 瞬态；探测全程 unknown（杀软拦 PS）→ fail-open 瞬态；两者非持续性 → 原样保持可重试终态。
+    if (!isPersistentTunFailure(obs)) return err;
+    // 探测可用且预算内从未见适配器 → 持续性 TUN init 失败终态。
+    const terminal = new CoreStartTunPersistentError();
+    this.logToManager(
+      'error',
+      `Windows TUN 适配器（${resolveWinTunInterfaceName(this.currentConfig as UserConfig)}）持续未建立，起核重试预算耗尽 → 终态诊断，停止无谓重试（常见 wintun 被拦/驱动异常/冲突 VPN，亦可能配置/端口/内核致起核失败——开诊断采集看日志拍板）`
+    );
+    // 经既有 EVENT_PROXY_ERROR 通道上渲染端（携结构化 code 驱动诊断卡）；start() 收口的 invoke rejection 另设 proxyError。
+    this.sendEventToRenderer(IPC_CHANNELS.EVENT_PROXY_ERROR, {
+      message: terminal.message,
+      errorCode: ProxyErrorCode.TUN_INIT_PERSISTENT,
+      code: -3,
+    });
+    return terminal;
   }
 
   private async startSingBoxProcess(startGen: number): Promise<void> {

--- a/src/main/services/__tests__/core-readiness.test.ts
+++ b/src/main/services/__tests__/core-readiness.test.ts
@@ -3,7 +3,13 @@
  * waitForCoreReady 注入 isAlive/isReady/sleep（零真实进程/计时器）；probeTcpReachable 用真实 net.Server 验通断。
  */
 import { createServer, type AddressInfo } from 'net';
-import { waitForCoreReady, probeTcpReachable } from '../core-readiness';
+import {
+  waitForCoreReady,
+  probeTcpReachable,
+  startMessageIsNonRetryable,
+  CoreStartRetryError,
+  CoreStartTunPersistentError,
+} from '../core-readiness';
 
 const noSleep = async (): Promise<void> => {};
 
@@ -106,6 +112,51 @@ describe('waitForCoreReady', () => {
       }
     );
     expect(r).toBe('superseded');
+  });
+});
+
+// issue #324：持续性 TUN 失败终态标记错误——独立类型，走 instanceof（不进 nonRetryableErrors 词表），非 CoreStartRetryError 子类。
+describe('CoreStartTunPersistentError (issue #324)', () => {
+  it('携默认可操作诊断文案，且与 CoreStartRetryError 互不 instanceof', () => {
+    const e = new CoreStartTunPersistentError();
+    expect(e).toBeInstanceOf(CoreStartTunPersistentError);
+    expect(e).toBeInstanceOf(Error);
+    expect(e).not.toBeInstanceOf(CoreStartRetryError); // 终态类 ≠ 可重试类：instanceof 判别不误重试
+    expect(new CoreStartRetryError('x')).not.toBeInstanceOf(CoreStartTunPersistentError);
+    expect(e.name).toBe('CoreStartTunPersistentError');
+    expect(e.message).toMatch(/wintun|TUN 适配器/); // 携指向 wintun/适配器的可操作提示
+  });
+
+  it('接受自定义文案', () => {
+    expect(new CoreStartTunPersistentError('自定义').message).toBe('自定义');
+  });
+});
+
+// review Low#5：起核 retry 词表判据守卫——issue #324 A1/A3 新增 CoreStartRetryError 文案必须**不**命中 nonRetryable 词表
+// （否则可重试文案被静默判为不可重试），且既有黑名单词照常命中（防未来加词漂移）。
+describe('startMessageIsNonRetryable (issue #176/#324 retry 词表守卫)', () => {
+  it('#324 A1「TUN 适配器未建立」文案 → 可重试（不命中词表）', () => {
+    expect(
+      startMessageIsNonRetryable('sing-box 已就绪但 TUN 适配器 flowz-tun0 未建立，正在自动重试')
+    ).toBe(false);
+  });
+  it('#324 A3「TUN 适配器从未创建」文案 → 可重试', () => {
+    expect(
+      startMessageIsNonRetryable(
+        'sing-box 启动期退出（TUN 适配器从未创建，疑 wintun 被拦/驱动异常），正在自动重试'
+      )
+    ).toBe(false);
+  });
+  it('既有「TUN 初始化未完成」dead 文案 → 可重试（不回归）', () => {
+    expect(
+      startMessageIsNonRetryable('sing-box 启动期退出（TUN 初始化未完成），正在自动重试')
+    ).toBe(false);
+  });
+  it('黑名单词照常命中不可重试（权限/找不到/坏配置，大小写不敏感）', () => {
+    expect(startMessageIsNonRetryable('管理员权限被拒绝')).toBe(true);
+    expect(startMessageIsNonRetryable('文件找不到')).toBe(true);
+    expect(startMessageIsNonRetryable('Invalid Config: bad field')).toBe(true); // 大写也命中
+    expect(startMessageIsNonRetryable('EACCES: permission denied')).toBe(true);
   });
 });
 

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -1,0 +1,247 @@
+/**
+ * ProxyManager 正向 TUN 就绪门 + 持续性失败终态转化单测（issue #324）。
+ *
+ * 覆盖 waitForCoreReadyOrThrow 的 win32+TUN 编排（A1 硬闸 / A3 dead 文案 / 平台闸 no-op / fail-open）与
+ * maybeToTunPersistentError 的终态分类矩阵（A2）。私有方法/字段经 `(svc as any)` 直调注入，不启动 sing-box、
+ * 不碰真实网卡/PowerShell——adapterPresenceProbe/coreReadyProbe/isProcessAlive/helperManager 全为桩。
+ * 真实 Get-NetAdapter 探测与适配器可见延迟属真机项（无 Windows 环境，不在单测覆盖）。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-tun324-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFile: jest.fn(),
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import {
+  CoreStartRetryError,
+  CoreStartSupersededError,
+  CoreStartTunPersistentError,
+} from '../core-readiness';
+import type { AdapterPresence, TunAdapterObservation } from '../win-tun-adapter';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function makeSvc(): any {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  const svc: any = new ProxyManager(undefined, undefined, configPath, '/fake/sing-box');
+  svc.tailscaleApiPort = 9099; // 有管理 API 端口 → 不走 fail-open 早退
+  svc.currentConfig = { proxyModeType: 'tun', servers: [], tunConfig: {} };
+  svc.helperManager = { stopCore: jest.fn().mockResolvedValue(undefined) };
+  return svc;
+}
+
+/** win32+TUN tracker（startInternal 会置；此处直接注入模拟已开观测）。 */
+function armTun(svc: any): TunAdapterObservation {
+  const obs: TunAdapterObservation = { adapterEverSeen: false, probeEverConclusive: false };
+  svc.tunReadyObservation = obs;
+  return obs;
+}
+
+/** 定序三态 probe（用尽后恒返回末值）。 */
+function seqProbe(seq: AdapterPresence[]): () => Promise<AdapterPresence> {
+  let i = 0;
+  return async () => (i < seq.length ? seq[i++] : (seq[seq.length - 1] ?? 'absent'));
+}
+
+describe('issue #324 — waitForCoreReadyOrThrow 正向 TUN 就绪门（win32+TUN 编排）', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('平台/模式闸 no-op：tunReadyObservation=null（非 win32+TUN）→ ready 直放行，探针零调用', async () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = null; // 模拟 macOS/Linux/非 TUN
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => true;
+    const probe = jest.fn(async () => 'present' as AdapterPresence);
+    svc.adapterPresenceProbe = probe;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).resolves.toBeUndefined(); // 先挂 handler，防 advance 期未捕获
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(probe).not.toHaveBeenCalled(); // 变异「平台闸翻转」→ 此断言失败
+  });
+
+  it('ready + 观测窗内适配器出现 → 放行，tracker.adapterEverSeen=true（无需 grace）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => true;
+    svc.adapterPresenceProbe = seqProbe(['present']);
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).resolves.toBeUndefined();
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(obs.adapterEverSeen).toBe(true);
+    expect(svc.helperManager.stopCore).not.toHaveBeenCalled(); // 成功不停核
+  });
+
+  it('ready 但适配器确证 absent（探测可用）→ 硬闸 reject CoreStartRetryError + 停核（拒假连接）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => true;
+    svc.adapterPresenceProbe = async () => 'absent' as AdapterPresence; // 永不出现
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    // 变异「A1 硬闸 throw 改 warn 放行」→ 会 resolve → 此 rejects 断言失败
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+    expect(svc.helperManager.stopCore).toHaveBeenCalled(); // 停掉「API 通但无 TUN」的半死核
+    expect(obs.probeEverConclusive).toBe(true); // clean absent 记入 tracker（供预算耗尽后判持续性）
+    expect(obs.adapterEverSeen).toBe(false);
+  });
+
+  // review High#1：A1 grace 窗内被更新的 start/stop 接管（#176 高发）→ 静默让位，**绝不 stopCore**（拆接管方核）、不发幻影 started。
+  it('ready 后 A1 grace 窗内被接管 → 抛 CoreStartSupersededError，绝不 stopCore', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    const startGen = svc.lifecycleGeneration;
+    svc.isProcessAlive = () => true;
+    let readyReturned = false;
+    svc.coreReadyProbe = async () => {
+      readyReturned = true; // 就绪窗未接管（gen 未变）→ 正常 ready
+      return true;
+    };
+    // 观测窗探测（readyReturned 前）不接管；进入 grace（readyReturned 后）首个探测即模拟接管方 bump 世代。
+    svc.adapterPresenceProbe = async () => {
+      if (readyReturned) svc.lifecycleGeneration = startGen + 1;
+      return 'absent' as AdapterPresence;
+    };
+
+    const p = svc.waitForCoreReadyOrThrow(1234, startGen);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartSupersededError);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    // 变异「grace 不判 supersede」→ 会走 absent-timeout 分支 stopCore+CoreStartRetryError → 下面两断言失败
+    expect(svc.helperManager.stopCore).not.toHaveBeenCalled();
+  });
+
+  // review Med#2：A1 每腿独立验证——不吃跨腿 sticky adapterEverSeen（前腿见旧适配器不代表本腿 TUN 已建）。
+  it('前腿 sticky adapterEverSeen=true 但本腿探测 absent → A1 仍硬闸 reject（不靠 sticky 免检）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    obs.adapterEverSeen = true; // 模拟前一重试腿曾见（可能是 #159 残留同名旧适配器）
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => true;
+    svc.adapterPresenceProbe = async () => 'absent' as AdapterPresence; // 本腿实际未建
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    // 变异「保留 if(adapterEverSeen)return 免检」→ 会 resolve（假连接漏过）→ 此 rejects 断言失败
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+    expect(svc.helperManager.stopCore).toHaveBeenCalled();
+  });
+
+  it('ready 但适配器探测全 unknown（杀软拦 PS）→ fail-open 放行，不 reject、不停核', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => true;
+    svc.adapterPresenceProbe = async () => 'unknown' as AdapterPresence;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).resolves.toBeUndefined(); // fail-open：绝不据探测失败判失败
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+    expect(svc.helperManager.stopCore).not.toHaveBeenCalled();
+    expect(obs.probeEverConclusive).toBe(false); // 全 unknown → 不 conclusive → 后续判瞬态
+  });
+
+  it('dead + 探测可用却从未见适配器 → A3 文案「TUN 适配器从未创建，疑 wintun 被拦」', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    svc.isProcessAlive = () => false; // 起核期进程死
+    svc.coreReadyProbe = async () => false;
+    svc.adapterPresenceProbe = async () => 'absent' as AdapterPresence; // 探测可用、始终无网卡
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toThrow(/从未创建/);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(svc.helperManager.stopCore).toHaveBeenCalled();
+  });
+
+  it('dead + 曾见适配器（瞬态）→ 保持原「TUN 初始化未完成」文案（不误报 wintun 异常）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    svc.isProcessAlive = () => false;
+    svc.coreReadyProbe = async () => false;
+    svc.adapterPresenceProbe = seqProbe(['present']); // 观测窗曾见 → 瞬态族
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toThrow(/TUN 初始化未完成/);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(obs.adapterEverSeen).toBe(true);
+  });
+});
+
+describe('issue #324 — maybeToTunPersistentError 终态分类矩阵（A2）', () => {
+  const retry = (): CoreStartRetryError => new CoreStartRetryError('TUN 初始化未完成');
+
+  it('从未见 + 探测可用 → 转 CoreStartTunPersistentError + emit TUN_INIT_PERSISTENT', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = { adapterEverSeen: false, probeEverConclusive: true };
+    const emit = jest.spyOn(svc, 'sendEventToRenderer').mockImplementation(() => {});
+    const out = svc.maybeToTunPersistentError(retry());
+    expect(out).toBeInstanceOf(CoreStartTunPersistentError);
+    const call = emit.mock.calls.find((c: any[]) => c[1]?.errorCode === 'TUN_INIT_PERSISTENT');
+    expect(call).toBeTruthy(); // 结构化 code 上渲染端驱动诊断卡
+  });
+
+  it('曾见适配器 → 保持原 CoreStartRetryError（瞬态族，不转终态）', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = { adapterEverSeen: true, probeEverConclusive: true };
+    const err = retry();
+    expect(svc.maybeToTunPersistentError(err)).toBe(err);
+  });
+
+  it('探测全 unknown（!conclusive）→ fail-open 保持原错误（绝不误判终态）', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = { adapterEverSeen: false, probeEverConclusive: false };
+    const err = retry();
+    // 变异「删 fail-open」→ 会转终态 → 此 toBe 失败
+    expect(svc.maybeToTunPersistentError(err)).toBe(err);
+  });
+
+  it('obs=null（非 win32+TUN）→ 原样（平台闸）', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = null;
+    const err = retry();
+    expect(svc.maybeToTunPersistentError(err)).toBe(err);
+  });
+
+  it('非 CoreStartRetryError（如普通 Error）→ 原样（只转可重试起核错误）', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = { adapterEverSeen: false, probeEverConclusive: true };
+    const err = new Error('权限不足');
+    expect(svc.maybeToTunPersistentError(err)).toBe(err);
+  });
+});

--- a/src/main/services/__tests__/win-tun-adapter.test.ts
+++ b/src/main/services/__tests__/win-tun-adapter.test.ts
@@ -3,7 +3,14 @@
  * 注入 probe/sleep，零真实计时器、零真实网卡：验早退 / 超时 fail-open / 轮次与 sleep 次数。
  * 真实 Get-NetAdapter 探测属真机项（无 Windows 环境，不在单测覆盖）。
  */
-import { waitForAdapterReleased } from '../win-tun-adapter';
+import {
+  waitForAdapterReleased,
+  waitForAdapterPresent,
+  recordAdapterPresence,
+  isPersistentTunFailure,
+  type AdapterPresence,
+  type TunAdapterObservation,
+} from '../win-tun-adapter';
 import { resolveWinTunInterfaceName, FLOWZ_WIN_TUN_INTERFACE } from '../../../shared/tun-interface';
 import type { UserConfig } from '../../../shared/types';
 
@@ -51,6 +58,172 @@ describe('waitForAdapterReleased', () => {
     const { deps } = mkDeps([false]);
     const r = await waitForAdapterReleased('x', { timeoutMs: 0, pollMs: 0 }, deps);
     expect(r.released).toBe(true);
+  });
+});
+
+// issue #324：正向 TUN 就绪等待（等适配器「出现」，#159 反向门镜像）。注入三态 probe/sleep，零真实计时器/网卡。
+function mkPresenceDeps(seq: Array<AdapterPresence | 'THROW'>): {
+  sleeps: number[];
+  probeCalls: number;
+  deps: { probe: () => Promise<AdapterPresence>; sleep: (ms: number) => Promise<void> };
+  meta: { probeCalls: number };
+} {
+  let i = 0;
+  const sleeps: number[] = [];
+  const meta = { probeCalls: 0 };
+  return {
+    sleeps,
+    probeCalls: 0,
+    meta,
+    deps: {
+      probe: async () => {
+        meta.probeCalls++;
+        const v = i < seq.length ? seq[i++] : 'absent';
+        if (v === 'THROW') throw new Error('powershell 缺失/被拦');
+        return v;
+      },
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    },
+  };
+}
+
+describe('waitForAdapterPresent (issue #324 正向就绪门)', () => {
+  it('网卡当即出现 → 一次探测早退（present，polls=1，零等待）', async () => {
+    const { deps, sleeps, meta } = mkPresenceDeps(['present']);
+    const r = await waitForAdapterPresent('flowz-tun0', { timeoutMs: 8000, pollMs: 1000 }, deps);
+    expect(r.outcome).toBe('present');
+    expect(r.polls).toBe(1);
+    expect(sleeps).toHaveLength(0);
+    expect(meta.probeCalls).toBe(1);
+  });
+
+  it('数轮 absent 后出现 → 早退 present（轮次/sleep 对应）', async () => {
+    const { deps, sleeps } = mkPresenceDeps(['absent', 'absent', 'present']);
+    const r = await waitForAdapterPresent('flowz-tun0', { timeoutMs: 8000, pollMs: 1000 }, deps);
+    expect(r.outcome).toBe('present');
+    expect(r.polls).toBe(3);
+    expect(sleeps).toEqual([1000, 1000]); // 前两轮 absent 后各 sleep，第三轮 present 即退
+  });
+
+  it('始终 absent（探测可用）→ absent-timeout（可据此硬闸/判持续性）', async () => {
+    const { deps } = mkPresenceDeps(Array(20).fill('absent'));
+    const r = await waitForAdapterPresent('flowz-tun0', { timeoutMs: 3000, pollMs: 1000 }, deps);
+    expect(r.outcome).toBe('absent-timeout');
+  });
+
+  it('始终 unknown（探测失败）→ unknown（fail-open，绝不据此判失败）', async () => {
+    const { deps } = mkPresenceDeps(Array(20).fill('unknown'));
+    const r = await waitForAdapterPresent('flowz-tun0', { timeoutMs: 3000, pollMs: 1000 }, deps);
+    expect(r.outcome).toBe('unknown');
+  });
+
+  it('probe 抛错（PS 缺/被拦）全程 → unknown（fail-open，捕获 throw）', async () => {
+    const { deps } = mkPresenceDeps(Array(20).fill('THROW'));
+    const r = await waitForAdapterPresent('flowz-tun0', { timeoutMs: 3000, pollMs: 1000 }, deps);
+    expect(r.outcome).toBe('unknown'); // throw 被捕获按 unknown 处理，非崩溃、非误判 absent-timeout
+  });
+
+  it('混入一次 clean absent → absent-timeout 压过零星 unknown（证明探测链路可用）', async () => {
+    // 全程未 present；出现过 clean absent（PS 可用）+ 若干 unknown → 判 absent-timeout（可判持续性），非 fail-open。
+    const { deps } = mkPresenceDeps(['unknown', 'absent', 'unknown', 'unknown']);
+    const r = await waitForAdapterPresent('flowz-tun0', { timeoutMs: 3000, pollMs: 1000 }, deps);
+    expect(r.outcome).toBe('absent-timeout');
+  });
+
+  it('退化参数（timeout/poll=0）不崩，至少探测一次', async () => {
+    const { deps } = mkPresenceDeps(['present']);
+    const r = await waitForAdapterPresent('x', { timeoutMs: 0, pollMs: 0 }, deps);
+    expect(r.outcome).toBe('present');
+  });
+
+  // review High#1：grace 轮询须继承 #176 supersede 纪律——被接管即让位（不 present/不 absent-timeout）。
+  it('起始即被接管（isSuperseded=true）→ superseded，零探测（不 stopCore/不判存在）', async () => {
+    const { deps, meta } = mkPresenceDeps(Array(20).fill('absent'));
+    const r = await waitForAdapterPresent(
+      'flowz-tun0',
+      { timeoutMs: 8000, pollMs: 1000 },
+      { ...deps, isSuperseded: () => true }
+    );
+    expect(r.outcome).toBe('superseded');
+    expect(meta.probeCalls).toBe(0); // 让位先于任何探测
+  });
+
+  it('grace 中途被接管 → superseded（不误判 absent-timeout，不据 stale 结果硬闸）', async () => {
+    const { deps } = mkPresenceDeps(Array(20).fill('absent'));
+    let polls = 0;
+    let superseded = false;
+    const r = await waitForAdapterPresent(
+      'flowz-tun0',
+      { timeoutMs: 8000, pollMs: 1000 },
+      {
+        probe: deps.probe,
+        sleep: async () => {
+          if (++polls >= 2) superseded = true; // 第 2 轮 sleep 后被更新的 start/stop 接管
+        },
+        isSuperseded: () => superseded,
+      }
+    );
+    expect(r.outcome).toBe('superseded'); // 变异「grace 不判 supersede」→ 会返回 absent-timeout → 此断言失败
+  });
+});
+
+describe('recordAdapterPresence (issue #324 sticky tracker)', () => {
+  const fresh = (): TunAdapterObservation => ({
+    adapterEverSeen: false,
+    probeEverConclusive: false,
+  });
+
+  it('present → adapterEverSeen + probeEverConclusive 均置真', () => {
+    const o = fresh();
+    recordAdapterPresence(o, 'present');
+    expect(o).toEqual({ adapterEverSeen: true, probeEverConclusive: true });
+  });
+
+  it('absent → 仅 probeEverConclusive 置真（证明探测可用），adapterEverSeen 不动', () => {
+    const o = fresh();
+    recordAdapterPresence(o, 'absent');
+    expect(o).toEqual({ adapterEverSeen: false, probeEverConclusive: true });
+  });
+
+  it('unknown → 两者皆不动（fail-open，不作数）', () => {
+    const o = fresh();
+    recordAdapterPresence(o, 'unknown');
+    expect(o).toEqual({ adapterEverSeen: false, probeEverConclusive: false });
+  });
+
+  it('monotonic：present 后再 absent/unknown 也永不复位 adapterEverSeen（跨腿累计）', () => {
+    const o = fresh();
+    recordAdapterPresence(o, 'present'); // leg-1 见过
+    recordAdapterPresence(o, 'absent'); // leg-2 未见（进程死后适配器消失）
+    recordAdapterPresence(o, 'unknown');
+    expect(o.adapterEverSeen).toBe(true); // 曾见即 sticky → 判瞬态；变异「每腿复位」会让此断言失败
+  });
+});
+
+describe('isPersistentTunFailure (issue #324 终态判据 — 分类矩阵穷举)', () => {
+  // 矩阵四角（对齐 doc「瞬态 vs 持续性」分类表），穷举逃逸面：
+  it('从未见 + 探测可用（clean absent 过）→ true（持续性 TUN init 失败）', () => {
+    expect(isPersistentTunFailure({ adapterEverSeen: false, probeEverConclusive: true })).toBe(
+      true
+    );
+  });
+  it('曾见适配器 → false（瞬态释放竞态族 #159/#176），即便 conclusive', () => {
+    expect(isPersistentTunFailure({ adapterEverSeen: true, probeEverConclusive: true })).toBe(
+      false
+    );
+  });
+  it('从未见 + 探测全 unknown（杀软拦 PS）→ false（fail-open，绝不据此判终态）', () => {
+    // 变异「删 fail-open（去掉 probeEverConclusive 条件）」→ 此例会误判 true → 被本用例杀死。
+    expect(isPersistentTunFailure({ adapterEverSeen: false, probeEverConclusive: false })).toBe(
+      false
+    );
+  });
+  it('曾见 + 探测未 conclusive（防御性组合）→ false', () => {
+    expect(isPersistentTunFailure({ adapterEverSeen: true, probeEverConclusive: false })).toBe(
+      false
+    );
   });
 });
 

--- a/src/main/services/core-readiness.ts
+++ b/src/main/services/core-readiness.ts
@@ -37,6 +37,49 @@ export class CoreStartSupersededError extends Error {
 }
 
 /**
+ * issue #324：Windows TUN「持续性初始化失败」终态标记错误。
+ * 与 CoreStartRetryError 的关键区别：**终态、不重试**。语义——单次 start 内起核重试预算耗尽，且全程（跨所有重试腿）
+ * 从未观测到自家 wintun 适配器出现、而适配器探测链路本身可用（排除杀软拦 PowerShell 的 unknown 误判）→ 判定
+ * 不是瞬态释放竞态（#159/#176），而是 wintun 驱动/被拦/冲突 VPN 类持续性故障，继续「正在自动重试」只会无限循环
+ * 误导用户。故转为携可操作诊断的终态错误上抛，由 start() 收口 + EVENT_PROXY_ERROR（errorCode=TUN_INIT_PERSISTENT）
+ * 驱动渲染端诊断卡。走 instanceof 判别（对齐 CoreStartSupersededError 先例），**不进 nonRetryableErrors 词表**。
+ * 不跨 start 累计计数（下次冷启环境可能已修复，应允许重试）——单次 start 内「预算耗尽且从未见适配器」已是强判据。
+ */
+export class CoreStartTunPersistentError extends Error {
+  // review Low#4：终态判据（预算耗尽 + 探测可用但全程未见适配器）对「非 wintun 类持续起核失败」（坏配置/端口占用/慢机
+  // 冷启拉 ruleset 超时）同样命中——那些场景适配器也从未创建。故文案**不独指 wintun**：先陈述观测事实 + 引导开诊断采集
+  // 定位（真正拍板证据），再把 wintun/冲突 VPN 列为常见原因之一。定向到具体根因的日志佐证留真机项 #1 后增强。
+  constructor(
+    message = 'TUN 适配器持续未能建立，起核重试均未成功——已停止无谓重试。常见原因：wintun 驱动被杀软拦截/损坏、其它 VPN/TUN 客户端占用，或内核/配置/端口导致起核失败。请开启「诊断采集」重导日志以定位；若确为 wintun，检查杀软隔离区的 wintun.dll 并关闭其它 TUN/VPN 客户端后重试。'
+  ) {
+    super(message);
+    this.name = 'CoreStartTunPersistentError';
+  }
+}
+
+/**
+ * 起核错误「按文案判不可重试」的关键词黑名单（issue #176 起核 retry 分类）。权限/找不到/坏配置类无论重试多少次
+ * 都不会好 → 直接失败。**新增 CoreStartRetryError 文案时务必不误命中这些词**（issue #324 A1「…未建立」/A3
+ * 「…从未创建」/「…初始化未完成」均已避开，由 startMessageIsNonRetryable 单测守卫，防未来加词静默把可重试文案变不可重试）。
+ */
+export const NON_RETRYABLE_START_ERROR_PATTERNS = [
+  '找不到',
+  '权限',
+  'permission',
+  'enoent',
+  'eacces',
+  'eperm',
+  '配置文件格式错误',
+  'invalid config',
+] as const;
+
+/** message 是否命中「不可重试」黑名单（大小写不敏感）。runStartWithRetry.shouldRetry 与单测共用同一判据，杜绝漂移。 */
+export function startMessageIsNonRetryable(message: string): boolean {
+  const m = message.toLowerCase();
+  return NON_RETRYABLE_START_ERROR_PATTERNS.some((p) => m.includes(p));
+}
+
+/**
  * TCP 可连探测（管理 API 已绑定即就绪）。零提权。连上 → true；超时/拒绝/错误 → false。
  */
 export function probeTcpReachable(host: string, port: number, timeoutMs = 1000): Promise<boolean> {

--- a/src/main/services/win-tun-adapter.ts
+++ b/src/main/services/win-tun-adapter.ts
@@ -14,34 +14,13 @@ import { execFile } from 'child_process';
 import { powershellPath } from '../utils/win-system32';
 
 /**
- * 探测 Windows 上是否仍存在名为 `name` 的网卡（设备级，零提权）。
+ * 探测 Windows 上是否仍存在名为 `name` 的网卡（设备级，零提权）。#159 反向释放门用。
  * 命中 → true；查不到 / PowerShell 失败 / 超时 → false（宁判「已释放」放行，绝不卡死启动）。
+ * 委托三态版 `probeWinTunAdapterPresence`（单一 Get-NetAdapter 实现，杜绝两处漂移，issue #324 review Low#3）：
+ * present→true；absent/unknown 皆→false，正是本方向的 fail-open 语义（探测失败=按「已释放」放行）。
  */
 export function probeWinTunAdapterPresent(name: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    // -Name 精确匹配（PS 单引号内 '' 转义防注入）；命中输出网卡名，未命中经 SilentlyContinue 吞错→空输出。
-    const psName = name.replace(/'/g, "''");
-    // 绝对路径调 PowerShell（不依赖 PATH）：PATH 缺/被劫持 System32 时裸 'powershell.exe'
-    // spawn 失败 → fail-open 永久判「已释放」→ #159 僵尸 wintun 释放门变 no-op。见 win-system32.ts。
-    execFile(
-      powershellPath(),
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        `Get-NetAdapter -Name '${psName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name`,
-      ],
-      { timeout: 4000, windowsHide: true },
-      (err, stdout) => {
-        if (err) return resolve(false); // 查询失败 → fail-open（按已释放处理）
-        resolve(
-          String(stdout)
-            .split(/\r?\n/)
-            .some((line) => line.trim() === name)
-        );
-      }
-    );
-  });
+  return probeWinTunAdapterPresence(name).then((p) => p === 'present');
 }
 
 /** waitForAdapterReleased 注入依赖（单测可替换为桩，零真实计时器/网卡）。 */
@@ -74,4 +53,143 @@ export async function waitForAdapterReleased(
   // 末轮 sleep 后再确认一次（覆盖最后一个 pollMs 窗口内刚释放的情形）。
   if (!(await deps.probe(name))) return { released: true, polls: maxPolls + 1 };
   return { released: false, polls: maxPolls + 1 };
+}
+
+// ============================================================================
+// issue #324：正向 TUN 就绪验证（等自家 wintun 适配器「出现」，#159 反向门的镜像）。
+// ============================================================================
+
+/**
+ * 适配器存在性三态（issue #324 正向门用）。
+ *  - `present`：查到本名网卡；
+ *  - `absent`：查询成功但无此网卡（证明 Get-NetAdapter 可用 → 可据此判「从未创建」）；
+ *  - `unknown`：探测本身失败（PowerShell 缺/被杀软拦/超时）→ fail-open 信号，绝不据此判终态失败。
+ * 与布尔版 probeWinTunAdapterPresent 的区别：后者把 absent/unknown 都塌成 false（#159 反向门 fail-open=false 正确）；
+ * 正向门必须区分「确实没有」与「查不了」——否则杀软拦 PS 的机器会被误判成持续性 TUN 失败。
+ */
+export type AdapterPresence = 'present' | 'absent' | 'unknown';
+
+/**
+ * 三态探测名为 `name` 的网卡是否存在（issue #324）。与 probeWinTunAdapterPresent 同一 Get-NetAdapter 机制，
+ * 仅返回值语义更细：err（spawn/执行失败）→ 'unknown'；命中本名 → 'present'；查询成功但空 → 'absent'。
+ */
+export function probeWinTunAdapterPresence(name: string): Promise<AdapterPresence> {
+  return new Promise((resolve) => {
+    const psName = name.replace(/'/g, "''");
+    execFile(
+      powershellPath(),
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Get-NetAdapter -Name '${psName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name`,
+      ],
+      { timeout: 4000, windowsHide: true },
+      (err, stdout) => {
+        // err = PowerShell spawn/执行失败（PS 缺/被拦/超时）→ unknown（fail-open）。
+        // -ErrorAction SilentlyContinue 使「网卡不存在」不报错、输出为空 → 落 'absent'（证明 PS 本身可用）。
+        if (err) return resolve('unknown');
+        const hit = String(stdout)
+          .split(/\r?\n/)
+          .some((line) => line.trim() === name);
+        resolve(hit ? 'present' : 'absent');
+      }
+    );
+  });
+}
+
+/** waitForAdapterPresent 注入依赖（单测可替换为桩；probe 可抛错，内部按 unknown/fail-open 处理）。 */
+export interface AdapterPresenceWaitDeps {
+  probe: (name: string) => Promise<AdapterPresence>;
+  sleep: (ms: number) => Promise<void>;
+  /**
+   * issue #176/#324 High#1：本腿是否已被更新的 start/stop 接管（可选；缺省视作未接管）。每轮先判——接管后本腿继续
+   * 验适配器/停核/发 started 都会抢放接管方的核，故立即让位（outcome='superseded'），调用方绝不 stopCore/emit started。
+   */
+  isSuperseded?: () => boolean;
+}
+
+/**
+ * 正向等待结果：
+ *  - `present`：确认网卡出现（硬闸放行）；
+ *  - `absent-timeout`：预算内**曾拿到过 clean absent** 但网卡始终未出现（Get-NetAdapter 可用 → 判「从未创建」，硬闸失败本腿）；
+ *  - `unknown`：预算内探测从未给出 clean 结论（全 unknown/抛错）→ fail-open 放行（绝不据此判终态失败）；
+ *  - `superseded`：等待期被更新的 start/stop 接管（#176）→ 让位（不 present/不 absent-timeout，调用方不 stopCore、不 emit started）。
+ * polls = 实际探测次数。
+ */
+export interface AdapterPresentResult {
+  outcome: 'present' | 'absent-timeout' | 'unknown' | 'superseded';
+  polls: number;
+}
+
+/**
+ * 有界轮询等名为 `name` 的网卡「出现」（issue #324，镜像 waitForAdapterReleased/waitForCoreReady 结构）。
+ * 每轮先判 isSuperseded（被接管即让位，#176 纪律）；present 立即早退；probe 抛错/返回 unknown → 不早退但记；
+ * 查得 absent → 记 sawAbsent（证明 PS 可用）。预算耗尽仍未 present：sawAbsent → 'absent-timeout'（可据此硬闸/判持续性）；
+ * 否则（只见过 unknown）→ 'unknown'（fail-open）。一次 clean absent 即证明探测链路可用，压过零星 unknown。
+ */
+export async function waitForAdapterPresent(
+  name: string,
+  opts: { timeoutMs: number; pollMs: number },
+  deps: AdapterPresenceWaitDeps
+): Promise<AdapterPresentResult> {
+  const pollMs = Math.max(1, opts.pollMs);
+  const maxPolls = Math.max(1, Math.ceil(opts.timeoutMs / pollMs));
+  // 一次 clean absent 即证明 Get-NetAdapter 探测链路可用；据此把「确实没建起」（→ 硬闸/终态）与「探测本身失败」
+  // （全 unknown → fail-open）区分开。零星 unknown 被一次 clean absent 压过。
+  let sawAbsent = false;
+  const step = async (): Promise<AdapterPresence> => {
+    try {
+      return await deps.probe(name);
+    } catch {
+      return 'unknown'; // probe 抛错 → fail-open（按 unknown 处理，绝不据此判失败）
+    }
+  };
+  for (let i = 0; i < maxPolls; i++) {
+    if (deps.isSuperseded?.()) return { outcome: 'superseded', polls: i }; // #176：接管先于一切，立即让位
+    const p = await step();
+    if (p === 'present') return { outcome: 'present', polls: i + 1 };
+    if (p === 'absent') sawAbsent = true;
+    await deps.sleep(pollMs);
+  }
+  if (deps.isSuperseded?.()) return { outcome: 'superseded', polls: maxPolls };
+  // 末轮 sleep 后再确认一次（覆盖最后一个 pollMs 窗口内刚出现的情形）。
+  const last = await step();
+  if (last === 'present') return { outcome: 'present', polls: maxPolls + 1 };
+  if (last === 'absent') sawAbsent = true;
+  return { outcome: sawAbsent ? 'absent-timeout' : 'unknown', polls: maxPolls + 1 };
+}
+
+/**
+ * issue #324 分类 tracker：单次 start 内、跨所有重试腿 sticky 累计的适配器观测。
+ *  - adapterEverSeen：任一腿曾观测到适配器出现（→ 瞬态释放竞态族 #159/#176）。
+ *  - probeEverConclusive：探测链路曾给出 clean 结论（present/absent）——排除全 unknown（杀软拦 PowerShell）误判终态。
+ */
+export interface TunAdapterObservation {
+  adapterEverSeen: boolean;
+  probeEverConclusive: boolean;
+}
+
+/**
+ * 把一次探测结果并入 sticky tracker（**monotonic：只置 true、永不复位**——保证跨重试腿累计，一腿见过后续腿死也判瞬态）。
+ * present → adapterEverSeen + probeEverConclusive；absent → probeEverConclusive；unknown → 不动（fail-open，不作数）。
+ */
+export function recordAdapterPresence(obs: TunAdapterObservation, p: AdapterPresence): void {
+  if (p === 'present') {
+    obs.adapterEverSeen = true;
+    obs.probeEverConclusive = true;
+  } else if (p === 'absent') {
+    obs.probeEverConclusive = true;
+  }
+}
+
+/**
+ * issue #324 终态判据：给定跨腿 sticky tracker，判是否「持续性 TUN init 失败」（vs 瞬态释放竞态）。
+ * **true ⟺ 全程未见适配器（!adapterEverSeen）且探测链路曾给出 clean 结论（probeEverConclusive）**。
+ *  - 曾见适配器 → 瞬态（false，#159/#176 族，照旧重试语义）。
+ *  - 探测全 unknown（!probeEverConclusive，杀软拦 PS）→ fail-open 瞬态（false，绝不据此判终态）。
+ * 调用方：dead 分支文案细分（A3）+ 预算耗尽终态转化（A2）共用同一判据，避免两处漂移。
+ */
+export function isPersistentTunFailure(obs: TunAdapterObservation): boolean {
+  return !obs.adapterEverSeen && obs.probeEverConclusive;
 }

--- a/src/renderer/lib/error-handler.ts
+++ b/src/renderer/lib/error-handler.ts
@@ -138,6 +138,7 @@ export function proxyErrorCategory(code: unknown): ErrorCategory | null {
     case ProxyErrorCode.BINARY_NOT_EXECUTABLE:
     case ProxyErrorCode.BINARY_NOT_FOUND:
     case ProxyErrorCode.CRONET_LIB_MISSING:
+    case ProxyErrorCode.TUN_INIT_PERSISTENT:
       return ErrorCategory.System;
     case ProxyErrorCode.STARTUP_FAILED:
     case ProxyErrorCode.PROCESS_KILLED:

--- a/src/shared/types/runtime.ts
+++ b/src/shared/types/runtime.ts
@@ -33,6 +33,7 @@ export enum ProxyErrorCode {
   BINARY_NOT_EXECUTABLE = 'BINARY_NOT_EXECUTABLE', // 退出码 126
   BINARY_NOT_FOUND = 'BINARY_NOT_FOUND', // 退出码 127
   CRONET_LIB_MISSING = 'CRONET_LIB_MISSING', // 'cronet: library not found' / dlopen 失败（naive 出站缺/坏 libcronet → 整核 FATAL，自愈冷路径触发）
+  TUN_INIT_PERSISTENT = 'TUN_INIT_PERSISTENT', // issue #324：Windows wintun 适配器持续未建立（起核重试预算耗尽且全程未见适配器）→ 终态可操作诊断，非「正在自动重试」
   // 进程生命周期类 → ErrorCategory.Process
   STARTUP_FAILED = 'STARTUP_FAILED', // 退出码 1
   PROCESS_KILLED = 'PROCESS_KILLED', // 退出码 137


### PR DESCRIPTION
## 问题（#324）
Windows 10 下 TUN 无法开启，`sing-box 启动期退出（TUN 初始化未完成），正在自动重试` 每 ~6s 无限循环、永不成功。

诊断报告实证：sing-box 进程存活且 mixed 代理正常（youtube/cloudflare 经节点建连成功），但全程无 `inbound/tun[tun-in]: started`——TUN 网卡（flowz-tun0 / wintun）从未创建。旧就绪门只探管理 API 端口（非 TUN 接口真存在），无法区分「真起来」与「进程活但 TUN 没起」，落入误导性无限重试。

## 改动
- **A1** 起核后正向验证 `flowz-tun0` 适配器出现（`waitForAdapterPresent`，每腿独立验证），缺失=本腿失败；probe 自身失败（PowerShell 缺 / 被杀软拦）fail-open 放行；grace 轮询注入 isSuperseded，被接管抛 `CoreStartSupersededError`、绝不 stopCore（守 #176 双 TUN 释放纪律）。
- **A2** 就绪窗内并行 sticky 观测适配器，重试预算耗尽且全程未见→ `CoreStartTunPersistentError` 终态诊断，停「正在自动重试」误导，给可操作提示（wintun / 杀软 / 冲突 VPN）。
- 仅 win32 + TUN，macOS/Linux 零改动。

## 验证
- gate：tsc / jest（新增 ~36 tests，分类矩阵变异全覆盖）/ eslint 0。
- 三轮独立复审零 Crit/High/Med/Low/Nit（#176 回归、fail-open、每腿验证、平台隔离逐条核实）。

## ⚠️ 待真机验证 + 根因分层
本 PR 修的是 **FlowZ 侧设计缺口**（就绪门不验 TUN 接口 + 持续性失败当瞬态无限重试），把「假连接 / 误导性死循环」变成「正确检测 + 可操作诊断」。

但 reporter **实际 TUN 起不来的主因在其机器**（wintun.dll 被杀软隔离 / 残留 adapter / 冲突 VPN / 或 alpha 核回归），本 PR 不直接修复该主因——需 reporter 开诊断采集（debug）重导抓 wintun 错误行确认。故**暂不 Closes #324**，待真机确认失败模式改善 + 主因定位后再定 issue 去留。

Refs #324