### PR TITLE
fix(speedtest): 端点 DNS 规则弃用 legacy strategy，拆掉与 query_type 共存即起核 FATAL 的隐患

### DIFF
--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -845,13 +845,38 @@ export class SpeedTestService {
           server_port: 53,
           detour: tag, // 查询穿本端点隧道 → AliDNS 按出口地理(ECS)返 IP
         });
-        // WG localAddress 含 v6 → prefer_ipv4（避免 v6 优先落不可达）；纯 v4 → ipv4_only（消 v6 解析噪声）。
+        // 族别偏好（语义不变，写法迁移）：WG localAddress 含 v6 → v4 优先但保留 v6（避免 v6 优先落不可达）；
+        // 纯 v4 → 只取 A（消 v6 解析噪声）。
+        //
+        // 迁移背景（sing-box 1.14.0，随包核 1.14.0-beta.2 本机 loopback 实测）：rule-action 上的 legacy
+        // `strategy` 已废弃、run 时 WARN、1.16.0 移除；更要命的是它与**同一份 dns 配置内**任何带
+        // `query_type`/`ip_version` 的规则（含引用带 query_type 的 rule-set）**互斥**——共存则 `sing-box run`
+        // 与 `check` 双双硬拒（`initialize dns router: Legacy strategy ... is deprecated` FATAL）。主配置
+        // （singbox-dns-builder）大量用 query_type，测速配置用 rule-action strategy，此前只是**恰好错开**。
+        // 新写法改用 query_type 规则项表达，两侧不再有 legacy strategy，该雷结构性拆除。
+        //
+        //  · 旧 `prefer_ipv4` → **不下发任何东西**：本配置无顶层 `dns.strategy`（见下方 `dns` 组装），内核默认
+        //    并发 A/AAAA 且把 v4 排在 v6 前（sortAddresses 对 AsIS 与 prefer_ipv4 同一分支）。实测两形态返回
+        //    的地址列表逐项同序。⚠️ 该等价性**依赖测速配置不带顶层 dns.strategy**，由 speed-test-endpoint-dns
+        //    单测「全仓禁 legacy rule-action strategy」一例锁死。
+        //  · 旧 `ipv4_only` → 给该 inbound 的 AAAA 查询前置一条 predefined 空 NOERROR：AAAA 就地返空、不出网，
+        //    结果集只剩 A。实测与 legacy ipv4_only 的出网查询与解析结果逐字节一致。
+        //
+        // 顺序有牙：抑制规则必须排在本节点 route 规则**之前**——DNS 规则先匹配先命中，route 规则是该 inbound 的
+        // catch-all，排它前面则 AAAA 先被 route 吃掉、抑制静默失效（实测反证）。
         const hasV6 = !!server.wireguardSettings?.localAddress?.some((a) => a.includes(':'));
+        if (!hasV6) {
+          dnsRules.push({
+            inbound: [inboundTag],
+            query_type: ['AAAA'],
+            action: 'predefined',
+            rcode: 'NOERROR', // 空答复：等价旧 ipv4_only 的「不要 v6」，且不触发拒绝日志噪声
+          });
+        }
         dnsRules.push({
           inbound: [inboundTag], // 端点入站的目标解析走穿隧道 DNS（按出口地理）
           action: 'route',
           server: exitDnsTag,
-          strategy: hasV6 ? 'prefer_ipv4' : 'ipv4_only',
           disable_cache: true, // 多端点并测出口 geo 答案各异，禁缓存防互污染（cache 按 question 全局共享）
         });
       } else {
@@ -868,6 +893,9 @@ export class SpeedTestService {
     //    ⚠️ 勿引入 sniff / outbound.domain_strategy / 针对目标的本地解析——会破坏此不变量。
     //  · 端点（WG/WARP…L3）：**必本地解析**目标（内核强制）。故上方用 inbound 键控 dns.rule 把端点的目标解析压到穿隧道
     //    223.5.5.5（AliDNS ECS 按出口地理返 IP、geo 正确、单形态覆盖境内外出口）；default_domain_resolver 仍解节点 server 地址。
+    // ⚠️ 恒不下发顶层 `dns.strategy`：端点族别偏好靠上方的 query_type 规则项表达，而「无顶层 strategy」
+    // 正是「省略 prefer_ipv4 == prefer_ipv4」这一等价性的前提（顶层若为 prefer_ipv6，端点解析会翻成 v6 优先，
+    // 实测确证）。要加顶层 strategy 必须同时重新推导端点规则，别只加一半。单测锁死本不变量。
     const dns: Record<string, unknown> = { servers: dnsServers };
     if (dnsRules.length > 0) dns.rules = dnsRules; // 仅有端点节点时下发；纯代理配置零变化
     const config: Record<string, unknown> = {

--- a/src/main/services/__tests__/speed-test-endpoint-dns.test.ts
+++ b/src/main/services/__tests__/speed-test-endpoint-dns.test.ts
@@ -3,7 +3,14 @@
  * 端点(WG/WARP)是 L3、目标域名必被本地解析：默认 dns-direct 从本机解析 → 本机 geo IP、端点出口够不着 → 超时/失真。
  * 修复(单形态):端点目标解析经 inbound 键控 dns.rule 定向到「穿本节点隧道」的 223.5.5.5(AliDNS 有大陆节点 + ECS,
  * 按出口地理返 IP → 境外/国内出口都对；1.1.1.1 因 anycast 无大陆 PoP、国内出口反挂,故用 223.5.5.5)。
- * 验:端点单入站、穿隧道 dns server(223.5.5.5/detour)、inbound 键控 dns.rule(disable_cache/strategy)、纯代理零变化。
+ * 验:端点单入站、穿隧道 dns server(223.5.5.5/detour)、inbound 键控 dns.rule(disable_cache)、纯代理零变化。
+ *
+ * 2026-07 迁移(sing-box 1.14.0):rule-action 的 legacy `strategy` 已废弃(run 时 WARN、1.16.0 移除),且与同一份
+ * dns 配置内任何 query_type/ip_version 规则**互斥**(共存 → run 与 check 双双 FATAL)。改用 query_type 规则项表达:
+ *   · 旧 prefer_ipv4 → 不下发任何东西(本配置无顶层 dns.strategy,内核默认并发 A/AAAA 且 v4 排前,实测同序)
+ *   · 旧 ipv4_only  → 该 inbound 的 AAAA 前置一条 predefined 空 NOERROR(AAAA 就地返空不出网,实测逐字节等价)
+ * 本文件用 toEqual 锁精确形状 + 显式锁顺序/顶层无 strategy —— 顺序反了抑制静默失效(实测反证),
+ * 顶层加了 strategy 则「省略 == prefer_ipv4」的等价前提被破坏。
  */
 import { SpeedTestService } from '../SpeedTestService';
 
@@ -31,7 +38,7 @@ const vless = (id: string): Usable => ({
 });
 
 describe('测速临时 config:端点目标解析穿隧道 223.5.5.5（单形态）', () => {
-  it('WG 端点:单入站 + 穿隧道 223.5.5.5 dns server(detour) + inbound 键控 dns.rule(disable_cache/ipv4_only)', () => {
+  it('WG 端点:单入站 + 穿隧道 223.5.5.5 dns server(detour) + inbound 键控 dns.rule(AAAA 抑制 + 禁缓存)', () => {
     const cfg = gen([wg('wgnode01', ['172.16.0.2/32'])], [21001]);
     expect(cfg.inbounds.map((i: any) => i.tag)).toEqual(['http-in-wgnode01']); // 单入站(无 local 兜底)
     expect(cfg.endpoints).toHaveLength(1); // WG 进 endpoints[]
@@ -41,21 +48,79 @@ describe('测速临时 config:端点目标解析穿隧道 223.5.5.5（单形态�
       server: '223.5.5.5',
       detour: 'out-wgnode01',
     });
-    // inbound 键控 dns.rule:端点入站、禁缓存、v4-only(无 v6 localAddress)
+    // 纯 v4 localAddress(旧 ipv4_only):AAAA 抑制规则必须**在前**,route catch-all 在后
     expect(cfg.dns.rules).toEqual([
+      {
+        inbound: ['http-in-wgnode01'],
+        query_type: ['AAAA'],
+        action: 'predefined',
+        rcode: 'NOERROR',
+      },
       {
         inbound: ['http-in-wgnode01'],
         action: 'route',
         server: 'dns-exit-wgnode01',
-        strategy: 'ipv4_only',
         disable_cache: true,
       },
     ]);
   });
 
-  it('WG localAddress 含 v6 → strategy prefer_ipv4', () => {
+  it('WG localAddress 含 v6(旧 prefer_ipv4)→ 只有 route 规则、无 AAAA 抑制、无 strategy', () => {
     const cfg = gen([wg('wgnodv61', ['172.16.0.2/32', '2606:4700::1/128'])], [21001]);
-    expect(cfg.dns.rules[0].strategy).toBe('prefer_ipv4');
+    expect(cfg.dns.rules).toEqual([
+      {
+        inbound: ['http-in-wgnodv61'],
+        action: 'route',
+        server: 'dns-exit-wgnodv61',
+        disable_cache: true,
+      },
+    ]);
+  });
+
+  it('全仓禁 legacy rule-action strategy:与 query_type 共存即 sing-box 启动/check FATAL', () => {
+    const cfg = gen(
+      [wg('wgnode01', ['172.16.0.2/32']), wg('wgnodv61', ['172.16.0.2/32', 'fd00::2/128'])],
+      [21001, 21003]
+    );
+    // 1.14 硬不兼容:同一份 dns 配置里 query_type/ip_version 与 legacy strategy 不能共存。
+    // 本配置确实带 query_type(下条断言防空集平凡通过)→ 任何 strategy 复活都会炸核。
+    expect(cfg.dns.rules.some((r: any) => 'query_type' in r)).toBe(true);
+    expect(cfg.dns.rules.filter((r: any) => 'strategy' in r)).toEqual([]);
+    // 顶层 dns.strategy 恒不下发:它是「省略 prefer_ipv4 == prefer_ipv4」等价性的前提
+    expect('strategy' in cfg.dns).toBe(false);
+  });
+
+  it('多端点混合(纯v4 + 含v6):按节点各自成组,抑制规则恒排在同 inbound 的 route 规则之前', () => {
+    const cfg = gen(
+      [wg('wgnode01', ['172.16.0.2/32']), wg('wgnodv61', ['172.16.0.2/32', 'fd00::2/128'])],
+      [21001, 21003]
+    );
+    expect(cfg.dns.rules).toEqual([
+      {
+        inbound: ['http-in-wgnode01'],
+        query_type: ['AAAA'],
+        action: 'predefined',
+        rcode: 'NOERROR',
+      },
+      {
+        inbound: ['http-in-wgnode01'],
+        action: 'route',
+        server: 'dns-exit-wgnode01',
+        disable_cache: true,
+      },
+      {
+        inbound: ['http-in-wgnodv61'],
+        action: 'route',
+        server: 'dns-exit-wgnodv61',
+        disable_cache: true,
+      },
+    ]);
+    // 顺序不变量显式化:抑制规则若排到本 inbound 的 route(catch-all)之后,AAAA 会先被 route 吃掉、抑制静默失效
+    const idx = (p: (r: any) => boolean) => cfg.dns.rules.findIndex(p);
+    const sup = idx((r: any) => r.inbound?.[0] === 'http-in-wgnode01' && r.action === 'predefined');
+    const route = idx((r: any) => r.inbound?.[0] === 'http-in-wgnode01' && r.action === 'route');
+    expect(sup).toBeGreaterThanOrEqual(0);
+    expect(sup).toBeLessThan(route);
   });
 
   it('纯代理配置:无 dns.rules、单入站、无 endpoints、进 outbounds', () => {
@@ -69,7 +134,11 @@ describe('测速临时 config:端点目标解析穿隧道 223.5.5.5（单形态�
 
   it('混合:代理条目零变化(单入站/无 dns.rule),仅端点有 dns.rule', () => {
     const cfg = gen([vless('vlessn01'), wg('wgnode01', ['172.16.0.2/32'])], [21001, 21003]);
-    expect(cfg.dns.rules.map((r: any) => r.inbound[0])).toEqual(['http-in-wgnode01']); // 只端点有 dns.rule
+    // 只端点有 dns.rule(代理入站一条不发);端点两条=AAAA 抑制 + route
+    expect(cfg.dns.rules.map((r: any) => r.inbound[0])).toEqual([
+      'http-in-wgnode01',
+      'http-in-wgnode01',
+    ]);
     expect(cfg.inbounds.find((i: any) => i.tag === 'http-in-vlessn01').listen_port).toBe(21001);
     expect(cfg.inbounds.map((i: any) => i.tag).sort()).toEqual([
       'http-in-vlessn01',


### PR DESCRIPTION
## 问题

测速临时 config（`SpeedTestService.generateProxyTestConfig`）里端点（WG/WARP 等 L3）目标域名解析用的 `dns.rules[]`，把族别偏好写在 **rule-action 的 `strategy`** 上。sing-box 1.14.0 起这是 legacy 写法：

1. **`sing-box run` 输出 deprecation 警告**，1.16.0 移除。`sing-box check` **静默放行**（实测 exit=0）——现有的配置校验抓不到它。
2. **更要命：与同一份 DNS 配置内任何带 `query_type` / `ip_version` 的规则（含引用带 `query_type` 的 rule-set）互斥**，共存则在 `initialize dns router` 阶段被直接拒绝，`check` 与 `run` **双双硬失败**，代理起不来。

第 2 条此前只是**恰好没踩上**，不是设计：主配置（`singbox-dns-builder.ts`）大量用 `query_type: ['A','AAAA']`，但 `strategy` 只出现在**顶层** `dns.strategy`（非 rule-action）；测速配置有 rule-action `strategy` 却零 `query_type`。**任一侧加一个字段就炸。**

## 改动

改用 `query_type` 规则项表达族别偏好，**FlowZ 全仓不再有 rule-action `strategy`**，上述组合结构性不可能出现——埋雷是拆除，不是缓解。

```jsonc
// 纯 v4 localAddress（旧 ipv4_only）：抑制规则在前 + route catch-all 在后
{ "inbound": ["http-in-<id8>"], "query_type": ["AAAA"], "action": "predefined", "rcode": "NOERROR" },
{ "inbound": ["http-in-<id8>"], "action": "route", "server": "dns-exit-<id8>", "disable_cache": true }

// localAddress 含 v6（旧 prefer_ipv4）：只剩 route 规则，不下发任何 strategy
{ "inbound": ["http-in-<id8>"], "action": "route", "server": "dns-exit-<id8>", "disable_cache": true }
```

等价性依据（核源码 + 实测双证）：

- **旧 `prefer_ipv4` ≡ 什么都不写**：`dns/client.go` 的 `sortAddresses` 只对 `prefer_ipv6` 走 v6-first 分支，**AsIS 与 prefer_ipv4 落同一分支**（v4 在前）；测速 config **无顶层 `dns.strategy`** → 内核并发 A/AAAA 后 v4 排前。
- **旧 `ipv4_only` ≡ AAAA 就地返空**：`predefined` + `rcode: NOERROR` 让该 inbound 的 AAAA 在核内直接返空、**不出网**，结果集只剩 A。
- 前提是 1.14.0 起 `query_type` / `ip_version` 在**内部解析**（WG/Tailscale endpoint 解自身目标地址、SOCKS4 等）上开始生效——1.14 之前这些字段只对客户端来的查询有效、内部解析静默忽略。正是这条变化让 rule-items 能替代 rule-action strategy。

**§5 的行为一字未改**：端点目标解析仍经 inbound 键控规则定向到穿本节点隧道的 223.5.5.5（AliDNS ECS 按出口地理返 IP），`detour` / `disable_cache` / 单入站 / 代理路径全部零改动。

## 实测（本机 loopback，零宿主网络；随包核 `1.14.0-beta.2`）

装置：两台 loopback 假 DNS（A→`198.51.100.<n>`、AAAA→`2001:db8::<n>`，按 listen port 区分被查的是哪台、逐条记 qtype），http inbound → **WireGuard endpoint**（gVisor 用户态、peer 指 127.0.0.1 死端口，无 TUN/netns/iptables），`curl -x` 触发端点对 `probe.test` 的本地解析。观测三件：run 日志的 deprecation 行、假 DNS 收到的 qtype、核 `lookup succeed for probe.test: <addrs>`（**含顺序**）。

| # | 形态 | deprecation | 出网 qtype | 解析结果 |
|---|---|---|---|---|
| v0 | 旧 `strategy: ipv4_only` | **WARN** | A | `198.51.100.2` |
| v0b | 旧 `strategy: prefer_ipv4` | **WARN** | AAAA + A | `198.51.100.2 2001:db8::2` |
| **v1** | 新：无 strategy | **无** | AAAA + A | `198.51.100.2 2001:db8::2` ＝ **与 v0b 逐项同序** |
| **v2** | 新：`query_type:[AAAA] → predefined NOERROR` + route | **无** | **仅 A** | `198.51.100.2` ＝ **与 v0 一致** |
| v3 | 旧 strategy + 任一 `query_type` 规则 | — | — | **`check` exit=1 且 run FATAL**（埋雷坐实） |
| v4 | 新形态 + 额外 `query_type` 规则 | 无 | 仅 A | 正常启动（新形态与 query_type 可共存） |
| **v5**（变异反证） | 新形态但抑制规则排到 route **之后** | 无 | **A + AAAA** | 抑制静默失效 → 顺序不变量有牙 |
| v6 | 双端点混合（节点1 纯 v4 / 节点2 含 v6） | 无 | 节点1 仅 A、节点2 A+AAAA，各走自家 exit DNS | `198.51.100.2` / `198.51.100.3 2001:db8::3` — **per-inbound 隔离成立、无跨节点缓存污染** |

**真实发射物端到端复核**（不是手搓 config）：把 `generateProxyTestConfig` 实际发射的双端点配置落盘，仅把 stub outbound 补成完整 WG endpoint、把 223.5.5.5 改指 loopback 假 DNS（确保零出网），其余逐字节原样过核：

| 形态 | `sing-box check` | `sing-box run` |
|---|---|---|
| 本 PR 后 | exit=0 | 启动 OK，**deprecation 行数 = 0** |
| 本 PR 前 | exit=0（静默） | 启动 OK，**WARN deprecation** |
| 本 PR 前 + 一条 `query_type` 规则 | **exit=1** | **FATAL，起不来** |

## 顺序不变量

抑制规则**必须排在同 inbound 的 route 规则之前**。route 规则是该 inbound 的 catch-all，DNS 规则先匹配先命中——顺序反了则 AAAA 先被 route 吃掉、抑制**静默失效**，而配置照样 check 过、照样启动（上表 v5 实跑坐实）。单测显式锁 `indexOf(predefined) < indexOf(route)`。

## 语义差异（如实声明）

**唯一不等价点**：legacy rule-action `strategy` 能**覆盖顶层 `dns.strategy`**，新写法不能——省略即回落顶层默认。实测量化：顶层 `dns.strategy: prefer_ipv6` 下，旧 `strategy: prefer_ipv4` 返 `198.51.100.2 2001:db8::2`（v4 先），新写法返 `2001:db8::2 198.51.100.2`（v6 先）。

**对 FlowZ 无影响**：测速配置从不下发顶层 `dns.strategy`（`dns` 只有 `servers` + 可选 `rules`）。该前提已由单测 `expect('strategy' in cfg.dns).toBe(false)` 锁死 + 源码处显式注释；将来若要给测速配置加顶层 strategy，必须同时重新推导端点规则，不能只加一半。

另一处需知（无实际差别）：新写法下内核仍会**发起** AAAA 查询，只是被 `predefined` 就地返空、**不出网**；legacy `ipv4_only` 压根不发。对出网流量、解析结果、耗时均无差别，仅核内多一次规则匹配。

## 测试

`speed-test-endpoint-dns.test.ts` 用 `toEqual` 锁**精确形状**（非属性点检），覆盖两档规则组 / 规则顺序 / 多端点互不串扰 / 禁 rule-action `strategy` 复活（配「确有 query_type」前置断言防空集平凡通过）/ 禁顶层 `dns.strategy`。

六个变异逐个实跑**转红**：删抑制规则、条件反转（v6 档发 v4 档不发）、`strategy` 复活、键名 typo（`rcode`→`rcod`，`sing-box check` 对 rule 内未知键无牙）、偷加顶层 `dns.strategy`、抑制规则与 route 顺序颠倒。

gate 全绿：`gen-build-info` + `tsc -p tsconfig.main.json` + `tsc -p tsconfig.renderer.json` 双 0 错；jest **3515 passed / 6 skipped / 37 snapshots**（235 suites）；eslint **0 errors / 63 warnings**（与现有基线一致，全部落在本 PR 未触碰的行）。

## 补充：上游文档尚未发布

deprecation 消息指向的 anchor `#migrate-dns-rule-action-strategy-to-rule-items` 在上游 `testing` 分支 `docs/migration.md` 里**不存在**（1.14 仍 beta，该节未写）。本 PR 的新写法系用随包核实测定型 + 核源码（`dns/router.go` `resolveLegacyDNSMode` / `lookupWithRules`、`dns/client.go` `sortAddresses`）交叉验证，非照抄文档。
