### PR TITLE
fix(startup): replay config to renderer on RENDERER_READY (autostart)

### DIFF
--- a/src/main/__tests__/renderer-ready-replay.test.ts
+++ b/src/main/__tests__/renderer-ready-replay.test.ts
@@ -1,0 +1,65 @@
+/**
+ * replayConfigOnRendererReady 纯逻辑 DI 单测（#325）。钉住协议保证：收到 RENDERER_READY 恰重放一次终态 config、
+ * 中止态不发、读失败只 warn 不抛、二次 RENDERER_READY（reload）再重放。运行期 webContents/时序副作用由真机验。
+ * 循 mount-health-gate.test.ts 的纯逻辑 DI 模式。
+ */
+import { replayConfigOnRendererReady } from '../renderer-ready-replay';
+
+type Cfg = { tag: string };
+
+function makeDeps(overrides: Partial<Parameters<typeof replayConfigOnRendererReady<Cfg>>[0]> = {}) {
+  const send = jest.fn<void, [Cfg]>();
+  const warn = jest.fn<void, [string]>();
+  const isAborted = jest.fn<boolean, []>().mockReturnValue(false);
+  const loadConfig = jest.fn<Promise<Cfg>, []>().mockResolvedValue({ tag: 'terminal' });
+  return {
+    deps: { loadConfig, send, isAborted, warn, ...overrides },
+    send,
+    warn,
+    isAborted,
+    loadConfig,
+  };
+}
+
+describe('replayConfigOnRendererReady', () => {
+  it('T4 收到 RENDERER_READY → 恰一次 send，payload 为 loadConfig 返回的终态 config', async () => {
+    const { deps, send, warn } = makeDeps();
+    await replayConfigOnRendererReady(deps);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({ tag: 'terminal' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('T5 已中止（isQuitting / wc destroyed）→ 不 send、不读 config', async () => {
+    const { deps, send, loadConfig } = makeDeps({ isAborted: jest.fn().mockReturnValue(true) });
+    await replayConfigOnRendererReady(deps);
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('T5b await 期间转入中止（读 config 后 wc 已销毁）→ 不 send', async () => {
+    // 第一次查（读前）false 放行，第二次查（await 后）true 拦截 → 不得向已销毁 wc send。
+    const isAborted = jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(true);
+    const { deps, send, warn } = makeDeps({ isAborted });
+    await replayConfigOnRendererReady(deps);
+    expect(send).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('T6 loadConfig reject → 调 warn、不 send、不抛（绝不打断 mount gate）', async () => {
+    const { deps, send, warn } = makeDeps({
+      loadConfig: jest.fn().mockRejectedValue(new Error('read fail')),
+    });
+    await expect(replayConfigOnRendererReady(deps)).resolves.toBeUndefined();
+    expect(send).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('read fail');
+  });
+
+  it('T7 二次 RENDERER_READY（reload）→ 再次重放（幂等，每次挂载都发）', async () => {
+    const { deps, send } = makeDeps();
+    await replayConfigOnRendererReady(deps);
+    await replayConfigOnRendererReady(deps);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -87,6 +87,7 @@ import type { HelperStatus, UserConfig } from '../shared/types';
 import { ipcEventEmitter } from './ipc/ipc-events';
 import { buildTrayCallbacks } from './tray-actions';
 import { scheduleStartupTasks } from './startup-tasks';
+import { replayConfigOnRendererReady } from './renderer-ready-replay';
 import { registerConfigChangeListener } from './config-change-handler';
 import { mainEventEmitter, MAIN_EVENTS } from './ipc/main-events';
 import { initUserDataPath, getConfigPath } from './utils/paths';
@@ -1028,6 +1029,15 @@ async function createWindow(forceShow = false) {
   // 注册报错。renderer 用 invoke（preload 未暴露单向 send），故用 .handle（fire-and-forget，返回 undefined）。
   gateWin.webContents.ipc.handle(IPC_CHANNELS.RENDERER_READY, () => {
     runMountGate('rendererReady');
+    // #325 config 重放：renderer 每次挂载后无条件补发一次终态 config，补偿 silent-start 期无窗口订阅者而被静默
+    // 丢弃的 event:configChanged（否则首页定格「无节点」直到退出重开）。fire-and-forget，绝不阻塞/打断 mount gate。
+    void replayConfigOnRendererReady<UserConfig>({
+      loadConfig: () => configManager.loadConfig(),
+      send: (config) =>
+        gateWin.webContents.send(IPC_CHANNELS.EVENT_CONFIG_CHANGED, { newValue: config }),
+      isAborted: () => isQuitting || gateWin.isDestroyed(),
+      warn: (message) => logManager.addLog('warn', message, 'Main'),
+    });
     return undefined;
   });
   // 终局错误页「重新加载」（L3）：主进程复位健康门 + 对本窗重新 loadFile 真实应用。经主进程 loadFile 绕开 Chromium
@@ -1855,6 +1865,11 @@ if (gotTheLock) {
       logManager,
       () => proxyManager?.getStatus().running ?? false,
       (cfg) => {
+        // #325 打点：silent-start 期（无窗口订阅者）该 configChanged 会被 sendToAll 静默丢弃 → 记 debug 使其可观测，
+        // 真机验证时与 RENDERER_READY 后的 replay 记录成对出现（钉窗口 + 验 replay 确实兜住丢失的事件）。
+        if (ipcEventEmitter.getWindowCount() === 0) {
+          logManager.addLog('debug', 'configChanged dropped: no window (silent-start?)', 'Main');
+        }
         ipcEventEmitter.sendToAll('event:configChanged', { newValue: cfg });
         // P2-2：后台订阅更新增删节点后刷新托盘「选择服务器」子菜单（updateTrayMenuState 重载最新 config）。
         // 走 tray-only 刷新、不发 MAIN_EVENTS.CONFIG_CHANGED → 不触发 switchMode 重启，守住「不打断连接」不变量。

--- a/src/main/renderer-ready-replay.ts
+++ b/src/main/renderer-ready-replay.ts
@@ -1,0 +1,47 @@
+/**
+ * RENDERER_READY 配置重放 —— 从 index.ts 的 RENDERER_READY handler 抽出（DI 化以可单测；index.ts 是无测试单体，
+ * 循 startup-tasks.ts / config-change-handler.ts 从 index.ts 抽出的既有先例）。
+ *
+ * 不变量（#325）：renderer 每次挂载（含 reload）后必收到一次「当时终态 config」。silent-start 期主进程发出的
+ * event:configChanged 在 renderer 挂载前无窗口订阅者、被静默丢弃（见 ipc-events.sendToAll 遍历空 windows 集合），
+ * 而 mount-time 单发 loadConfig 快照若恰落在启动 churn 中（订阅补更改写 servers / F14 reselect 改 selectedServerId）
+ * 即定格「无节点」。此处在收到 RENDERER_READY 时向该 webContents **无条件**重放一次终态 config 补偿——把不变量从
+ * 「碰运气」变协议保证。一次 replay 同覆盖三类丢失：①silent-start 无窗期（本 issue）②建窗后 renderer boot 到
+ * listener 注册前的空窗 ③mount-gate reload 后的空窗（reload 重发 RENDERER_READY → 再 replay，白捡自愈）。
+ *
+ * 幂等：多发一次同值事件 → renderer applyConfigFromEvent 同值 setState 无害；不依赖 silent-start 门控 / mount-gate
+ * 状态（避免与 gate 状态机耦合）。绝不打断 mount gate：读 config 失败只 warn 不抛。
+ */
+
+/** DI 依赖：与 index.ts / Electron / configManager 解耦，纯逻辑可单测。 */
+export interface RendererReadyReplayDeps<C> {
+  /** 读当时终态 config（configManager.loadConfig，读内存缓存近零成本）。 */
+  loadConfig: () => Promise<C>;
+  /** 向目标 webContents 发 EVENT_CONFIG_CHANGED（payload { newValue }）。 */
+  send: (config: C) => void;
+  /** 中止判定（isQuitting || webContents.isDestroyed()）；await 前后各查一次，避免向已销毁 wc send 抛错。 */
+  isAborted: () => boolean;
+  /** 读失败告警（logManager.addLog('warn', …)）；绝不影响 mount gate。 */
+  warn: (message: string) => void;
+}
+
+/**
+ * fire-and-forget：在 RENDERER_READY 时重放终态 config。异常内部吞（只 warn，绝不抛/阻塞 mount gate），
+ * 调用方 `void` 即可。
+ */
+export async function replayConfigOnRendererReady<C>(
+  deps: RendererReadyReplayDeps<C>
+): Promise<void> {
+  const { loadConfig, send, isAborted, warn } = deps;
+  if (isAborted()) return;
+  try {
+    const config = await loadConfig();
+    // await 期间可能进入退出 / webContents 销毁 → 再查一次，防向已销毁 wc send 抛错。
+    if (isAborted()) return;
+    send(config);
+  } catch (err) {
+    warn(
+      `RENDERER_READY config replay failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/src/renderer/hooks/use-native-events.ts
+++ b/src/renderer/hooks/use-native-events.ts
@@ -197,7 +197,9 @@ function handleProcessError(data: NativeEventData['processError']) {
 function handleConfigChanged(data: NativeEventData['configChanged']) {
   // 当收到配置变更事件时，直接使用事件中的新配置更新 store（即使外部并发改动也能即时同步）
   if (data.newValue) {
-    useAppStore.setState({ config: data.newValue });
+    // A2 护栏：不直接 setState，改走 applyConfigFromEvent（set config + invalidate 在飞 pull）——replay 使「push 与
+    // mount loadConfig 并发」每次挂载必然发生，裸 setState 会被迟到的旧 pull 快照覆盖（#325）。
+    useAppStore.getState().applyConfigFromEvent(data.newValue);
   } else {
     // 如果没有新配置数据，则重新加载；loadConfig 自带单飞，无需再用全局 isLoading 守卫
     useAppStore.getState().loadConfig();

--- a/src/renderer/store/__tests__/load-config-generation.test.ts
+++ b/src/renderer/store/__tests__/load-config-generation.test.ts
@@ -8,6 +8,9 @@
 const mockConfigGet = jest.fn();
 const mockGetPrivacyMode = jest.fn().mockResolvedValue(false);
 const mockServerDelete = jest.fn().mockResolvedValue(undefined);
+// TS 登录缓存 mock：可配置 cache 内容 + 稳定 removeCached spy，供孤儿 GC 用例断言。
+const mockRemoveCached = jest.fn();
+let mockLoginCache: Record<string, unknown> = {};
 
 jest.mock('../../ipc', () => ({
   api: {
@@ -22,7 +25,11 @@ jest.mock('../../i18n', () => ({ __esModule: true, default: { t: (k: string) => 
 jest.mock('../use-tailscale-login-cache-store', () => ({
   loadTailscaleLoginStatesFromCache: () => ({}),
   useTailscaleLoginCacheStore: {
-    getState: () => ({ cache: {}, removeCached: jest.fn(), setCached: jest.fn() }),
+    getState: () => ({
+      cache: mockLoginCache,
+      removeCached: mockRemoveCached,
+      setCached: jest.fn(),
+    }),
   },
 }));
 
@@ -81,5 +88,99 @@ describe('loadConfig 代际护栏', () => {
     only.resolve(makeConfig(['X', 'Y']));
     await load;
     expect(serverIdsInStore()).toEqual(['X', 'Y']);
+  });
+});
+
+// #325 A2：main push 的 config 事件（replay + 常规 configChanged newValue）经 applyConfigFromEvent 落地——
+// 写 config + 作废在飞旧 pull，防「push 与 mount pull 并发」时旧 pull 迟到覆盖新 push。
+describe('applyConfigFromEvent（#325 replay 护栏）', () => {
+  beforeEach(() => {
+    mockConfigGet.mockReset();
+    mockGetPrivacyMode.mockReset();
+    mockGetPrivacyMode.mockResolvedValue(false);
+    mockRemoveCached.mockReset();
+    mockLoginCache = {};
+    useAppStore.setState({ config: null, isPrivacyMode: false });
+  });
+
+  it('T1 丢事件后补偿 + 清在飞句柄：mount pull 在飞时 apply 终态 → config 即落地，且 invalidate 清句柄使后续 loadConfig 真实重拉（非复用旧 promise）', async () => {
+    // silent-start：mount loadConfig 已起飞但快照未回（churn 中）→ config 仍 null。
+    const churnPull = deferred<any>();
+    mockConfigGet.mockReturnValueOnce(churnPull.promise);
+    const churnLoad = useAppStore.getState().loadConfig();
+    expect(mockConfigGet).toHaveBeenCalledTimes(1);
+    expect(serverIdsInStore()).toBeUndefined(); // 尚未回填
+
+    // replay push 终态 → config 即落地（不等 churn pull），并 invalidate 在飞句柄。
+    useAppStore.getState().applyConfigFromEvent(makeConfig(['NODE-A', 'NODE-B']) as any);
+    expect(serverIdsInStore()).toEqual(['NODE-A', 'NODE-B']);
+
+    // 杀变异「apply 只 gen++ 不清 inflight」：若句柄未清，下面 loadConfig 会复用 churnPull（单飞早退、不再调
+    // api.config.get）→ toHaveBeenCalledTimes(2) 失败。清了才会真实第二次拉取。
+    const reloadPull = deferred<any>();
+    mockConfigGet.mockReturnValueOnce(reloadPull.promise);
+    const reload = useAppStore.getState().loadConfig();
+    expect(mockConfigGet).toHaveBeenCalledTimes(2);
+
+    // churn pull 迟到 resolve：代际已变 → 丢弃，不覆盖 push 的 config；reload pull 回填最新。
+    churnPull.resolve(makeConfig(['STALE']));
+    reloadPull.resolve(makeConfig(['NODE-A', 'NODE-B', 'NODE-C']));
+    await Promise.all([churnLoad, reload]);
+    expect(serverIdsInStore()).toEqual(['NODE-A', 'NODE-B', 'NODE-C']);
+  });
+
+  it('T2 push-while-pull-in-flight：mount loadConfig 在飞时 apply(v2) → 在飞旧 pull 迟到 resolve 被代际丢弃，store 保持 v2 不回退', async () => {
+    const inflightPull = deferred<any>();
+    mockConfigGet.mockReturnValueOnce(inflightPull.promise);
+
+    // 1) mount loadConfig 起飞（快照 v1 尚未 resolve）
+    const load = useAppStore.getState().loadConfig();
+
+    // 2) main push 终态 v2 → set config=v2 + invalidateLoadConfig（自增代际、置空句柄）
+    useAppStore.getState().applyConfigFromEvent(makeConfig(['V2']) as any);
+    expect(serverIdsInStore()).toEqual(['V2']);
+
+    // 3) 在飞旧 pull 迟到 resolve 返回 v1 旧快照：代际已变 → 丢弃，不覆盖 v2
+    inflightPull.resolve(makeConfig(['V1-STALE']));
+    await load;
+    expect(serverIdsInStore()).toEqual(['V2']);
+  });
+
+  it('T-High（复审 High 1）apply-during-pull：在飞 mount pull 的 isPrivacyMode 水合不被 replay 作废 → 隐私锁不旁路', async () => {
+    // silent-start + autoPrivacyMode：main 无窗期已 setPrivacyMode(true)，ENTER 事件丢失 → 挂载期隐私态唯一水合
+    // 路径 = mount pull 的 getPrivacyMode。若 isPrivacyMode 随 config 代际护栏被 replay 一起作废 → 恒 false = 锁旁路。
+    const pull = deferred<any>();
+    mockConfigGet.mockReturnValueOnce(pull.promise);
+    mockGetPrivacyMode.mockResolvedValueOnce(true); // 主进程隐私锁已开
+
+    const load = useAppStore.getState().loadConfig();
+
+    // replay push 终态 config v2 → invalidate 在飞 pull 的 config回填（但不得殃及 isPrivacyMode 水合）。
+    useAppStore.getState().applyConfigFromEvent(makeConfig(['V2']) as any);
+
+    // 在飞 pull resolve：config 快照陈旧被代际丢弃；isPrivacyMode 必须仍水合为 true。
+    pull.resolve(makeConfig(['V1-STALE']));
+    await load;
+
+    expect(useAppStore.getState().isPrivacyMode).toBe(true); // 遮罩正确出现，锁未旁路
+    expect(serverIdsInStore()).toEqual(['V2']); // config 仍是 push v2，不被 stale 覆盖
+  });
+
+  it('T-GC（复审追零 Nit）apply-during-pull：在飞 pull 的孤儿 GC 被作废跳过时，push 落地补跑 GC → 挂载期不漏清 TS 缓存孤儿', async () => {
+    mockLoginCache = { KEEP: {}, ORPHAN: {} }; // 缓存含一存活 + 一孤儿条目
+    const pull = deferred<any>();
+    mockConfigGet.mockReturnValueOnce(pull.promise);
+    const load = useAppStore.getState().loadConfig(); // mount pull 在飞
+
+    // replay push 终态 servers=[KEEP]：apply 路径同步跑孤儿 GC，清 ORPHAN、留 KEEP（不依赖在飞 pull 的 GC）。
+    useAppStore.getState().applyConfigFromEvent(makeConfig(['KEEP']) as any);
+    expect(mockRemoveCached).toHaveBeenCalledWith('ORPHAN');
+    expect(mockRemoveCached).not.toHaveBeenCalledWith('KEEP');
+
+    // 在飞 pull 迟到 resolve：gen 已变 → config回填 + 其 GC 被守卫跳过（否则会用陈旧 servers 再 GC）。
+    mockRemoveCached.mockClear();
+    pull.resolve(makeConfig(['STALE-SERVER']));
+    await load;
+    expect(mockRemoveCached).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/store/app-store.ts
+++ b/src/renderer/store/app-store.ts
@@ -79,6 +79,18 @@ function invalidateLoadConfig(): void {
   loadConfigInflight = null;
 }
 
+// TS 登录态缓存孤儿 GC：清不在当前 servers 的缓存条目——覆盖所有绕过渲染端 deleteServer 的删节点路径
+// （ConfigManager sanitize 丢多余 TS / 损坏备份导入 / 手改配置 / 订阅补更删节点），免 localStorage 缓存条目无上限泄漏。
+// 抽共用（loadConfig 回填 + applyConfigFromEvent push 落地双调），避免双写漂移——replay 作废在飞 pull 时那次 pull 的
+// GC 被 gen 守卫跳过，push 路径补跑一次使挂载期短窗也不漏 GC（#325 复审追零 Nit）。入参为权威 servers，无陈旧覆盖。
+function gcOrphanTailscaleLoginCache(servers: UserConfig['servers']): void {
+  const liveServerIds = new Set(servers.map((s) => s.id));
+  const loginCache = useTailscaleLoginCacheStore.getState();
+  for (const id of Object.keys(loginCache.cache)) {
+    if (!liveServerIds.has(id)) loginCache.removeCached(id);
+  }
+}
+
 /**
  * D4 删选中节点时的兜底出口候选（按列表序）：只纳入「可作真实全隧道出口」的剩余节点——
  *   ① isServerComplete（配置齐备、协议受支持、非空发射；已内含 !isMeshNodeUnroutable）；
@@ -233,6 +245,9 @@ interface AppState {
   // Configuration Actions
   loadConfig: () => Promise<void>;
   saveConfig: (config: UserConfig) => Promise<void>;
+  // 从 main 推送的 config 事件（handleConfigChanged newValue 路径）落地：写 config + 作废在飞旧 pull，
+  // 防「push 与 mount pull 并发」时旧 pull 迟到回填覆盖新 push（#325 A2 护栏）。
+  applyConfigFromEvent: (config: UserConfig) => void;
   updateProxyMode: (mode: ProxyMode) => Promise<void>;
   setConfigValue: (key: keyof UserConfig, value: any) => Promise<void>;
 
@@ -476,19 +491,19 @@ export const useAppStore = create<AppState>((set, get) => ({
         }
 
         const isPrivacyMode = await api.config.getPrivacyMode();
-        // 代际护栏：拉取期间发生了 mutation（loadConfigGeneration 已变）→ 本快照陈旧，丢弃不回填 store，
-        // 交由 mutation 触发的新一轮 loadConfig 回填最新配置（防删节点后旧快照复活已删节点）。
+        // isPrivacyMode 是主进程权威即时态、与 config 代际语义无耦合 → **无条件**回填，不随 config 代际护栏一起被
+        // 作废。挂载期这是隐私态的唯一水合路径（silent-start autoPrivacyMode 空闲锁的 ENTER 事件同样无窗期丢失，
+        // 见 index.ts:229-233/266-268），若被 replay / mutation 作废在飞 pull 时连带丢弃 → isPrivacyMode 恒留初值
+        // false → 首开窗隐私遮罩不出现＝隐私锁旁路（#325 复审 High 1）。
+        set({ isPrivacyMode });
+        // 代际护栏：拉取期间发生了 mutation / applyConfigFromEvent（loadConfigGeneration 已变）→ 本 config 快照陈旧，
+        // 丢弃不回填 store，交由推侧 push / mutation 触发的新一轮回填最新配置（防删节点后旧快照复活已删节点）。
+        // 仅 config 与依赖 config.servers 的 TS 缓存 GC 受此护栏；isPrivacyMode 已在上方无条件回填。
         if (gen !== loadConfigGeneration) return;
-        set({ config, isPrivacyMode });
+        set({ config });
         // Tailscale 登录态不在此拉取：1.14 由 api STATUS 流（EVENT_TAILSCALE_STATUS，随主核起停持续推送）
         // 实时驱动 tailscaleLoginStates，无需 loadConfig 时整表 IPC 刷新（已剥离 refreshTailscaleLoginStates）。
-        // 登录态缓存 GC：清不在当前 servers 的孤儿条目——一劳永逸覆盖所有绕过渲染端 deleteServer 的删节点路径
-        // （ConfigManager sanitize 丢多余 TS / 损坏备份导入 / 手改配置），免 localStorage 缓存条目无上限泄漏。
-        const liveServerIds = new Set(config.servers.map((s) => s.id));
-        const loginCache = useTailscaleLoginCacheStore.getState();
-        for (const id of Object.keys(loginCache.cache)) {
-          if (!liveServerIds.has(id)) loginCache.removeCached(id);
-        }
+        gcOrphanTailscaleLoginCache(config.servers);
       } catch (error) {
         console.error('[Store] Exception loading config:', error);
         toast.error(i18n.t('common.configLoadFail'));
@@ -500,6 +515,18 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     })();
     return loadConfigInflight;
+  },
+
+  // main push 的 config 事件落地（#325 replay + 常规 configChanged newValue 路径）。写 config 后同步作废在飞旧
+  // pull——replay 使「push 与 mount loadConfig 并发」每次挂载必然发生，若不 invalidate，在飞旧 pull 迟到 resolve
+  // 会用旧快照覆盖刚 push 的新 config（代际护栏只防 renderer mutation、不防 main push）。顺序循 saveConfig：先 set 再
+  // invalidate。这是用护栏自己的 API 扩其覆盖面（新增合法自增点），单飞语义不变、内部护栏不外泄。
+  applyConfigFromEvent: (config) => {
+    set({ config });
+    // 追零：replay 作废在飞 mount pull → 那次 pull 的孤儿 GC 被 gen 守卫跳过；push 落地同样跑一次（入参为
+    // push 的权威 servers，无陈旧覆盖），使挂载期短窗也不漏清 TS 登录缓存孤儿条目（#325 复审追零 Nit）。
+    gcOrphanTailscaleLoginCache(config.servers);
+    invalidateLoadConfig();
   },
 
   saveConfig: async (config) => {


### PR DESCRIPTION
## 问题（#325）
开机自启后主页显示「无节点」，但实际已连上默认节点，退出重开才恢复。

根因：首页节点显示纯由渲染端 store 的 config 派生（connection-control-card / home-status-bar），不读连接状态。silent-start「deferring window」期主进程发的 CONFIG_CHANGED 无订阅者被丢弃；渲染端挂载后只靠单发 loadConfig 快照——若落在自动连接 / 订阅补更 churn 中（servers 半更 / selectedServerId 未定），定格「无节点」，此后无事件再触发 reload。

## 改动
- main 收到 RENDERER_READY 时无条件 replay 一次终态 config（新 DI 模块 `renderer-ready-replay`，守 isQuitting/destroyed，读失败只 warn 不阻 mount gate），覆盖 silent-start 丢事件 + reload 后空窗。
- store `applyConfigFromEvent`（set + 作废在飞旧 pull，防 push 被旧 pull 覆盖）；抽共用 `gcOrphanTailscaleLoginCache` 双调，挂载期不漏孤儿 GC。
- silent-start 丢事件 debug 打点。

## 验证
- gate：tsc(main+renderer) / jest 3348 / eslint 0（新增 replay + store + GC 回归测试）。
- 三轮独立复审零 Crit/High/Med/Low/Nit（loadConfig 单飞/代际护栏、隐私态水合回归、replay 幂等逐条核实；过程中发现并修复一处隐私锁旁路 High）。

## 真机验证
三时刻唤窗时序（silent-start 无窗期 / 建窗到 listener 注册前 / reload 后）建议 runtime 复现验证；打点 debug 需 logLevel=debug。

Fixes #325
