### PR TITLE
fix(tun): TUN 地址被占用致 Windows 起核无限重试，改为避让 + 报出真因

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -93,6 +93,7 @@ import { mainEventEmitter, MAIN_EVENTS } from './ipc/main-events';
 import { initUserDataPath, getConfigPath } from './utils/paths';
 import { shouldDisableHardwareAcceleration } from './services/graphics-compat';
 import { IPC_CHANNELS, type StatsTopic } from '../shared/ipc-channels';
+import { ProxyErrorCode } from '../shared/types/runtime';
 import { LOGIN_ITEMS_SETTINGS_URL } from '../shared/constants';
 import { effectiveLogLevel } from '../shared/log-level';
 import { resolveAutoLanguage, resolveEffectiveLanguage } from '../shared/language';
@@ -1908,31 +1909,44 @@ if (gotTheLock) {
     // 说明：同节点「原地重启」由 ProxyManager 内部接管（handleProcessExit / 健康检查 → attemptAutoRestart，
     // 单一计数器 + 上限 + 冷却）。'error' 仅在「自动重启被抑制（核心更新校验窗口）或已达上限」时触发，
     // 故此处只需处理：核心回滚 → 放弃恢复并清理系统代理。崩溃不触发换节点（换节点交给心跳连通性检测）。
-    proxyManager.on('error', async (error: { message: string; code?: number }) => {
-      logManager.addLog('error', `Proxy error: ${error.message}`, 'Main');
-      // 严重错误桌面通知（受总开关管控）。正文用通用本地化文案（main i18n，5 语），不透传 error.message——
-      // 后者可能含端点地址；通知进系统通知中心/锁屏可见，避免泄漏节点身份。详情引导用户回应用内日志查看。
-      notifyUser(mt('proxyErrorTitle'), mt('proxyErrorBody'));
-      // 发生错误时，更新托盘显示为"连接异常"
-      updateTrayMenuState(false, true);
+    proxyManager.on(
+      'error',
+      async (error: { message: string; code?: number; errorCode?: string }) => {
+        logManager.addLog('error', `Proxy error: ${error.message}`, 'Main');
+        // 严重错误桌面通知（受总开关管控）。正文用通用本地化文案（main i18n，5 语），不透传 error.message——
+        // 后者可能含端点地址；通知进系统通知中心/锁屏可见，避免泄漏节点身份。详情引导用户回应用内日志查看。
+        notifyUser(mt('proxyErrorTitle'), mt('proxyErrorBody'));
+        // 发生错误时，更新托盘显示为"连接异常"
+        updateTrayMenuState(false, true);
 
-      // 1) 新核心首次启动失败（自动重启被抑制时）→ 自动回滚旧核心并重启
-      try {
-        const rolledBack = await coreUpdateService.autoRollbackIfPendingUpdate();
-        if (rolledBack) {
-          logManager.addLog('warn', '新核心启动失败，已自动回滚，正在以旧核心重启代理...', 'Main');
-          const cfg = await configManager.loadConfig();
-          await proxyManager?.start(cfg);
-          return;
+        // 1) 新核心首次启动失败（自动重启被抑制时）→ 自动回滚旧核心并重启。
+        //    issue #324：TUN 地址冲突（TUN_INIT_PERSISTENT）跳过回滚——它是**环境问题**（本机另一张网卡占了
+        //    同一地址），与核版本无关。若恰好紧跟一次核心更新发生，回滚会把健康的新核换掉、再以旧核重启一轮，
+        //    冲突照旧存在 → 白白回滚 + 多一轮重启，还把环境冲突误归因成「新核坏了」。
+        try {
+          const rolledBack =
+            error.errorCode === ProxyErrorCode.TUN_INIT_PERSISTENT
+              ? false
+              : await coreUpdateService.autoRollbackIfPendingUpdate();
+          if (rolledBack) {
+            logManager.addLog(
+              'warn',
+              '新核心启动失败，已自动回滚，正在以旧核心重启代理...',
+              'Main'
+            );
+            const cfg = await configManager.loadConfig();
+            await proxyManager?.start(cfg);
+            return;
+          }
+        } catch (rollbackErr) {
+          logManager.addLog('error', `自动回滚重启失败: ${rollbackErr}`, 'Main');
         }
-      } catch (rollbackErr) {
-        logManager.addLog('error', `自动回滚重启失败: ${rollbackErr}`, 'Main');
-      }
 
-      // 2) 系统代理清理同样不在此监听器做：'error' 由 giveUpAutoRestart / handleProcessExit 终态分支发出，
-      // 它们在 emit 之前已**同步门控**地调过 ensureSystemProxyCleared（stopping=false 的真终态会清）。此处再调
-      // 因前面有 await（核心回滚）会越过 stopping 门控（H-1），且属重复，故删除。
-    });
+        // 2) 系统代理清理同样不在此监听器做：'error' 由 giveUpAutoRestart / handleProcessExit 终态分支发出，
+        // 它们在 emit 之前已**同步门控**地调过 ensureSystemProxyCleared（stopping=false 的真终态会清）。此处再调
+        // 因前面有 await（核心回滚）会越过 stopping 门控（H-1），且属重复，故删除。
+      }
+    );
 
     // 主进程更新链路（应用/资源/订阅/核心）+ renderer 外部图片（图标库/自定义图标/国旗，经 flowz-icon://
     // 协议）已全迁 UpdateNetwork 专用会话经 update-in 入站；default session 不再 pin FlowZ http 入站，回归

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -48,7 +48,7 @@ import {
 } from './singbox-config-helpers';
 import { buildDnsConfig } from './singbox-dns-builder';
 import { buildRouteConfig } from './singbox-route-builder';
-import { buildInbounds } from './singbox-inbounds-builder';
+import { buildInbounds, getOwnLanCidrs } from './singbox-inbounds-builder';
 import { buildLogConfig } from './singbox-log-builder';
 import { IPC_CHANNELS } from '../../shared/ipc-channels';
 import { LOGIN_ITEMS_SETTINGS_URL } from '../../shared/constants';
@@ -126,6 +126,7 @@ import {
   isPersistentTunFailure,
   type AdapterPresence,
   type TunAdapterObservation,
+  probeWinIpv4AddressUsage,
 } from './win-tun-adapter';
 import {
   probeTcpReachable,
@@ -135,6 +136,20 @@ import {
   CoreStartSupersededError,
   CoreStartTunPersistentError,
 } from './core-readiness';
+import {
+  classifySingBoxFatal,
+  extractLastFatal,
+  sliceSinceRunStart,
+  type SingBoxFatalInfo,
+} from '../../shared/singbox-fatal';
+import {
+  pickTunInet4Address,
+  ipv4InInterfaceMap,
+  excludeOwnTunCidrs,
+  TUN_INET4_CANDIDATES,
+  type AddressUsage,
+  type TunAddressPick,
+} from '../../shared/tun-address';
 import coreManifest from '../../shared/core-manifest.json';
 
 /**
@@ -558,6 +573,17 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   //   adapterEverSeen=任一腿曾见适配器（→ 瞬态释放竞态族）；probeEverConclusive=探测链路曾给出 clean present/absent
   //   （排除杀软拦 PS 的全 unknown 误判）。预算耗尽 && !adapterEverSeen && probeEverConclusive → 持续性 TUN 失败终态。
   private tunReadyObservation: TunAdapterObservation | null = null;
+  // issue #324 P0-1：本次 start 内从核 stderr（singbox_startup.log）捞到的最后一条 FATAL 的分类结果。核自己写的
+  //   失败原因，比任何按适配器存在性做的反推都准，且**跨平台**。每次 startInternal 复位；dead 分支填；
+  //   终态转化（maybeToTunPersistentError）与日志共用。
+  private lastStartupFatal: SingBoxFatalInfo | null = null;
+  // issue #324 P0-1：本腿起核前 singbox_startup.log 的字节大小，作 run 边界锚点。sing-box 的 `FATAL[0000]` 只有
+  //   启动相对秒、无墙钟时间戳，而 helper 写侧是 O_APPEND 永不截断——不锚点就会把几个月前的残留 FATAL 当成本次
+  //   原因（比不报更糟）。每条启动腿在 startSingBoxProcess 顶部刷新。
+  private startupLogOffset = 0;
+  // issue #324 P0-2：本次起核经冲突预检选定的 TUN IPv4 裸地址（掩码由 buildInbounds 按平台拼）。null=未预检
+  //   （非 TUN / 用户已显式配置 / 预检未跑）→ 沿用平台默认，行为零变化。每次 startInternal 重算。
+  private effectiveTunInet4Address: string | null = null;
   // issue #176 诊断计数：本次启动经几次「就绪重试」才成功（runStartWithRetry 累计）。>0 = 起核慢（多因 Windows
   // 重启争用下 wintun 适配器未及时释放），与「核崩溃自动重启」（restartCount/AUTO_RESTARTING）是不同轴，纳入诊断
   // 区分「核崩」vs「争用慢起」。每次 startInternal 复位。
@@ -762,6 +788,13 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // 修复可能被 root 创建的文件权限（从 TUN 模式切换到系统代理模式时）
     await this.fixFilePermissions();
 
+    // 3.2 issue #324：TUN 地址冲突预检**在此发起**，与下面的节点域名预解析 / race server 启动并行跑，
+    //   到生成配置前才 await。探测是 PowerShell spawn（4s 超时封顶，候选连撞时串行多次），串在起核关键
+    //   路径上会给 Windows 冷启加 0.5–2s；这些前置步骤本就是异步等待，白等不如并行。
+    //   语义见 applyTunAddressPreflight 的 await 点（3.9.5）。
+    this.lastStartupFatal = null;
+    const tunAddressPick = this.startTunAddressPreflight(config, isTunMode);
+
     // 检查是否选择了服务器
     if (!config.selectedServerId) {
       throw new Error('No server selected');
@@ -852,6 +885,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     //     的本地 server 起停 + effective config 降级见下（startNodeDnsRaceServer）。
     await this.startNodeDnsRaceServer(config);
 
+    // 3.9.5 issue #324：收 3.2 发起的地址冲突预检结果（此刻必须落定：地址要随本次配置下发给核）。
+    await this.applyTunAddressPreflight(tunAddressPick);
+
     // 4. 生成 sing-box 配置文件
     const singboxConfig = this.generateSingBoxConfig(config, resolvedServerIps);
 
@@ -899,32 +935,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         maxRetries: startRetryBudget.maxRetries,
         delay: startRetryBudget.delay,
         exponentialBackoff: startRetryBudget.exponentialBackoff,
-        shouldRetry: (error) => {
-          // issue #176：被更新的 start/stop 接管（CoreStartSupersededError）→ 绝不重试（接管方拥有生命周期）。
-          if (error instanceof CoreStartSupersededError) {
-            return false;
-          }
-          // issue #324：CoreStartTunPersistentError 的「不重试」是**结构性**的——它仅由 maybeToTunPersistentError 在
-          //   runStartWithRetry() reject 之后（startInternal catch 收口）生成，直达 start() catch，**永不经 retry()**，
-          //   故 shouldRetry 见不到它，无需在此加 instanceof 守卫（避免留测不到的防御死路径，YAGNI）。
-          // 启动 gate 备用腿（补 check 盲区）：run 阶段 `dependency[X] not found` FATAL（detour/selector 幽灵
-          // tag）→ 允许重试一次（onRetry 会解析 tag、pruneTagsClosure 修正重写盘），refFixAttempted 闸保证只修一次。
-          if (/dependency\[(.+?)\] not found/i.test(error.message)) {
-            return !this.refFixAttempted;
-          }
-          // libcronet 缺库 FATAL：内层裸重试无意义（库还是坏的）→ 不重试，交由外层 cronet 自愈闭环 strong 重拷后整体重启一次。
-          if (this.isCronetLibError(error.message)) {
-            return false;
-          }
-          // 不重试的错误类型（权限/找不到/坏配置）：判据下沉 core-readiness.startMessageIsNonRetryable（单测守卫，
-          //   保证 issue #324 A1/A3 新增文案不被词表误命中而变不可重试，review Low#5）。
-          if (startMessageIsNonRetryable(error.message)) {
-            return false;
-          }
-
-          // 其他错误可以重试
-          return true;
-        },
+        shouldRetry: (error) => this.shouldRetryStartError(error),
         onRetry: (error, attempt) => {
           readyRetries = attempt; // issue #176 诊断：累计就绪重试次数
           // issue #176：软化文案——多数是「起核较慢/争用」而非真失败，避免「启动失败」吓到用户（#176 即因此报 bug）。
@@ -1017,13 +1028,15 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
             await runStartWithRetry();
           } catch (e) {
             // 重拷成功但重启仍失败（库与核版本不匹配等）→ 计失败数（否则诊断「触发但最终失败」漏计），抛出由 start() 收口。
+            // 经 maybeToTunPersistentError：二败若是 TUN 地址冲突/持续性 TUN 失败，同样该转终态诊断而非继续
+            // 「正在自动重试」（对非 CoreStartRetryError 是 no-op，零风险）。
             this.cronetHealFailedCount++;
-            throw e;
+            throw this.maybeToTunPersistentError(e);
           }
         } else {
           // 未恢复（拷贝失败/无内置库）→ 计失败数 + 抛原错误（含 cronet 文案，UI 引导改协议/查权限）。
           this.cronetHealFailedCount++;
-          throw err;
+          throw this.maybeToTunPersistentError(err);
         }
       } else {
         // issue #324：起核重试预算耗尽的收口——win32+TUN 且全程未见适配器（探测可用）→ 转持续性 TUN 失败终态诊断，
@@ -3564,6 +3577,8 @@ done
         // §15 主核测速探测池：注入 K 个 probe-in-k http 入站。空=不注入。
         probePoolPorts: this.probePoolPorts,
         log: (level, message) => this.logToManager(level, message),
+        // issue #324：起核前冲突预检选出的 TUN 地址（null=未预检，如诊断/快照路径）→ builder 回落平台默认。
+        tunInet4Address: this.effectiveTunInet4Address ?? undefined,
       }),
       outbounds: outboundsResult.outbounds,
       route: buildRouteConfig(config, idToTagMap, {
@@ -4527,9 +4542,29 @@ rm -f "$STOPFLAG"
     // ——startSingBoxProcess 的 helper catch 会透传它给 runStartWithRetry 静默重起（而非误判 helper 启动失败弹 UAC/osascript）。
     await this.helperManager?.stopCore().catch(() => {});
     if (outcome === 'dead') {
+      // issue #324 P0-1：核死了 → 它自己写的 FATAL 就在 stderr 里，先捞出来。这是唯一的一手证据，比下面
+      //   任何按适配器存在性做的反推都准。sticky 存起来供预算耗尽后的终态转化（maybeToTunPersistentError）用。
+      //   **绝不拼进 CoreStartRetryError.message**：NON_RETRYABLE_START_ERROR_PATTERNS 含 permission/eacces/
+      //   enoent 等词，FATAL 原文极易命中，会把本可重试的起核失败静默判成终态。真因只走日志 + 终态错误。
+      //   世代守卫：`waitForCoreReady` 返回 dead 后还要 drain 在途适配器观测（execFile 4s 封顶），这个窗口里
+      //   新 start 可能已接管——它已清空 lastStartupFatal 并改写了 startupLogOffset。此时本腿再读会用**接管方
+      //   的锚点**切片（错锚），再把结果写回去污染接管方的判据。故被接管就整段跳过（不改控制流：仍按原逻辑
+      //   抛可重试错误，由上层 supersede 处理收口）。
+      const superseded = this.lifecycleGeneration !== startGen;
+      const fatal = superseded ? null : this.readLastStartupFatal();
+      // **无条件覆盖**（含 null）：本腿的观测就是最新事实。若只在捞到时赋值，上一腿的 FATAL 会残留下来——
+      // 第 1 腿撞地址冲突、第 2 腿因别的原因死且没写 FATAL 时，终态转化会拿着陈旧的地址冲突结论下判断。
+      if (!superseded) this.lastStartupFatal = fatal;
+      if (fatal) {
+        this.logToManager('error', `sing-box 启动失败：${fatal.message}`);
+        this.logToManager('debug', `sing-box FATAL 原文：${fatal.raw}`);
+      }
       // issue #324 A3：dead 分支文案细分——win32+TUN 且探测可用（probeEverConclusive）却全程未见适配器 → 疑 wintun 被拦/
       //   驱动异常（非瞬态释放竞态）。否则（曾见适配器=瞬态，或探测全 unknown 无从判定）保持原「TUN 初始化未完成」文案。
-      if (obs && isPersistentTunFailure(obs)) {
+      //   P2 收敛：**拿到 FATAL 真因且真因不是「适配器创建失败」时，不再输出这条推断**——#324 实证它会把
+      //   地址冲突误导成杀软/驱动方向，白白浪费用户几轮排查。有一手证据时推断必须让位。
+      const inferenceContradicted = !!fatal && fatal.kind !== 'tun-adapter-create';
+      if (obs && isPersistentTunFailure(obs) && !inferenceContradicted) {
         throw new CoreStartRetryError(
           'sing-box 启动期退出（TUN 适配器从未创建，疑 wintun 被拦/驱动异常），正在自动重试'
         );
@@ -4541,6 +4576,236 @@ rm -f "$STOPFLAG"
   }
 
   /**
+   * 起核失败是否该重试（runStartWithRetry 的 shouldRetry 判据，单一真值）。
+   *
+   * 抽成方法而非内联闭包，是为了可直接单测——它决定「确定性终态会不会被塞回重试循环」，而那个错误只有在
+   * 跑完整条起核链路时才碰得到，内联版本实际上无门可拦（issue #324 R2 复审指出的活逃逸）。
+   */
+  private shouldRetryStartError(error: Error): boolean {
+    // issue #176：被更新的 start/stop 接管（CoreStartSupersededError）→ 绝不重试（接管方拥有生命周期）。
+    if (error instanceof CoreStartSupersededError) {
+      return false;
+    }
+    // issue #324：CoreStartTunPersistentError = 确定性终态，**绝不重试**。
+    //   这条守卫是必需的，不是防御性死代码：H2 之后它有了**两个产地**——除了 maybeToTunPersistentError
+    //   （在 retry 之后、startInternal catch 收口生成，确实见不到），buildWrapperStartFailure 会在 **retry
+    //   循环内部**（startSingBoxProcess 的 setTimeout 回调）reject 它。没有这条守卫它会落到末尾的
+    //   `return true`：每腿重弹 UAC + 空等 waitForPidFile 60s + 重复发诊断卡——恰是本 issue 要消灭的 UX。
+    if (error instanceof CoreStartTunPersistentError) {
+      return false;
+    }
+    // 启动 gate 备用腿（补 check 盲区）：run 阶段 `dependency[X] not found` FATAL（detour/selector 幽灵
+    // tag）→ 允许重试一次（onRetry 会解析 tag、pruneTagsClosure 修正重写盘），refFixAttempted 闸保证只修一次。
+    if (/dependency\[(.+?)\] not found/i.test(error.message)) {
+      return !this.refFixAttempted;
+    }
+    // libcronet 缺库 FATAL：内层裸重试无意义（库还是坏的）→ 不重试，交由外层 cronet 自愈闭环 strong 重拷后整体重启一次。
+    if (this.isCronetLibError(error.message)) {
+      return false;
+    }
+    // 不重试的错误类型（权限/找不到/坏配置）：判据下沉 core-readiness.startMessageIsNonRetryable（单测守卫，
+    //   保证 issue #324 A1/A3 新增文案不被词表误命中而变不可重试，review Low#5）。
+    if (startMessageIsNonRetryable(error.message)) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * issue #324 H2：wrapper（Windows UAC 看护 / macOS osascript）路径拿不到 PID 时的失败构造。
+   *
+   * 这是该路径的启动期失败汇合点：核 FATAL 自杀后 PID 文件写不出来，此前只报一句「无法获取进程 PID」——
+   * 真因就在 startup log 里却没人读。#324 报告者走的正是这条路径（其日志首行的 watchdog banner 由 UAC 看护
+   * 脚本写出），helper 路径的 dead 分支对他完全不生效。
+   *
+   * 抽成方法而非内联在 setTimeout 回调里，是为了可单测——内联在那里只能靠跑完整个 startSingBoxProcess 才碰得到。
+   */
+  private buildWrapperStartFailure(startGen: number): Error {
+    // 世代守卫：前置的 waitForPidFile 可空转 **60s**，是比 dead 分支 drain（≤4s）宽一个量级的接管窗口。
+    // 期间新 start B 接管后会改写 startupLogOffset、复位 startedViaWrapper、清空 lastStartupFatal——本腿此刻
+    // 再读会错锚、写会污染 B，甚至对着 B 的会话发一张终态诊断卡。被接管就退回原始语义，不读不写不发事件。
+    if (this.lifecycleGeneration !== startGen) {
+      return new Error('启动 sing-box 进程失败：无法获取进程 PID');
+    }
+    const fatal = this.readLastStartupFatal();
+    this.lastStartupFatal = fatal;
+    if (fatal) {
+      this.logToManager('error', `sing-box 启动失败：${fatal.message}`);
+      this.logToManager('debug', `sing-box FATAL 原文：${fatal.raw}`);
+    }
+    const error = '启动 sing-box 进程失败：无法获取进程 PID';
+    this.logToManager('error', error);
+    // 地址冲突是确定性失败（重试一万次也不会好）→ 直接给终态，跳过外层 retry 预算。其余情况保持原有普通
+    // Error 语义不变（交 runStartWithRetry 按既有规则判重试）。
+    return fatal?.kind === 'tun-address-conflict' && this.isTunModeNow()
+      ? this.buildTunAddressConflictError(fatal)
+      : new Error(error);
+  }
+
+  /**
+   * issue #324：把「TUN 地址冲突」的 FATAL 结论构造成终态错误 + 上报渲染端诊断卡。
+   *
+   * 三条起核路径共用（helper 的预算耗尽收口 / wrapper 的 PID 等待失败 / 运行期崩溃回调），避免文案与事件
+   * 三处漂移。地址冲突是**确定性**失败：占用方不挪走，重试一万次也不会好，继续「正在自动重试」纯属误导。
+   */
+  private buildTunAddressConflictError(fatal: SingBoxFatalInfo): CoreStartTunPersistentError {
+    // 文案只承诺当前真能做到的动作：TUN 地址尚未开放配置（P1-1 未落地），故引导「移除/禁用占用方网卡」，
+    // 不写「到设置里改地址」——UI 上没有那个入口，那是把用户支到死路。
+    const terminal = new CoreStartTunPersistentError(
+      `${fatal.message}请断开或禁用占用该地址的网卡（其它 VPN/TUN 客户端的残留适配器），然后重试。`
+    );
+    this.logToManager('error', `TUN 地址冲突，停止重试：${fatal.raw}`);
+    this.sendEventToRenderer(IPC_CHANNELS.EVENT_PROXY_ERROR, {
+      message: terminal.message,
+      errorCode: ProxyErrorCode.TUN_INIT_PERSISTENT,
+      code: -3,
+    });
+    return terminal;
+  }
+
+  /**
+   * issue #324 P0-2：发起 TUN 地址冲突预检（不阻塞，结果由 applyTunAddressPreflight 收）。
+   *
+   * 硬编码的 `172.19.0.1` 撞上本机已有的同址接口时，sing-box 在 `configure tun interface: set ipv4 address`
+   * 直接 FATAL 自杀（Windows: `CreateUnicastIpAddressEntry` → ERROR_OBJECT_ALREADY_EXISTS），外层只会无限
+   * 重试、用户无从得知。起核前探一次，**确证冲突**才换到备选；探不了或无冲突一律沿用默认（fail-open——
+   * 换地址本身有代价：用户钉着旧地址的路由/防火墙规则会失效，不能因一次探测失败就乱换）。
+   *
+   * 不预检的两种情况都返回 null（沿用平台默认，行为零变化）：
+   *  - 非 TUN 模式；
+   *  - 用户显式配置了 `tunConfig.inet4Address` —— 用户显式约束优先于「更优解」，照办不避让。
+   */
+  private async startTunAddressPreflight(
+    config: UserConfig,
+    isTunMode: boolean
+  ): Promise<TunAddressPick | null> {
+    // 上次避让结果的捕获与复位都归本方法（而不是留在 startInternal）：这两步与下面的「旧核在跑就沿用上次」
+    // 是同一个决策的组成部分，拆到调用方会让接线本身无法被单测覆盖——测试直调本方法就绕过了捕获逻辑，
+    // 变异「prev 恒 null」将无门可拦（issue #324 R3 实测过这条逃逸）。
+    const prevAddress = this.effectiveTunInet4Address;
+    this.effectiveTunInet4Address = null;
+    if (!isTunMode || config.tunConfig?.inet4Address) return null;
+    // 旧核仍在跑（#176 supersede 交错：用户连点连接）→ **跳过探测**。此刻本机接口上挂着的 `172.19.0.1` 是
+    // **我们自己**的 TUN，探成 in-use 会让新腿静默切到备选、下次正常重启又切回——地址乒乓。Windows 侧已由
+    // InterfaceAlias 过滤挡住（自家网卡名固定），但 macOS 的 utun 名由内核分配、无法按名排除，只能从状态侧堵。
+    //
+    // 关键：跳过探测 ≠ 回落默认。**沿用上次选定的地址**——在默认地址真冲突的机器上回落默认，等于把已经工作
+    // 着的避让扔掉再撞一次同样的 FATAL（而上一秒它还好好的）。reason 用 'default' 使调用方零日志（这不是一次
+    // 新的避让决策，只是延续既有选择）。
+    if (this.activeCorePid()) {
+      return prevAddress ? { address: prevAddress, reason: 'default', skipped: [] } : null;
+    }
+    const ownTunAlias =
+      process.platform === 'win32' ? resolveWinTunInterfaceName(config) : undefined;
+    return pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: (ip) => this.probeIpv4AddressUsage(ip, ownTunAlias),
+      ownLanCidrs: () => excludeOwnTunCidrs(getOwnLanCidrs(), TUN_INET4_CANDIDATES),
+    }).catch(() => null); // 预检是诊断增强，任何异常都不得阻断起核
+  }
+
+  /** issue #324 P0-2：收预检结果并落地为本次起核的 TUN 地址（必须在 generateSingBoxConfig 之前完成）。 */
+  private async applyTunAddressPreflight(pending: Promise<TunAddressPick | null>): Promise<void> {
+    const pick = await pending;
+    if (!pick) return;
+    this.effectiveTunInet4Address = pick.address;
+    const describe = (c: TunAddressPick['skipped'][number]['cause']): string =>
+      c === 'in-use' ? '已被本机接口占用' : c === 'own-lan' ? '与本机网段重叠' : '探测不可用';
+    if (pick.reason === 'fallback') {
+      this.logToManager(
+        'warn',
+        `TUN 地址冲突已避让：${pick.skipped
+          .map((s) => `${s.address}（${describe(s.cause)}）`)
+          .join(
+            '、'
+          )} → 本次改用 ${pick.address}。占用方常是其它 VPN/TUN 客户端的残留网卡（可能已断开或隐藏，设备管理器默认不显示）`
+      );
+    } else if (pick.reason === 'exhausted') {
+      // 逐条列出淘汰原因：只报「全部不可用」而回落到其中一个，读起来自相矛盾，也丢掉了「备选是探测不可用
+      // 而非确证冲突」这个关键区别。
+      this.logToManager(
+        'warn',
+        `TUN 地址候选池无一可用（${pick.skipped
+          .map((s) => `${s.address}=${describe(s.cause)}`)
+          .join('、')}），回落默认 ${pick.address}——若起核失败请检查本机是否有占用该网段的残留网卡`
+      );
+    }
+  }
+
+  /**
+   * issue #324 P0-2：探某个裸 IPv4 是否已被本机任一接口占用（起核前 TUN 地址冲突预检）。
+   *
+   * Windows 走 PowerShell `Get-NetIPAddress`（见 win-tun-adapter.probeWinIpv4AddressUsage 的说明：Node 的
+   * 接口枚举看不到 Disconnected 适配器，而 #324 的冲突源正是那种）。其它平台用 os.networkInterfaces()——
+   * 零 spawn，覆盖 Up 接口的撞车（macOS 默认 172.19.0.1/30 同样会撞）；对非 Up 接口的漏检是已知代价，
+   * 该平台的完整探测留待真实案例出现再补，不预先引入未验证的 ifconfig/ip 解析。
+   */
+  private async probeIpv4AddressUsage(
+    ip: string,
+    excludeInterfaceAlias?: string
+  ): Promise<AddressUsage> {
+    if (process.platform === 'win32') return probeWinIpv4AddressUsage(ip, excludeInterfaceAlias);
+    try {
+      return ipv4InInterfaceMap(ip, require('os').networkInterfaces()) ? 'in-use' : 'free';
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  /**
+   * issue #324 P0-1：从核 stderr（singbox_startup.log）捞本腿写入的最后一条 FATAL 并分类。
+   *
+   * 为什么必须读这个文件：sing-box 启动失败的 FATAL 只写 stderr，永不进 config 里 `log.output` 指定的
+   * singbox.log（见 shared/singbox-fatal.ts 文件头）。#324 之前只有诊断报告导出时才读它，起核失败路径靠
+   * 适配器存在性反推，真因躺在文件里三天没人看见。
+   *
+   * run 边界：按 startSingBoxProcess 顶部记的 startupLogOffset 切（helper 写侧 O_APPEND 永不截断，
+   * FATAL[0000] 又没有墙钟时间戳——不切就会读到上一次甚至几个月前的 FATAL）。读失败一律返回 null（诊断
+   * 增强绝不能反过来影响起核流程）。
+   */
+  private readLastStartupFatal(): SingBoxFatalInfo | null {
+    try {
+      const fsSync = require('fs');
+      const logPath = getSingBoxStartupLogPath();
+      const st = fsSync.statSync(logPath);
+      // 只读尾部：helper 写侧 O_APPEND 永不截断，真机上这个文件可以有几 MB，整读是白费。64KB 与诊断报告
+      // 的 tail 预算同量级，足够容纳一次起核的全部输出。同步 I/O：只在起核失败路径上跑一次、文件小，
+      // 且异步版会与单测的 fake timer 纠缠（fs/promises 的回调派发被 fake 掉 → 永不 settle）。
+      const cap = Math.min(st.size, 64 * 1024);
+      if (cap <= 0) return null;
+      const fd = fsSync.openSync(logPath, 'r');
+      let text: string;
+      try {
+        const buf = Buffer.alloc(cap);
+        // 必须用 readSync 的返回值：stat 与 read 之间文件被外部截短时读不满 cap，buf 余下是 \0，
+        // 整块 toString 会把 NUL 带进行尾（trim 不剥 NUL）并落进 raw 日志。
+        const n = fsSync.readSync(fd, buf, 0, cap, st.size - cap);
+        text = buf.subarray(0, n).toString('utf-8');
+      } finally {
+        fsSync.closeSync(fd);
+      }
+      // 写侧决定 run 边界怎么切（两侧语义相反，见 sliceSinceRunStart 的适用边界）：
+      //  · wrapper 路径（Windows UAC 看护的 -RedirectStandardError / macOS wrapper 的 `> "$LOG"`）**每次起核
+      //    截断** → 文件里的内容就是本次会话的，整读；套 offset 差分反而会在「重复失败腿写出逐字节相同内容」
+      //    时把 sizeNow===offset 误判成零写入，FATAL 系统性丢失。
+      //  · helper 路径 `O_APPEND` 永不截断 → 必须按锚点切，否则读到上次甚至几个月前的残留。
+      const text2 = this.startedViaWrapper
+        ? text
+        : sliceSinceRunStart(text, this.startupLogOffset, st.size);
+      const line = extractLastFatal(text2);
+      if (!line) return null;
+      // 下发给核的实际地址：优先用户显式配置，其次本次预检选定值，最后平台默认——三者与 buildInbounds 同源，
+      // 用于把「地址已被占用」这类文案点名到具体地址。
+      const tunAddress =
+        this.currentConfig?.tunConfig?.inet4Address ||
+        this.effectiveTunInet4Address ||
+        TUN_INET4_CANDIDATES[0];
+      return classifySingBoxFatal(line, { tunAddress });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * issue #324 A2：起核重试预算耗尽后的持续性 TUN 失败终态转化。仅 win32+TUN（tunReadyObservation 非 null）且原错误
    *   为可重试的 CoreStartRetryError 时判定；跨所有重试腿 sticky 观测：
    *   - 曾见适配器（adapterEverSeen）→ 瞬态释放竞态族（#159/#176），保持原错误（照旧终态但不改语义）。
@@ -4549,9 +4814,20 @@ rm -f "$STOPFLAG"
    * 不碰 retry 循环语义（blast radius 最小）；瞬态场景重试预算原封不动。
    */
   private maybeToTunPersistentError(err: unknown): unknown {
+    if (!(err instanceof CoreStartRetryError)) return err; // 仅转化可重试的起核错误
+
+    // issue #324 P0-1：核自己写的 FATAL 是最强判据，先于适配器观测判定，且**跨平台**——地址冲突在 macOS
+    //   同样会发生（那里默认同址 /30）。地址冲突属确定性失败：重试一万次也不会好，且本案里适配器**创建成功**
+    //   （adapterEverSeen=true）→ isPersistentTunFailure 恒 false → 光靠观测判据会永远重试下去，正是 #324
+    //   报告者看到的现象。故这里独立成一路。
+    //   只把 tun-address-conflict 列为确定性：wintun 创建失败可能是驱动加载竞态（瞬态），保守留给预算耗尽判。
+    const fatal = this.lastStartupFatal;
+    if (fatal?.kind === 'tun-address-conflict' && this.isTunModeNow()) {
+      return this.buildTunAddressConflictError(fatal);
+    }
+
     const obs = this.tunReadyObservation;
     if (!obs) return err; // 非 win32+TUN → 原样（obs 仅 win32+TUN 时非 null）
-    if (!(err instanceof CoreStartRetryError)) return err; // 仅转化可重试的起核错误
     // 曾出现 → 瞬态；探测全程 unknown（杀软拦 PS）→ fail-open 瞬态；两者非持续性 → 原样保持可重试终态。
     if (!isPersistentTunFailure(obs)) return err;
     // 探测可用且预算内从未见适配器 → 持续性 TUN init 失败终态。
@@ -4577,6 +4853,17 @@ rm -f "$STOPFLAG"
     // 同上：包装进程标志也每腿复位，由下方实际启动路径置位（helper 路径保持 false——helper 起核时 singboxPid
     // 即核本身，非包装进程）。
     this.startedViaWrapper = false;
+
+    // issue #324 P0-1：记本腿起核前 startup log 的字节大小作 run 边界锚点。三个写侧的截断语义相反（helper
+    //   O_APPEND 永不截断 / UAC 的 -RedirectStandardError 与 macOS wrapper 每次截断），而 sing-box 的
+    //   `FATAL[0000]` 只有启动相对秒、没有墙钟时间戳——不锚点就无法判断读到的 FATAL 属于哪次会话。置于本方法
+    //   顶部（而非 startInternal）→ helper / UAC / osascript 三条支路与每个重试腿都对齐各自的边界。
+    //   stat 失败（文件还不存在）→ 0，即「整文件都是本次的」，与首启语义一致。
+    try {
+      this.startupLogOffset = require('fs').statSync(getSingBoxStartupLogPath()).size;
+    } catch {
+      this.startupLogOffset = 0; // 文件还不存在（首启）→ 整文件都是本次的
+    }
 
     // issue #159：起核前（win32&&TUN）等上一轮自家 wintun 适配器释放。置于本方法顶部（而非 startInternal）→ 每次
     //   runStartWithRetry 重启腿、以及下方 helper / UAC 两条启动支路都经此门控（不止首次），杜绝重试立刻再撞僵尸适配器。
@@ -4995,11 +5282,10 @@ rm -f "$STOPFLAG"
               startupResolved = true;
               resolve();
             } else {
-              const error = '启动 sing-box 进程失败：无法获取进程 PID';
-              this.logToManager('error', error);
+              const failure = this.buildWrapperStartFailure(startGen);
               // 启动失败，清理状态，避免健康检查使用错误的 PID
               this.cleanup();
-              reject(new Error(error));
+              reject(failure);
             }
           } else {
             // 系统代理模式或 Linux
@@ -5850,14 +6136,34 @@ rm -f "$STOPFLAG"
       return;
     }
 
+    // 世代快照：下面的异步探活（Windows tasklist ~50-100ms）与分支体之间存在 TOCTOU 窗口。`isRestarting` 只挡
+    //   attemptAutoRestart 的重启腿，**不挡用户手动重连**——旧核死、用户点重连、新 startInternal 在途时，这个
+    //   tick 的分支体会对着新 start 执行：清它刚设的 pid、写它的 lastStartupFatal，而地址冲突短路更会直接
+    //   emit 'error'+'stopped'+cleanup()，把一次本可能成功的启动打掉并给渲染端发终态卡。
+    const healthGen = this.lifecycleGeneration;
     // 改异步探活（原 execSync 每 10s 阻塞主进程 50-100ms on Windows）。
     if (!(await this.isProcessAliveAsync(activePid))) {
+      // 新 start 已接管 → pid/状态归它管，本 tick 静默让位（同时保护既有自动重启分支与新增的终态短路）。
+      if (this.lifecycleGeneration !== healthGen) return;
       // 尝试获取更多退出信息
       const exitInfo = this.getProcessExitInfo();
       this.logToManager(
         'error',
         `检测到 sing-box 进程 (PID: ${activePid}) 已意外退出${exitInfo ? `，${exitInfo}` : ''}`
       );
+
+      // issue #324 H2：**这里才是 wrapper（Windows UAC 看护 / macOS osascript）路径核死于 'started' 之后的
+      //   唯一检测通道**——那种核是 detached、由看护脚本托管，不是子进程，死亡不产生 'exit' 事件；launcher
+      //   自身退出码 0 时 exit 回调显式早退不调 handleProcessExit。#324 最高概率的时序正是：看护脚本写 PID →
+      //   waitForPidFile 抓到活核（核存活 0.2–0.8s）→ emit('started') → 核自杀 → 由本方法 10s 节拍发现。
+      //   读取放在状态复位之前：当前复位的是 startedViaHelper、不含 readLastStartupFatal 依赖的
+      //   startedViaWrapper，故这个前置眼下是空约束——留着是防将来有人在此追加复位（写侧判定会跟着坏）。
+      const exitFatal = this.readLastStartupFatal();
+      if (exitFatal) {
+        this.lastStartupFatal = exitFatal;
+        this.logToManager('error', `sing-box 退出原因：${exitFatal.message}`);
+        this.logToManager('debug', `sing-box FATAL 原文：${exitFatal.raw}`);
+      }
 
       // 清理资源（但不停止健康检查，因为可能要重启）
       this.singboxProcess = null;
@@ -5866,6 +6172,25 @@ rm -f "$STOPFLAG"
       // 进程已死 → 复位 helper 标志，避免随后自动重启若回退非 helper 路径时，停止仍误走 helper 分支。
       this.startedViaHelper = false;
       this.stopLogFileWatcher();
+
+      // 地址冲突是确定性失败：占用方不挪走，重启多少次都是同一条 FATAL。放进自动重启循环只会烧完预算、
+      //   期间反复抢建/拆除适配器（wrapper 路径还会每腿弹 UAC），且全程显示「正在自动重试」误导用户——
+      //   #324 报告者看到的就是这个。故**先于 shouldAutoRestart 短路**，终态闭环镜像下方 else 分支。
+      if (exitFatal?.kind === 'tun-address-conflict' && this.isTunModeNow()) {
+        const terminal = this.buildTunAddressConflictError(exitFatal); // 内部已 log + 发诊断卡
+        // payload 携 errorCode：index.ts 的 'error' 监听头号动作是「新核待验证时自动回滚」，而地址冲突是
+        // 环境问题、与核版本无关，回滚健康的新核纯属误伤（见设计 doc）。
+        this.emit('error', {
+          message: terminal.message,
+          errorCode: ProxyErrorCode.TUN_INIT_PERSISTENT,
+          code: -3,
+        });
+        this.emit('stopped');
+        this.sendEventToRenderer(IPC_CHANNELS.EVENT_PROXY_STOPPED, {});
+        void this.ensureSystemProxyCleared();
+        this.cleanup();
+        return;
+      }
 
       // 尝试自动重启
       if (this.shouldAutoRestart()) {

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -245,3 +245,690 @@ describe('issue #324 — maybeToTunPersistentError 终态分类矩阵（A2）', 
     expect(svc.maybeToTunPersistentError(err)).toBe(err);
   });
 });
+
+// ============================================================================
+// issue #324 P0-1：核 stderr 的 FATAL 真因解析 → 上屏 + 终态转化（dead 分支编排）。
+// ============================================================================
+
+const { getSingBoxStartupLogPath } = require('../../utils/paths');
+const { startMessageIsNonRetryable } = require('../core-readiness');
+
+const ADDR_CONFLICT_FATAL =
+  '\x1b[31mFATAL\x1b[0m[0000] start service: start inbound/tun[tun-in]: configure tun interface: set ipv4 address: The object already exists.';
+
+/** 让 waitForCoreReadyOrThrow 走 dead 分支（进程死 + API 从未绑定）。 */
+function armDead(svc: any): void {
+  svc.isProcessAlive = () => false;
+  svc.coreReadyProbe = async () => false;
+  // 必须桩掉：默认实现走真实 PowerShell，而本文件把 child_process.execFile mock 成了永不回调的 jest.fn()
+  // → 并行的适配器观测 Promise 永挂 → 整个 waitForCoreReadyOrThrow 超时（不是失败，是挂死）。
+  // 用 'unknown' 保持 tracker 中立（monotonic 记录不受影响），让各用例自己决定 obs 的初值。
+  svc.adapterPresenceProbe = async () => 'unknown' as AdapterPresence;
+}
+
+/** 写 startup log，并把起核锚点设在写入之前（=本腿新写的全部可见）。 */
+function writeStartupLog(svc: any, content: string, offset = 0): void {
+  fsSync.writeFileSync(getSingBoxStartupLogPath(), content, 'utf-8');
+  svc.startupLogOffset = offset;
+}
+
+describe('issue #324 P0-1 — dead 分支从 stderr 捞 FATAL 真因', () => {
+  // dead 分支要读真实的 startup log 文件，而 fs/promises 的回调派发走 setImmediate——一并 fake 掉会让
+  // readLastStartupFatal 永不 settle（测试超时而非失败，最难排查的那种）。故只 fake 定时器、放过 setImmediate。
+  beforeEach(() => jest.useFakeTimers({ doNotFake: ['setImmediate'] }));
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('地址冲突 FATAL → 记录分类结果，但错误 message 绝不含 FATAL 原文', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    const logs: Array<[string, string]> = [];
+    svc.logToManager = (level: string, msg: string) => logs.push([level, msg]);
+    writeStartupLog(svc, ADDR_CONFLICT_FATAL);
+
+    const captured = svc
+      .waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration)
+      .catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(30000);
+    const err = await captured;
+
+    expect(err).toBeInstanceOf(CoreStartRetryError);
+    expect(svc.lastStartupFatal?.kind).toBe('tun-address-conflict');
+    // 真因进日志（用户在日志面板立刻可见）。
+    const errLine = logs.find(([lv]) => lv === 'error')?.[1] ?? '';
+    expect(errLine).toContain('已被本机其它网络接口占用');
+    // **硬约束**：FATAL 原文绝不能拼进 CoreStartRetryError.message。
+    expect(err.message).not.toContain('The object already exists');
+  });
+
+  it('FATAL 含 permission denied 时，错误 message 不因此变成「不可重试」', async () => {
+    // 守门测试：一旦有人把 FATAL 原文拼进 message，NON_RETRYABLE_START_ERROR_PATTERNS 的 'permission'
+    // 会命中 → 可重试的起核失败被静默判成终态失败，用户连自动重试都没有了。
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    svc.logToManager = () => {};
+    writeStartupLog(
+      svc,
+      'FATAL[0000] start service: start inbound/tun[tun-in]: configure tun interface: create adapter: permission denied'
+    );
+
+    const captured = svc
+      .waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration)
+      .catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(30000);
+    const err = await captured;
+
+    expect(err).toBeInstanceOf(CoreStartRetryError);
+    expect(err.message).not.toContain('permission denied');
+    expect(startMessageIsNonRetryable(err.message)).toBe(false);
+  });
+
+  it('run 边界：锚点之前的上次残留 FATAL 不被当成本次原因', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    svc.logToManager = () => {};
+    const stale = 'FATAL[0000] configure tun interface: create adapter: STALE\n';
+    // 锚点 = 残留内容的长度 ⟹ 本腿一个字节都没写。
+    writeStartupLog(svc, stale, Buffer.byteLength(stale));
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+    expect(svc.lastStartupFatal).toBeNull();
+  });
+
+  it('P2：拿到非适配器类的 FATAL 真因时，不再输出「疑 wintun 被拦」的推断文案', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    obs.probeEverConclusive = true; // 探测可用且从未见适配器 → 旧逻辑会输出 A3 推断文案
+    armDead(svc);
+    svc.logToManager = () => {};
+    writeStartupLog(svc, ADDR_CONFLICT_FATAL);
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toThrow(/TUN 初始化未完成/);
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+    // 变异「删 inferenceContradicted 判定」→ 文案变回「疑 wintun 被拦」，上面的正则失败。
+  });
+
+  it('适配器创建类 FATAL 与推断一致时，保留 A3 文案', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    obs.probeEverConclusive = true;
+    armDead(svc);
+    svc.logToManager = () => {};
+    writeStartupLog(svc, 'FATAL[0000] configure tun interface: create adapter: Access is denied.');
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toThrow(/疑 wintun 被拦/);
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+  });
+
+  it('startup log 不存在 → 静默降级，不影响原有失败语义', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    svc.logToManager = () => {};
+    svc.startupLogOffset = 0;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(30000);
+    await assertion;
+    expect(svc.lastStartupFatal).toBeNull();
+  });
+});
+
+describe('issue #324 P0-1 — 地址冲突转终态（maybeToTunPersistentError）', () => {
+  const retryErr = (): Error =>
+    new CoreStartRetryError('sing-box 启动期退出（TUN 初始化未完成），正在自动重试');
+
+  it('地址冲突：即便适配器曾出现（adapterEverSeen=true）也转终态', () => {
+    // #324 的真实形态：wintun 适配器**创建成功**、卡在配地址 → isPersistentTunFailure 恒 false →
+    // 只靠观测判据会永远重试下去。变异「删掉 FATAL 这一路」→ 本例失败。
+    const svc = makeSvc();
+    svc.tunReadyObservation = { adapterEverSeen: true, probeEverConclusive: true };
+    svc.lastStartupFatal = {
+      kind: 'tun-address-conflict',
+      raw: 'FATAL[0000] ... set ipv4 address: The object already exists.',
+      message: 'TUN 地址 172.19.0.1 已被本机其它网络接口占用。',
+    };
+    svc.sendEventToRenderer = () => {};
+    svc.logToManager = () => {};
+    const out = svc.maybeToTunPersistentError(retryErr());
+    expect(out).toBeInstanceOf(CoreStartTunPersistentError);
+    expect((out as Error).message).toContain('172.19.0.1');
+    // 文案只能引导当前真做得到的动作（TUN 地址尚未开放配置）。
+    expect((out as Error).message).not.toContain('设置');
+  });
+
+  it('地址冲突判定跨平台：非 win32（obs=null）同样转终态', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = null; // macOS/Linux
+    svc.lastStartupFatal = {
+      kind: 'tun-address-conflict',
+      raw: 'x',
+      message: 'TUN 地址已被占用。',
+    };
+    svc.sendEventToRenderer = () => {};
+    svc.logToManager = () => {};
+    expect(svc.maybeToTunPersistentError(retryErr())).toBeInstanceOf(CoreStartTunPersistentError);
+  });
+
+  it('非 TUN 模式不转终态（FATAL 可能来自上一次 TUN 会话）', () => {
+    const svc = makeSvc();
+    svc.currentConfig = { proxyModeType: 'systemProxy', servers: [], tunConfig: {} };
+    svc.tunReadyObservation = null;
+    svc.lastStartupFatal = { kind: 'tun-address-conflict', raw: 'x', message: 'y' };
+    const err = retryErr();
+    expect(svc.maybeToTunPersistentError(err)).toBe(err);
+  });
+
+  it('适配器创建类 FATAL 不提前转终态（可能是驱动加载竞态，交预算耗尽判）', () => {
+    const svc = makeSvc();
+    svc.tunReadyObservation = { adapterEverSeen: true, probeEverConclusive: true };
+    svc.lastStartupFatal = { kind: 'tun-adapter-create', raw: 'x', message: 'y' };
+    const err = retryErr();
+    expect(svc.maybeToTunPersistentError(err)).toBe(err);
+  });
+});
+
+describe('issue #324 P0-1 — 跨重试腿的 FATAL 状态卫生', () => {
+  beforeEach(() => jest.useFakeTimers({ doNotFake: ['setImmediate'] }));
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('本腿没捞到 FATAL → 清掉上一腿的结论，不留陈旧真因', async () => {
+    // 变异守卫：改成「只在捞到时赋值」→ 第 1 腿的地址冲突结论会残留，第 2 腿因别的原因死时，
+    // 终态转化会拿着过期结论把可重试错误判成地址冲突终态。
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    svc.logToManager = () => {};
+    svc.lastStartupFatal = {
+      kind: 'tun-address-conflict',
+      raw: 'stale',
+      message: '上一腿的结论',
+    };
+    // 本腿：文件里只有锚点之前的旧内容 ⟹ 本腿零写入。
+    const stale =
+      'FATAL[0000] configure tun interface: set ipv4 address: The object already exists.\n';
+    writeStartupLog(svc, stale, Buffer.byteLength(stale));
+
+    const captured = svc
+      .waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration)
+      .catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(30000);
+    await captured;
+
+    expect(svc.lastStartupFatal).toBeNull();
+  });
+});
+
+describe('issue #324 M1 — supersede 交错时的 FATAL 状态卫生', () => {
+  beforeEach(() => jest.useFakeTimers({ doNotFake: ['setImmediate'] }));
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('dead 判定后、drain 观测期间被接管 → 不再读写 FATAL 状态（不错锚、不污染接管方）', async () => {
+    // 真实时序：waitForCoreReady 先返回 dead（此刻世代还没变），随后 dead 分支要 await 在途适配器观测
+    // （execFile 4s 封顶）。**这个窗口里** start B 接管——B 已清空 lastStartupFatal 并改写 startupLogOffset。
+    // A 此刻若继续读，会用 B 的锚点切片（错锚），再把结果写回污染 B 的终态判据。
+    // 注意不能在调用前就改世代：那样 waitForCoreReady 首轮 isSuperseded 就早退，根本走不到 dead 分支。
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    svc.logToManager = () => {};
+    writeStartupLog(svc, ADDR_CONFLICT_FATAL);
+
+    const startGen = svc.lifecycleGeneration;
+    svc.lastStartupFatal = null;
+    // 接管必须发生在 waitForCoreReady 判出 dead **之后**：它自己每轮先查 isSuperseded，提前改世代只会让它
+    // 早退成 'superseded'，根本走不到 dead 分支（那样测的是另一条路径，变异也杀不掉）。isProcessAlive 返回
+    // false 正是 dead 的判据，在它里面递增世代即精确落在这个窗口。
+    svc.isProcessAlive = () => {
+      svc.lifecycleGeneration = startGen + 1;
+      return false;
+    };
+
+    const captured = svc.waitForCoreReadyOrThrow(1234, startGen).catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(30000);
+    await captured;
+
+    // 变异守卫：去掉世代守卫 → A 会把地址冲突结论写进 lastStartupFatal 污染 B，本例失败。
+    expect(svc.lastStartupFatal).toBeNull();
+  });
+
+  it('未被接管时照常读写（守卫不误伤正常路径）', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    armDead(svc);
+    svc.logToManager = () => {};
+    writeStartupLog(svc, ADDR_CONFLICT_FATAL);
+
+    const captured = svc
+      .waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration)
+      .catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(30000);
+    await captured;
+
+    expect(svc.lastStartupFatal?.kind).toBe('tun-address-conflict');
+  });
+});
+
+// ============================================================================
+// issue #324 H2：wrapper（Windows UAC 看护 / macOS osascript）路径也要读 FATAL 真因并停止无谓重试。
+// 报告者走的正是这条路径——helper 路径的 dead 分支对他完全不生效。
+// ============================================================================
+
+describe('issue #324 H2 — wrapper 路径的 FATAL 真因与终态', () => {
+  afterEach(() => {
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('wrapper 写侧是截断语义：整读文件，不套 offset 差分', () => {
+    // 变异守卫：wrapper 路径也走 sliceSinceRunStart(offset) → 重复失败腿写出逐字节相同内容时
+    // sizeNow===offset 被误判成「本腿零写入」→ FATAL 系统性丢失，恰好是本路径最常见的形态。
+    const svc = makeSvc();
+    svc.startedViaWrapper = true;
+    const content = ADDR_CONFLICT_FATAL;
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), content, 'utf-8');
+    svc.startupLogOffset = Buffer.byteLength(content); // 等长：追加语义下会被判成零写入
+
+    expect(svc.readLastStartupFatal()?.kind).toBe('tun-address-conflict');
+  });
+
+  it('helper 写侧仍按锚点切（守卫不误伤追加语义）', () => {
+    const svc = makeSvc();
+    svc.startedViaWrapper = false;
+    const stale = ADDR_CONFLICT_FATAL;
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), stale, 'utf-8');
+    svc.startupLogOffset = Buffer.byteLength(stale);
+
+    expect(svc.readLastStartupFatal()).toBeNull();
+  });
+
+  it('地址冲突 FATAL → 终态错误（跳过外层 retry 预算）', () => {
+    // 变异守卫：该分支不读 startup log → 返回普通 Error，本例失败。#324 报告者走的就是这条路径。
+    const svc = makeSvc();
+    svc.startedViaWrapper = true;
+    svc.logToManager = () => {};
+    svc.sendEventToRenderer = () => {};
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), ADDR_CONFLICT_FATAL, 'utf-8');
+    svc.startupLogOffset = 0;
+
+    const err = svc.buildWrapperStartFailure(svc.lifecycleGeneration);
+    expect(err).toBeInstanceOf(CoreStartTunPersistentError);
+    expect(err.message).toContain('172.19.0.1');
+    expect(svc.lastStartupFatal?.kind).toBe('tun-address-conflict');
+  });
+
+  it('无 FATAL → 保持原有普通 Error 语义（交外层按既有规则判重试）', () => {
+    const svc = makeSvc();
+    svc.startedViaWrapper = true;
+    svc.logToManager = () => {};
+    svc.startupLogOffset = 0;
+
+    const err = svc.buildWrapperStartFailure(svc.lifecycleGeneration);
+    expect(err).not.toBeInstanceOf(CoreStartTunPersistentError);
+    expect(err.message).toContain('无法获取进程 PID');
+  });
+
+  it('非 TUN 模式不转终态', () => {
+    const svc = makeSvc();
+    svc.currentConfig = { proxyModeType: 'systemProxy', servers: [], tunConfig: {} };
+    svc.startedViaWrapper = true;
+    svc.logToManager = () => {};
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), ADDR_CONFLICT_FATAL, 'utf-8');
+    svc.startupLogOffset = 0;
+
+    expect(svc.buildWrapperStartFailure(svc.lifecycleGeneration)).not.toBeInstanceOf(
+      CoreStartTunPersistentError
+    );
+  });
+});
+
+describe('issue #324 M-2 — buildWrapperStartFailure 的 supersede 守卫', () => {
+  afterEach(() => {
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('本腿已被接管 → 不读不写不发事件，退回原始语义', () => {
+    // waitForPidFile 可空转 60s，是比 dead 分支 drain（≤4s）宽一个量级的接管窗口。变异守卫：去掉世代守卫 →
+    // 本腿会对着接管方的会话读错锚、污染 lastStartupFatal、还发一张终态诊断卡，本例失败。
+    const svc = makeSvc();
+    svc.startedViaWrapper = true;
+    svc.logToManager = () => {};
+    const events: unknown[] = [];
+    svc.sendEventToRenderer = (_ch: string, d: unknown) => events.push(d);
+    svc.lastStartupFatal = null;
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), ADDR_CONFLICT_FATAL, 'utf-8');
+    svc.startupLogOffset = 0;
+
+    const err = svc.buildWrapperStartFailure(svc.lifecycleGeneration - 1); // 本腿世代已过期
+
+    expect(err).not.toBeInstanceOf(CoreStartTunPersistentError);
+    expect(svc.lastStartupFatal).toBeNull();
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('issue #324 L1 — readSync 短读不得把 NUL 带进解析文本', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('stat 与 read 之间文件被截短 → 只解析实际读到的字节', () => {
+    // 变异守卫：忽略 readSync 返回值、整块 toString → buf 尾部的 \0 进入 raw 并落日志，本例失败。
+    const svc = makeSvc();
+    svc.startedViaWrapper = true;
+    const content = ADDR_CONFLICT_FATAL;
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), content, 'utf-8');
+    svc.startupLogOffset = 0;
+
+    const real = fsSync.readSync;
+    jest.spyOn(fsSync, 'readSync').mockImplementation((...args: unknown[]) => {
+      // 模拟并发缩容：只读到一半，剩余 buf 保持 \0
+      const [fd, buf, off, len, pos] = args as [number, Buffer, number, number, number];
+      return real(fd, buf, off, Math.floor(len / 2), pos);
+    });
+
+    const info = svc.readLastStartupFatal();
+    // 半截行仍可能解析不出 FATAL（取决于切点），但无论如何绝不能带 NUL。
+    expect(info?.raw ?? '').not.toContain('\0');
+  });
+});
+
+// ============================================================================
+// issue #324 H2 修正：wrapper 路径「核死于 started 之后」的**真实通道**是 performHealthCheck，
+// 不是 handleProcessExit —— 那种核 detached 由看护脚本托管、不是子进程，死亡不产生 'exit' 事件，
+// 且 launcher 退出码 0 时 exit 回调显式早退。R2 复审指出前一版测试直调 handleProcessExit 测的是方法体、
+// 生产接线从未被走过（假绿），故改走真实通道。
+// ============================================================================
+
+describe('issue #324 H2 — performHealthCheck 才是 wrapper 核死的真实检测通道', () => {
+  afterEach(() => {
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  /** 装配一个「核已 started、随后死掉」的健康检查现场。 */
+  function armDeadCore(svc: any): {
+    autoRestart: jest.Mock;
+    events: Array<{ errorCode?: string }>;
+    errorPayloads: Array<{ errorCode?: string }>;
+  } {
+    svc.startedViaWrapper = true;
+    svc.singboxPid = 4321;
+    svc.pid = 4321;
+    svc.logToManager = () => {};
+    svc.isProcessAliveAsync = async () => false; // 核已死
+    svc.getProcessExitInfo = () => '';
+    svc.stopLogFileWatcher = () => {};
+    svc.ensureSystemProxyCleared = async () => {};
+    svc.cleanup = () => {};
+    svc.reconcileLoginFallback = () => {};
+    svc.selectedExitBackendState = () => null;
+    const autoRestart = jest.fn();
+    svc.attemptAutoRestart = autoRestart;
+    svc.shouldAutoRestart = () => true;
+    const events: Array<{ errorCode?: string }> = [];
+    svc.sendEventToRenderer = (_ch: string, d: { errorCode?: string }) => events.push(d);
+    // 收集 'error' payload：index.ts 靠它的 errorCode 决定跳过核心自动回滚，契约的生产者侧必须有断言。
+    const errorPayloads: Array<{ errorCode?: string }> = [];
+    svc.on('error', (e: { errorCode?: string }) => errorPayloads.push(e));
+    svc.startupLogOffset = 0;
+    return { autoRestart, events, errorPayloads };
+  }
+
+  it('地址冲突 → 短路自动重启，发 TUN_INIT_PERSISTENT 终态', async () => {
+    // 变异守卫：短路块被删/接回 handleProcessExit → attemptAutoRestart 被调用，本例失败。
+    const svc = makeSvc();
+    const { autoRestart, events, errorPayloads } = armDeadCore(svc);
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), ADDR_CONFLICT_FATAL, 'utf-8');
+
+    await svc.performHealthCheck();
+
+    expect(autoRestart).not.toHaveBeenCalled();
+    expect(events.some((e) => e.errorCode === 'TUN_INIT_PERSISTENT')).toBe(true);
+    expect(svc.lastStartupFatal?.kind).toBe('tun-address-conflict');
+    // 契约生产者侧：'error' payload 必须携 errorCode，index.ts 据此跳过核心自动回滚（地址冲突是环境问题、
+    // 与核版本无关，回滚健康的新核纯属误伤）。变异守卫：漏带该字段 → 本断言失败。
+    expect(errorPayloads.some((e) => e.errorCode === 'TUN_INIT_PERSISTENT')).toBe(true);
+  });
+
+  it('非地址冲突的核死 → 自动重启照旧（不误伤既有崩溃恢复）', async () => {
+    const svc = makeSvc();
+    const { autoRestart } = armDeadCore(svc);
+    fsSync.writeFileSync(
+      getSingBoxStartupLogPath(),
+      'FATAL[0000] start service: start inbound/mixed[mixed-in]: listen tcp: bind: address already in use',
+      'utf-8'
+    );
+
+    await svc.performHealthCheck();
+
+    expect(autoRestart).toHaveBeenCalled();
+  });
+
+  it('无 FATAL 的核死 → 自动重启照旧', async () => {
+    const svc = makeSvc();
+    const { autoRestart } = armDeadCore(svc);
+
+    await svc.performHealthCheck();
+
+    expect(autoRestart).toHaveBeenCalled();
+  });
+
+  it('非 TUN 模式不短路（FATAL 可能来自上一次 TUN 会话）', async () => {
+    const svc = makeSvc();
+    svc.currentConfig = { proxyModeType: 'systemProxy', servers: [], tunConfig: {} };
+    const { autoRestart } = armDeadCore(svc);
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), ADDR_CONFLICT_FATAL, 'utf-8');
+
+    await svc.performHealthCheck();
+
+    expect(autoRestart).toHaveBeenCalled();
+  });
+});
+
+describe('issue #324 H-2 — 确定性终态绝不进重试循环', () => {
+  it('CoreStartTunPersistentError → shouldRetry=false', () => {
+    // 变异守卫：删掉 shouldRetryStartError 里的 instanceof 守卫 → 终态被重试：每腿重弹 UAC、空等
+    // waitForPidFile 60s、重复发诊断卡，恰是本 issue 要消灭的 UX。R2 复审指出这条当时是活逃逸
+    // （3485 例全绿却杀不掉），故必须有专门用例。
+    const svc = makeSvc();
+    expect(svc.shouldRetryStartError(new CoreStartTunPersistentError())).toBe(false);
+  });
+
+  it('终态文案不靠词表匹配（词表命中与否都不影响判定）', () => {
+    // 判据是 instanceof，不是文案——终态文案里没有任何 NON_RETRYABLE_START_ERROR_PATTERNS 的词，
+    // 若哪天有人把守卫改回文案匹配，这条会挂。
+    const svc = makeSvc();
+    const terminal = new CoreStartTunPersistentError('TUN 地址 172.19.0.1 已被占用。');
+    expect(startMessageIsNonRetryable(terminal.message)).toBe(false);
+    expect(svc.shouldRetryStartError(terminal)).toBe(false);
+  });
+
+  it('被接管（Superseded）→ 不重试；普通可重试错误 → 重试', () => {
+    const svc = makeSvc();
+    expect(svc.shouldRetryStartError(new CoreStartSupersededError())).toBe(false);
+    expect(
+      svc.shouldRetryStartError(
+        new CoreStartRetryError('sing-box 启动期退出（TUN 初始化未完成），正在自动重试')
+      )
+    ).toBe(true);
+  });
+});
+
+describe('issue #324 M-2 — performHealthCheck 的世代守卫', () => {
+  afterEach(() => {
+    try {
+      fsSync.unlinkSync(getSingBoxStartupLogPath());
+    } catch {
+      /* 文件可能不存在 */
+    }
+  });
+
+  it('探活期间用户手动重连（新 start 接管）→ 本 tick 让位，不清状态不发终态', async () => {
+    // isRestarting 只挡自动重启腿，不挡手动重连。变异守卫：去掉世代守卫 → 本 tick 会对着在途的新 start
+    // 执行 cleanup + emit 'error'/'stopped'，把一次本可能成功的启动打掉并发终态卡。
+    const svc = makeSvc();
+    svc.startedViaWrapper = true;
+    svc.singboxPid = 4321;
+    svc.pid = 4321;
+    svc.logToManager = () => {};
+    const gen = svc.lifecycleGeneration;
+    svc.isProcessAliveAsync = async () => {
+      svc.lifecycleGeneration = gen + 1; // 探活期间新 start 接管
+      return false;
+    };
+    const autoRestart = jest.fn();
+    svc.attemptAutoRestart = autoRestart;
+    svc.shouldAutoRestart = () => true;
+    const cleanup = jest.fn();
+    svc.cleanup = cleanup;
+    const events: unknown[] = [];
+    svc.sendEventToRenderer = (_ch: string, d: unknown) => events.push(d);
+    svc.on('error', () => {});
+    fsSync.writeFileSync(getSingBoxStartupLogPath(), ADDR_CONFLICT_FATAL, 'utf-8');
+    svc.startupLogOffset = 0;
+
+    await svc.performHealthCheck();
+
+    expect(autoRestart).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('issue #324 M-1 — 旧核仍在跑时跳过地址探测（防 mac/linux 地址漂移）', () => {
+  const tunCfg = { proxyModeType: 'tun', servers: [], tunConfig: {} };
+
+  it('旧核在跑 → 跳过探测（不让自家 TUN 地址被探成冲突）', async () => {
+    // 变异守卫：去掉这道闸 → supersede 交错（用户连点连接）时自家 utun 上的 172.19.0.1 被探成 in-use →
+    // 新腿静默切备选、下次正常重启又切回，R1-H1 的地址乒乓在 mac/linux 复活。
+    const svc = makeSvc();
+    svc.activeCorePid = () => 4321;
+    const probe = jest.fn();
+    svc.probeIpv4AddressUsage = probe;
+
+    await svc.startTunAddressPreflight(tunCfg, true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('旧核在跑且上次避让过 → 沿用上次地址，绝不回落默认', async () => {
+    // 变异守卫：闸中 return null（回落平台默认）→ 在默认地址真冲突的机器上（#324 报告者型），用户连点重连
+    // 就会把已经工作着的避让扔掉、再撞一次同一条 FATAL，还给出「请禁用网卡」的假终态。这是 R2→R3 之间
+    // 被 review 抓出的真回归。
+    const svc = makeSvc();
+    svc.activeCorePid = () => 4321;
+    svc.probeIpv4AddressUsage = jest.fn();
+
+    svc.effectiveTunInet4Address = '172.20.0.1'; // 上一次 start 避让到的地址
+    const pick = await svc.startTunAddressPreflight(tunCfg, true);
+    expect(pick?.address).toBe('172.20.0.1');
+    expect(pick?.reason).toBe('default'); // 延续既有选择，不是新决策 → 调用方零日志
+  });
+
+  it('旧核在跑但从未避让过 → null（回落平台默认，行为零变化）', async () => {
+    const svc = makeSvc();
+    svc.activeCorePid = () => 4321;
+    svc.probeIpv4AddressUsage = jest.fn();
+
+    await expect(svc.startTunAddressPreflight(tunCfg, true)).resolves.toBeNull();
+  });
+
+  it('无旧核 → 正常探测（prev 不干扰重新决策）', async () => {
+    const svc = makeSvc();
+    svc.activeCorePid = () => null;
+    svc.probeIpv4AddressUsage = async () => 'free';
+
+    svc.effectiveTunInet4Address = '172.20.0.1';
+    const pick = await svc.startTunAddressPreflight(tunCfg, true);
+    expect(pick?.address).toBe('172.19.0.1'); // 探测说默认可用就用默认，不被 prev 钉死
+  });
+
+  it('非 TUN / 用户已显式配地址 → 不探测', async () => {
+    const svc = makeSvc();
+    svc.activeCorePid = () => null;
+    const probe = jest.fn();
+    svc.probeIpv4AddressUsage = probe;
+
+    await expect(svc.startTunAddressPreflight(tunCfg, false)).resolves.toBeNull();
+    await expect(
+      svc.startTunAddressPreflight({ ...tunCfg, tunConfig: { inet4Address: '10.7.7.1/24' } }, true)
+    ).resolves.toBeNull();
+    expect(probe).not.toHaveBeenCalled();
+  });
+});
+
+describe('issue #324 M-1 — prev 的捕获与复位归属预检方法本身（接线可测）', () => {
+  const tunCfg = { proxyModeType: 'tun', servers: [], tunConfig: {} };
+
+  it('方法内复位 effectiveTunInet4Address（调用方不必也不该再 reset）', async () => {
+    const svc = makeSvc();
+    svc.effectiveTunInet4Address = '172.20.0.1';
+    svc.activeCorePid = () => null;
+    svc.probeIpv4AddressUsage = async () => 'free';
+
+    await svc.startTunAddressPreflight(tunCfg, true);
+    // 复位发生在方法入口：本次决策由探测重新给出，不残留上次的值。
+    expect(svc.effectiveTunInet4Address).toBeNull();
+  });
+
+  it('捕获发生在复位之前 —— 旧核在跑时才能沿用上次地址', async () => {
+    // 变异守卫：把捕获挪到复位之后（或写死 null）→ prev 恒 null → 真冲突机器上 supersede 重连回落默认。
+    // 这条逃逸在 prev 由调用方传参时无门可拦（测试直调方法体会绕过捕获），故把两步收进本方法。
+    const svc = makeSvc();
+    svc.effectiveTunInet4Address = '172.31.0.1';
+    svc.activeCorePid = () => 4321;
+    svc.probeIpv4AddressUsage = jest.fn();
+
+    const pick = await svc.startTunAddressPreflight(tunCfg, true);
+    expect(pick?.address).toBe('172.31.0.1');
+  });
+});

--- a/src/main/services/__tests__/singbox-inbounds-builder.test.ts
+++ b/src/main/services/__tests__/singbox-inbounds-builder.test.ts
@@ -88,6 +88,64 @@ describe('buildInbounds — mixed + probe', () => {
   });
 });
 
+describe('buildInbounds — TUN 地址（issue #324 冲突避让）', () => {
+  it('未预检（deps 缺省）→ 平台默认地址，字节与历史一致', () => {
+    expect(
+      byTag(
+        withPlatform('win32', () =>
+          buildInbounds(cfg({ proxyModeType: 'tun' }), undefined, deps())
+        ),
+        'tun-in'
+      ).address
+    ).toEqual(['172.19.0.1/16']);
+    expect(
+      byTag(
+        withPlatform('darwin', () =>
+          buildInbounds(cfg({ proxyModeType: 'tun' }), undefined, deps())
+        ),
+        'tun-in'
+      ).address
+    ).toEqual(['172.19.0.1/30']);
+  });
+
+  it('预检选出备选地址 → 主机地址替换，掩码仍按平台取', () => {
+    // 变异守卫：掩码跟着候选一起漂（如恒用 /16）→ macOS 断言失败。前缀长度是平台调优结论，与冲突无关。
+    const d = deps({ tunInet4Address: '172.20.0.1' });
+    expect(
+      byTag(
+        withPlatform('win32', () => buildInbounds(cfg({ proxyModeType: 'tun' }), undefined, d)),
+        'tun-in'
+      ).address
+    ).toEqual(['172.20.0.1/16']);
+    expect(
+      byTag(
+        withPlatform('darwin', () => buildInbounds(cfg({ proxyModeType: 'tun' }), undefined, d)),
+        'tun-in'
+      ).address
+    ).toEqual(['172.20.0.1/30']);
+  });
+
+  it('用户显式配置的 inet4Address 优先于预检结果（用户显式约束不被「更优解」覆盖）', () => {
+    const ibs = withPlatform('win32', () =>
+      buildInbounds(
+        cfg({
+          proxyModeType: 'tun',
+          tunConfig: {
+            mtu: 9000,
+            stack: 'auto',
+            autoRoute: true,
+            strictRoute: true,
+            inet4Address: '10.7.7.1/24',
+          },
+        }),
+        undefined,
+        deps({ tunInet4Address: '172.20.0.1' })
+      )
+    );
+    expect(byTag(ibs, 'tun-in').address).toEqual(['10.7.7.1/24']);
+  });
+});
+
 describe('buildInbounds — TUN', () => {
   it('TUN：增 tun-in；route_exclude_address 含回环；macOS gvisor 栈 + http_proxy platform', () => {
     const ibs = withPlatform('darwin', () =>

--- a/src/main/services/__tests__/win-tun-adapter.test.ts
+++ b/src/main/services/__tests__/win-tun-adapter.test.ts
@@ -11,6 +11,8 @@ jest.mock('child_process', () => ({
 import { execFile } from 'child_process';
 import {
   probeWinIpv4AddressUsage,
+  probeWinTunAdapterPresence,
+  probeWinTunAdapterPresent,
   waitForAdapterReleased,
   waitForAdapterPresent,
   recordAdapterPresence,
@@ -18,6 +20,7 @@ import {
   type AdapterPresence,
   type TunAdapterObservation,
 } from '../win-tun-adapter';
+import { powershellPath } from '../../utils/win-system32';
 import { resolveWinTunInterfaceName, FLOWZ_WIN_TUN_INTERFACE } from '../../../shared/tun-interface';
 import type { UserConfig } from '../../../shared/types';
 
@@ -274,30 +277,168 @@ describe('resolveWinTunInterfaceName', () => {
 // ============================================================================
 
 /** 桩 execFile：按 (err, stdout) 回调；返回本次实际下发的 -Command 串供断言。 */
-function stubExecFile(err: Error | null, stdout: string): { lastCommand: () => string } {
-  let cmd = '';
+function stubExecFile(
+  err: Error | null,
+  stdout: string
+): {
+  lastCommand: () => string;
+  lastArgs: () => string[];
+  lastBin: () => string;
+  lastOpts: () => Record<string, unknown>;
+} {
+  let lastArgs: string[] = [];
+  let lastBin = '';
+  let lastOpts: Record<string, unknown> = {};
   (execFile as unknown as jest.Mock).mockImplementation(
-    (_bin: string, args: string[], _opts: unknown, cb: (e: Error | null, o: string) => void) => {
-      cmd = args[args.length - 1];
+    (
+      bin: string,
+      args: string[],
+      opts: Record<string, unknown>,
+      cb: (e: Error | null, o: string) => void
+    ) => {
+      lastArgs = args;
+      lastBin = bin;
+      lastOpts = opts;
       cb(err, stdout);
       return undefined as never;
     }
   );
-  return { lastCommand: () => cmd };
+  return {
+    lastBin: () => lastBin,
+    lastOpts: () => lastOpts,
+    // 脚本经 -EncodedCommand（UTF-16LE base64）传入，还原回文本供断言。
+    lastCommand: () => {
+      const i = lastArgs.indexOf('-EncodedCommand');
+      return i < 0 || i + 1 >= lastArgs.length
+        ? ''
+        : Buffer.from(lastArgs[i + 1], 'base64').toString('utf16le');
+    },
+    lastArgs: () => lastArgs,
+  };
 }
+
+/**
+ * 探测链路可用时的 stdout：哨兵首行 + 若干结果行。
+ * 直接写裸结果（不带哨兵）的用例一律等价于「脚本没跑到哨兵那行」，必须落 unknown——这正是 #324 真机缺陷的守卫点。
+ */
+function okStdout(...lines: string[]): string {
+  return ['PROBE_OK', ...lines].join('\r\n') + '\r\n';
+}
+
+/**
+ * 真机实证过的脚本原文（逐字，issue #324）。
+ *
+ * **为什么是全文精确断言，而不是若干条 toContain/顺序断言**：这个字符串是与 `powershell.exe` 的**契约**，
+ * 它的每一段都在 Windows 真机上被实际执行验证过（空闲地址→free、占用→in-use、网卡不存在→absent、
+ * 网卡存在→present、CIM 被拦→unknown 五态）。子串与顺序断言挡不住产出侧被改坏——独立 review 用 38 条
+ * 变异实测出 15 条逃逸，其中 8 条会在真机重新触发 #324 的 P0，例如：
+ *   - 删 `foreach ($x in $r) { Write-Output $x }` → 结果行永不输出 → 恒 free + 恒 absent（原始 P0 原样回归）
+ *   - 删 `Select-Object -ExpandProperty` → 同上
+ *   - 把哨兵提出 if 块、留下空的 `if (...) { }` → 判据文本还在、顺序还对，但已不再门控哨兵
+ *   - `$ErrorActionPreference='Stop'` + 删内联 `-ErrorAction` → 恒 unknown
+ *   - `Get-NetAdapter` 拼写错（`indexOf` 返 -1，与正数比反而「通过」——顺序断言在最该报警时失效）
+ *
+ * **改动此处的纪律**：脚本文本变了就等于契约变了，必须重新在 Windows 真机上验完五态再同步这里的常量。
+ * 合法重构（改缩进、`-e` 简写、单行 join）也会让本组用例失败——**那是设计意图**：它逼你回去重验，
+ * 而不是让一次「看起来无害」的重写把避让机制静默改回失效状态。
+ */
+const SCRIPT_IP_PLAIN = `$ErrorActionPreference = 'SilentlyContinue'
+$Error.Clear()
+try {
+  $r = @(Get-NetIPAddress -IPAddress '172.19.0.1' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty IPAddress)
+  if (@($Error | Where-Object { $_.CategoryInfo.Category -ne 'ObjectNotFound' }).Count -eq 0) {
+    Write-Output 'PROBE_OK'
+    foreach ($x in $r) { Write-Output $x }
+  }
+} catch { }
+exit 0`;
+
+const SCRIPT_IP_WITH_ALIAS = `$ErrorActionPreference = 'SilentlyContinue'
+$Error.Clear()
+try {
+  $r = @(Get-NetIPAddress -IPAddress '172.19.0.1' -ErrorAction SilentlyContinue | Where-Object { $_.InterfaceAlias -ne 'flowz-tun0' } | Select-Object -ExpandProperty IPAddress)
+  if (@($Error | Where-Object { $_.CategoryInfo.Category -ne 'ObjectNotFound' }).Count -eq 0) {
+    Write-Output 'PROBE_OK'
+    foreach ($x in $r) { Write-Output $x }
+  }
+} catch { }
+exit 0`;
+
+const SCRIPT_ADAPTER = `$ErrorActionPreference = 'SilentlyContinue'
+$Error.Clear()
+try {
+  $r = @(Get-NetAdapter -Name 'flowz-tun0' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name)
+  if (@($Error | Where-Object { $_.CategoryInfo.Category -ne 'ObjectNotFound' }).Count -eq 0) {
+    Write-Output 'PROBE_OK'
+    foreach ($x in $r) { Write-Output $x }
+  }
+} catch { }
+exit 0`;
+
+describe('PowerShell 探测脚本形态（#324 真机契约）', () => {
+  beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
+
+  it('地址探测（无别名）生成的脚本逐字等于真机实证过的原文', async () => {
+    const h = stubExecFile(null, okStdout());
+    await probeWinIpv4AddressUsage('172.19.0.1');
+    expect(h.lastCommand()).toBe(SCRIPT_IP_PLAIN);
+  });
+
+  it('地址探测（带别名排除）生成的脚本逐字等于真机实证过的原文', async () => {
+    const h = stubExecFile(null, okStdout());
+    await probeWinIpv4AddressUsage('172.19.0.1', 'flowz-tun0');
+    expect(h.lastCommand()).toBe(SCRIPT_IP_WITH_ALIAS);
+  });
+
+  it('网卡探测生成的脚本逐字等于真机实证过的原文', async () => {
+    const h = stubExecFile(null, okStdout());
+    await probeWinTunAdapterPresence('flowz-tun0');
+    expect(h.lastCommand()).toBe(SCRIPT_ADAPTER);
+  });
+
+  it('走 -EncodedCommand 而非 -Command（命令行转义面 + 脚本可含多行/exit）', async () => {
+    // 这条不在脚本文本里，故仍需单独断言 argv 形态。
+    const h = stubExecFile(null, okStdout());
+    await probeWinIpv4AddressUsage('172.19.0.1');
+    expect(h.lastArgs()).toContain('-EncodedCommand');
+    expect(h.lastArgs()).not.toContain('-Command');
+  });
+
+  it('spawn 的是 powershellPath() 的绝对路径，且带 timeout / windowsHide', async () => {
+    // 变异守卫：删 `timeout: 4000` → 被杀软挂住的 PowerShell 永不回调，起核卡死无兜底；
+    // 把 bin 换成裸名 'powershell' → PATH 劫持面。两者单测都能钉。
+    const h = stubExecFile(null, okStdout());
+    await probeWinIpv4AddressUsage('172.19.0.1');
+    expect(h.lastBin()).toBe(powershellPath());
+    expect(h.lastOpts()).toMatchObject({ timeout: 4000, windowsHide: true });
+  });
+});
 
 describe('probeWinIpv4AddressUsage', () => {
   beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
 
   it('查到该地址 → in-use', async () => {
-    stubExecFile(null, '172.19.0.1\r\n');
+    stubExecFile(null, okStdout('172.19.0.1'));
     await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('in-use');
   });
 
-  it('查询成功但无输出 → free（证明探测链路可用）', async () => {
+  it('哨兵在、无结果行 → free（证明探测链路可用）', async () => {
     // 变异守卫：把 hit 判定反转 → 本例与上例同时失败。
-    stubExecFile(null, '');
+    stubExecFile(null, okStdout());
     await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('free');
+  });
+
+  it('stdout 空且无哨兵 → unknown，绝不是 free（#324 真机缺陷的核心守卫）', async () => {
+    // 旧实现在这里判 free，而真机给的正是「stdout 空」+ 退出码 1。哨兵把「查询确实跑过」变成可观测事实，
+    // 没有它就不许得出 free——否则 PowerShell 被杀软拦住的机器会被当成「所有候选都空闲」。
+    // 变异守卫：删掉 runPsProbe 里的 `if (at < 0)` 短路 → 本例得到 free 而失败。
+    stubExecFile(null, '');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('unknown');
+  });
+
+  it('有输出但无哨兵（脚本中途夭折 / 输出被截断）→ unknown', async () => {
+    stubExecFile(null, '172.19.0.1\r\n');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('unknown');
   });
 
   it('PowerShell 失败/超时 → unknown，绝不是 free 也绝不是 in-use', async () => {
@@ -307,34 +448,96 @@ describe('probeWinIpv4AddressUsage', () => {
     await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('unknown');
   });
 
+  it('err 非 null 且 stdout 已有完整哨兵输出（超时杀进程但输出已到）→ 仍是 unknown', async () => {
+    // 这个输入组合此前零覆盖，而它恰恰是 execFile 超时的真实形态：进程被 SIGTERM 前 stdout 已经写完。
+    // 变异守卫：把 err 短路改成 `if (err && !stdout.includes(哨兵))` → 本例得到 in-use 而失败。
+    // 为什么必须是 unknown：进程被中途杀掉时，stdout 可能只是「看起来完整」，不能据此判定查询真的跑完了。
+    stubExecFile(new Error('ETIMEDOUT'), okStdout('172.19.0.1'));
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('unknown');
+    stubExecFile(new Error('ETIMEDOUT'), okStdout());
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('unknown');
+  });
+
   it('多行输出里按整行 trim 精确匹配，不做子串匹配', async () => {
-    stubExecFile(null, '172.19.0.10\r\n172.19.0.100\r\n');
+    stubExecFile(null, okStdout('172.19.0.10', '172.19.0.100'));
     await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('free');
-    stubExecFile(null, '10.0.0.5\r\n  172.19.0.1  \r\n');
+    stubExecFile(null, okStdout('10.0.0.5', '  172.19.0.1  '));
     await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('in-use');
   });
 
   it('非法 IP 字面量 → unknown 且不 spawn（命令拼接面的纵深防御）', async () => {
-    stubExecFile(null, 'x');
+    stubExecFile(null, okStdout('x'));
     await expect(probeWinIpv4AddressUsage("1.2.3.4'; rm -rf /")).resolves.toBe('unknown');
     expect(execFile as unknown as jest.Mock).not.toHaveBeenCalled();
   });
 
   it('传入自家接口别名 → 命令里带 InterfaceAlias 排除（H1：自家残留不算冲突）', async () => {
-    const h = stubExecFile(null, '');
+    const h = stubExecFile(null, okStdout());
     await probeWinIpv4AddressUsage('172.19.0.1', 'flowz-tun0');
     expect(h.lastCommand()).toContain("$_.InterfaceAlias -ne 'flowz-tun0'");
   });
 
-  it('不传别名 → 命令里无 Where-Object（保持最简查询）', async () => {
-    const h = stubExecFile(null, '');
+  it('不传别名 → 查询管道里无 InterfaceAlias 过滤（保持最简查询）', async () => {
+    // 断言 InterfaceAlias 而非 Where-Object：脚本模板自身的 ObjectNotFound 判据也用 Where-Object，
+    // 拿它做否定断言等于把「有没有 alias 过滤」寄托在一个与语义无关的词上。
+    const h = stubExecFile(null, okStdout());
     await probeWinIpv4AddressUsage('172.19.0.1');
-    expect(h.lastCommand()).not.toContain('Where-Object');
+    expect(h.lastCommand()).not.toContain('InterfaceAlias');
   });
 
   it('别名里的单引号被转义（PowerShell 字面量闭合）', async () => {
-    const h = stubExecFile(null, '');
+    const h = stubExecFile(null, okStdout());
     await probeWinIpv4AddressUsage('172.19.0.1', "it's");
     expect(h.lastCommand()).toContain("-ne 'it''s'");
+  });
+});
+
+/**
+ * `probeWinTunAdapterPresence` 的 execFile 级契约（此前只有注入桩的 waitForAdapterPresent 用例，
+ * 这一层从未被覆盖——#324 的同源缺陷正是从这个缺口漏出去的）。
+ */
+describe('probeWinTunAdapterPresence', () => {
+  beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
+
+  it('哨兵在、命中本名 → present', async () => {
+    stubExecFile(null, okStdout('flowz-tun0'));
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('present');
+  });
+
+  it('哨兵在、无结果行 → absent（据此可判「从未创建」→ 硬闸失败本腿）', async () => {
+    // 真机上这正是「网卡不存在」的场景，旧实现因退出码 1 落 unknown → waitForAdapterPresent 的 sawAbsent
+    // 恒 false → outcome 恒 'unknown' → 硬闸永远 fail-open，#327 的就绪验证形同虚设。
+    stubExecFile(null, okStdout());
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('absent');
+  });
+
+  it('无哨兵 → unknown，绝不是 absent（不把「查不了」误判成「确实没有」）', async () => {
+    stubExecFile(null, '');
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
+  });
+
+  it('PowerShell 失败/超时 → unknown（fail-open，绝不据此判终态失败）', async () => {
+    stubExecFile(new Error('spawn ENOENT'), '');
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
+  });
+
+  it('按整行精确匹配，同前缀网卡名不误判', async () => {
+    stubExecFile(null, okStdout('flowz-tun00', 'flowz-tun0-old'));
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('absent');
+  });
+
+  it('网卡名里的单引号被转义（PowerShell 字面量闭合）', async () => {
+    const h = stubExecFile(null, okStdout());
+    await probeWinTunAdapterPresence("it's");
+    expect(h.lastCommand()).toContain("-Name 'it''s'");
+  });
+
+  it('布尔版 probeWinTunAdapterPresent：absent/unknown 均塌成 false（#159 反向门 fail-open）', async () => {
+    stubExecFile(null, okStdout());
+    await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(false);
+    stubExecFile(null, '');
+    await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(false);
+    stubExecFile(null, okStdout('flowz-tun0'));
+    await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(true);
   });
 });

--- a/src/main/services/__tests__/win-tun-adapter.test.ts
+++ b/src/main/services/__tests__/win-tun-adapter.test.ts
@@ -3,7 +3,14 @@
  * 注入 probe/sleep，零真实计时器、零真实网卡：验早退 / 超时 fail-open / 轮次与 sleep 次数。
  * 真实 Get-NetAdapter 探测属真机项（无 Windows 环境，不在单测覆盖）。
  */
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFile: jest.fn(),
+}));
+
+import { execFile } from 'child_process';
 import {
+  probeWinIpv4AddressUsage,
   waitForAdapterReleased,
   waitForAdapterPresent,
   recordAdapterPresence,
@@ -259,5 +266,75 @@ describe('resolveWinTunInterfaceName', () => {
     expect(resolveWinTunInterfaceName(cfg({ tunConfig: { interfaceName: 'flowz_tun-1' } }))).toBe(
       'flowz_tun-1'
     );
+  });
+});
+
+// ============================================================================
+// issue #324 P0-2：TUN 地址占用探测（Windows 侧 fail-open 的另一半，纯逻辑层的用例杀不到这里）。
+// ============================================================================
+
+/** 桩 execFile：按 (err, stdout) 回调；返回本次实际下发的 -Command 串供断言。 */
+function stubExecFile(err: Error | null, stdout: string): { lastCommand: () => string } {
+  let cmd = '';
+  (execFile as unknown as jest.Mock).mockImplementation(
+    (_bin: string, args: string[], _opts: unknown, cb: (e: Error | null, o: string) => void) => {
+      cmd = args[args.length - 1];
+      cb(err, stdout);
+      return undefined as never;
+    }
+  );
+  return { lastCommand: () => cmd };
+}
+
+describe('probeWinIpv4AddressUsage', () => {
+  beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
+
+  it('查到该地址 → in-use', async () => {
+    stubExecFile(null, '172.19.0.1\r\n');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('in-use');
+  });
+
+  it('查询成功但无输出 → free（证明探测链路可用）', async () => {
+    // 变异守卫：把 hit 判定反转 → 本例与上例同时失败。
+    stubExecFile(null, '');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('free');
+  });
+
+  it('PowerShell 失败/超时 → unknown，绝不是 free 也绝不是 in-use', async () => {
+    // 变异守卫：err 分支 resolve('free') 或 'in-use' → 本例失败。这是 fail-open 在 Windows 侧的落点：
+    // 判 free 会让预检对被杀软拦住的机器形同虚设；判 in-use 会让所有这类机器无谓换地址。
+    stubExecFile(new Error('spawn ENOENT'), '');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('unknown');
+  });
+
+  it('多行输出里按整行 trim 精确匹配，不做子串匹配', async () => {
+    stubExecFile(null, '172.19.0.10\r\n172.19.0.100\r\n');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('free');
+    stubExecFile(null, '10.0.0.5\r\n  172.19.0.1  \r\n');
+    await expect(probeWinIpv4AddressUsage('172.19.0.1')).resolves.toBe('in-use');
+  });
+
+  it('非法 IP 字面量 → unknown 且不 spawn（命令拼接面的纵深防御）', async () => {
+    stubExecFile(null, 'x');
+    await expect(probeWinIpv4AddressUsage("1.2.3.4'; rm -rf /")).resolves.toBe('unknown');
+    expect(execFile as unknown as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('传入自家接口别名 → 命令里带 InterfaceAlias 排除（H1：自家残留不算冲突）', async () => {
+    const h = stubExecFile(null, '');
+    await probeWinIpv4AddressUsage('172.19.0.1', 'flowz-tun0');
+    expect(h.lastCommand()).toContain("$_.InterfaceAlias -ne 'flowz-tun0'");
+  });
+
+  it('不传别名 → 命令里无 Where-Object（保持最简查询）', async () => {
+    const h = stubExecFile(null, '');
+    await probeWinIpv4AddressUsage('172.19.0.1');
+    expect(h.lastCommand()).not.toContain('Where-Object');
+  });
+
+  it('别名里的单引号被转义（PowerShell 字面量闭合）', async () => {
+    const h = stubExecFile(null, '');
+    await probeWinIpv4AddressUsage('172.19.0.1', "it's");
+    expect(h.lastCommand()).toContain("-ne 'it''s'");
   });
 });

--- a/src/main/services/singbox-inbounds-builder.ts
+++ b/src/main/services/singbox-inbounds-builder.ts
@@ -44,6 +44,12 @@ export interface InboundsDeps {
   probePoolPorts?: number[];
   /** 可选日志回调（记「连入来源排除」的 mesh/fakeip/物理 LAN 剔除告警）。缺省（单测）不记。 */
   log?: (level: 'debug' | 'info' | 'warn' | 'error' | 'fatal', message: string) => void;
+  /**
+   * issue #324：本次起核经冲突预检选出的 TUN IPv4 **裸地址**（不含掩码，掩码由本模块按平台拼）。
+   * 缺省/空 = 未预检（诊断报告、快照导出、单测等非起核路径）→ 沿用平台默认地址，行为零变化。
+   * 优先级低于用户显式配置的 `tunConfig.inet4Address`（用户指定即照办，不做避让）。
+   */
+  tunInet4Address?: string;
 }
 
 /**
@@ -53,8 +59,12 @@ export interface InboundsDeps {
  * 已知 efficacy 代价（可接受）：连入源经本机也接着的 overlay 接口（如本机也在同一 ZeroTier）到达时，其段与该接口段
  * 相交 → 被 guard 剔除 → 该段的排除 no-op；但此时连入源已是"经 overlay 的同段"、多半本就被 sing-tun 最长前缀保护，剔除无害。
  * 快照语义：在 buildInbounds 运行时读一次；换网络后由重生成刷新（M6 真机复核）。best-effort，取不到接口返空。
+ *
+ * 导出供 issue #324 的 TUN 地址冲突预检复用（候选地址不得落在本机接口网段内）——同一份「本机网段」口径，
+ * 不另写一套。注意它只看得到 **OperStatus=Up** 的接口（libuv 的 uv_interface_addresses 在 Windows 上跳过
+ * 非 Up 适配器），故不能用它代替地址占用探测：#324 的冲突源正是一张 Disconnected 的适配器。
  */
-function getOwnLanCidrs(): string[] {
+export function getOwnLanCidrs(): string[] {
   const out: string[] = [];
   try {
     for (const addrs of Object.values(os.networkInterfaces())) {
@@ -363,9 +373,12 @@ export function buildInbounds(
     }
 
     // 恢复至对应平台最稳定的网段：Windows v3.4.0 用 /16、Mac v3.3.18 用 /30 最稳定。
+    // issue #324：掩码恒按平台取，主机地址允许被冲突预检替换（deps.tunInet4Address）——换段只为避开占用，
+    // 前缀长度是平台调优结论、与冲突无关，不该跟着漂。用户显式配置的完整 CIDR 仍最高优先（照办不避让）。
+    const tunPrefix = process.platform === 'darwin' ? '/30' : '/16';
     const tunAddress = [
       config.tunConfig?.inet4Address ||
-        (process.platform === 'darwin' ? '172.19.0.1/30' : '172.19.0.1/16'),
+        (deps.tunInet4Address ? `${deps.tunInet4Address}${tunPrefix}` : `172.19.0.1${tunPrefix}`),
     ];
     // macOS 默认分配 IPv6 以提高与本地网络服务的兼容性，与 3.3.18 保持一致
     // （此前 darwin / 非 darwin 两分支逻辑完全相同，已合并消重）

--- a/src/main/services/win-tun-adapter.ts
+++ b/src/main/services/win-tun-adapter.ts
@@ -14,6 +14,82 @@ import { execFile } from 'child_process';
 import { powershellPath } from '../utils/win-system32';
 import type { AddressUsage } from '../../shared/tun-address';
 
+/** 哨兵首行：脚本跑到这一行 == 探测链路可用（cmdlet 存在、模块加载成功、PS 未被拦）。 */
+const PROBE_SENTINEL = 'PROBE_OK';
+
+/** runPsProbe 结果。`ok=false` 表示探测链路本身不可用（调用方一律落 unknown / fail-open）。 */
+interface PsProbeResult {
+  /** 拿到哨兵 == 查询确实执行了；据此可把「查询成功且为空」与「查不了」区分开。 */
+  ok: boolean;
+  /** 哨兵之后的输出行（已 trim、已去空行）。 */
+  lines: string[];
+}
+
+/**
+ * 跑一段 PowerShell 探测管道，把「探测链路可用」与「查询结果为空」区分开。
+ *
+ * **为什么不能直接 `-Command <cmdlet ... -ErrorAction SilentlyContinue>`**（原实现，issue #324 真机实测推翻）：
+ * `-ErrorAction SilentlyContinue` 只抑制错误的**显示**，不改 `$?`——查不到对象时 `powershell.exe` 退出码仍是 **1**。
+ * Node `execFile` 据此把 `err` 置非 null，于是「查询成功且结果为空」（= absent / free，本模块最需要的那个结论）
+ * 被整片吞成 `unknown`。真机实测（Windows 11 26200）：
+ *   `Get-NetIPAddress -IPAddress <空闲地址>` → exit=1 stdout 空；`Get-NetAdapter -Name <不存在>` → exit=1 stdout 空。
+ * 后果是三条门在真实 Windows 上全部恒 fail-open：#159 释放门恒放行、#324 正向就绪门 `sawAbsent` 恒 false、
+ * #324 地址冲突预检永远返不出 `free`（候选池逐个落 unverified → `exhausted` → 退回被占用的首选地址，避让完全失效）。
+ * 单测把 `execFile` 整个替换成桩，从未验过这条真实契约，故 4 轮 review + 38 条变异全绿仍漏。
+ *
+ * 现在：脚本自己 `exit 0`，把「探测链路可用」用哨兵首行显式表达，结论完全由 stdout 承载；退出码只用来兜
+ * **真正的**执行失败（PS 缺失 / 被杀软拦 / 超时）。终止性错误（模块加载失败、cmdlet 不存在）落 catch → 无哨兵 → 同样 unknown。
+ *
+ * **哨兵不能无条件发**——这是第二个真机实测才看清的坑。`-ErrorAction SilentlyContinue` 吞掉的是**非终止性**错误，
+ * 它们不进 catch，管道照样空。若此时照发哨兵，「目标确实不存在」与「查询根本没跑通」就被合并成同一个结论 `absent`/`free`，
+ * 后果比原缺陷更糟：CIM/WMI 被 EDR 拦住的**健康**机器会被判成「TUN 网卡从未创建」→ `absent-timeout` → 硬闸 stopCore
+ * → 三腿耗尽 → `CoreStartTunPersistentError` 永久拒连。旧实现靠退出码 1 把这两类一起归进 `unknown`（fail-open，
+ * 安全但门失效），两者都不对。真机实测（`$Error` 的 CategoryInfo）显示这两类明确可分：
+ *   地址空闲 / 网卡不存在 → `ObjectNotFound`（`CmdletizationQuery_NotFound_*`）；CIM 会话不可用 → `ResourceUnavailable`。
+ * 故哨兵的发放条件是「零错误，或被吞的错误**全部**是 ObjectNotFound」。
+ *
+ * 脚本经 `-EncodedCommand`（UTF-16LE base64）传入，消掉命令行层的转义面；PowerShell 语法层仍靠调用方的
+ * 单引号转义 + 输入校验（IP 正则 / 网卡名字符集）把关。
+ *
+ * **stdout 只可用来比对 ASCII**：中文 Windows 的 PowerShell 按 OEM codepage（936）写 stdout，Node execFile
+ * 默认按 utf8 解码 → 非 ASCII 输出必成乱码（真机实测：网卡名「以太网」回传即乱码）。本模块的比对对象全是
+ * ASCII——IP 字面量、受 resolveWinTunInterfaceName 限制在 [A-Za-z0-9_-] 的自家网卡名、哨兵本身——故不受影响。
+ * 若将来要拿它比对用户可自定义的中文网卡名/别名，必须先在脚本里 `[Console]::OutputEncoding = [Text.Encoding]::UTF8`。
+ */
+function runPsProbe(pipeline: string): Promise<PsProbeResult> {
+  const script = [
+    `$ErrorActionPreference = 'SilentlyContinue'`,
+    `$Error.Clear()`,
+    `try {`,
+    `  $r = @(${pipeline})`,
+    `  if (@($Error | Where-Object { $_.CategoryInfo.Category -ne 'ObjectNotFound' }).Count -eq 0) {`,
+    `    Write-Output '${PROBE_SENTINEL}'`,
+    `    foreach ($x in $r) { Write-Output $x }`,
+    `  }`,
+    `} catch { }`,
+    `exit 0`,
+  ].join('\n');
+  const encoded = Buffer.from(script, 'utf16le').toString('base64');
+  return new Promise((resolve) => {
+    execFile(
+      powershellPath(),
+      ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+      { timeout: 4000, windowsHide: true },
+      (err, stdout) => {
+        if (err) return resolve({ ok: false, lines: [] });
+        const lines = String(stdout)
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .filter((l) => l.length > 0);
+        const at = lines.indexOf(PROBE_SENTINEL);
+        // 无哨兵 = 脚本没跑到那一行（终止性错误）或输出被截断 → 按探测失败处理，绝不当成「查询为空」。
+        if (at < 0) return resolve({ ok: false, lines: [] });
+        resolve({ ok: true, lines: lines.slice(at + 1) });
+      }
+    );
+  });
+}
+
 /**
  * 探测 Windows 上是否仍存在名为 `name` 的网卡（设备级，零提权）。#159 反向释放门用。
  * 命中 → true；查不到 / PowerShell 失败 / 超时 → false（宁判「已释放」放行，绝不卡死启动）。
@@ -75,27 +151,14 @@ export type AdapterPresence = 'present' | 'absent' | 'unknown';
  * 仅返回值语义更细：err（spawn/执行失败）→ 'unknown'；命中本名 → 'present'；查询成功但空 → 'absent'。
  */
 export function probeWinTunAdapterPresence(name: string): Promise<AdapterPresence> {
-  return new Promise((resolve) => {
-    const psName = name.replace(/'/g, "''");
-    execFile(
-      powershellPath(),
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        `Get-NetAdapter -Name '${psName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name`,
-      ],
-      { timeout: 4000, windowsHide: true },
-      (err, stdout) => {
-        // err = PowerShell spawn/执行失败（PS 缺/被拦/超时）→ unknown（fail-open）。
-        // -ErrorAction SilentlyContinue 使「网卡不存在」不报错、输出为空 → 落 'absent'（证明 PS 本身可用）。
-        if (err) return resolve('unknown');
-        const hit = String(stdout)
-          .split(/\r?\n/)
-          .some((line) => line.trim() === name);
-        resolve(hit ? 'present' : 'absent');
-      }
-    );
+  const psName = name.replace(/'/g, "''");
+  // 哨兵在、命中本名 → present；哨兵在、无命中 → absent（查询确实跑过，可据此判「从未创建」）；
+  // 哨兵不在 → unknown（fail-open）。见 runPsProbe 头注：退出码不再参与「空结果」判定。
+  return runPsProbe(
+    `Get-NetAdapter -Name '${psName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name`
+  ).then((r) => {
+    if (!r.ok) return 'unknown';
+    return r.lines.some((line) => line === name) ? 'present' : 'absent';
   });
 }
 
@@ -225,23 +288,12 @@ export function probeWinIpv4AddressUsage(
   const aliasFilter = excludeInterfaceAlias
     ? ` | Where-Object { $_.InterfaceAlias -ne '${excludeInterfaceAlias.replace(/'/g, "''")}' }`
     : '';
-  return new Promise((resolve) => {
-    execFile(
-      powershellPath(),
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        `Get-NetIPAddress -IPAddress '${ip}' -ErrorAction SilentlyContinue${aliasFilter} | Select-Object -ExpandProperty IPAddress`,
-      ],
-      { timeout: 4000, windowsHide: true },
-      (err, stdout) => {
-        if (err) return resolve('unknown');
-        const hit = String(stdout)
-          .split(/\r?\n/)
-          .some((line) => line.trim() === ip);
-        resolve(hit ? 'in-use' : 'free');
-      }
-    );
+  // 哨兵在、命中该地址 → in-use；哨兵在、无命中 → free（**这条是避让机制的全部价值所在**：旧实现因退出码 1
+  // 恒落 unknown，候选池永远给不出 free，冲突时经 exhausted 退回被占用的首选地址）。哨兵不在 → unknown。
+  return runPsProbe(
+    `Get-NetIPAddress -IPAddress '${ip}' -ErrorAction SilentlyContinue${aliasFilter} | Select-Object -ExpandProperty IPAddress`
+  ).then((r) => {
+    if (!r.ok) return 'unknown';
+    return r.lines.some((line) => line === ip) ? 'in-use' : 'free';
   });
 }

--- a/src/main/services/win-tun-adapter.ts
+++ b/src/main/services/win-tun-adapter.ts
@@ -12,6 +12,7 @@
  */
 import { execFile } from 'child_process';
 import { powershellPath } from '../utils/win-system32';
+import type { AddressUsage } from '../../shared/tun-address';
 
 /**
  * 探测 Windows 上是否仍存在名为 `name` 的网卡（设备级，零提权）。#159 反向释放门用。
@@ -192,4 +193,55 @@ export function recordAdapterPresence(obs: TunAdapterObservation, p: AdapterPres
  */
 export function isPersistentTunFailure(obs: TunAdapterObservation): boolean {
   return !obs.adapterEverSeen && obs.probeEverConclusive;
+}
+
+// ============================================================================
+// issue #324：TUN IPv4 地址占用探测（起核前冲突预检用，见 shared/tun-address.ts）。
+// ============================================================================
+
+/**
+ * 探测某个裸 IPv4 是否已存在于本机任一接口（Windows，零提权）。
+ *
+ * **必须走 Get-NetIPAddress，不能用 os.networkInterfaces()**：后者（libuv `uv_interface_addresses`）在
+ * Windows 上跳过 `OperStatus != IfOperStatusUp` 的适配器，而 #324 的冲突源正是一张 **Disconnected** 的
+ * TAP-Windows 适配器——地址条目仍在系统 IP 表里占位（AddressState=Tentative）、照样让
+ * `CreateUnicastIpAddressEntry` 返回 ERROR_OBJECT_ALREADY_EXISTS，但 Node 的接口枚举完全看不到它。
+ * Get-NetIPAddress 查的是 IP 地址表本身，不受接口 OperStatus 限制（#324 报告者机器实证命中）。
+ *
+ * 三态语义与 probeWinTunAdapterPresence 一致：err（PS 缺/被拦/超时）→ 'unknown'（fail-open，绝不据此换地址）。
+ */
+export function probeWinIpv4AddressUsage(
+  ip: string,
+  excludeInterfaceAlias?: string
+): Promise<AddressUsage> {
+  // 纵深防御：调用方只传候选池常量，但仍拒绝非法字面量（PowerShell 命令拼接面）。
+  if (!/^[0-9]{1,3}(\.[0-9]{1,3}){3}$/.test(ip)) return Promise.resolve('unknown');
+  // **必须排除自家 TUN 接口**：预检跑在 startInternal，**早于** #159 的适配器释放门（在 startSingBoxProcess
+  // 顶部）。节点切换重启 / 崩溃自动重启时，上一个核的 wintun 适配器连同它的地址条目还滞留着（#159 的存在
+  // 本身就是这个滞留的证据）→ 不排除就会把自家残留判成「别人占用」→ 换地址；下次重启地址已释放 → 换回。
+  // 地址在重启之间乒乓漂移，恰好造成避让机制声称要避免的代价（用户钉着旧地址的规则失效），且日志会把
+  // 自家残留误导性归因为「其它 VPN 客户端」。别名经 resolveWinTunInterfaceName 校验（仅 [A-Za-z0-9_-]），
+  // 单引号转义后无注入面。
+  const aliasFilter = excludeInterfaceAlias
+    ? ` | Where-Object { $_.InterfaceAlias -ne '${excludeInterfaceAlias.replace(/'/g, "''")}' }`
+    : '';
+  return new Promise((resolve) => {
+    execFile(
+      powershellPath(),
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Get-NetIPAddress -IPAddress '${ip}' -ErrorAction SilentlyContinue${aliasFilter} | Select-Object -ExpandProperty IPAddress`,
+      ],
+      { timeout: 4000, windowsHide: true },
+      (err, stdout) => {
+        if (err) return resolve('unknown');
+        const hit = String(stdout)
+          .split(/\r?\n/)
+          .some((line) => line.trim() === ip);
+        resolve(hit ? 'in-use' : 'free');
+      }
+    );
+  });
 }

--- a/src/shared/__tests__/singbox-fatal.test.ts
+++ b/src/shared/__tests__/singbox-fatal.test.ts
@@ -1,0 +1,181 @@
+/**
+ * issue #324 P0-1：sing-box FATAL 解析纯函数。
+ *
+ * 变异逃逸面（每条都必须有测试杀掉，非「碰巧在真数据上对」）：
+ *  - 取第一条 FATAL 而非最后一条
+ *  - 删 stripAnsi
+ *  - 互换两个分类分支
+ *  - 删 run 边界过滤（读到上次会话的残留 FATAL）
+ */
+import {
+  stripAnsi,
+  extractLastFatal,
+  classifySingBoxFatal,
+  sliceSinceRunStart,
+} from '../singbox-fatal';
+
+/** #324 报告者机器 singbox_startup.log 的真实字节（含 ANSI 色码）。 */
+const REAL_FATAL =
+  '\x1b[31mFATAL\x1b[0m[0000] start service: start inbound/tun[tun-in]: configure tun interface: set ipv4 address: The object already exists.';
+
+describe('stripAnsi', () => {
+  it('剥掉 sing-box 默认 logger 的色码', () => {
+    expect(stripAnsi(REAL_FATAL)).toBe(
+      'FATAL[0000] start service: start inbound/tun[tun-in]: configure tun interface: set ipv4 address: The object already exists.'
+    );
+  });
+
+  it('无色码的行原样返回', () => {
+    expect(stripAnsi('FATAL[0000] plain')).toBe('FATAL[0000] plain');
+  });
+});
+
+describe('extractLastFatal', () => {
+  it('从混着看护脚本自述行的日志里挑出 FATAL', () => {
+    const text = [
+      'FlowZ watchdog starting...',
+      '22:08:55 [watchdog] sing-box started, PID 5704',
+      '22:08:56 [watchdog] sing-box exited by itself',
+      REAL_FATAL,
+    ].join('\n');
+    expect(extractLastFatal(text)).toContain('set ipv4 address');
+  });
+
+  it('多条 FATAL 时取最后一条（不是第一条）', () => {
+    // 变异守卫：改成取第一条 → 本例失败。helper 写侧 O_APPEND 会累积多腿的 FATAL，最后一条最接近本次失败。
+    const text = [
+      'FATAL[0000] start service: start inbound/tun[tun-in]: configure tun interface: create adapter: old failure',
+      'FATAL[0000] start service: start inbound/tun[tun-in]: configure tun interface: set ipv4 address: The object already exists.',
+    ].join('\n');
+    expect(extractLastFatal(text)).toContain('set ipv4 address');
+    expect(extractLastFatal(text)).not.toContain('create adapter');
+  });
+
+  it('返回值已剥色码（供下游字符串匹配）', () => {
+    // 变异守卫：删 stripAnsi → 返回串含 \x1b，本例失败。
+    const line = extractLastFatal(REAL_FATAL);
+    expect(line).not.toContain('\x1b');
+    expect(line?.startsWith('FATAL')).toBe(true);
+  });
+
+  it('无 FATAL 行 → null', () => {
+    expect(extractLastFatal('INFO[0000] all good\n')).toBeNull();
+  });
+
+  it('空文本 → null', () => {
+    expect(extractLastFatal('')).toBeNull();
+  });
+});
+
+describe('classifySingBoxFatal', () => {
+  it('地址冲突：点名具体地址', () => {
+    const info = classifySingBoxFatal(stripAnsi(REAL_FATAL), { tunAddress: '172.19.0.1/16' });
+    expect(info.kind).toBe('tun-address-conflict');
+    expect(info.message).toContain('172.19.0.1');
+    // 掩码不该出现在给用户看的文案里（冲突的是地址本身）。
+    expect(info.message).not.toContain('/16');
+    // 必须提「已断开或隐藏的适配器」——#324 报告者正是因为设备管理器看不到而回答「没有残留」。
+    expect(info.message).toContain('隐藏');
+  });
+
+  it('地址冲突：无地址上下文时仍给出正确分类', () => {
+    const info = classifySingBoxFatal(
+      'FATAL[0000] ... set ipv4 address: The object already exists.'
+    );
+    expect(info.kind).toBe('tun-address-conflict');
+    expect(info.message).toContain('已被本机其它网络接口占用');
+  });
+
+  it('IPv6 地址冲突同归一类，但文案绝不点名 v4 地址', () => {
+    // 变异守卫：v4/v6 不分叉 → message 会拼上 ctx.tunAddress（恒为 v4），把用户引去找占用 172.19.0.1 的
+    // 网卡，方向全错。macOS 默认给 TUN 配 IPv6，这条路径是真会走到的。
+    const info = classifySingBoxFatal(
+      'FATAL[0000] ... set ipv6 address: The object already exists.',
+      {
+        tunAddress: '172.19.0.1/30',
+      }
+    );
+    expect(info.kind).toBe('tun-address-conflict');
+    expect(info.message).not.toContain('172.19.0.1');
+    expect(info.message).toContain('IPv6');
+  });
+
+  it('适配器创建失败：与地址冲突分属不同类', () => {
+    // 变异守卫：互换两个分类分支 → 本例与上面的地址冲突例同时失败。
+    const info = classifySingBoxFatal(
+      'FATAL[0000] start service: start inbound/tun[tun-in]: configure tun interface: create adapter: Access is denied.'
+    );
+    expect(info.kind).toBe('tun-adapter-create');
+    expect(info.message).toContain('wintun');
+  });
+
+  it('open existing adapter 也归适配器类', () => {
+    const info = classifySingBoxFatal('FATAL[0000] ... open existing adapter: foo');
+    expect(info.kind).toBe('tun-adapter-create');
+  });
+
+  it('DNS 下发失败单独一类', () => {
+    const info = classifySingBoxFatal('FATAL[0000] ... configure tun interface: set ipv4 dns: bar');
+    expect(info.kind).toBe('tun-dns');
+  });
+
+  it('tun.New 窗口内的未知错误：透传原文，不编造原因', () => {
+    const raw = 'FATAL[0000] ... configure tun interface: some brand new error';
+    const info = classifySingBoxFatal(raw);
+    expect(info.kind).toBe('tun-other');
+    expect(info.message).toContain('some brand new error');
+  });
+
+  it('非 TUN 的 FATAL：归 other 且透传原文', () => {
+    const raw =
+      'FATAL[0000] start service: start inbound/mixed[mixed-in]: listen tcp: bind: cannot assign requested address';
+    const info = classifySingBoxFatal(raw);
+    expect(info.kind).toBe('other');
+    expect(info.message).toContain('bind');
+  });
+
+  it('raw 恒为剥色码后的原文', () => {
+    expect(classifySingBoxFatal(REAL_FATAL).raw).not.toContain('\x1b');
+  });
+});
+
+describe('sliceSinceRunStart', () => {
+  const prevRun = 'FATAL[0000] configure tun interface: create adapter: STALE FROM LAST MONTH\n';
+  const thisRun =
+    'FATAL[0000] configure tun interface: set ipv4 address: The object already exists.';
+
+  it('追加语义（helper O_APPEND）：只取本腿写入的尾部', () => {
+    // 变异守卫：删 run 边界过滤 → 会读到上个月的残留 FATAL 并当成本次原因，本例失败。
+    const full = prevRun + thisRun;
+    const sliced = sliceSinceRunStart(full, Buffer.byteLength(prevRun), Buffer.byteLength(full));
+    expect(sliced).toContain('set ipv4 address');
+    expect(sliced).not.toContain('STALE');
+  });
+
+  it('文件被截断过（UAC / macOS wrapper 写侧）→ 现有内容全部属于本次', () => {
+    // sizeNow < offset ⟹ 上次记录锚点之后文件被重建，不能再按「新增字节」切，否则会切空。
+    const sliced = sliceSinceRunStart(thisRun, 999999, Buffer.byteLength(thisRun));
+    expect(sliced).toContain('set ipv4 address');
+  });
+
+  it('锚点为 0（文件此前不存在）→ 全文', () => {
+    expect(sliceSinceRunStart(thisRun, 0, Buffer.byteLength(thisRun))).toBe(thisRun);
+  });
+
+  it('追加写侧下「本腿零写入」→ 空串（不回落到旧内容）', () => {
+    // 命名刻意点出「追加写侧」：本判据对截断写侧不成立（重复失败腿写出等长内容时会被误判成零写入），
+    // 见函数 doc 的适用边界。H2 若把截断写侧接进来，必须走「整文件即本次」而不是复用本函数。
+    const size = Buffer.byteLength(prevRun);
+    expect(sliceSinceRunStart(prevRun, size, size)).toBe('');
+  });
+
+  it('中文/多字节内容不产生乱码残行', () => {
+    const head = '看护脚本自述行：核已启动\n';
+    const tail =
+      'FATAL[0000] configure tun interface: set ipv4 address: The object already exists.';
+    const full = head + tail;
+    const sliced = sliceSinceRunStart(full, Buffer.byteLength(head), Buffer.byteLength(full));
+    expect(sliced).toContain('set ipv4 address');
+    expect(sliced).not.toContain('�');
+  });
+});

--- a/src/shared/__tests__/tun-address.test.ts
+++ b/src/shared/__tests__/tun-address.test.ts
@@ -1,0 +1,215 @@
+/**
+ * issue #324 P0-2：TUN 地址冲突避让纯逻辑。
+ *
+ * 变异逃逸面（每条都必须有测试杀掉）：
+ *  - 候选池只试第一个、不迭代
+ *  - 与本机网段的相交判定反向
+ *  - fail-open 改成 fail-closed（探测不可用就换地址/阻断——会把杀软拦 PowerShell 的机器全部拖下水，
+ *    是本模块最危险的逃逸）
+ *  - 确证冲突后仍返回原地址
+ */
+import {
+  pickTunInet4Address,
+  ipv4InInterfaceMap,
+  excludeOwnTunCidrs,
+  TUN_INET4_CANDIDATES,
+  type AddressUsage,
+} from '../tun-address';
+
+/** 按 IP → 状态表造 probe；未列出的一律 free。 */
+const probeFrom =
+  (table: Record<string, AddressUsage>) =>
+  (ip: string): Promise<AddressUsage> =>
+    Promise.resolve(table[ip] ?? 'free');
+
+const noLan = (): string[] => [];
+
+describe('pickTunInet4Address', () => {
+  it('默认地址空闲 → 用默认，不换', () => {
+    return pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: probeFrom({}),
+      ownLanCidrs: noLan,
+    }).then((pick) => {
+      expect(pick.address).toBe('172.19.0.1');
+      expect(pick.reason).toBe('default');
+      expect(pick.skipped).toEqual([]);
+    });
+  });
+
+  it('#324 现场：默认地址被占用 → 换到下一个候选', async () => {
+    // 变异守卫：候选池只试第一个不迭代 → 返回 172.19.0.1，本例失败。
+    //          确证冲突后仍返回原地址 → 同样失败。
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: probeFrom({ '172.19.0.1': 'in-use' }),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.address).toBe('172.20.0.1');
+    expect(pick.reason).toBe('fallback');
+    expect(pick.skipped).toEqual([{ address: '172.19.0.1', cause: 'in-use' }]);
+  });
+
+  it('连撞多个 → 一直往后找', async () => {
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: probeFrom({ '172.19.0.1': 'in-use', '172.20.0.1': 'in-use' }),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.address).toBe('172.31.0.1');
+    expect(pick.skipped.map((s) => s.address)).toEqual(['172.19.0.1', '172.20.0.1']);
+  });
+
+  it('候选落在本机接口网段内 → 跳过（不能把 TUN 地址放进物理 LAN 段）', async () => {
+    // 变异守卫：相交判定反向 → 会跳过所有不相交的候选、选中相交的那个，本例失败。
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: probeFrom({}),
+      ownLanCidrs: () => ['172.19.0.5/24'],
+    });
+    expect(pick.address).toBe('172.20.0.1');
+    expect(pick.skipped).toEqual([{ address: '172.19.0.1', cause: 'own-lan' }]);
+  });
+
+  it('本机网段不相交时不误伤', async () => {
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: probeFrom({}),
+      ownLanCidrs: () => ['192.168.1.7/24', 'fe80::1/64'],
+    });
+    expect(pick.address).toBe('172.19.0.1');
+    expect(pick.reason).toBe('default');
+  });
+
+  it('探测链路不可用（杀软拦 PowerShell）→ fail-open 沿用默认，绝不换地址', async () => {
+    // 变异守卫：把 unknown 当 in-use（fail-closed）→ 会换到 172.20.0.1，本例失败。
+    // 这是本模块最危险的逃逸：换地址会让用户钉着旧地址的路由/防火墙规则失效，而 unknown 根本没证据说明冲突。
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: () => Promise.resolve('unknown' as AddressUsage),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.address).toBe('172.19.0.1');
+    expect(pick.reason).toBe('default-unverified');
+  });
+
+  it('默认已确证冲突、备选探不了 → 继续找能确证的，不落在未知地址上', async () => {
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: (ip) =>
+        Promise.resolve(ip === '172.19.0.1' ? 'in-use' : ip === '172.20.0.1' ? 'unknown' : 'free'),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.address).toBe('172.31.0.1');
+    expect(pick.reason).toBe('fallback');
+  });
+
+  it('候选池全军覆没 → 回落默认（绝不阻断启动）', async () => {
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: () => Promise.resolve('in-use' as AddressUsage),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.address).toBe(TUN_INET4_CANDIDATES[0]);
+    expect(pick.reason).toBe('exhausted');
+    expect(pick.skipped).toHaveLength(TUN_INET4_CANDIDATES.length);
+  });
+
+  it('ownLanCidrs 抛错 → 不阻断启动，按无约束继续', async () => {
+    // 变异守卫：去掉内部 try/catch → 异常穿透到 startInternal，整个代理起不来。拿诊断增强换掉代理可用性
+    // 是本次改动最不可接受的回归。
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: probeFrom({}),
+      ownLanCidrs: () => {
+        throw new Error('boom');
+      },
+    });
+    expect(pick.address).toBe('172.19.0.1');
+    expect(pick.reason).toBe('default');
+  });
+
+  it('probe 抛错 → 按 unknown 处理（fail-open），同样不阻断', async () => {
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      probe: () => Promise.reject(new Error('powershell missing')),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.address).toBe('172.19.0.1');
+    expect(pick.reason).toBe('default-unverified');
+  });
+
+  it('候选池首项恒为历史默认地址（换掉它=改变所有正常机器的行为）', () => {
+    expect(TUN_INET4_CANDIDATES[0]).toBe('172.19.0.1');
+  });
+});
+
+describe('ipv4InInterfaceMap', () => {
+  it("Node ≥18 的 family='IPv4' 能命中", () => {
+    expect(
+      ipv4InInterfaceMap('172.19.0.1', { eth0: [{ family: 'IPv4', address: '172.19.0.1' }] })
+    ).toBe(true);
+  });
+
+  it('旧版 Node 的 family=4 同样能命中', () => {
+    // 变异守卫：只认其中一种 → 换运行时后探测恒返回「未占用」，冲突预检静默变成摆设（不报错、不生效）。
+    expect(ipv4InInterfaceMap('172.19.0.1', { eth0: [{ family: 4, address: '172.19.0.1' }] })).toBe(
+      true
+    );
+  });
+
+  it('IPv6 同串不误命中', () => {
+    expect(
+      ipv4InInterfaceMap('172.19.0.1', { eth0: [{ family: 'IPv6', address: '172.19.0.1' }] })
+    ).toBe(false);
+  });
+
+  it('地址不同 → false；空表 → false；undefined 项不炸', () => {
+    expect(
+      ipv4InInterfaceMap('172.19.0.1', { eth0: [{ family: 'IPv4', address: '10.0.0.5' }] })
+    ).toBe(false);
+    expect(ipv4InInterfaceMap('172.19.0.1', {})).toBe(false);
+    expect(ipv4InInterfaceMap('172.19.0.1', { lo: undefined })).toBe(false);
+  });
+});
+
+describe('excludeOwnTunCidrs（H1：自家 TUN 不算冲突源）', () => {
+  it('剔除主机地址等于候选的条目（= 自家上一轮未释放的 TUN）', () => {
+    // 变异守卫：不剔 → 重启时 own-lan 命中自家残留 → 换地址；下次释放后换回，地址乒乓漂移。
+    expect(excludeOwnTunCidrs(['172.19.0.1/16', '192.168.1.7/24'], TUN_INET4_CANDIDATES)).toEqual([
+      '192.168.1.7/24',
+    ]);
+  });
+
+  it('候选池里每个地址都被认作自家（不只默认那个）', () => {
+    // 上一轮已避让到 172.20.0.1 时，本轮同样不能把它当成别人占用。
+    expect(excludeOwnTunCidrs(['172.20.0.1/16'], TUN_INET4_CANDIDATES)).toEqual([]);
+    expect(excludeOwnTunCidrs(['10.255.255.1/16'], TUN_INET4_CANDIDATES)).toEqual([]);
+  });
+
+  it('同网段但主机地址不同 → 保留（那是真的物理 LAN，不是自家 TUN）', () => {
+    expect(excludeOwnTunCidrs(['172.19.0.55/16'], TUN_INET4_CANDIDATES)).toEqual([
+      '172.19.0.55/16',
+    ]);
+  });
+
+  it('IPv6 与空表不受影响', () => {
+    expect(excludeOwnTunCidrs(['fe80::1/64'], TUN_INET4_CANDIDATES)).toEqual(['fe80::1/64']);
+    expect(excludeOwnTunCidrs([], TUN_INET4_CANDIDATES)).toEqual([]);
+  });
+
+  it('端到端：自家 TUN 在场时仍选默认地址，不漂移', async () => {
+    const pick = await pickTunInet4Address(TUN_INET4_CANDIDATES, {
+      // probe 已在 Windows 侧按 InterfaceAlias 排除自家适配器 → 这里返回 free。
+      probe: probeFrom({}),
+      ownLanCidrs: () =>
+        excludeOwnTunCidrs(['172.19.0.1/16', '192.168.1.7/24'], TUN_INET4_CANDIDATES),
+    });
+    expect(pick.address).toBe('172.19.0.1');
+    expect(pick.reason).toBe('default');
+  });
+});
+
+describe('skipped.cause=unverified（N2：exhausted 日志要能区分「确证冲突」与「探不了」）', () => {
+  it('后续候选探不了时记 unverified，不冒充 in-use', async () => {
+    const pick = await pickTunInet4Address(['172.19.0.1', '172.20.0.1'], {
+      probe: (ip) => Promise.resolve(ip === '172.19.0.1' ? 'in-use' : 'unknown'),
+      ownLanCidrs: noLan,
+    });
+    expect(pick.reason).toBe('exhausted');
+    expect(pick.skipped).toEqual([
+      { address: '172.19.0.1', cause: 'in-use' },
+      { address: '172.20.0.1', cause: 'unverified' },
+    ]);
+  });
+});

--- a/src/shared/singbox-fatal.ts
+++ b/src/shared/singbox-fatal.ts
@@ -1,0 +1,151 @@
+/**
+ * sing-box 启动失败 FATAL 行的解析与分类（issue #324）。
+ *
+ * 背景：sing-box 启动失败的 FATAL 只写 stderr，**永不进 config 里 `log.output` 指定的文件**（`log/export.go`
+ * 的包级 std logger 在 init() 固定绑 os.Stderr，cmd_run.go 的 run() 出错走它）。FlowZ 把这条 stderr 重定向到
+ * `singbox_startup.log`（helper 路径 / macOS wrapper / Windows UAC 看护三写侧，见 utils/paths.ts），但在
+ * #324 之前只有诊断报告导出时才读它——启动失败路径完全不读，用户看到的永远是「TUN 初始化未完成」这类
+ * 按适配器存在性反推的文案。#324 的真因（TUN 地址被占用）因此在文件里躺了三天，靠人肉传日志才定位。
+ *
+ * 本模块是纯函数（零 IO），供 ProxyManager 在起核失败时把真因捞出来上屏。
+ *
+ * **硬约束：解析结果绝不能拼进 `CoreStartRetryError.message`。** core-readiness.ts 的
+ * NON_RETRYABLE_START_ERROR_PATTERNS 含 permission/eacces/enoent 等词，FATAL 原文极易命中（例如
+ * `permission denied`），会把本可重试的起核失败静默判成终态。只走 logToManager + 结构化事件字段。
+ */
+
+/** sing-box CLI 默认 logger 即使重定向到文件也带 ANSI 色码（`\x1b[31mFATAL\x1b[0m[0000]`）。 */
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+/** 剥 ANSI 色码。匹配失败即原样返回（非 sing-box 写的行也安全）。 */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '');
+}
+
+/**
+ * 从 startup log 文本里取**最后一条** FATAL 行（已剥色码、已 trim）。无则 null。
+ *
+ * 取最后一条而非第一条：helper 写侧是 `O_APPEND` 永不截断（helper-win/winproc.go），同一次 start 的多轮重试
+ * 会追加多条同样的 FATAL，且调用方即便按 run 边界切过片段，片段内仍可能有多腿。最后一条最接近本次失败。
+ */
+export function extractLastFatal(text: string): string | null {
+  const lines = stripAnsi(text).split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    // sing-box 的格式是 `FATAL[0000] <msg>`。只宽松了 FATAL 之后的分隔符（`[` 或空白），行首锚点是刻意的：
+    // 放宽成行内匹配会把「日志里提到 FATAL 的普通行」也认成 FATAL。若上游哪天在 FATAL 前加了墙钟时间戳前缀，
+    // 这里会失配 —— 那属于必须随核升级复核的契约，不是这条正则该兜的。
+    if (/^FATAL[[\s]/.test(line)) return line;
+  }
+  return null;
+}
+
+/**
+ * FATAL 分类。`tun-*` 三档对应 sing-tun 在 `tun.New()` 里的不同失败点，用户可操作性差异很大；
+ * `other` = 认得是 FATAL 但不在已知表内（照原文透传，永远好过编造）。
+ */
+export type SingBoxFatalKind =
+  | 'tun-address-conflict'
+  | 'tun-adapter-create'
+  | 'tun-dns'
+  | 'tun-other'
+  | 'other';
+
+export interface SingBoxFatalInfo {
+  kind: SingBoxFatalKind;
+  /** 原始 FATAL 行（已剥色码），供日志留证。 */
+  raw: string;
+  /** 面向用户的中文说明（可操作）。 */
+  message: string;
+}
+
+/**
+ * 把一条 FATAL 行分类成可操作的中文说明。
+ *
+ * @param line   FATAL 行（stripAnsi 后的原文）
+ * @param ctx.tunAddress 本次实际下发的 TUN IPv4 地址（裸 IP 或 CIDR），用于地址冲突文案点名具体地址。
+ */
+export function classifySingBoxFatal(
+  line: string,
+  ctx?: { tunAddress?: string }
+): SingBoxFatalInfo {
+  const raw = stripAnsi(line).trim();
+  const lower = raw.toLowerCase();
+  const addr = ctx?.tunAddress ? ctx.tunAddress.split('/')[0] : '';
+
+  // 地址冲突（#324 实证）：Windows `CreateUnicastIpAddressEntry` 撞 ERROR_OBJECT_ALREADY_EXISTS，
+  // 消息是 "The object already exists."。占用方可能是一张 Disconnected/隐藏的适配器（本案是残留的
+  // TAP-Windows V9），设备管理器默认看不到，故文案必须点出这一点，否则用户会回答「没有别的网卡」。
+  if (lower.includes('set ipv4 address') || lower.includes('set ipv6 address')) {
+    // v4/v6 必须分叉：macOS 默认给 TUN 配 IPv6，v6 撞车时点名 ctx.tunAddress（恒为 v4）会把用户引去找占用
+    // 172.19.0.1 的网卡——方向全错。且 P0-2 的候选池只避让 v4，对 v6 冲突无避让，文案不能暗示已处理。
+    const isV6 = lower.includes('set ipv6 address');
+    const suffix =
+      '无法配置到虚拟网卡。占用方可能是一张已断开或隐藏的适配器（设备管理器默认不显示），常见于其它 VPN/TUN 客户端的残留网卡。';
+    return {
+      kind: 'tun-address-conflict',
+      raw,
+      message: isV6
+        ? `TUN 的 IPv6 地址已被本机其它网络接口占用，${suffix}`
+        : addr
+          ? `TUN 地址 ${addr} 已被本机其它网络接口占用，${suffix}`
+          : `TUN 地址已被本机其它网络接口占用，${suffix}`,
+    };
+  }
+
+  // 适配器创建失败（驱动层）：wintun 从内存反射加载（sing-tun/internal/wintun/memmod），是杀软启发式的
+  // 高命中面；也可能是其它厂商的 wintun 驱动版本冲突或 HVCI 拒绝。
+  if (lower.includes('create adapter') || lower.includes('open existing adapter')) {
+    return {
+      kind: 'tun-adapter-create',
+      raw,
+      message:
+        '虚拟网卡（wintun）创建失败。常见原因：wintun 驱动被安全软件拦截或隔离、驱动版本与其它 VPN 客户端冲突。',
+    };
+  }
+
+  if (lower.includes('set ipv4 dns') || lower.includes('set ipv6 dns')) {
+    return { kind: 'tun-dns', raw, message: 'TUN 接口的 DNS 下发失败。' };
+  }
+
+  // 仍在 tun.New() 窗口内但不在已知表：透传原文，不编造原因。
+  if (lower.includes('configure tun interface')) {
+    return { kind: 'tun-other', raw, message: `TUN 接口配置失败：${raw}` };
+  }
+
+  return { kind: 'other', raw, message: `sing-box 启动失败：${raw}` };
+}
+
+/**
+ * 按 run 边界切出「本次起核」写入的片段。
+ *
+ * 两个写侧的截断语义相反（见 utils/paths.ts）：Windows helper 侧 `O_APPEND` 永不截断，文件会跨会话无限
+ * 追加；UAC 看护脚本的 `-RedirectStandardError` 与 macOS wrapper 则每次起核截断。而 sing-box 的
+ * `FATAL[0000]` 只有启动相对秒、**没有墙钟时间戳**，光看内容无法判断某条 FATAL 属于哪次会话。
+ * 故调用方在起核前记录文件大小作锚点，失败时按锚点切——不切就会读到几个月前的残留 FATAL 并当成本次原因，
+ * 那比不报更糟。
+ *
+ * **适用边界（勿误用）**：本函数按「文件只增不减」推断 run 边界，只对**追加写侧**成立（当前三平台 helper 路径
+ * 均为 `O_APPEND`）。对**截断写侧**（Windows UAC 的 `-RedirectStandardError`、macOS wrapper 的 `> "$LOG"`）
+ * 不可用：重复失败腿写出逐字节相同的内容时 `sizeNow === offsetBytes`，会被判成「本腿零写入」而切成空串，
+ * FATAL 系统性丢失。截断写侧的调用方应直接按「整文件即本次」处理（写侧类型可由 `startedViaWrapper` 判定）。
+ *
+ * @param text        起核后读到的文件全文（或 tail）
+ * @param offsetBytes 起核前记录的文件字节大小
+ * @param sizeNow     当前文件字节大小；小于 offsetBytes 说明文件被截断过 → 全文都是本次的
+ */
+export function sliceSinceRunStart(text: string, offsetBytes: number, sizeNow: number): string {
+  if (offsetBytes <= 0) return text;
+  // 截断过 → 现有内容全部属于本次起核。
+  if (sizeNow < offsetBytes) return text;
+  // 追加语义：text 可能只是 tail（起始被裁过），此时按「新增字节数」从尾部取。
+  const appended = sizeNow - offsetBytes;
+  if (appended <= 0) return '';
+  const buf = Buffer.from(text, 'utf-8');
+  if (appended >= buf.length) return text;
+  const sliced = buf.subarray(buf.length - appended).toString('utf-8');
+  // 切点可能落在多字节字符/行中间 → 丢弃首个不完整行，保持可读。
+  const nl = sliced.indexOf('\n');
+  return nl >= 0 ? sliced.slice(nl + 1) : sliced;
+}

--- a/src/shared/tun-address.ts
+++ b/src/shared/tun-address.ts
@@ -1,0 +1,157 @@
+/**
+ * TUN 接口 IPv4 地址的冲突避让（issue #324）。
+ *
+ * 背景：FlowZ 的 TUN 地址长期硬编码 `172.19.0.1`（Windows /16、macOS /30），起核前不做任何冲突检测。
+ * #324 报告者机器上有一张残留的 TAP-Windows 适配器（Disconnected）被人工配了 `172.19.0.1/29`，Windows
+ * 要求单播地址在同一 network compartment 内唯一，sing-box 给自家虚拟网卡配同一地址时
+ * `CreateUnicastIpAddressEntry` 返回 ERROR_OBJECT_ALREADY_EXISTS → TUN inbound 起不来 → 进程 FATAL 自杀
+ * → 外层无限重试。用户没有任何自救手段（该地址当时不可配置）。
+ *
+ * 本模块是纯逻辑（探测经 deps 注入），选出本次起核实际下发的 TUN 地址。
+ *
+ * **fail-open 纪律**：探测链路不可用（杀软拦 PowerShell 等）时绝不阻断启动、也绝不乱换地址——沿用默认地址
+ * 照常起核。换地址本身有代价（用户的自定义路由/防火墙规则可能钉着旧地址），只在**确证**冲突时才换。
+ * 这与 #159 释放门控、#324 正向适配器门的 fail-open 同源。
+ */
+import { cidrOverlapsAny } from './ip';
+
+/**
+ * TUN IPv4 地址候选池（按序尝试）。
+ *
+ * 选段理由：
+ * - `172.19.0.1` —— 历史默认，与 sing-box 上游默认同段，保持不变以免影响绝大多数正常机器。
+ * - `172.20.0.1` / `172.31.0.1` —— 同在 RFC 1918 的 172.16/12 内，与家用 LAN 常用的 192.168/16、10/8
+ *   不相交。172.16/12 段里 Docker Desktop 会占用 172.17–172.31 的一部分，故给两个候选而非一个；
+ *   真撞上会被预检跳过（候选池的长度比单个候选的选择更重要）。
+ * - `10.255.255.1` —— 最后兜底。10/8 与企业 LAN 撞车的先验最高，故排在最后。
+ *
+ * 候选池顺序在真实用户环境里的撞车概率未量化，后续可按反馈调整（设计 doc §8-6 已登记）。
+ */
+export const TUN_INET4_CANDIDATES = [
+  '172.19.0.1',
+  '172.20.0.1',
+  '172.31.0.1',
+  '10.255.255.1',
+] as const;
+
+/**
+ * 某个 IPv4 地址在本机的占用状态。
+ * - `in-use`：查询成功且该地址已存在于本机某个接口（含 Disconnected/隐藏接口）；
+ * - `free`：查询成功且不存在（证明探测链路可用 → 可据此放心使用）；
+ * - `unknown`：探测本身失败 → fail-open 信号，绝不据此换地址。
+ */
+export type AddressUsage = 'in-use' | 'free' | 'unknown';
+
+/**
+ * `os.networkInterfaces()` 的返回值里是否已存在该 IPv4。
+ *
+ * 抽成纯函数是因为 family 字段有版本漂移：Node ≥18 给 `'IPv4'` 字符串，更早给数字 `4`。只认一种，换运行时
+ * 就会静默失效——探测恒返回「未占用」，冲突预检整个变成摆设而没有任何报错。
+ *
+ * 注意它只覆盖 **OperStatus=Up** 的接口（libuv 的 uv_interface_addresses 在 Windows 上跳过非 Up 适配器），
+ * 故 Windows 必须走 Get-NetIPAddress，不能用它——#324 的冲突源正是一张 Disconnected 的适配器。
+ */
+export function ipv4InInterfaceMap(
+  ip: string,
+  ifaces: Record<string, Array<{ family: string | number; address: string }> | undefined>
+): boolean {
+  for (const addrs of Object.values(ifaces)) {
+    for (const a of addrs ?? []) {
+      if ((a.family === 'IPv4' || a.family === 4) && a.address === ip) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * 从「本机接口网段」里剔除**自家 TUN** 的条目（issue #324 H1）。
+ *
+ * 判据：主机地址正好等于候选池里的某一个 —— 只有我们自己配的 TUN 会用这些地址。为什么必须剔：地址预检跑在
+ * `startInternal`，**早于** #159 的适配器释放门（在 `startSingBoxProcess` 顶部），节点切换/崩溃重启时上一个核
+ * 的 TUN 还挂着 `172.19.0.1` → own-lan 检查命中自家残留 → 换地址；下次重启它已释放 → 换回，地址在重启之间
+ * 乒乓漂移，恰好造成避让机制声称要避免的代价。
+ *
+ * 真冲突方（如 #324 那张手工配了 172.19.0.1 的 TAP）也会被这条一并剔出 own-lan 清单，但它由 `probe` 的
+ * `in-use` 判据抓住 —— 两道检查职责不同，不漏。
+ */
+export function excludeOwnTunCidrs(cidrs: string[], candidates: readonly string[]): string[] {
+  return cidrs.filter((c) => !candidates.includes(c.split('/')[0]));
+}
+
+export interface TunAddressPickDeps {
+  /** 探测某个裸 IPv4 是否已被本机占用。 */
+  probe: (ip: string) => Promise<AddressUsage>;
+  /** 本机各接口的网段（用于避开与物理 LAN 相交的候选）。 */
+  ownLanCidrs: () => string[];
+}
+
+/**
+ * 选择结果。
+ * - `default`：默认候选探测为 free，正常放行。**也用于 carry-over**——调用方在「旧核仍在跑、跳过探测」时
+ *   沿用上次已选定的地址（可能是备选段），复用本 reason 表示「这不是一次新的避让决策，只是延续既有选择」，
+ *   使调用方零日志。故 `reason === 'default'` **不蕴含** `address === candidates[0]`；
+ * - `default-unverified`：默认候选探测 unknown（探测链路不可用）→ fail-open 沿用默认；
+ * - `fallback`：默认候选确证冲突，已换到备选；
+ * - `exhausted`：所有候选都被排除 → 仍回落默认（绝不阻断启动，让核去报真实错误，由 P0-1 的 FATAL 解析上屏）。
+ */
+export interface TunAddressPick {
+  /** 选定的裸 IPv4（不含掩码，掩码由调用方按平台拼）。 */
+  address: string;
+  reason: 'default' | 'default-unverified' | 'fallback' | 'exhausted';
+  /**
+   * 被跳过的候选及原因，供日志说明「为什么换了地址」。
+   * `unverified` = 探测链路对该候选给不出结论（只可能出现在非首个候选上：首个候选 unknown 直接 fail-open 沿用）。
+   * 记它是为了让 exhausted 日志能区分「确证冲突」与「探不了」——只说「全部不可用」会读成前者。
+   */
+  skipped: Array<{ address: string; cause: 'in-use' | 'own-lan' | 'unverified' }>;
+}
+
+/**
+ * 按候选池顺序选出可用的 TUN IPv4 地址。
+ *
+ * 每个候选两道检查：
+ *  1. 与本机接口网段相交 → 跳过（把 TUN 地址放进物理 LAN 段内会让该段的真实主机不可达）；
+ *  2. probe 判 `in-use` → 跳过（这是 #324 的直接病因）。
+ *
+ * probe 返回 `unknown` 时的处理按候选位置分叉：**首个候选**（= 默认地址）unknown → 直接沿用（fail-open，
+ * 不换地址）；**后续候选** unknown → 保守跳过（既然已经确证默认地址冲突、必须换，就只换到能确证可用的地址上，
+ * 否则等于把一次已知冲突换成一次未知冲突）。
+ */
+export async function pickTunInet4Address(
+  candidates: readonly string[],
+  deps: TunAddressPickDeps
+): Promise<TunAddressPick> {
+  const fallbackAddress = candidates[0];
+  const skipped: TunAddressPick['skipped'] = [];
+  // 本模块跑在起核关键路径上：注入实现抛错绝不能阻断启动（那是拿一个诊断增强换掉整个代理可用性）。
+  // 取不到本机网段 → 视作无约束，交由下面的占用探测把关。
+  let lanCidrs: string[];
+  try {
+    lanCidrs = deps.ownLanCidrs();
+  } catch {
+    lanCidrs = [];
+  }
+
+  for (let i = 0; i < candidates.length; i++) {
+    const ip = candidates[i];
+    // /32 与本机接口网段做家族感知相交判定。
+    if (cidrOverlapsAny(`${ip}/32`, lanCidrs)) {
+      skipped.push({ address: ip, cause: 'own-lan' });
+      continue;
+    }
+    // 同上：probe 抛错按 unknown 处理（fail-open），不让异常穿透到起核流程。
+    const usage = await deps.probe(ip).catch((): AddressUsage => 'unknown');
+    if (usage === 'free') {
+      return { address: ip, reason: i === 0 ? 'default' : 'fallback', skipped };
+    }
+    if (usage === 'unknown') {
+      // 首个候选探不了 → fail-open 用它；后续候选探不了 → 不冒险，继续往下找能确证的（并记原因）。
+      if (i === 0) return { address: ip, reason: 'default-unverified', skipped };
+      skipped.push({ address: ip, cause: 'unverified' });
+      continue;
+    }
+    skipped.push({ address: ip, cause: 'in-use' });
+  }
+
+  return { address: fallbackAddress, reason: 'exhausted', skipped };
+}


### PR DESCRIPTION
Closes #324

## 根因

TUN 地址硬编码 `172.19.0.1`，撞上本机已有同址接口时 sing-box 在 `configure tun interface: set ipv4 address` 直接 FATAL 自杀（Windows `CreateUnicastIpAddressEntry` 返回 `ERROR_OBJECT_ALREADY_EXISTS`），外层只会无限「正在自动重试」。

报告者机器上的占用方是一张 **Disconnected 的 TAP-Windows 适配器**（人工配了 `172.19.0.1/29`），设备管理器默认不显示——所以「没有残留网卡」这类自查会得到反向结论。mihomo 的 TUN 默认用 `198.18.0.1`，不撞这张卡，这解释了「以前跑 mihomo 正常、第一次跑 sing-box TUN 就不行」。

决定性证据在 `singbox_startup.log`，而不在 `singbox.log`——见下。

## 改动

**1. 起核前地址冲突预检 + 候选池避让**

候选池 `172.19.0.1 → 172.20.0.1 → 172.31.0.1 → 10.255.255.1`，掩码仍按平台取（Win `/16`、mac `/30`）。纪律：

- **确证冲突才换**，探测不可用（杀软拦 PowerShell 等）一律沿用默认（fail-open）——换地址本身有代价，用户钉着旧地址的路由/防火墙规则会失效
- **旧核仍在跑时跳过探测并沿用上次已选地址**：预检早于 #159 的适配器释放门，不这样做会把自家残留判成冲突，地址在重启之间乒乓
- Windows 走 `Get-NetIPAddress` 并按 `InterfaceAlias` 排除自家网卡——**Node 的接口枚举（libuv）跳过非 Up 适配器**，看不到本 issue 这种 Disconnected 的冲突源
- 用户显式配置的 `tunConfig.inet4Address` 优先，不做避让

**2. 解析核 stderr 的 FATAL 并上屏**

sing-box 启动失败的 FATAL **只写 stderr、永不进 config 里 `log.output` 指定的文件**（`log/export.go` 的包级 logger 在 init 时固定绑 `os.Stderr`）。此前只有诊断报告导出时才读 `singbox_startup.log`，起核失败路径靠「TUN 适配器有没有出现」反推，用户看到的永远是「TUN 初始化未完成」。

三条起核路径现在都读：helper 就绪门的 dead 分支 / wrapper 的 PID 等待失败 / 运行期健康检查（wrapper 的核是 detached 由看护脚本托管，死亡不产生 exit 事件，这条才是它的唯一检测通道）。run 边界按写侧分叉：wrapper 是截断语义整读，helper 是 `O_APPEND` 按起核前锚点切——`FATAL[0000]` 只有启动相对秒、没有墙钟时间戳，不切就会把上次甚至更早的 FATAL 当成本次原因。

**3. 地址冲突转终态，停止无谓重试**

该类失败是确定性的：占用方不挪走，重试多少次都是同一条 FATAL，而 wrapper 路径每条重试腿还会重弹一次 UAC。终态携 `TUN_INIT_PERSISTENT`，主进程据此**跳过核心自动回滚**——地址冲突是环境问题，与核版本无关，回滚健康的新核属误伤。

**4. FATAL 原文不进 `CoreStartRetryError.message`**

其中的 `permission` / `enoent` 等词会命中 `NON_RETRYABLE_START_ERROR_PATTERNS`，把本可重试的起核失败静默判成终态。真因只走日志与终态错误。

**5. 修 PowerShell 探测的退出码契约（真机实测抓出，曾使 1 与就绪门全部失效）**

三处探测原本写成 `execFile(powershell, ['-Command', '<cmdlet> -ErrorAction SilentlyContinue | Select-Object ...'])`，靠 `err == null` 承载「查询成功且结果为空」。真机实测（Windows 11 26200）：

```
Get-NetIPAddress -IPAddress 172.19.0.1   (空闲)    → exit=1  stdout=[]
Get-NetIPAddress -IPAddress 192.168.10.207 (占用)  → exit=0  stdout=[192.168.10.207]
Get-NetAdapter   -Name flowz-tun0 (不存在)         → exit=1  stdout=[]
```

`-ErrorAction SilentlyContinue` 只抑制错误的**显示**，不改 `$?`；Node `execFile` 对非零退出码置 `err` 非 null。于是「查询成功且为空」这个结论在真实 Windows 上永远得不到——地址避让 100% 失效（所有空闲候选都落 `unknown` 被跳过，循环耗尽后退回被占用的 `172.19.0.1`），#327 的正向就绪门也恒 fail-open。

改法：抽 `runPsProbe` 单一原语经 `-EncodedCommand` 传入，用**哨兵行**把「探测确实跑过」从隐式假设（退出码）变成显式可观测事实，结论只由 stdout 承载。哨兵受判据门控——零错误、或被吞的错误**全部**是 `ObjectNotFound` 才发：

```powershell
$ErrorActionPreference = 'SilentlyContinue'
$Error.Clear()
try {
  $r = @(<pipeline>)
  if (@($Error | Where-Object { $_.CategoryInfo.Category -ne 'ObjectNotFound' }).Count -eq 0) {
    Write-Output 'PROBE_OK'
    foreach ($x in $r) { Write-Output $x }
  }
} catch { }
exit 0
```

这一层必须区分「目标确实不存在」（`ObjectNotFound`）与「查询根本没跑通」（如 CIM 被 EDR 拦，`CimJob_BrokenCimSession`）——后者若被当成「网卡从未创建」，健康机器会走 `absent-timeout → stopCore → 三腿耗尽 → 永久拒连`，比原 bug 更糟。两类的可分性已在真机上按 `$Error.CategoryInfo` 取证。

## 验证

- 新增单测 60+ 例，全量 **3513 passed / 0 failed**，tsc / eslint 零 warning
- `config-snapshot` **37 份金样零变化** —— 默认路径（未预检 / 探测不可用）下发给核的配置逐字节不变，正常机器不受影响
- **变异验证 45 条全部 KILLED**，含几条关键逃逸：探测不可用改 fail-closed（会把所有杀软拦 PowerShell 的机器拖下水）、预检异常穿透起核路径、`shouldRetry` 对终态返回 true、v4/v6 文案串台
- 改动 5 的脚本原文是与 `powershell.exe` 的契约，用全文比对钉死（合法重构也会让用例失败，那是设计意图——脚本文本变了就要回真机重验五态），另加 **19 条变异全 KILLED** 与 argv/spawn 参数守卫
- 4 轮独立 review 收敛至零 High/Med/Low

**Windows 真机验证（Windows 11 Build 26200，随包核 1.14.0-beta.2）**

| 场景 | 结果 |
|---|---|
| 正常起核（无冲突） | TUN 起得来，`flowz-tun0` Up 带 `172.19.0.1/16`，app.log 零 `absent-timeout`、零终态错误 |
| 构造同址冲突（给以太网加 secondary `172.19.0.1/16`） | 预检判 in-use → **避让到 `172.20.0.1`**，核正常起、代理可用，零重试风暴、零重复 UAC |
| 候选池 4 个全占满 | 回落默认 → `singbox_startup.log` 拿到 FATAL → **真因上屏并透到 UI** → `TUN 地址冲突，停止重试`（终态） |

第三项复现出与 issue 里一字不差的 `set ipv4 address: The object already exists.` 与 `[watchdog] sing-box exited by itself`，且不再出现「wintun 被拦/驱动异常」与「UAC 授权失败，退出码: null」这两条误报。

## 已知边界

- helper **服务**路径下 `singbox_startup.log` 的 ACL 未验（真机三轮走的都是 UAC 看护路径，文件属提升的用户而非 SYSTEM）
- run 边界在 3 腿重试下的分段未验（地址冲突一腿即终态，没制造出多腿场景）
- 非 Windows 的占用探测只覆盖 `OperStatus=Up` 的接口，mac/linux 上「接口已断开但地址仍占位」会漏检（此时由 FATAL 终态兜底给出准确原因，不会无限重试）
- Linux 直起路径（setcap 回退、helper 缺位）无 startup log 写侧，冲突不会短路，会烧完重启预算才停
- TUN 地址仍未开放到 UI，用户无法自行改地址绕开——单独跟进
