### PR TITLE
fix(win): UAC 看护路径重定向核 stderr，关掉 #324 的最后一处诊断盲区

### DIFF
--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -27,7 +27,12 @@ import {
   sampleCoreProcess,
   serializeMemoryTimelineCsv,
 } from './process-sampler';
-import { getLogsPath, getSingBoxLogPath, getSingBoxStartupLogPath } from '../utils/paths';
+import {
+  getLogsPath,
+  getSingBoxLogPath,
+  getSingBoxStartupLogPath,
+  getWindowsWatchdogLogPath,
+} from '../utils/paths';
 import path from 'path';
 import type { LogManager } from './LogManager';
 import type { ProxyManager } from './ProxyManager';
@@ -104,7 +109,7 @@ export class DiagnosticService {
       : process.platform === 'darwin'
         ? '写侧 osascript wrapper：核 stdout+stderr，每次启动截断'
         : process.platform === 'win32'
-          ? '写侧 UAC 看护脚本：**仅看护脚本自述行，不含核输出**'
+          ? '写侧 UAC 看护脚本：核 stderr（-RedirectStandardError），每次起核截断；看护脚本自述行见下一段'
           : '非 helper 路径（直起）：核输出走 app.log 管道，本文件不被写入';
     try {
       const st = await fs.stat(getSingBoxStartupLogPath());
@@ -124,12 +129,17 @@ export class DiagnosticService {
     // startupLogTail = 提权/看护路径下的核启动日志。核在 logger 建起前挂掉或 panic 时，singbox.log 里什么
     // 都没有、失败原因只走 stderr（issue #324：两轮诊断报告都因缺这段而定不了位）。恒纳入报告——文件不存在
     // 时 readTail 给「(无日志文件)」占位，这本身也是信息（该机从未走过提权启动路径）。
-    const [appLogTail, singboxLogTail, startupLogTail, startupLogSource] = await Promise.all([
-      this.readTail(path.join(getLogsPath(), 'app.log'), LOG_TAIL_BYTES),
-      this.readTail(getSingBoxLogPath(), LOG_TAIL_BYTES),
-      this.readTail(getSingBoxStartupLogPath(), LOG_TAIL_BYTES),
-      this.describeStartupLog(),
-    ]);
+    const [appLogTail, singboxLogTail, startupLogTail, startupLogSource, watchdogLogTail] =
+      await Promise.all([
+        this.readTail(path.join(getLogsPath(), 'app.log'), LOG_TAIL_BYTES),
+        this.readTail(getSingBoxLogPath(), LOG_TAIL_BYTES),
+        this.readTail(getSingBoxStartupLogPath(), LOG_TAIL_BYTES),
+        this.describeStartupLog(),
+        // 看护脚本自述日志只有 Windows UAC 路径会写；其它平台不出该段（避免恒定的「(无日志文件)」噪声）。
+        process.platform === 'win32'
+          ? this.readTail(getWindowsWatchdogLogPath(), LOG_TAIL_BYTES)
+          : Promise.resolve(undefined),
+      ]);
 
     const coreVersion = await this.proxyManager.getCoreVersion().catch(() => 'unknown');
     const status = this.proxyManager.getStatus();
@@ -282,6 +292,7 @@ export class DiagnosticService {
       singboxLogTail,
       startupLogTail,
       startupLogSource,
+      watchdogLogTail,
       // issue #147：节点 outbound.server 已恒为域名（不再烧 IP），无额外预解析 IP 需补脱敏 → 仅扫 config.servers。
       nodeIdentifiers: collectNodeIdentifiers(config),
       hint: wantDeeper

--- a/src/main/services/PlatformPrivilegeService.ts
+++ b/src/main/services/PlatformPrivilegeService.ts
@@ -104,6 +104,11 @@ export interface ElevatedLaunchPaths {
   pidFile: string;
   /** 启动日志文件路径（macOS/win 提权后台进程 stdout 无法捕获，经此文件 tail）。 */
   startupLogFile: string;
+  /**
+   * Windows UAC 看护脚本自身的日志路径（macOS 分支不使用）。必须与 startupLogFile 分文件——后者被
+   * Start-Process 的 -RedirectStandardError 独占，看护脚本再往里写会失败（真机实测）。
+   */
+  watchdogLog: string;
   /** 停止信号文件路径（app 普通用户写入，看护脚本检测后自杀 sing-box）。 */
   stopFlag: string;
   /** macOS root 看护脚本路径（osascript 以 root 执行）。 */
@@ -121,6 +126,99 @@ export interface ElevatedLaunchPaths {
 /**
  * 提权脚本生成 / 提权文件操作的纯函数集合。constructor 注入 ctx + helperManager（DI）。
  */
+/**
+ * Windows UAC 看护脚本正文（纯函数，无 IO）。**唯一真值**——PlatformPrivilegeService 与 ProxyManager 的
+ * 未注入兜底路径共用它。此前两处各存一份脚本文本，改一处漏一处就会让兜底路径的参数链与脚本 param 数量
+ * 对不上（Mandatory 缺参 → 隐藏窗口里挂起），issue #324 的 review 已点过这个漂移风险。
+ */
+export function windowsWatchdogScriptText(): string {
+  return `# FlowZ elevated watchdog (run by UAC-elevated PowerShell via -File). Do not edit manually.
+param(
+  [Parameter(Mandatory = $true)][string]$SbPath,
+  [Parameter(Mandatory = $true)][string]$CfgPath,
+  [Parameter(Mandatory = $true)][string]$PidFile,
+  [Parameter(Mandatory = $true)][string]$StopFlag,
+  [Parameter(Mandatory = $true)][int]$ParentPid,
+  [Parameter(Mandatory = $true)][string]$ParentName,
+  [Parameter(Mandatory = $true)][string]$LogFile,
+  [Parameter(Mandatory = $true)][string]$WatchdogLog,
+  [string]$Forward = '0'
+)
+$ErrorActionPreference = 'Continue'
+# Watchdog's own lines go to $WatchdogLog; $LogFile is reserved for sing-box stderr (see Start-Process below).
+# They MUST be separate files: while redirected, Out-File on $LogFile fails with a sharing violation.
+function Log([string]$Msg) {
+  try { ((Get-Date -Format 'HH:mm:ss') + ' [watchdog] ' + $Msg) | Out-File -FilePath $WatchdogLog -Append -Encoding UTF8 } catch {}
+}
+try { 'FlowZ watchdog starting...' | Out-File -FilePath $WatchdogLog -Encoding UTF8 } catch {}
+if (-not (Test-Path -LiteralPath $SbPath)) { Log 'ERROR: sing-box not found'; exit 1 }
+if (-not (Test-Path -LiteralPath $CfgPath)) { Log 'ERROR: config not found'; exit 1 }
+
+# (a) sweep leftover sing-box started from OUR core path (reuses this elevation).
+try {
+  $orphans = @(Get-CimInstance Win32_Process -Filter "Name='sing-box.exe'" | Where-Object { $_.ExecutablePath -eq $SbPath })
+  foreach ($o in $orphans) {
+    Log ('Killing leftover sing-box PID ' + $o.ProcessId)
+    Stop-Process -Id $o.ProcessId -Force -ErrorAction SilentlyContinue
+  }
+  if ($orphans.Count -gt 0) { Start-Sleep -Milliseconds 500 }
+} catch { Log ('Orphan sweep failed: ' + $_.Exception.Message) }
+
+if ($Forward -eq '1') {
+  try {
+    Set-NetIPInterface -Forwarding Enabled
+    Set-NetIPInterface -AddressFamily IPv6 -Forwarding Enabled
+    Log 'IP forwarding enabled'
+  } catch { Log ('Enable IP forwarding failed: ' + $_.Exception.Message) }
+}
+
+# (b) start sing-box (already elevated, no inner RunAs); PID file protocol unchanged.
+# Config path is explicitly quoted: -ArgumentList does NOT auto-quote elements with spaces.
+# -RedirectStandardError: sing-box start failures (FATAL / panic) go to stderr ONLY, never to the
+#   log.output file from the config (verified on a real Windows box: log.output held a single
+#   "updated default interface" line and zero FATAL - exactly what issue #324 reported).
+#   Without this redirect the failure reason is lost for good and diagnostics can never pin it down.
+# stderr only, no stdout redirect: (1) PowerShell refuses both pointing at the same path;
+#   (2) FlowZ always sets log.output, so stdout measured 0 bytes - a second file buys nothing.
+# The redirect truncates on open, so each start begins a fresh run - report readers cannot mistake
+#   a previous session's FATAL for this one (sing-box stamps FATAL[0000], a relative second, not a clock).
+try {
+  $proc = Start-Process -FilePath $SbPath -ArgumentList 'run', '-c', ('"' + $CfgPath + '"') -RedirectStandardError $LogFile -PassThru -WindowStyle Hidden
+} catch {
+  Log ('ERROR: failed to start sing-box: ' + $_.Exception.Message)
+  exit 1
+}
+if (-not ($proc -and $proc.Id)) { Log 'ERROR: Start-Process returned null'; exit 1 }
+$sbId = $proc.Id
+try {
+  $sbId | Out-File -FilePath $PidFile -Encoding ASCII -NoNewline
+} catch {
+  Log ('ERROR: failed to write PID file: ' + $_.Exception.Message)
+  Stop-Process -Id $sbId -Force -ErrorAction SilentlyContinue
+  exit 1
+}
+Log ('sing-box started, PID ' + $sbId)
+
+# (c) babysit: exit when core dies; kill core on stopflag or parent death (name check vs PID reuse).
+while ($true) {
+  $sb = Get-Process -Id $sbId -ErrorAction SilentlyContinue
+  if (-not $sb -or $sb.ProcessName -ne 'sing-box') { Log 'sing-box exited by itself'; break }
+  if (Test-Path -LiteralPath $StopFlag) { Log 'Stopflag detected'; break }
+  $parent = Get-Process -Id $ParentPid -ErrorAction SilentlyContinue
+  if (-not $parent -or $parent.ProcessName -ne $ParentName) { Log 'Parent process gone'; break }
+  Start-Sleep -Seconds 1
+}
+$sb = Get-Process -Id $sbId -ErrorAction SilentlyContinue
+if ($sb -and $sb.ProcessName -eq 'sing-box') {
+  Stop-Process -Id $sbId -Force -ErrorAction SilentlyContinue
+  Log 'sing-box stopped by watchdog'
+}
+Remove-Item -LiteralPath $StopFlag -Force -ErrorAction SilentlyContinue
+Log 'Watchdog exit'
+exit 0
+`;
+}
+
 export class PlatformPrivilegeService {
   constructor(
     private readonly ctx: PrivilegeContext,
@@ -274,81 +372,7 @@ rm -f "$STOPFLAG"
    * 迁自 ProxyManager.writeWindowsWatchdogScript。UAC 提权 PowerShell 以 -File 执行此脚本托管 sing-box。
    */
   writeWindowsWatchdogScript(): void {
-    const script = `# FlowZ elevated watchdog (run by UAC-elevated PowerShell via -File). Do not edit manually.
-param(
-  [Parameter(Mandatory = $true)][string]$SbPath,
-  [Parameter(Mandatory = $true)][string]$CfgPath,
-  [Parameter(Mandatory = $true)][string]$PidFile,
-  [Parameter(Mandatory = $true)][string]$StopFlag,
-  [Parameter(Mandatory = $true)][int]$ParentPid,
-  [Parameter(Mandatory = $true)][string]$ParentName,
-  [Parameter(Mandatory = $true)][string]$LogFile,
-  [string]$Forward = '0'
-)
-$ErrorActionPreference = 'Continue'
-function Log([string]$Msg) {
-  try { ((Get-Date -Format 'HH:mm:ss') + ' [watchdog] ' + $Msg) | Out-File -FilePath $LogFile -Append -Encoding UTF8 } catch {}
-}
-try { 'FlowZ watchdog starting...' | Out-File -FilePath $LogFile -Encoding UTF8 } catch {}
-if (-not (Test-Path -LiteralPath $SbPath)) { Log 'ERROR: sing-box not found'; exit 1 }
-if (-not (Test-Path -LiteralPath $CfgPath)) { Log 'ERROR: config not found'; exit 1 }
-
-# (a) sweep leftover sing-box started from OUR core path (reuses this elevation).
-try {
-  $orphans = @(Get-CimInstance Win32_Process -Filter "Name='sing-box.exe'" | Where-Object { $_.ExecutablePath -eq $SbPath })
-  foreach ($o in $orphans) {
-    Log ('Killing leftover sing-box PID ' + $o.ProcessId)
-    Stop-Process -Id $o.ProcessId -Force -ErrorAction SilentlyContinue
-  }
-  if ($orphans.Count -gt 0) { Start-Sleep -Milliseconds 500 }
-} catch { Log ('Orphan sweep failed: ' + $_.Exception.Message) }
-
-if ($Forward -eq '1') {
-  try {
-    Set-NetIPInterface -Forwarding Enabled
-    Set-NetIPInterface -AddressFamily IPv6 -Forwarding Enabled
-    Log 'IP forwarding enabled'
-  } catch { Log ('Enable IP forwarding failed: ' + $_.Exception.Message) }
-}
-
-# (b) start sing-box (already elevated, no inner RunAs); PID file protocol unchanged.
-# Config path is explicitly quoted: -ArgumentList does NOT auto-quote elements with spaces.
-try {
-  $proc = Start-Process -FilePath $SbPath -ArgumentList 'run', '-c', ('"' + $CfgPath + '"') -PassThru -WindowStyle Hidden
-} catch {
-  Log ('ERROR: failed to start sing-box: ' + $_.Exception.Message)
-  exit 1
-}
-if (-not ($proc -and $proc.Id)) { Log 'ERROR: Start-Process returned null'; exit 1 }
-$sbId = $proc.Id
-try {
-  $sbId | Out-File -FilePath $PidFile -Encoding ASCII -NoNewline
-} catch {
-  Log ('ERROR: failed to write PID file: ' + $_.Exception.Message)
-  Stop-Process -Id $sbId -Force -ErrorAction SilentlyContinue
-  exit 1
-}
-Log ('sing-box started, PID ' + $sbId)
-
-# (c) babysit: exit when core dies; kill core on stopflag or parent death (name check vs PID reuse).
-while ($true) {
-  $sb = Get-Process -Id $sbId -ErrorAction SilentlyContinue
-  if (-not $sb -or $sb.ProcessName -ne 'sing-box') { Log 'sing-box exited by itself'; break }
-  if (Test-Path -LiteralPath $StopFlag) { Log 'Stopflag detected'; break }
-  $parent = Get-Process -Id $ParentPid -ErrorAction SilentlyContinue
-  if (-not $parent -or $parent.ProcessName -ne $ParentName) { Log 'Parent process gone'; break }
-  Start-Sleep -Seconds 1
-}
-$sb = Get-Process -Id $sbId -ErrorAction SilentlyContinue
-if ($sb -and $sb.ProcessName -eq 'sing-box') {
-  Stop-Process -Id $sbId -Force -ErrorAction SilentlyContinue
-  Log 'sing-box stopped by watchdog'
-}
-Remove-Item -LiteralPath $StopFlag -Force -ErrorAction SilentlyContinue
-Log 'Watchdog exit'
-exit 0
-`;
-    require('fs').writeFileSync(this.getWindowsWatchdogScriptPath(), script);
+    require('fs').writeFileSync(this.getWindowsWatchdogScriptPath(), windowsWatchdogScriptText());
   }
 
   // ─── 文件权限 / 提权复制（迁自 ProxyManager.fixFilePermissions / CoreUpdateService.copyFileElevatedWindows）──
@@ -1026,6 +1050,7 @@ exit 0
       parentPid,
       parentName,
       startupLogFile,
+      watchdogLog,
       fwd,
     } = paths;
 
@@ -1050,9 +1075,11 @@ exit 0
       `'${parentPid}'`,
       q(parentName),
       q(startupLogFile),
+      q(watchdogLog),
       `'${fwd}'`,
     ].join(',');
-    const logFileEsc = startupLogFile.replace(/'/g, "''");
+    // 外层 UAC 发起失败的 ERROR 行写看护日志，不写 startupLogFile（后者归 sing-box stderr 独占）
+    const logFileEsc = watchdogLog.replace(/'/g, "''");
     const psScript = [
       "$ErrorActionPreference = 'Stop'",
       'try {',

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -29,7 +29,7 @@ import type { ILogManager } from './LogManager';
 import { HelperManager } from './HelperManager';
 import type { IPrivilegedHelper } from './IPrivilegedHelper';
 import { MeshExitRouteManager } from './mesh-exit-route-manager';
-import { PlatformPrivilegeService } from './PlatformPrivilegeService';
+import { PlatformPrivilegeService, windowsWatchdogScriptText } from './PlatformPrivilegeService';
 import { type ISystemProxyManager, SystemProxyBase } from './SystemProxyManager';
 import { type ISystemDnsManager } from './SystemDnsManager';
 import { DnsInterfaceWatcher, shouldReconcileDns } from './DnsInterfaceWatcher';
@@ -102,6 +102,7 @@ import {
   getSingBoxConfigPath,
   getSingBoxLogPath,
   getSingBoxStartupLogPath,
+  getWindowsWatchdogLogPath,
   getSingBoxPidPath,
   getCachePath,
   getCustomRulesDir,
@@ -4356,81 +4357,9 @@ rm -f "$STOPFLAG"
       this.privilegeService.writeWindowsWatchdogScript();
       return;
     }
-    const script = `# FlowZ elevated watchdog (run by UAC-elevated PowerShell via -File). Do not edit manually.
-param(
-  [Parameter(Mandatory = $true)][string]$SbPath,
-  [Parameter(Mandatory = $true)][string]$CfgPath,
-  [Parameter(Mandatory = $true)][string]$PidFile,
-  [Parameter(Mandatory = $true)][string]$StopFlag,
-  [Parameter(Mandatory = $true)][int]$ParentPid,
-  [Parameter(Mandatory = $true)][string]$ParentName,
-  [Parameter(Mandatory = $true)][string]$LogFile,
-  [string]$Forward = '0'
-)
-$ErrorActionPreference = 'Continue'
-function Log([string]$Msg) {
-  try { ((Get-Date -Format 'HH:mm:ss') + ' [watchdog] ' + $Msg) | Out-File -FilePath $LogFile -Append -Encoding UTF8 } catch {}
-}
-try { 'FlowZ watchdog starting...' | Out-File -FilePath $LogFile -Encoding UTF8 } catch {}
-if (-not (Test-Path -LiteralPath $SbPath)) { Log 'ERROR: sing-box not found'; exit 1 }
-if (-not (Test-Path -LiteralPath $CfgPath)) { Log 'ERROR: config not found'; exit 1 }
-
-# (a) sweep leftover sing-box started from OUR core path (reuses this elevation).
-try {
-  $orphans = @(Get-CimInstance Win32_Process -Filter "Name='sing-box.exe'" | Where-Object { $_.ExecutablePath -eq $SbPath })
-  foreach ($o in $orphans) {
-    Log ('Killing leftover sing-box PID ' + $o.ProcessId)
-    Stop-Process -Id $o.ProcessId -Force -ErrorAction SilentlyContinue
-  }
-  if ($orphans.Count -gt 0) { Start-Sleep -Milliseconds 500 }
-} catch { Log ('Orphan sweep failed: ' + $_.Exception.Message) }
-
-if ($Forward -eq '1') {
-  try {
-    Set-NetIPInterface -Forwarding Enabled
-    Set-NetIPInterface -AddressFamily IPv6 -Forwarding Enabled
-    Log 'IP forwarding enabled'
-  } catch { Log ('Enable IP forwarding failed: ' + $_.Exception.Message) }
-}
-
-# (b) start sing-box (already elevated, no inner RunAs); PID file protocol unchanged.
-# Config path is explicitly quoted: -ArgumentList does NOT auto-quote elements with spaces.
-try {
-  $proc = Start-Process -FilePath $SbPath -ArgumentList 'run', '-c', ('"' + $CfgPath + '"') -PassThru -WindowStyle Hidden
-} catch {
-  Log ('ERROR: failed to start sing-box: ' + $_.Exception.Message)
-  exit 1
-}
-if (-not ($proc -and $proc.Id)) { Log 'ERROR: Start-Process returned null'; exit 1 }
-$sbId = $proc.Id
-try {
-  $sbId | Out-File -FilePath $PidFile -Encoding ASCII -NoNewline
-} catch {
-  Log ('ERROR: failed to write PID file: ' + $_.Exception.Message)
-  Stop-Process -Id $sbId -Force -ErrorAction SilentlyContinue
-  exit 1
-}
-Log ('sing-box started, PID ' + $sbId)
-
-# (c) babysit: exit when core dies; kill core on stopflag or parent death (name check vs PID reuse).
-while ($true) {
-  $sb = Get-Process -Id $sbId -ErrorAction SilentlyContinue
-  if (-not $sb -or $sb.ProcessName -ne 'sing-box') { Log 'sing-box exited by itself'; break }
-  if (Test-Path -LiteralPath $StopFlag) { Log 'Stopflag detected'; break }
-  $parent = Get-Process -Id $ParentPid -ErrorAction SilentlyContinue
-  if (-not $parent -or $parent.ProcessName -ne $ParentName) { Log 'Parent process gone'; break }
-  Start-Sleep -Seconds 1
-}
-$sb = Get-Process -Id $sbId -ErrorAction SilentlyContinue
-if ($sb -and $sb.ProcessName -eq 'sing-box') {
-  Stop-Process -Id $sbId -Force -ErrorAction SilentlyContinue
-  Log 'sing-box stopped by watchdog'
-}
-Remove-Item -LiteralPath $StopFlag -Force -ErrorAction SilentlyContinue
-Log 'Watchdog exit'
-exit 0
-`;
-    require('fs').writeFileSync(this.getWindowsWatchdogScriptPath(), script);
+    // 脚本正文走 PlatformPrivilegeService 的导出纯函数（唯一真值），此处只负责落盘——两份脚本文本
+    // 各自维护必然漂移（参数链与 param 数量对不上 → 兜底路径在隐藏窗口里挂起）。
+    require('fs').writeFileSync(this.getWindowsWatchdogScriptPath(), windowsWatchdogScriptText());
   }
 
   /** 停止收尾：删 PID 文件 + 资源清理 + 通知前端。 */
@@ -4787,6 +4716,7 @@ exit 0
               configPath: this.configPath,
               pidFile,
               startupLogFile,
+              watchdogLog: getWindowsWatchdogLogPath(),
               stopFlag,
               wrapper: wd.path,
               watchdog: wd.path,
@@ -4836,6 +4766,7 @@ exit 0
               configPath: this.configPath,
               pidFile,
               startupLogFile,
+              watchdogLog: getWindowsWatchdogLogPath(),
               stopFlag,
               wrapper: wd.path,
               watchdog: wd.path,
@@ -4872,9 +4803,11 @@ exit 0
               `'${parentPid}'`,
               q(parentName),
               q(startupLogFile),
+              q(getWindowsWatchdogLogPath()),
               `'${fwd}'`,
             ].join(',');
-            const logFileEsc = startupLogFile.replace(/'/g, "''");
+            // ERROR 行写看护日志：startupLogFile 已归 sing-box stderr 独占（-RedirectStandardError）
+            const logFileEsc = getWindowsWatchdogLogPath().replace(/'/g, "''");
             const psScript = [
               "$ErrorActionPreference = 'Stop'",
               'try {',

--- a/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
+++ b/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
@@ -22,7 +22,12 @@ jest.mock('electron', () => ({
 }));
 
 import { DiagnosticService } from '../DiagnosticService';
-import { getLogsPath, getSingBoxLogPath, getSingBoxStartupLogPath } from '../../utils/paths';
+import {
+  getLogsPath,
+  getSingBoxLogPath,
+  getSingBoxStartupLogPath,
+  getWindowsWatchdogLogPath,
+} from '../../utils/paths';
 
 afterAll(() => {
   try {
@@ -69,18 +74,39 @@ describe('DiagnosticService — 日志取数路径收口', () => {
     expect(md).toMatch(/## singbox_startup\.log[\s\S]*tail-of:singbox_startup\.log/);
   });
 
-  it('Windows 非 helper 路径的段标题如实标注「不含核输出」（#324 假阴性防线）', async () => {
+  it('Windows UAC 路径：startup 段标注核 stderr，并额外收看护脚本自述日志', async () => {
     const real = process.platform;
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
     try {
       const svc = makeSvc({ startedViaHelper: false });
-      jest.spyOn(svc, 'readTail').mockResolvedValue('FlowZ watchdog starting...');
+      const seen: string[] = [];
+      jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
+        const p = args[0] as string;
+        seen.push(p);
+        return `tail-of:${path.basename(p)}`;
+      });
       const md = await svc.buildReport();
       expect(md).toContain('写侧 UAC 看护脚本');
-      expect(md).toContain('不含核输出');
+      expect(md).toContain('核 stderr');
+      // 看护自述日志是「谁停的核」的判据，与 FATAL 互补，Windows 上必须一并收
+      expect(seen).toContain(getWindowsWatchdogLogPath());
+      expect(md).toContain('## flowz-win-watchdog.log');
+      expect(md).toContain('tail-of:flowz-win-watchdog.log');
     } finally {
       Object.defineProperty(process, 'platform', { value: real, configurable: true });
     }
+  });
+
+  it('非 Windows 不出看护脚本日志段（避免恒定的「(无日志文件)」噪声）', async () => {
+    const svc = makeSvc({ startedViaHelper: true });
+    const seen: string[] = [];
+    jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
+      seen.push(args[0] as string);
+      return 'x';
+    });
+    const md = await svc.buildReport();
+    expect(seen).not.toContain(getWindowsWatchdogLogPath());
+    expect(md).not.toContain('## flowz-win-watchdog.log');
   });
 
   it('helper 路径标注为含核 stdout+stderr 且只追加不截断', async () => {

--- a/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
+++ b/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
@@ -52,17 +52,33 @@ function makeSvc(opts: { startedViaHelper?: boolean } = {}): any {
   return new DiagnosticService(configManager, logManager, proxyManager, systemProxyManager) as any;
 }
 
+/**
+ * 本文件的断言与 `process.platform` 强相关（Windows 会多收一段看护脚本日志），故每条用例都**显式 pin
+ * 平台**，绝不吃宿主平台的默认值——否则本地 Linux 全绿、Windows CI runner 上必挂（已实际踩过）。
+ */
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const real = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: real, configurable: true });
+  }
+}
+
 describe('DiagnosticService — 日志取数路径收口', () => {
   it('三段日志各读各的文件，startup log 走 getSingBoxStartupLogPath()（不与 singbox.log 同源）', async () => {
-    const svc = makeSvc();
-    const seen: string[] = [];
-    jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
-      const p = args[0] as string;
-      seen.push(p);
-      return `tail-of:${path.basename(p)}`;
+    // pin 非 Windows：Windows 会多收一段看护脚本日志，seen 就不是三条了
+    const { seen, md } = await withPlatform('linux', async () => {
+      const svc = makeSvc();
+      const seen: string[] = [];
+      jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
+        const p = args[0] as string;
+        seen.push(p);
+        return `tail-of:${path.basename(p)}`;
+      });
+      return { seen, md: (await svc.buildReport()) as string };
     });
-
-    const md = await svc.buildReport();
 
     expect(seen).toHaveLength(3);
     expect(new Set(seen).size).toBe(3); // 三个互不相同 → 排除「两段读同一文件」的漂移
@@ -75,9 +91,7 @@ describe('DiagnosticService — 日志取数路径收口', () => {
   });
 
   it('Windows UAC 路径：startup 段标注核 stderr，并额外收看护脚本自述日志', async () => {
-    const real = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    try {
+    const { seen, md } = await withPlatform('win32', async () => {
       const svc = makeSvc({ startedViaHelper: false });
       const seen: string[] = [];
       jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
@@ -85,34 +99,36 @@ describe('DiagnosticService — 日志取数路径收口', () => {
         seen.push(p);
         return `tail-of:${path.basename(p)}`;
       });
-      const md = await svc.buildReport();
-      expect(md).toContain('写侧 UAC 看护脚本');
-      expect(md).toContain('核 stderr');
-      // 看护自述日志是「谁停的核」的判据，与 FATAL 互补，Windows 上必须一并收
-      expect(seen).toContain(getWindowsWatchdogLogPath());
-      expect(md).toContain('## flowz-win-watchdog.log');
-      expect(md).toContain('tail-of:flowz-win-watchdog.log');
-    } finally {
-      Object.defineProperty(process, 'platform', { value: real, configurable: true });
-    }
+      return { seen, md: (await svc.buildReport()) as string };
+    });
+    expect(md).toContain('写侧 UAC 看护脚本');
+    expect(md).toContain('核 stderr');
+    // 看护自述日志是「谁停的核」的判据，与 FATAL 互补，Windows 上必须一并收
+    expect(seen).toContain(getWindowsWatchdogLogPath());
+    expect(md).toContain('## flowz-win-watchdog.log');
+    expect(md).toContain('tail-of:flowz-win-watchdog.log');
   });
 
   it('非 Windows 不出看护脚本日志段（避免恒定的「(无日志文件)」噪声）', async () => {
-    const svc = makeSvc({ startedViaHelper: true });
-    const seen: string[] = [];
-    jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
-      seen.push(args[0] as string);
-      return 'x';
+    const { seen, md } = await withPlatform('linux', async () => {
+      const svc = makeSvc({ startedViaHelper: true });
+      const seen: string[] = [];
+      jest.spyOn(svc, 'readTail').mockImplementation(async (...args: unknown[]) => {
+        seen.push(args[0] as string);
+        return 'x';
+      });
+      return { seen, md: (await svc.buildReport()) as string };
     });
-    const md = await svc.buildReport();
     expect(seen).not.toContain(getWindowsWatchdogLogPath());
     expect(md).not.toContain('## flowz-win-watchdog.log');
   });
 
   it('helper 路径标注为含核 stdout+stderr 且只追加不截断', async () => {
-    const svc = makeSvc({ startedViaHelper: true });
-    jest.spyOn(svc, 'readTail').mockResolvedValue('FATAL[0000] boom');
-    const md = await svc.buildReport();
+    const md = await withPlatform('linux', async () => {
+      const svc = makeSvc({ startedViaHelper: true });
+      jest.spyOn(svc, 'readTail').mockResolvedValue('FATAL[0000] boom');
+      return (await svc.buildReport()) as string;
+    });
     expect(md).toContain('核 stdout+stderr');
     expect(md).toContain('只追加不截断');
   });

--- a/src/main/services/__tests__/platform-privilege-service.test.ts
+++ b/src/main/services/__tests__/platform-privilege-service.test.ts
@@ -32,6 +32,7 @@ import {
   PlatformPrivilegeService,
   PrivilegeContext,
   ElevatedLaunchPaths,
+  windowsWatchdogScriptText,
 } from '../PlatformPrivilegeService';
 import type { LogLevel } from '../../../shared/types';
 import { powershellPath } from '../../utils/win-system32';
@@ -96,6 +97,7 @@ function makePaths(): ElevatedLaunchPaths {
     configPath: '/app/config.json',
     pidFile: '/app/sb.pid',
     startupLogFile: '/app/startup.log',
+    watchdogLog: '/app/watchdog.log',
     stopFlag: '/app/stop.flag',
     wrapper: '/app/wrapper.sh',
     watchdog: 'C:\\app\\watchdog.ps1',
@@ -277,5 +279,79 @@ describe('PlatformPrivilegeService.generateWatchdogScript', () => {
     expect(script).toContain('$parent.ProcessName -ne $ParentName');
     // 强停兜底
     expect(script).toContain('Stop-Process -Id $sbId -Force');
+  });
+});
+
+// ============================================================================
+// 六、Windows 看护脚本正文 × 提权参数链（issue #324：核 stderr 必须落盘）
+// ============================================================================
+
+describe('windowsWatchdogScriptText — 核 stderr 落盘与文件分工', () => {
+  const script = windowsWatchdogScriptText();
+
+  it('脚本正文必须是纯 ASCII（PowerShell 5.1 按 ANSI 解码无 BOM 文件，非 ASCII 会破坏语法）', () => {
+    // 真机实测：脚本里放中文注释 → `fs.writeFileSync` 写出 UTF-8 无 BOM → PowerShell 5.1 按 GBK 解码，
+    // 多字节序列被拆出反引号/引号 → ParserError「表达式或语句中包含意外的标记」→ 看护脚本根本不启动，
+    // 核也就永远起不来。这条本地跑不出来（Linux/Node 读 UTF-8 一切正常），只有真机会暴露。
+    const offenders = [...script].filter((ch) => ch.charCodeAt(0) > 127);
+    expect(offenders).toEqual([]);
+  });
+
+  it('Start-Process 重定向 sing-box 的 stderr 到 $LogFile', () => {
+    // sing-box 启动失败的 FATAL 只走 stderr，不进 config 的 log.output（Windows 真机实测：log.output
+    // 文件里只有一行 "updated default interface"）。不重定向 = #324 的失败原因彻底丢失。
+    expect(script).toMatch(/Start-Process[^\n]*-RedirectStandardError \$LogFile/);
+  });
+
+  it('不重定向 stdout：PowerShell 禁止两者指向同一路径（真机实测抛错）', () => {
+    expect(script).not.toContain('-RedirectStandardOutput');
+  });
+
+  it('看护脚本自述行写 $WatchdogLog，不写 $LogFile（后者被重定向独占，真机实测写入报文件占用）', () => {
+    expect(script).toMatch(/param\([\s\S]*\$WatchdogLog[\s\S]*\)/);
+    expect(script).toMatch(/function Log[\s\S]*Out-File -FilePath \$WatchdogLog/);
+    // 起始行也落看护日志，不能再写 $LogFile
+    expect(script).toMatch(/'FlowZ watchdog starting\.\.\.' \| Out-File -FilePath \$WatchdogLog/);
+    expect(script).not.toMatch(/Out-File -FilePath \$LogFile/);
+  });
+
+  it('脚本 param 个数与提权参数链长度一致（缺参会让看护脚本在隐藏窗口里挂起）', () => {
+    setPlatform('win32');
+    const svc = makeSvc(true);
+    const { args } = svc.buildElevatedLaunchCommand(makePaths());
+    const psScript = args[4] as string;
+
+    // 脚本 param(...) 块里声明的参数个数
+    const paramBlock = script.slice(
+      script.indexOf('param('),
+      script.indexOf(')\n$ErrorActionPreference')
+    );
+    // 只数形如 `[string]$Xxx` 的形参名——裸 `\$[A-Za-z]\w*` 会把 `Mandatory = $true` 里的 $true 也算进去
+    const declared = (paramBlock.match(/\]\$[A-Za-z]\w*/g) ?? []).length;
+
+    // -ArgumentList 里 '-File' 之后的元素：第一个是脚本自身路径，其余是传给 param 的实参
+    // psScript 各行用 '; ' 拼接，-ArgumentList 链止于该行末尾的分号（fixture 路径不含分号）
+    const afterFile = psScript.slice(psScript.indexOf("'-File'") + "'-File'".length);
+    const argList = afterFile.slice(0, afterFile.indexOf(';'));
+    const passed = argList.split(',').filter((x) => x.trim().length > 0).length - 1;
+
+    expect(declared).toBeGreaterThan(0);
+    expect(passed).toBe(declared);
+  });
+
+  it('提权参数链把 watchdogLog 传进去（顺序：startupLogFile → watchdogLog → fwd）', () => {
+    setPlatform('win32');
+    const svc = makeSvc(true);
+    const paths = makePaths();
+    const { args } = svc.buildElevatedLaunchCommand(paths);
+    const psScript = args[4] as string;
+    expect(psScript).toContain(paths.watchdogLog);
+    expect(psScript.indexOf(paths.watchdogLog)).toBeGreaterThan(
+      psScript.indexOf(paths.startupLogFile)
+    );
+    // UAC 发起失败的 ERROR 行也落看护日志（不污染归 stderr 独占的 startupLogFile）
+    expect(psScript).toMatch(
+      /ERROR launching watchdog[\s\S]*Out-File -FilePath '[^']*watchdog\.log'/
+    );
   });
 });

--- a/src/main/utils/paths.ts
+++ b/src/main/utils/paths.ts
@@ -205,6 +205,17 @@ export function getSingBoxStartupLogPath(): string {
   return path.join(getUserDataPath(), 'singbox_startup.log');
 }
 
+/**
+ * Windows UAC 看护脚本自身的日志（`flowz-win-watchdog.log`）。与 singbox_startup.log **必须分文件**：
+ * Start-Process 的 -RedirectStandardError 会独占打开目标文件（Windows 真机实测：重定向期间 PowerShell
+ * `Out-File -Append` 报「文件正由另一进程使用」），两者同文件会让看护脚本自述行全部写失败。
+ * 看护脚本自述行（"sing-box exited by itself" / "Stopflag detected" / "Parent process gone"）是区分
+ * 「核自杀 vs 被外部杀」的判据，与核 stderr 同等重要，故各写各的、诊断报告两段都收。
+ */
+export function getWindowsWatchdogLogPath(): string {
+  return path.join(getUserDataPath(), 'flowz-win-watchdog.log');
+}
+
 export function getCachePath(): string {
   return path.join(getUserDataPath(), 'cache.db');
 }

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -353,6 +353,13 @@ export interface DiagnosticReportInput {
   startupLogTail?: string;
   /** 本段内容的来源与元信息（写侧路径描述 + 文件大小/最后写入时刻）；缺省则段标题只写文件名。 */
   startupLogSource?: string;
+  /**
+   * Windows UAC 看护脚本自身的日志（`flowz-win-watchdog.log`）尾部。与核 stderr 分文件（Start-Process 的
+   * 重定向独占目标文件）。它记的是「谁停的核」——`sing-box exited by itself` / `Stopflag detected` /
+   * `Parent process gone`，是区分「核自杀」与「被外部杀」的判据，和 FATAL 文本互补。
+   * 仅 Windows UAC 路径有内容；其它平台/路径不提供，不出该段。
+   */
+  watchdogLogTail?: string;
   /** 节点标识符 → 占位符（P0.6）：构建末尾在全报告统一替换，打码节点身份（域名/IP/SNI/节点名），保留形态与跨段相关性。 */
   nodeIdentifiers?: readonly NodeIdentifier[];
   /** 当前级别不含连接明细（>info）且日志疑似有连接/DNS 错误 → 提示开启诊断采集复现。 */
@@ -514,6 +521,14 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
     lines.push(`## singbox_startup.log（近期${src}）`);
     lines.push('');
     lines.push(fence('text', input.startupLogTail));
+    lines.push('');
+  }
+
+  // Windows UAC 看护脚本自述日志：回答「谁停的核」，与上面的 FATAL 文本互补（见 watchdogLogTail 注释）。
+  if (input.watchdogLogTail !== undefined) {
+    lines.push('## flowz-win-watchdog.log（近期 · Windows UAC 看护脚本自述）');
+    lines.push('');
+    lines.push(fence('text', input.watchdogLogTail));
     lines.push('');
   }
 


### PR DESCRIPTION
## 背景

#330 把核启动日志接进了诊断报告，但留了一处缺口：**未装 helper 的 Windows 用户走 UAC 看护脚本路径，而该脚本的 `Start-Process` 没有任何输出重定向**。sing-box 启动失败的 FATAL / panic 只走 stderr、不进 config 的 `log.output`，所以那条路径下失败原因彻底丢失——报告里 `singbox_startup.log` 那段只有看护脚本自述行，#324 这类问题永远查不出根因。

本 PR 关掉这个缺口。

## 改动

- 看护脚本 `Start-Process` 加 `-RedirectStandardError $LogFile`；stdout 不重定向
- 看护脚本自述行改写 `$WatchdogLog`（新增 `getWindowsWatchdogLogPath()` → `flowz-win-watchdog.log`），与核 stderr 分文件；UAC 发起失败的 ERROR 行同样落看护日志
- 诊断报告新增「flowz-win-watchdog.log」段（仅 Windows）。自述行记的是**谁停的核**（`sing-box exited by itself` / `Stopflag detected` / `Parent process gone`），与 FATAL 文本互补，是区分「核自杀」与「被外部杀」的判据
- 看护脚本正文抽成导出纯函数 `windowsWatchdogScriptText()`，`PlatformPrivilegeService` 与 `ProxyManager` 的未注入兜底共用。此前两处各存一份脚本文本，改一处漏一处就会让参数链与 `param` 数量对不上（Mandatory 缺参 → 隐藏窗口里挂起）

## Windows 真机实测

这些都是 code review 判不准的 runtime 语义，逐条实跑：

1. `-RedirectStandardError` 确实拿到 `FATAL[0000] start service: start inbound/mixed[mixed-in]: ... bind: The requested address is not valid`，而**同一次运行的 `log.output` 文件里 hasFATAL=False**——与 #324 报告者的日志形态完全一致
2. `-RedirectStandardOutput` 与 `-RedirectStandardError` 指向同一路径 → `Start-Process` 直接抛错，故只能重定向 stderr（FlowZ 恒下发 `log.output`，实测 stdout 为 0 字节，另开文件无收益）
3. 重定向期间对同一文件 `Out-File -Append` 报「文件正由另一进程使用」→ 看护自述行必须分文件
4. 重定向是**截断**语义（预置行不保留）→ 每次起核自动清空，天然构成 run 边界，读报告时不会把上次会话的 FATAL 误当本次
5. 用编译产物生成的真实脚本在真机跑通两个场景：**核起不来**时 FATAL 落 `$LogFile` + 自述行落 `$WatchdogLog`；**核正常起**时 pid 文件写出、stderr 为 0 字节、stopflag 停核链路完好

真机还暴露一个本地测不出的问题：脚本正文里的中文注释经 `fs.writeFileSync` 写成 UTF-8 无 BOM，PowerShell 5.1 按 ANSI 解码 → `ParserError`，看护脚本根本不启动。已全部改回 ASCII，并加断言钉死「脚本正文必须纯 ASCII」。

## 验证

- gate 全绿：tsc、eslint（触及文件 0 warning）、jest 3410 passed
- 新增 6 条门经**变异验证**：去掉 stderr 重定向 / 自述行写回 `$LogFile` / 参数链漏传 watchdogLog / Windows 不收看护日志 —— 逐条注入均被杀
- **未验**：`Start-Process -Verb RunAs` 那层 UAC 弹窗本身（需桌面交互），该层本次未改动

Refs #324
