### PR TITLE
fix: 诊断报告补齐核启动日志 + 修模式切换误报「UAC 授权失败」

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowz",
-  "version": "4.2.9",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowz",
-      "version": "4.2.9",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowz",
-  "version": "4.2.9",
+  "version": "4.3.0",
   "description": "FlowZ - 简洁现代的跨平台代理客户端",
   "desktopName": "flowz",
   "main": "dist/main/main/index.js",

--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -1,7 +1,7 @@
 /**
  * 把「运行态系统里已有的诊断事实」汇成单个脱敏 Markdown：环境快照 + 运行态 + 脱敏 UserConfig +
  * 脱敏「实际下发给内核的 sing-box 配置」（#57 类一眼可见 DNS/route 根因）+ app.log / singbox.log /
- * singbox_startup.log（提权路径下核的 stdout+stderr，#324 盲区）近期 tail。
+ * singbox_startup.log（提权路径下的核启动日志，#324 盲区；内容按写侧而异，见 describeStartupLog）近期 tail。
  *
  * 设计取舍：单 Markdown 文件（非 zip）—— 一个文件更易上传、人可读、零新依赖（package.json 无 zip 库）。
  * 脱敏走单一真值 shared/diagnostic-redact，绝不漏密钥（公开 issue 附件零明文密钥，红线）。
@@ -79,7 +79,39 @@ export class DiagnosticService {
         await fd.close();
       }
     } catch (e: any) {
-      return e?.code === 'ENOENT' ? '(无日志文件)' : `(读取失败: ${e?.message ?? e})`;
+      // 只回错误码，不回 e.message：Node 的 EACCES/EPERM message 内嵌完整路径（含 OS 用户名），而本报告是
+      // 给公开 issue 当附件用的，redactIdentifiers 只打码节点标识符、不碰路径。singbox_startup.log 在
+      // Windows helper 路径下由 SYSTEM 创建、fixFilePermissions 又只修 darwin，是三个 tail 里最可能踩到
+      // 非 ENOENT 失败的那个。
+      return e?.code === 'ENOENT' ? '(无日志文件)' : `(读取失败: ${e?.code ?? '未知错误'})`;
+    }
+  }
+
+  /**
+   * 描述 startup log 的**写侧**与文件元信息，供报告段标题如实标注。
+   *
+   * 为什么必须标：三个写侧写进去的东西根本不同（见 main/utils/paths.ts getSingBoxStartupLogPath），其中
+   * Windows UAC 看护脚本压根不重定向核的输出——若段标题一律写「核 stdout/stderr」，读报告的人会把「只有
+   * 看护脚本自述行、没有 FATAL」误读成「核什么都没打印」，与 issue #324 里那条假的「UAC 授权失败」是同一
+   * 类误导。另外 Windows helper 侧 O_APPEND 永不截断，必须给出文件大小与最后写入时刻，否则无法判断这
+   * 64KB tail 属于哪次会话（sing-box 的 FATAL[0000] 是启动相对秒，非墙钟时间）。
+   */
+  private async describeStartupLog(): Promise<string> {
+    // isStartedViaHelper 反映最近一次启动走的路径（代理已停时即上一次），是此处能拿到的最准信息。
+    const viaHelper = this.proxyManager.isStartedViaHelper();
+    const writer = viaHelper
+      ? '写侧 helper 服务：核 stdout+stderr，只追加不截断'
+      : process.platform === 'darwin'
+        ? '写侧 osascript wrapper：核 stdout+stderr，每次启动截断'
+        : process.platform === 'win32'
+          ? '写侧 UAC 看护脚本：**仅看护脚本自述行，不含核输出**'
+          : '非 helper 路径（直起）：核输出走 app.log 管道，本文件不被写入';
+    try {
+      const st = await fs.stat(getSingBoxStartupLogPath());
+      const mb = (st.size / (1024 * 1024)).toFixed(2);
+      return `${writer} · ${mb} MB · 最后写入 ${st.mtime.toISOString()}`;
+    } catch {
+      return writer; // 文件缺失/不可读：tail 那边已给占位，此处不重复报错
     }
   }
 
@@ -89,13 +121,14 @@ export class DiagnosticService {
     // 落盘待写日志先 flush，确保 tail 含最新行
     await this.logManager.flush().catch(() => {});
 
-    // startupLogTail = 提权/看护路径下核的 stdout+stderr。核在 logger 建起前挂掉或 panic 时，singbox.log 里
-    // 什么都没有、失败原因只在这条流里（issue #324：两轮诊断报告都因缺这段而定不了位）。恒纳入报告——
-    // 文件不存在时 readTail 给「(无日志文件)」占位，这本身也是信息（该机从未走过提权启动路径）。
-    const [appLogTail, singboxLogTail, startupLogTail] = await Promise.all([
+    // startupLogTail = 提权/看护路径下的核启动日志。核在 logger 建起前挂掉或 panic 时，singbox.log 里什么
+    // 都没有、失败原因只走 stderr（issue #324：两轮诊断报告都因缺这段而定不了位）。恒纳入报告——文件不存在
+    // 时 readTail 给「(无日志文件)」占位，这本身也是信息（该机从未走过提权启动路径）。
+    const [appLogTail, singboxLogTail, startupLogTail, startupLogSource] = await Promise.all([
       this.readTail(path.join(getLogsPath(), 'app.log'), LOG_TAIL_BYTES),
       this.readTail(getSingBoxLogPath(), LOG_TAIL_BYTES),
       this.readTail(getSingBoxStartupLogPath(), LOG_TAIL_BYTES),
+      this.describeStartupLog(),
     ]);
 
     const coreVersion = await this.proxyManager.getCoreVersion().catch(() => 'unknown');
@@ -248,6 +281,7 @@ export class DiagnosticService {
       appLogTail,
       singboxLogTail,
       startupLogTail,
+      startupLogSource,
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。
       nodeIdentifiers: collectNodeIdentifiers(config),
       hint: wantDeeper

--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -1,6 +1,7 @@
 /**
  * 把「运行态系统里已有的诊断事实」汇成单个脱敏 Markdown：环境快照 + 运行态 + 脱敏 UserConfig +
- * 脱敏「实际下发给内核的 sing-box 配置」（#57 类一眼可见 DNS/route 根因）+ app.log/singbox.log 近期 tail。
+ * 脱敏「实际下发给内核的 sing-box 配置」（#57 类一眼可见 DNS/route 根因）+ app.log / singbox.log /
+ * singbox_startup.log（提权路径下核的 stdout+stderr，#324 盲区）近期 tail。
  *
  * 设计取舍：单 Markdown 文件（非 zip）—— 一个文件更易上传、人可读、零新依赖（package.json 无 zip 库）。
  * 脱敏走单一真值 shared/diagnostic-redact，绝不漏密钥（公开 issue 附件零明文密钥，红线）。
@@ -26,7 +27,7 @@ import {
   sampleCoreProcess,
   serializeMemoryTimelineCsv,
 } from './process-sampler';
-import { getLogsPath, getSingBoxLogPath } from '../utils/paths';
+import { getLogsPath, getSingBoxLogPath, getSingBoxStartupLogPath } from '../utils/paths';
 import path from 'path';
 import type { LogManager } from './LogManager';
 import type { ProxyManager } from './ProxyManager';
@@ -88,9 +89,13 @@ export class DiagnosticService {
     // 落盘待写日志先 flush，确保 tail 含最新行
     await this.logManager.flush().catch(() => {});
 
-    const [appLogTail, singboxLogTail] = await Promise.all([
+    // startupLogTail = 提权/看护路径下核的 stdout+stderr。核在 logger 建起前挂掉或 panic 时，singbox.log 里
+    // 什么都没有、失败原因只在这条流里（issue #324：两轮诊断报告都因缺这段而定不了位）。恒纳入报告——
+    // 文件不存在时 readTail 给「(无日志文件)」占位，这本身也是信息（该机从未走过提权启动路径）。
+    const [appLogTail, singboxLogTail, startupLogTail] = await Promise.all([
       this.readTail(path.join(getLogsPath(), 'app.log'), LOG_TAIL_BYTES),
       this.readTail(getSingBoxLogPath(), LOG_TAIL_BYTES),
+      this.readTail(getSingBoxStartupLogPath(), LOG_TAIL_BYTES),
     ]);
 
     const coreVersion = await this.proxyManager.getCoreVersion().catch(() => 'unknown');
@@ -242,6 +247,7 @@ export class DiagnosticService {
       rendererWatchdog,
       appLogTail,
       singboxLogTail,
+      startupLogTail,
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。
       nodeIdentifiers: collectNodeIdentifiers(config),
       hint: wantDeeper

--- a/src/main/services/PlatformPrivilegeService.ts
+++ b/src/main/services/PlatformPrivilegeService.ts
@@ -36,6 +36,7 @@ import {
   getUserDataPath,
   getCachePath,
   getSingBoxLogPath,
+  getSingBoxStartupLogPath,
   getSingBoxPidPath,
 } from '../utils/paths';
 import { system32, powershellPath } from '../utils/win-system32';
@@ -370,12 +371,11 @@ exit 0
       return;
     }
 
-    const userDataPath = getUserDataPath();
     const filesToFix = [
       getCachePath(),
       getSingBoxLogPath(),
       getSingBoxPidPath(),
-      path.join(userDataPath, 'singbox_startup.log'),
+      getSingBoxStartupLogPath(),
     ];
 
     const fsSync = require('fs');

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -101,6 +101,7 @@ import {
   getUserDataPath,
   getSingBoxConfigPath,
   getSingBoxLogPath,
+  getSingBoxStartupLogPath,
   getSingBoxPidPath,
   getCachePath,
   getCustomRulesDir,
@@ -4226,12 +4227,11 @@ done
       return;
     }
 
-    const userDataPath = getUserDataPath();
     const filesToFix = [
       getCachePath(),
       getSingBoxLogPath(),
       getSingBoxPidPath(),
-      path.join(userDataPath, 'singbox_startup.log'),
+      getSingBoxStartupLogPath(),
     ];
 
     const fsSync = require('fs');
@@ -4436,7 +4436,7 @@ exit 0
       throw new Error(`找不到 sing-box 可执行文件: ${this.singboxPath}`);
     }
     const pidFile = getSingBoxPidPath();
-    const startupLogFile = path.join(getUserDataPath(), 'singbox_startup.log');
+    const startupLogFile = getSingBoxStartupLogPath();
     const forward = !!this.currentConfig?.allowLan;
     this.logToManager(
       'info',
@@ -4732,7 +4732,7 @@ exit 0
           // macOS: osascript 一次授权 → 以 root 跑「看护脚本」托管 sing-box（停止/退出/崩溃回收无需再提权）。
           // 路径单引号包裹以容忍空格（与原实现一样不处理路径内引号——FlowZ 路径不含单/双引号）。
           const pidFile = getSingBoxPidPath();
-          const startupLogFile = path.join(getUserDataPath(), 'singbox_startup.log');
+          const startupLogFile = getSingBoxStartupLogPath();
           const stopFlag = this.getStopFlagPath();
           const fwd = this.currentConfig?.allowLan ? '1' : '0';
           const parentPid = process.pid; // Electron 主进程 PID：退出即让看护脚本联动停 sing-box，杜绝孤儿
@@ -4781,7 +4781,7 @@ exit 0
           // osascript 看护路径）。正常停止经 stopflag 零 UAC；GUI 崩溃/强杀由看护脚本按父 PID
           // 联动收割，杜绝提权孤儿。UAC 次数与旧实现一致（每次 TUN 启动仍 1 次）。
           const pidFile = getSingBoxPidPath();
-          const startupLogFile = path.join(getUserDataPath(), 'singbox_startup.log');
+          const startupLogFile = getSingBoxStartupLogPath();
           const stopFlag = this.getStopFlagPath();
           const parentPid = process.pid; // Electron 主进程 PID：父死即看护脚本收割 sing-box
           // 父进程名（无扩展名，对应 PS Get-Process 的 ProcessName）：配合 PID 校验防 PID 复用误判

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -4728,7 +4728,15 @@ exit 0
         let command: string;
         let args: string[];
 
-        if (this.needsOsascript()) {
+        // 启动路径在 spawn 前固化成局部量：exit / setTimeout 回调必须按【本次 spawn 实际走的路径】判定，
+        // 不能在回调里现查 needsOsascript()/needsWindowsUAC()——二者读 this.currentConfig（**当前**模式）。
+        // 模式切换（系统代理→TUN）时旧核被 SIGTERM 停，其 exit 回调此刻已看到新模式 tun → 直起的 sing-box
+        // 被当成 UAC 包装进程判定，一次正常停核被误报成「UAC 授权失败，退出码: null」（issue #324 排查噪声，
+        // 用户/维护者据此误判成提权失败）。局部量随 attempt 走，杜绝该错配。
+        const launchViaOsascript = this.needsOsascript();
+        const launchViaWindowsUAC = !launchViaOsascript && this.needsWindowsUAC();
+
+        if (launchViaOsascript) {
           // macOS: osascript 一次授权 → 以 root 跑「看护脚本」托管 sing-box（停止/退出/崩溃回收无需再提权）。
           // 路径单引号包裹以容忍空格（与原实现一样不处理路径内引号——FlowZ 路径不含单/双引号）。
           const pidFile = getSingBoxPidPath();
@@ -4776,7 +4784,7 @@ exit 0
             'info',
             `TUN 模式需要管理员权限${this.currentConfig?.allowLan ? '及开启 IP 转发' : ''}，正在请求（仅此一次，后续启停免授权）...`
           );
-        } else if (this.needsWindowsUAC()) {
+        } else if (launchViaWindowsUAC) {
           // Windows TUN 模式：UAC 一次授权 → 以管理员跑「看护脚本」托管 sing-box（镜像 macOS
           // osascript 看护路径）。正常停止经 stopflag 零 UAC；GUI 崩溃/强杀由看护脚本按父 PID
           // 联动收割，杜绝提权孤儿。UAC 次数与旧实现一致（每次 TUN 启动仍 1 次）。
@@ -4895,7 +4903,7 @@ exit 0
 
         // macOS/Windows TUN 模式下，这个 PID 是 osascript/PowerShell 的 PID，不是 sing-box 的
         // 实际的 sing-box PID 会在 waitForPidFile 中从 PID 文件读取
-        if (this.needsOsascript() || this.needsWindowsUAC()) {
+        if (launchViaOsascript || launchViaWindowsUAC) {
           this.logToManager('info', `正在启动 sing-box（权限提升进程 PID: ${this.pid}）...`);
         } else {
           this.logToManager('info', `正在启动 sing-box 进程 (PID: ${this.pid})...`);
@@ -4939,7 +4947,9 @@ exit 0
           this.logToManager('info', `sing-box process exited with code ${code}, signal ${signal}`);
 
           // 对于 macOS TUN 模式，osascript 退出码为 0 表示成功启动了后台进程
-          if (this.needsOsascript()) {
+          // code === null（被信号杀，如 stop/模式切换的 SIGTERM）不是授权失败 → 交下方通用启动期退出判定，
+          // 别按「退出码」编造授权失败文案（退出码根本不存在）。
+          if (launchViaOsascript && code !== null) {
             if (code === 0) {
               // osascript 成功执行，sing-box 在后台运行
               // PID 文件读取由 setTimeout 中的 waitForPidFile 统一处理
@@ -4958,7 +4968,8 @@ exit 0
           }
 
           // 对于 Windows TUN 模式，PowerShell 退出码为 0 表示成功启动了 sing-box
-          if (this.needsWindowsUAC()) {
+          // 同 osascript 分支：code === null（信号杀）不判 UAC 失败。
+          if (launchViaWindowsUAC && code !== null) {
             if (code === 0) {
               // PowerShell 成功执行，sing-box 以管理员权限在后台运行
               // PID 文件读取由 setTimeout 中的 waitForPidFile 统一处理
@@ -5002,8 +5013,9 @@ exit 0
           if (startupResolved) return;
           // macOS TUN 模式或 Windows TUN 模式：检查 singboxPid（从 PID 文件读取）
           // 其他模式：检查 singboxProcess 和 pid
-          const isMacTunMode = this.needsOsascript();
-          const isWindowsTunMode = this.needsWindowsUAC();
+          // 同 exit 回调：按本次 spawn 的实际启动路径判定（局部量），不现查当前模式。
+          const isMacTunMode = launchViaOsascript;
+          const isWindowsTunMode = launchViaWindowsUAC;
 
           if (isMacTunMode || isWindowsTunMode) {
             // TUN 模式：等待 PID 文件被写入

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -397,6 +397,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     | null = null;
   // 本次 sing-box 是否经 helper 启动（决定停止走 helper socket 还是 osascript）。
   private startedViaHelper: boolean = false;
+  // 本次 sing-box 是否经「包装进程」启动（macOS osascript / Windows UAC PowerShell）——决定 this.pid 是包装
+  // 进程还是核本身，getStatus / 健康检查 / 内存采样据此取 activePid。**必须是启动派生态，不能现查
+  //   needsOsascript()/needsWindowsUAC()**：那两个谓词读 currentConfig（当前模式），系统代理→TUN 切换的去抖
+  //   窗口内会翻转，让仍在运行的直起核被按包装模式取 pid（singboxPid 恒 null）→ getStatus 假 running:false、
+  //   健康检查空转、内存帧丢核。与 startedViaHelper 同批复位/置位。
+  private startedViaWrapper: boolean = false;
   // 远程 geo rule_set URL 可达性缓存（应用分流/自定义 geo 规则的 remote rule_set 预检用）。
   // 仅缓存"确定结论"：2xx→可达(6h)，404/403/410→缺失(30min，留恢复窗口)；瞬时错误不缓存。见 isRemoteRuleSetReachable。
   private ruleSetReachCache = new Map<string, { reachable: boolean; at: number }>();
@@ -2775,14 +2781,28 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     this.sendEventToRenderer(IPC_CHANNELS.EVENT_MESH_LOGIN_FALLBACK, { engaged: false });
   }
 
+  /**
+   * 本次运行中的 sing-box 真实 PID（取不到返回 null）。getStatus / 健康检查 / 内存采样的**单一真值**。
+   *
+   * 判定依据是 startedViaWrapper（启动派生态），不是现查 needsOsascript()/needsWindowsUAC()：
+   *   · 包装进程模式（mac osascript / Win UAC）：this.pid 是包装进程的，核的真 PID 在 singboxPid；包装进程
+   *     PID 绝不能当核用（它常已退出，或复用给别的进程）→ singboxPid 为空即视为无核。
+   *   · 直起 / helper 模式（含 Linux TUN）：singboxPid 有值取它，否则回落 this.pid。
+   * 现查谓词会在「系统代理→TUN」的去抖重启窗口内翻转，让仍在运行的直起核被按包装模式取 pid（singboxPid
+   * 恒 null）→ getStatus 假 running:false、健康检查空转、内存帧丢核。三个消费点共用本方法，杜绝各自漂移。
+   */
+  private activeCorePid(): number | null {
+    return this.startedViaWrapper ? this.singboxPid : this.singboxPid || this.pid;
+  }
+
   getStatus(): ProxyStatus {
     // 判定依据：是否经「包装进程」启动（macOS osascript / Windows UAC）。
     //   · 包装进程模式：this.pid 是 osascript/PowerShell 的 PID，真实 sing-box PID 在 singboxPid。
     //   · 直接 spawn 模式（含 Linux TUN）：只有 this.pid，singboxPid 恒 null。
     // 旧逻辑按 `proxyModeType==='tun'` 取 singboxPid → Linux TUN 直接 spawn 时 activePid 恒 null →
     // getStatus 恒返回 running:false（issue #33「连接状态/按钮不同步」根因，且令健康检查失效）。
-    const wrapperMode = this.needsOsascript() || this.needsWindowsUAC();
-    const activePid = wrapperMode ? this.singboxPid : this.singboxPid || this.pid;
+    // 取 pid 收口到 activeCorePid()（读启动派生态，不现查当前模式）——见该方法说明。
+    const activePid = this.activeCorePid();
 
     // 验证进程是否真正存活
     const isRunning = activePid !== null && this.isProcessAlive(activePid);
@@ -4625,6 +4645,9 @@ exit 0
     //   直起 UAC/osascript 路径保持 false）。修复 issue #159 就绪门控失败、重试腿回退直起时 startedViaHelper 残留 true
     //   → 后续 stop() 误走 helper 停核分支（停不动→回退提权 taskkill/osascript，降级但自愈）。每次启动腿都从干净态判定。
     this.startedViaHelper = false;
+    // 同上：包装进程标志也每腿复位，由下方实际启动路径置位（helper 路径保持 false——helper 起核时 singboxPid
+    // 即核本身，非包装进程）。
+    this.startedViaWrapper = false;
 
     // issue #159：起核前（win32&&TUN）等上一轮自家 wintun 适配器释放。置于本方法顶部（而非 startInternal）→ 每次
     //   runStartWithRetry 重启腿、以及下方 helper / UAC 两条启动支路都经此门控（不止首次），杜绝重试立刻再撞僵尸适配器。
@@ -4734,7 +4757,9 @@ exit 0
         // 被当成 UAC 包装进程判定，一次正常停核被误报成「UAC 授权失败，退出码: null」（issue #324 排查噪声，
         // 用户/维护者据此误判成提权失败）。局部量随 attempt 走，杜绝该错配。
         const launchViaOsascript = this.needsOsascript();
-        const launchViaWindowsUAC = !launchViaOsascript && this.needsWindowsUAC();
+        const launchViaWindowsUAC = this.needsWindowsUAC();
+        // 同一快照下沉为实例态，供回调之外的消费点（getStatus / 健康检查 / 内存采样）判「this.pid 是不是核」。
+        this.startedViaWrapper = launchViaOsascript || launchViaWindowsUAC;
 
         if (launchViaOsascript) {
           // macOS: osascript 一次授权 → 以 root 跑「看护脚本」托管 sing-box（停止/退出/崩溃回收无需再提权）。
@@ -5856,8 +5881,7 @@ exit 0
         });
       }
       // 核不在 Electron 进程树：单独采 RSS。PID 取法与 getStatus 一致（wrapper=singboxPid，直启=pid）。
-      const wrapperMode = this.needsOsascript() || this.needsWindowsUAC();
-      const corePid = wrapperMode ? this.singboxPid : this.singboxPid || this.pid;
+      const corePid = this.activeCorePid();
       if (corePid) {
         const rssMb = await sampleProcessRssMb(corePid).catch(() => null);
         if (rssMb != null) procs.push({ label: 'sing-box', pid: corePid, rssMb });
@@ -5887,8 +5911,7 @@ exit 0
 
     // 判定依据与 getStatus 一致：经包装进程(osascript/UAC)启动才取 singboxPid，否则取 pid。
     // 修复 Linux TUN（直接 spawn，singboxPid 恒 null）下健康检查/自动重启完全失效（issue #33）。
-    const wrapperMode = this.needsOsascript() || this.needsWindowsUAC();
-    const activePid = wrapperMode ? this.singboxPid : this.singboxPid || this.pid;
+    const activePid = this.activeCorePid();
 
     if (!activePid) {
       return;

--- a/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
+++ b/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
@@ -1,0 +1,93 @@
+/**
+ * DiagnosticService 的日志取数单测：守住「报告里三段日志各读各的文件」这条路径收口。
+ *
+ * 为什么必须有：`paths.ts` 的 `getSingBoxStartupLogPath()` 注释声明「诊断报告与写侧共用本函数，杜绝两边
+ * 路径漂移」，但在此之前这条声明只由 grep 保证——把 `getSingBoxStartupLogPath()` 误写成 `getSingBoxLogPath()`
+ * 全套测试照样绿（报告只是把 singbox.log 渲染两遍，两个标题都在），`Promise.all` 三元组顺序错位同理无人拦。
+ *
+ * 只桩 IO 与协作对象，不碰真实文件系统、不碰宿主网络。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-diagsvc-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { DiagnosticService } from '../DiagnosticService';
+import { getLogsPath, getSingBoxLogPath, getSingBoxStartupLogPath } from '../../utils/paths';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function makeSvc(opts: { startedViaHelper?: boolean } = {}): any {
+  const configManager: any = { loadConfig: jest.fn().mockResolvedValue({ logLevel: 'info' }) };
+  const logManager: any = { flush: jest.fn().mockResolvedValue(undefined) };
+  const proxyManager: any = {
+    getCoreVersion: jest.fn().mockResolvedValue('1.14.0-beta.2'),
+    getStatus: jest.fn().mockReturnValue({ running: false }),
+    isStartedViaHelper: jest.fn().mockReturnValue(!!opts.startedViaHelper),
+    generateSingBoxConfig: jest.fn().mockReturnValue({ log: { level: 'info' } }),
+    getCronetHealStats: jest.fn().mockReturnValue({ triggered: 0, failed: 0 }),
+    getLastStartReadyRetries: jest.fn().mockReturnValue(0),
+  };
+  const systemProxyManager: any = { getProxyStatus: jest.fn().mockResolvedValue(null) };
+  return new DiagnosticService(configManager, logManager, proxyManager, systemProxyManager) as any;
+}
+
+describe('DiagnosticService — 日志取数路径收口', () => {
+  it('三段日志各读各的文件，startup log 走 getSingBoxStartupLogPath()（不与 singbox.log 同源）', async () => {
+    const svc = makeSvc();
+    const seen: string[] = [];
+    jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
+      const p = args[0] as string;
+      seen.push(p);
+      return `tail-of:${path.basename(p)}`;
+    });
+
+    const md = await svc.buildReport();
+
+    expect(seen).toHaveLength(3);
+    expect(new Set(seen).size).toBe(3); // 三个互不相同 → 排除「两段读同一文件」的漂移
+    expect(seen[0]).toBe(path.join(getLogsPath(), 'app.log'));
+    expect(seen[1]).toBe(getSingBoxLogPath());
+    expect(seen[2]).toBe(getSingBoxStartupLogPath());
+    // 顺序错位（把 singboxLogTail 与 startupLogTail 调换）会被下面两条钉住
+    expect(md).toMatch(/## singbox\.log（近期）[\s\S]*tail-of:singbox\.log/);
+    expect(md).toMatch(/## singbox_startup\.log[\s\S]*tail-of:singbox_startup\.log/);
+  });
+
+  it('Windows 非 helper 路径的段标题如实标注「不含核输出」（#324 假阴性防线）', async () => {
+    const real = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const svc = makeSvc({ startedViaHelper: false });
+      jest.spyOn(svc, 'readTail').mockResolvedValue('FlowZ watchdog starting...');
+      const md = await svc.buildReport();
+      expect(md).toContain('写侧 UAC 看护脚本');
+      expect(md).toContain('不含核输出');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: real, configurable: true });
+    }
+  });
+
+  it('helper 路径标注为含核 stdout+stderr 且只追加不截断', async () => {
+    const svc = makeSvc({ startedViaHelper: true });
+    jest.spyOn(svc, 'readTail').mockResolvedValue('FATAL[0000] boom');
+    const md = await svc.buildReport();
+    expect(md).toContain('核 stdout+stderr');
+    expect(md).toContain('只追加不截断');
+  });
+});

--- a/src/main/services/__tests__/proxy-manager-launch-path-snapshot.test.ts
+++ b/src/main/services/__tests__/proxy-manager-launch-path-snapshot.test.ts
@@ -52,14 +52,16 @@ function makeFakeChild(): any {
 }
 
 /**
- * @param uacNow 谓词现值提供者：模拟「回调里现查当前模式」——测试可在 spawn 后翻转它。
+ * @param uacNow    Windows UAC 谓词现值提供者：模拟「回调里现查当前模式」——测试可在 spawn 后翻转它。
+ * @param osaNow    macOS osascript 谓词现值提供者（同上）。osascript 分支本体不含任何 process.platform 门，
+ *                  走的是同一套注入的 privilegeService，故在 Linux 宿主上可完整覆盖，不属「已知未覆盖面」。
  */
-function makeSvc(uacNow: () => boolean): any {
+function makeSvc(uacNow: () => boolean, osaNow: () => boolean = () => false): any {
   const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
   fsSync.writeFileSync(configPath, '{}');
   const svc: any = new ProxyManager(undefined, undefined, configPath, FAKE_CORE);
   svc.currentConfig = { proxyModeType: 'systemProxy', servers: [] };
-  svc.needsOsascript = () => false;
+  svc.needsOsascript = () => osaNow();
   svc.needsWindowsUAC = () => uacNow();
   // Windows UAC 分支的提权命令构造（走 service 注入路径，不落 inline PowerShell 兜底）
   svc.privilegeService = {
@@ -76,6 +78,9 @@ function makeSvc(uacNow: () => boolean): any {
   svc.startHealthCheck = jest.fn();
   svc.startLogFileWatcher = jest.fn();
   svc.waitForPidFile = jest.fn().mockResolvedValue(undefined);
+  // handleProcessExit 的尾部：绝不让单测碰宿主系统代理；attemptAutoRestart 桩为可观测出口（断言不被调用）。
+  svc.ensureSystemProxyCleared = jest.fn().mockResolvedValue(undefined);
+  svc.attemptAutoRestart = jest.fn().mockResolvedValue(undefined);
   return svc;
 }
 
@@ -151,6 +156,95 @@ describe('issue #324 — 启动路径按 spawn 时快照判定，不随模式切
     expect(svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n')).not.toMatch(
       /UAC 授权失败/
     );
+  });
+
+  it('已成功运行的核在模式切换后被 SIGTERM 停 → 走正常停核路径，不报 UAC 失败（#324 现场态）', async () => {
+    // #324 的真实现场：核**已启动成功**（startupResolved=true），随后模式切到 TUN 触发去抖重启的 stop 腿。
+    // 前面几条用例都停在「启动期退出」，覆盖不到这条路径——它才是 app.log 里那条假 ERROR 的产地。
+    let uac = false;
+    const svc = makeSvc(() => uac);
+    const stopped = jest.fn();
+    svc.on('stopped', stopped);
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+    await expect(p).resolves.toBeUndefined(); // 1s 判定成功 → startupResolved=true
+
+    uac = true;
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    child.emit('exit', null, 'SIGTERM');
+    await new Promise((r) => setImmediate(r));
+
+    // 修复前：落 Windows UAC 分支 → 记「UAC 授权失败，退出码: null」并 return，停核事件被吞
+    const logged = svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n');
+    expect(logged).not.toMatch(/UAC 授权失败/);
+    // 修复后：走 handleProcessExit 的信号退出分支 = 正常停核语义（与 Linux 一致，也是 stop() 注释声明的预期）
+    expect(stopped).toHaveBeenCalled();
+    // 信号退出不得触发崩溃自动重启（否则与外层 stop→start 双启动流并发）
+    expect(svc.attemptAutoRestart).not.toHaveBeenCalled();
+  });
+
+  it('直起的核运行中、模式切到 TUN → getStatus 仍按直起路径取 pid，不假报已停止', async () => {
+    // 回调之外的消费点同样不能现查谓词：去抖重启窗口（~1.5s）内 currentConfig 已是 tun，而核还是那个直起的
+    // 进程（singboxPid 恒 null）→ 现查会让 activePid 落空 → UI 闪「已停止」+ 诊断报告 proxyRunning 撒谎。
+    let uac = false;
+    const svc = makeSvc(() => uac);
+    svc.isProcessAlive = () => true;
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    await spawnedChild();
+    await expect(p).resolves.toBeUndefined();
+
+    expect(svc.getStatus().running).toBe(true);
+    uac = true;
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    expect(svc.getStatus().running).toBe(true);
+  });
+
+  it('macOS osascript 路径同样按 spawn 时快照判定（code=1 不误报「用户取消授权」）', async () => {
+    let osa = false; // spawn 时：直起
+    const svc = makeSvc(
+      () => false,
+      () => osa
+    );
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    osa = true; // 模式切换后谓词翻转
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    child.emit('exit', 1, null);
+
+    await expect(p).rejects.toThrow(/sing-box 启动失败，请检查配置文件和服务器设置/);
+    expect(svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n')).not.toMatch(
+      /用户取消了管理员权限请求/
+    );
+  });
+
+  it('osascript 路径下包装进程被信号杀（code=null）不判授权失败', async () => {
+    const svc = makeSvc(
+      () => false,
+      () => true
+    );
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    child.emit('exit', null, 'SIGTERM');
+
+    await expect(p).rejects.toThrow(/启动期退出 \(code=null, signal=SIGTERM\)/);
+    expect(svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n')).not.toMatch(
+      /启动失败，退出码/
+    );
+  });
+
+  it('osascript 路径下用户取消授权（code=1）仍报「用户取消了管理员权限请求」（不回归）', async () => {
+    const svc = makeSvc(
+      () => false,
+      () => true
+    );
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    child.emit('exit', 1, null);
+
+    await expect(p).rejects.toThrow(/用户取消了管理员权限请求/);
   });
 
   it('UAC 路径下用户取消授权（code=1）仍报「用户取消了管理员权限请求」（不回归）', async () => {

--- a/src/main/services/__tests__/proxy-manager-launch-path-snapshot.test.ts
+++ b/src/main/services/__tests__/proxy-manager-launch-path-snapshot.test.ts
@@ -1,0 +1,175 @@
+/**
+ * ProxyManager 启动路径快照单测（issue #324 排查噪声）。
+ *
+ * exit / setTimeout 回调必须按【本次 spawn 实际走的启动路径】判定，不能现查 needsOsascript()/
+ * needsWindowsUAC()——二者读 currentConfig（**当前**模式）。模式切换（系统代理 → TUN）时旧核被 SIGTERM 停，
+ * 其 exit 回调此刻已看到新模式 tun → 直起的 sing-box 被当成 UAC 包装进程判定，一次正常停核被误报成
+ * 「UAC 授权失败，退出码: null」，把排查带偏到提权方向。
+ *
+ * 平台谓词经 `(svc as any)` 打桩（宿主是 Linux），spawn 全 mock：不起真进程、不碰 PowerShell/网卡。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+const { EventEmitter } = require('events');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-launchpath-'));
+const FAKE_CORE = path.join(TMP, 'sing-box');
+fsSync.writeFileSync(FAKE_CORE, '#!/bin/sh\n');
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+const spawnMock = jest.fn();
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import { ProxyManager } from '../ProxyManager';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+/** spawn 出的假进程：只需 pid + exit 事件（stdout/stderr 置 null 走「无管道」分支）。 */
+function makeFakeChild(): any {
+  const child: any = new EventEmitter();
+  child.pid = 4321;
+  child.stdout = null;
+  child.stderr = null;
+  child.kill = jest.fn();
+  return child;
+}
+
+/**
+ * @param uacNow 谓词现值提供者：模拟「回调里现查当前模式」——测试可在 spawn 后翻转它。
+ */
+function makeSvc(uacNow: () => boolean): any {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  fsSync.writeFileSync(configPath, '{}');
+  const svc: any = new ProxyManager(undefined, undefined, configPath, FAKE_CORE);
+  svc.currentConfig = { proxyModeType: 'systemProxy', servers: [] };
+  svc.needsOsascript = () => false;
+  svc.needsWindowsUAC = () => uacNow();
+  // Windows UAC 分支的提权命令构造（走 service 注入路径，不落 inline PowerShell 兜底）
+  svc.privilegeService = {
+    // 宿主是 Linux：needsPrivilege 恒 false，让 needsLinuxTun 不把本用例拖进 Linux setcap/helper 支路。
+    needsPrivilege: () => false,
+    ensureCapabilities: jest.fn().mockResolvedValue(undefined),
+    generateWatchdogScript: () => ({ path: path.join(TMP, 'watchdog.ps1') }),
+    buildElevatedLaunchCommand: () => ({ command: 'powershell.exe', args: ['-NoProfile'] }),
+  };
+  svc.helperManager = undefined;
+  svc.logToManager = jest.fn();
+  svc.sendEventToRenderer = jest.fn();
+  svc.cleanup = jest.fn();
+  svc.startHealthCheck = jest.fn();
+  svc.startLogFileWatcher = jest.fn();
+  svc.waitForPidFile = jest.fn().mockResolvedValue(undefined);
+  return svc;
+}
+
+/** 等 spawn 真被调用（startSingBoxProcess 前置是 async），返回假子进程。 */
+async function spawnedChild(): Promise<any> {
+  for (let i = 0; i < 200 && spawnMock.mock.calls.length === 0; i++) {
+    await new Promise((r) => setImmediate(r));
+  }
+  expect(spawnMock).toHaveBeenCalled();
+  return spawnMock.mock.results[0].value;
+}
+
+describe('issue #324 — 启动路径按 spawn 时快照判定，不随模式切换漂移', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(() => makeFakeChild());
+  });
+
+  it('直起的核在启动期被 SIGTERM 停 + 期间模式已切到 TUN → 不误报「UAC 授权失败」', async () => {
+    let uac = false; // spawn 时：系统代理模式（直起）
+    const svc = makeSvc(() => uac);
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    // 模式切换：currentConfig 已变 tun，此刻谓词现值翻转（修复前 exit 回调会据此误判）
+    uac = true;
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    child.emit('exit', null, 'SIGTERM');
+
+    await expect(p).rejects.toThrow(/启动期退出 \(code=null, signal=SIGTERM\)/);
+    const logged = svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n');
+    expect(logged).not.toMatch(/UAC 授权失败/);
+    expect(logged).not.toMatch(/用户取消了管理员权限请求/);
+  });
+
+  it('直起的核以 code=1 退出 + 期间模式已切到 TUN → 按核退出码归因，不误报「用户取消授权」', async () => {
+    let uac = false; // spawn 时：系统代理模式（直起），退出码归 parseStartupError
+    const svc = makeSvc(() => uac);
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    uac = true; // 模式切换：谓词现值翻转（修复前 code===1 会被读成「用户取消 UAC」）
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+    child.emit('exit', 1, null);
+
+    await expect(p).rejects.toThrow(/sing-box 启动失败，请检查配置文件和服务器设置/);
+    expect(svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n')).not.toMatch(
+      /用户取消了管理员权限请求/
+    );
+  });
+
+  it('spawn 后 1s 成功判定期内模式切到 TUN → 仍按直起路径判成功，不去等 TUN 的 PID 文件', async () => {
+    let uac = false; // spawn 时：直起，成功判据是 singboxProcess && pid
+    const svc = makeSvc(() => uac);
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    await spawnedChild();
+
+    uac = true; // 1s 判定窗口内模式切换（修复前 setTimeout 会改走 waitForPidFile → 误判「无法获取 PID」）
+    svc.currentConfig = { proxyModeType: 'tun', servers: [] };
+
+    await expect(p).resolves.toBeUndefined();
+    expect(svc.waitForPidFile).not.toHaveBeenCalled();
+  });
+
+  it('确实走 UAC 包装路径时，包装进程被信号杀（code=null）也不判授权失败', async () => {
+    const svc = makeSvc(() => true); // 全程 Windows TUN 路径
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    child.emit('exit', null, 'SIGTERM');
+
+    await expect(p).rejects.toThrow(/启动期退出 \(code=null, signal=SIGTERM\)/);
+    expect(svc.logToManager.mock.calls.map((c: unknown[]) => String(c[1])).join('\n')).not.toMatch(
+      /UAC 授权失败/
+    );
+  });
+
+  it('UAC 路径下用户取消授权（code=1）仍报「用户取消了管理员权限请求」（不回归）', async () => {
+    const svc = makeSvc(() => true);
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    child.emit('exit', 1, null);
+
+    await expect(p).rejects.toThrow(/用户取消了管理员权限请求/);
+  });
+
+  it('UAC 路径下包装进程非零退出（code=2）仍报「UAC 授权失败」（不回归）', async () => {
+    const svc = makeSvc(() => true);
+    const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+    const child = await spawnedChild();
+
+    child.emit('exit', 2, null);
+
+    await expect(p).rejects.toThrow(/UAC 授权失败，退出码: 2/);
+  });
+});

--- a/src/main/utils/paths.ts
+++ b/src/main/utils/paths.ts
@@ -189,10 +189,17 @@ export function getSingBoxPidPath(): string {
 }
 
 /**
- * 提权/看护路径下 sing-box 的 stdout+stderr 落盘文件（mac osascript wrapper / Windows watchdog / Windows
- * helper 服务均把核的两条流重定向到此）。与 singbox.log（核自身 logger 按 log.output 写）是**两份不同的东西**：
- * 核在 logger 建起前挂掉、或 panic/运行时崩溃，只会出现在这里，singbox.log 里一个字都没有（issue #324 的
- * 诊断盲区正是如此）。诊断报告与写侧共用本函数，杜绝两边路径漂移。
+ * 提权/看护路径下的核启动日志。与 singbox.log（核自身 logger 按 log.output 写）是**两份不同的东西**：
+ * 核在 logger 建起前挂掉、或 panic/运行时崩溃，错误只走 stderr，singbox.log 里一个字都没有（issue #324 的
+ * 诊断盲区正是如此）。
+ *
+ * **各写侧内容不同，读报告时必须按平台区分**：
+ *   · mac osascript wrapper（ProxyManager.writeWrapperScript）：`> "$LOG" 2>&1` → 含核的 stdout+stderr，每次启动截断
+ *   · Windows helper 服务（helper-win/winproc.go startSingbox）：`c.Stdout/c.Stderr = lf` → 含核的两条流，**O_APPEND 永不截断**
+ *   · Windows UAC 看护脚本（PlatformPrivilegeService.writeWindowsWatchdogScript）：Start-Process **未重定向**
+ *     → **只有看护脚本自述行，不含核的任何输出**（未装 helper 的 Windows 用户在此仍是盲区，待补 -RedirectStandardError）
+ *
+ * 诊断报告与写侧共用本函数，杜绝两边路径漂移。
  */
 export function getSingBoxStartupLogPath(): string {
   return path.join(getUserDataPath(), 'singbox_startup.log');

--- a/src/main/utils/paths.ts
+++ b/src/main/utils/paths.ts
@@ -188,6 +188,16 @@ export function getSingBoxPidPath(): string {
   return path.join(getUserDataPath(), 'singbox.pid');
 }
 
+/**
+ * 提权/看护路径下 sing-box 的 stdout+stderr 落盘文件（mac osascript wrapper / Windows watchdog / Windows
+ * helper 服务均把核的两条流重定向到此）。与 singbox.log（核自身 logger 按 log.output 写）是**两份不同的东西**：
+ * 核在 logger 建起前挂掉、或 panic/运行时崩溃，只会出现在这里，singbox.log 里一个字都没有（issue #324 的
+ * 诊断盲区正是如此）。诊断报告与写侧共用本函数，杜绝两边路径漂移。
+ */
+export function getSingBoxStartupLogPath(): string {
+  return path.join(getUserDataPath(), 'singbox_startup.log');
+}
+
 export function getCachePath(): string {
   return path.join(getUserDataPath(), 'cache.db');
 }

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -213,19 +213,35 @@ describe('buildDiagnosticReport', () => {
     expect(md).toContain('(空)');
   });
 
-  it('有 startupLogTail 时渲染核 stdout/stderr 区块（issue #324 诊断盲区）', () => {
+  it('有 startupLogTail 时渲染核启动日志区块（issue #324 诊断盲区）', () => {
     const md = buildDiagnosticReport({
       ...base,
       startupLogTail: 'FATAL[0000] start service: initialize inbound/tun[tun-in]: boom',
     });
-    expect(md).toContain('## singbox_startup.log（近期 · 核 stdout/stderr）');
+    expect(md).toContain('## singbox_startup.log（近期）');
     expect(md).toContain('initialize inbound/tun[tun-in]: boom');
-    // 排在 singbox.log 之后，保持「核自身日志 → 核 stdout/stderr」的阅读顺序
+    // 排在 singbox.log 之后，保持「核自身日志 → 核启动日志」的阅读顺序
     expect(md.indexOf('## singbox_startup.log')).toBeGreaterThan(md.indexOf('## singbox.log'));
+  });
+
+  it('startupLogSource 如实进段标题（写侧不同 → 内容含义不同，不能一律写「核 stdout/stderr」）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      startupLogTail: 'FlowZ watchdog starting...',
+      startupLogSource:
+        '写侧 UAC 看护脚本：**仅看护脚本自述行，不含核输出** · 0.01 MB · 最后写入 2026-07-24T14:38:50.000Z',
+    });
+    expect(md).toContain('## singbox_startup.log（近期 · 写侧 UAC 看护脚本');
+    expect(md).toContain('最后写入 2026-07-24T14:38:50.000Z');
   });
 
   it('无 startupLogTail 时不渲染该区块（老调用点不受影响）', () => {
     expect(buildDiagnosticReport(base)).not.toContain('## singbox_startup.log');
+  });
+
+  it('startupLogTail 为空串时仍渲染该区块（文件存在但空 ≠ 未提供）', () => {
+    const md = buildDiagnosticReport({ ...base, startupLogTail: '' });
+    expect(md).toContain('## singbox_startup.log（近期）');
   });
 
   it('startupLogTail 同样经节点标识符打码（红线：零明文节点身份）', () => {

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -213,6 +213,31 @@ describe('buildDiagnosticReport', () => {
     expect(md).toContain('(空)');
   });
 
+  it('有 startupLogTail 时渲染核 stdout/stderr 区块（issue #324 诊断盲区）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      startupLogTail: 'FATAL[0000] start service: initialize inbound/tun[tun-in]: boom',
+    });
+    expect(md).toContain('## singbox_startup.log（近期 · 核 stdout/stderr）');
+    expect(md).toContain('initialize inbound/tun[tun-in]: boom');
+    // 排在 singbox.log 之后，保持「核自身日志 → 核 stdout/stderr」的阅读顺序
+    expect(md.indexOf('## singbox_startup.log')).toBeGreaterThan(md.indexOf('## singbox.log'));
+  });
+
+  it('无 startupLogTail 时不渲染该区块（老调用点不受影响）', () => {
+    expect(buildDiagnosticReport(base)).not.toContain('## singbox_startup.log');
+  });
+
+  it('startupLogTail 同样经节点标识符打码（红线：零明文节点身份）', () => {
+    const md = buildDiagnosticReport({
+      ...base,
+      startupLogTail: 'dial tcp: lookup node.example.com: no such host',
+      nodeIdentifiers: [{ value: 'node.example.com', placeholder: '<domain-1>' }],
+    });
+    expect(md).not.toContain('node.example.com');
+    expect(md).toContain('<domain-1>');
+  });
+
   it('有 hint 时输出提示行', () => {
     const md = buildDiagnosticReport({ ...base, hint: '建议开启诊断采集' });
     expect(md).toContain('建议开启诊断采集');

--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,11 +1,11 @@
 {
-  "bundledCoreVersion": "1.14.0-beta.1",
+  "bundledCoreVersion": "1.14.0-beta.2",
   "cronetVersion": "v148.0.7778.96-1",
   "coreArchiveSha256": {
-    "linux": "7f974db10db1195e0685ccdddc16ed031d8bdd2fc88b53475929578752c479b3",
-    "win": "d90a25a4e71dc64ea842747f58827be539d9e607ab3c82a30bbe32044a5bcc2c",
-    "mac-x64": "4b7a0f4f9389d470c8395dabb82cf7a662678e991c6bd1424fa1787c09733fe5",
-    "mac-arm64": "a06880bce698c2a82dd9c6baf154b3c14990124b270bc813ff768fe04bf64634"
+    "linux": "f68715815741e59f25e32904cabcd5924a0461a910d8e9c9612512b957709ef4",
+    "win": "4a50a0ffcd685ccf522ff0d45700ad175aae7cf85172b19ba0f27ed0ef1a65cb",
+    "mac-x64": "0c8e6cd7c5ca537ba2f0d125c24b9b4519d2359bfcfb6615d6751fe5caf10371",
+    "mac-arm64": "32a8130b8598eb70028164f4393e7d5777d866c7db9e487b8ab0f56d0d0e7735"
   },
   "cronetArchiveSha256": {
     "linux": "dc7293a929dffa695aae1a89555e7366158fa0a3f40bbe3012d445bc05c99672",

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -342,6 +342,12 @@ export interface DiagnosticReportInput {
   rendererWatchdog?: { discardCount: number; warnCount: number; thresholdMb: number };
   appLogTail: string;
   singboxLogTail: string;
+  /**
+   * 提权/看护路径下核的 stdout+stderr（singbox_startup.log）。核在 logger 建起前失败、panic、被环境拦下，
+   * 只会写到这条流——singbox.log 里一个字都没有。issue #324 两轮诊断都定不了位正因该段缺失。
+   * 可选：未提供则不出该段（老调用点/单测不受影响）。
+   */
+  startupLogTail?: string;
   /** 节点标识符 → 占位符（P0.6）：构建末尾在全报告统一替换，打码节点身份（域名/IP/SNI/节点名），保留形态与跨段相关性。 */
   nodeIdentifiers?: readonly NodeIdentifier[];
   /** 当前级别不含连接明细（>info）且日志疑似有连接/DNS 错误 → 提示开启诊断采集复现。 */
@@ -494,6 +500,14 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
   lines.push('');
   lines.push(fence('text', input.singboxLogTail));
   lines.push('');
+
+  // 核的 stdout/stderr：与 singbox.log 互补（见 startupLogTail 字段注释）。放在其后，同样进 redactIdentifiers。
+  if (input.startupLogTail !== undefined) {
+    lines.push('## singbox_startup.log（近期 · 核 stdout/stderr）');
+    lines.push('');
+    lines.push(fence('text', input.startupLogTail));
+    lines.push('');
+  }
 
   // P0.6：末尾在全报告（配置块 + 日志 + 运行态）统一打码节点标识符，跨段占位一致便于关联诊断。
   const redacted = redactIdentifiers(lines.join('\n'), input.nodeIdentifiers ?? []);

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -343,11 +343,16 @@ export interface DiagnosticReportInput {
   appLogTail: string;
   singboxLogTail: string;
   /**
-   * 提权/看护路径下核的 stdout+stderr（singbox_startup.log）。核在 logger 建起前失败、panic、被环境拦下，
-   * 只会写到这条流——singbox.log 里一个字都没有。issue #324 两轮诊断都定不了位正因该段缺失。
+   * 提权/看护路径下的核启动日志（singbox_startup.log）尾部。核在 logger 建起前失败、panic、被环境拦下，
+   * 错误只走 stderr——singbox.log 里一个字都没有。issue #324 两轮诊断都定不了位正因该段缺失。
+   * **内容按写侧而异**（见 main/utils/paths.ts getSingBoxStartupLogPath 的平台表）：mac wrapper / Windows
+   * helper 服务含核的 stdout+stderr；Windows UAC 看护脚本未重定向 → 只有看护脚本自述行。故本段标题不写死
+   * 「核 stdout/stderr」，由 startupLogSource 如实标注本机走的哪条写侧路径。
    * 可选：未提供则不出该段（老调用点/单测不受影响）。
    */
   startupLogTail?: string;
+  /** 本段内容的来源与元信息（写侧路径描述 + 文件大小/最后写入时刻）；缺省则段标题只写文件名。 */
+  startupLogSource?: string;
   /** 节点标识符 → 占位符（P0.6）：构建末尾在全报告统一替换，打码节点身份（域名/IP/SNI/节点名），保留形态与跨段相关性。 */
   nodeIdentifiers?: readonly NodeIdentifier[];
   /** 当前级别不含连接明细（>info）且日志疑似有连接/DNS 错误 → 提示开启诊断采集复现。 */
@@ -501,9 +506,12 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
   lines.push(fence('text', input.singboxLogTail));
   lines.push('');
 
-  // 核的 stdout/stderr：与 singbox.log 互补（见 startupLogTail 字段注释）。放在其后，同样进 redactIdentifiers。
+  // 核启动日志：与 singbox.log 互补（见 startupLogTail 字段注释）。放在其后，同样进 redactIdentifiers。
+  // 标题带来源描述 + 文件元信息：Windows helper 侧 O_APPEND 永不截断，仅凭 64KB tail 无法判断内容属于哪次
+  // 会话（sing-box 的 FATAL[0000] 是启动相对秒、非墙钟时间），故必须让读报告的人看见文件多大、何时最后写入。
   if (input.startupLogTail !== undefined) {
-    lines.push('## singbox_startup.log（近期 · 核 stdout/stderr）');
+    const src = input.startupLogSource ? ` · ${input.startupLogSource}` : '';
+    lines.push(`## singbox_startup.log（近期${src}）`);
     lines.push('');
     lines.push(fence('text', input.startupLogTail));
     lines.push('');


### PR DESCRIPTION
## 背景

#324（Win10 TUN 起不来）连续两轮诊断报告都定不了位。原因不是报告者没配合，是 FlowZ 的诊断报告收不到关键证据：**sing-box 启动失败打的 `FATAL` 只写 stderr，不进配置里 `log.output` 指定的 singbox.log**（已用同版本内核在本地构造启动失败实测坐实：日志文件里只有一行 `updated default interface`，一个字的错误都没有）。提权/看护路径下核的 stderr 落在 `singbox_startup.log`，而诊断报告只收 app.log + singbox.log。

排查中还踩到一条假 ERROR：`UAC 授权失败，退出码: null`——它把方向带到了提权问题上，实际是一次正常的停核。

## 改动

**1. 诊断报告纳入 `singbox_startup.log`**

- 新增 `getSingBoxStartupLogPath()` 作单一真值，替换写侧 5 处字面量（ProxyManager 4、PlatformPrivilegeService 1）
- 报告新增该段，排在 singbox.log 之后，同样过节点标识符打码
- 段标题由 `describeStartupLog()` **按实际写侧如实标注**，并带文件大小与最后写入时刻。三个写侧写进去的东西不同：mac osascript wrapper 与 Windows helper 服务重定向了核的两条流，而 Windows UAC 看护脚本的 `Start-Process` 没有 `-RedirectStandardError`，那条路径下文件里只有看护脚本自述行。不区分就会让「没有 FATAL」被误读成「核什么都没打印」。元信息是必需的：helper 侧 `O_APPEND` 永不截断，而 sing-box 的 `FATAL[0000]` 是启动相对秒不是墙钟时间，没有它无法判断这 64KB tail 属于哪次会话
- `readTail` 失败只回错误码不回 `e.message`（后者内嵌完整路径含 OS 用户名，而报告是公开 issue 附件）

**2. 修「UAC 授权失败，退出码: null」误报**

`exit` / 1s 成功判定回调**现查** `needsOsascript()` / `needsWindowsUAC()`，二者读 `currentConfig`（**当前**模式）而非本次 spawn 实际走的路径。系统代理→TUN 切换时 `currentConfig` 先被更新、再调度去抖重启，此时旧核的正常 SIGTERM 停会落进 Windows UAC 分支被判成授权失败。

- 启动路径在 spawn 前固化为局部量（`launchViaOsascript` / `launchViaWindowsUAC`），exit 与 1s 判定都按快照走
- 包装进程被信号杀（`code === null`）不再判授权失败——没有退出码就别按退出码编造文案
- 同一个 bug 类在回调之外还有三处：`getStatus` / `performHealthCheck` / `recordMemoryTimelineFrame` 各自现查谓词，去抖窗口内会让仍在运行的直起核被按包装模式取 pid（`singboxPid` 恒 null）→ `getStatus` 假 `running:false`、健康检查空转、内存帧丢核。收口到 `activeCorePid()`，读启动派生态 `startedViaWrapper`

**3. 内核升级 1.14.0-beta.1 → 1.14.0-beta.2**

4 平台 sha256 取自 GitHub API digest，linux 包另行下载本地校验一致。

**4. 版本 4.2.9 → 4.3.0**

## 验证

- 全量 gate 绿：tsc（main + renderer）、eslint（触及文件 0 warning）、jest 3403 passed
- 内核兼容性：37 份 config 金样跑 `sing-box check`，alpha.46 与 beta.2 结果完全一致、零 beta.2-only 失败（共有的 4 例失败是 fixture 假凭据；`naive` 那例差异是 beta.2 解包目录自带 libcronet.so，与核无关）
- 新增单测 17 例，覆盖 #324 现场态（已成功运行的核在模式切换后被 SIGTERM）、osascript 侧、getStatus 漂移、诊断取数路径收口
- **变异验证**：9 条逃逸路径逐一注入——启动路径快照失效、`code !== null` 失效、1s 判定分支漂移、`activeCorePid` 改回现查、startup 路径写成 singbox.log、`Promise.all` 顺序错位、写侧文案塌成恒定值、`!== undefined` 改 truthy、exit 分支现查谓词——全部被杀

## 已知缺口（不在本 PR）

**Windows UAC 看护脚本仍未重定向核的 stderr**，未装 helper 的用户那条路径依然拿不到 FATAL。补 `-RedirectStandardError` 属提权看护脚本改动（PowerShell 的 `-RedirectStandardOutput`/`-RedirectStandardError` 还不能指向同一路径），改坏会让整条 UAC 起核挂掉，必须 Windows 真机实测，另开一批。本 PR 已让报告如实标注这一点，不制造假阴性。

#324 的根因本身仍待 `singbox_startup.log` 拍板。失败窗口已锁死在 `tun.New()`（wintun 适配器创建 + 地址/DNS/MTU 下发）——`started at flowz-tun0` 这行日志是阶段分水岭，它从未出现，因此 `auto_route` 路由写入、`strict_route` WFP、`route_exclude_address` 展开这些都排在其后、根本没执行过，可以排除。

Refs #324
