### PR TITLE
fix(ui): 折叠头改用独立表面，修可发现性与层级倒挂

### DIFF
--- a/src/renderer/conduit.css
+++ b/src/renderer/conduit.css
@@ -136,18 +136,23 @@
 .pill.info { background: hsl(var(--flow-weak)); color: hsl(var(--flow-hi)); }
 .pill.idle { background: hsl(var(--surface-3)); color: hsl(var(--fg-faint)); }
 
-/* 折叠分组（原生 details，零脚本） */
-.set-collapse > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 11px 15px; font-size: 12.5px; font-weight: 600; color: hsl(var(--fg-dim)); user-select: none; }
+/* 折叠分组（原生 details，零脚本）
+   折叠头 = 独立「区段表面」：整幅 surface-2 底衬把「可展开的容器」与「单个设置行」在扫视层分开
+   （二者原本同构：左标签 + 右小元素，被读成一个看不懂的设置项）。
+   字号/颜色对齐 .srow-lbl 且字重更高 → 容器权重不低于其中任一条目（修层级倒挂）；
+   hover 提亮到 surface-3 作可点提示（原 hover 改字色的信号已被常态 --fg 吃掉）。
+   栅格不动：padding 不变（标签起点同 .srow），chevron 仍 margin-left:auto 贴行尾。 */
+.set-collapse > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 11px 15px; font-size: 13px; font-weight: 600; color: hsl(var(--fg)); background: hsl(var(--surface-2)); user-select: none; }
 .set-collapse > summary::-webkit-details-marker { display: none; }
-.set-collapse > summary:hover { color: hsl(var(--fg)); }
-.set-collapse > summary .chev { width: 14px; height: 14px; margin-left: auto; color: hsl(var(--fg-faint)); transition: transform 0.16s; }
+.set-collapse > summary:hover { background: hsl(var(--surface-3)); }
+.set-collapse > summary .chev { width: 14px; height: 14px; margin-left: auto; color: hsl(var(--fg-dim)); transition: transform 0.16s; }
 .set-collapse[open] > summary .chev { transform: rotate(90deg); }
 .sc-label { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .sc-body { padding: 0 15px 6px; border-top: 1px solid hsl(var(--hair)); display: flex; flex-direction: column; }
 .sc-body > .srow { padding-left: 0; padding-right: 0; }
 .sc-body > .srow:first-child { border-top: 0; }
-/* 嵌套折叠（竞速上游）：缩进 + 更浅背景 */
-.set-collapse.nested { border: 1px solid hsl(var(--hair)); border-radius: 9px; background: hsl(var(--surface-2) / 0.4); margin: 4px 0 8px; }
+/* 嵌套折叠（竞速上游）：缩进 + 更浅背景；overflow 让折叠头底衬被 9px 圆角裁掉（否则方角溢出边框） */
+.set-collapse.nested { border: 1px solid hsl(var(--hair)); border-radius: 9px; background: hsl(var(--surface-2) / 0.4); margin: 4px 0 8px; overflow: hidden; }
 .set-collapse.nested > summary { padding: 9px 12px; }
 .set-collapse.nested .sc-body { padding: 0 12px 10px; }
 .set-collapse.flush > summary { padding: 13px 15px; }


### PR DESCRIPTION
## 问题

设置页的折叠头与普通设置行**视觉同构**——都是「左边标签 + 右边一个小元素」，用户扫过去读到的是「一个我看不懂的设置项」，而不是「一个能打开的容器」。

三件事叠加造成的：

1. 原生 disclosure 三角被显式删掉（`list-style:none` + `::-webkit-details-marker`）——用户唯一天生认识的「可展开」符号没了
2. 替代的 chevron 被推到行尾（`margin-left:auto`），14px，用最淡的 `--fg-faint`
3. 行尾恰好是普通设置行放开关的位置

于是 chevron 不在提示可展开，它在伪装成某个控件的值。

**层级还是倒挂的**：装着 N 项的折叠头（12.5px / `--fg-dim`）比其中单独 1 项（`.srow-lbl` 13px / `--fg`）还弱。

## 改动

`src/renderer/conduit.css` 单文件，11 增 6 删，零 `.tsx` 改动：

- 折叠头加整幅 `surface-2` 底衬——把「区段」与「条目」在扫视层分开（核心）
- `12.5px/--fg-dim` → `13px/--fg`，字重仍 600 → 三轴均 ≥ 单个条目，同时未越级压过卡片标题（`.set-h` 660）
- hover 由「改字色」改为「改底色」——常态既已是 `--fg`，原 hover 信号被吃掉了，必须换载体
- chevron `--fg-faint` → `--fg-dim`，解决扫视层不进视野
- `.nested` 加 `overflow: hidden`，否则方角底衬溢出既有的 9px 圆角边框

**栅格一字不动**：`padding` 未改，`margin-left:auto` 保留。

## 验证

改前后用 CDP 量真实 DOM 对拍（`git stash` 出基线各重建一次渲染层）：

| 项 | before | after |
|---|---|---|
| 标签左缘 | 199 / nested 212 | 完全相同 |
| chevron 右缘 | 1140 / nested 1127 | 完全相同（== 同卡 `.srow-ctl` 右缘） |
| 折叠头宽 / 卡片宽 | 971 / 973 | 完全相同 |
| 折叠头高 | 40.8 | 41.5（字号 12.5→13 的 line-height 差） |

- **3 变体 × 双主题 × 5 个使用点**全部覆盖（`terminal-proxy-section.tsx:43` flush、`network-settings.tsx:327/553/706` base、`:1134` nested；全仓无其他消费者）
- 对承载面对比度 `1.000 → 1.166`（浅）/ `1.111`（深）
- 边框断言：`prev.border-bottom` 与 `self.border-top` 从不同时 >0（无双线）；头体交界单线；底衬整幅铺满卡内宽（无断线）
- hover 用真鼠标事件触发 + **取渲染像素**验证：浅 `srgb(221,226,233)`、深 `srgb(43,50,59)`，均等于 `--surface-3`
- `tsc` renderer OK / `eslint` 0 errors / `npm test` 233 suites 3410 passed

**未验证**：真机 macOS / Windows 渲染（仅 Linux Electron 42）。三平台字体栈与亚像素抗锯齿不同，底衬对比度的观感可能有差异，几何不受影响。

## 不在本 PR

有意分批，本批只解 affordance，验证面收敛在 CSS 层：

- 含非默认值的区默认展开（绕开发现问题本身）
- 计数徽章（仓里已有先例：嵌套折叠头「竞速上游（最多 3）」已带「已选 2 个 · …」）
- 展开态记忆（现为 `useState(!!defaultOpen)`，重挂载即收起）
- 分组轴重排（「高级」是按技术复杂度分的，不是按用户需要它的概率分的——轴不换，折叠区会持续失血）