### PR TITLE
fix(config): dashboard 显式声明 http_client

### DIFF
--- a/src/main/services/ConfigManager.ts
+++ b/src/main/services/ConfigManager.ts
@@ -814,10 +814,13 @@ export class ConfigManager implements IConfigManager {
       this.log('warn', 'appRoutingEnabled must be a boolean; resetting to default (disabled)');
       delete config.appRoutingEnabled;
     }
-    // singboxDashboard：纯开关字段（默认关）。非 boolean 一律删除而非 throw（同 appRoutingEnabled 标准，不回填默认）——
-    // throw 在 loadConfig 路径会触发默认配置覆盖落盘致用户节点/订阅/规则全丢，不值当。
+    // singboxDashboard：纯开关字段。**两个「默认」不是同一个**，别按其一去读另一个：
+    //   - **新装种子 = true**（见下方 getDefaultConfig 的 singboxDashboard），故全量新装用户开着面板；
+    //   - **本 sanitize 的回落 = undefined**，而读取端（ProxyManager 注入 dashboard、设置页）按 truthiness 判 ⇒ 关。
+    // 非 boolean 一律删除而非 throw（同 appRoutingEnabled 标准，不回填默认）——throw 在 loadConfig 路径会触发
+    // 默认配置覆盖落盘致用户节点/订阅/规则全丢，不值当。
     if (config.singboxDashboard !== undefined && typeof config.singboxDashboard !== 'boolean') {
-      this.log('warn', 'singboxDashboard must be a boolean; resetting to default (disabled)');
+      this.log('warn', 'singboxDashboard must be a boolean; dropping it (falls back to disabled)');
       delete config.singboxDashboard;
     }
     // singboxDashboardUrl：可选 download_url 覆盖。非字符串或空白一律删除（回落内置默认 URL）；sanitize 而非 throw。

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -3632,11 +3632,20 @@ done
       // 关闭时不注入 → 核默认不出网拉 dashboard 资源。同一 service，不重复注入。
       // dashboard #55：path 指向「运行时下载覆盖 > 随包内置」目录 → 核 serve 本地文件、零联网下载、打开即时离线可用；
       //   两者皆无（异常打包且未下载）→ path 省略，核回落联网下载兜底（保旧行为，不 brick）。
+      // http_client：**必须显式声明**（sing-box 1.14 弃用「隐式默认 HTTP client」，计划 1.16.0 移除；
+      //   移除后 dashboard 的 resolveTransport() 拿不到 transport → `create dashboard http client` 起服务失败，
+      //   影响面是全量开着 dashboard 的用户，不是静默降级）。语义见 SingBoxHttpClient。
+      // detour 取 route.final：被替换掉的隐式回落在核里就是「走默认出站」（DefaultOutbound=true →
+      //   outboundManager.Default()），而默认出站正是 route.final 指的 tag。写死 'direct' 会把 path 省略时的
+      //   联网下载腿从走代理改成走直连（墙内拉不动 GitHub），是用户可见的行为回退。
+      //   route 恒由 buildRouteConfig 产出且 final 恒有值；缺省兜底 'direct' 只为不留空串——空 detour 会被核判
+      //   IsEmpty() 而重新落回隐式默认，等于本注入失效。
       if (config.singboxDashboard) {
         const serveDir = resourceManager.resolveDashboardServeDir(getSingboxDashboardOverrideDir());
+        const http_client = { detour: singboxConfig.route?.final || 'direct' };
         singboxConfig.services[0].dashboard = serveDir
-          ? { enabled: true, path: serveDir }
-          : { enabled: true };
+          ? { enabled: true, path: serveDir, http_client }
+          : { enabled: true, http_client };
       }
     }
 

--- a/src/main/services/__tests__/explicit-http-client-gate.test.ts
+++ b/src/main/services/__tests__/explicit-http-client-gate.test.ts
@@ -1,0 +1,280 @@
+/**
+ * **显式 HTTP client 门**：锁住「生成产物里不存在任何依赖隐式默认 HTTP client 的消费点」。
+ *
+ * # 这扇门守的是什么
+ *
+ * sing-box 1.14.0 把「隐式默认 HTTP client（走默认出站）」标为弃用、**计划 1.16.0 移除**
+ * （上游 `experimental/deprecated/constants.go` 的 `OptionImplicitDefaultHTTPClient`：
+ * DeprecatedVersion "1.14.0" / ScheduledVersion "1.16.0"）。移除后
+ * `httpclient.Manager.DefaultTransport()` 拿不到回落工厂即返回 nil，消费点直接报错——
+ * 对 dashboard 是 `create dashboard http client` → api service 起不来。FlowZ 新装默认
+ * `singboxDashboard: true`（ConfigManager 种子），故影响面是全量新装用户。
+ *
+ * 核里**只有两个**消费点索取那个默认 transport（1.14.0-alpha.45 源码全仓 `DefaultTransport()`
+ * 调用面：`service/api/dashboard.go` 与 `route/rule/rule_set_remote.go`）。本门按这两条逐一断言。
+ *
+ * # 为什么门里带「谓词有牙」对照
+ *
+ * 本仓当前**不生成任何 `type:'remote'` rule_set**（远程能力已 fail-closed 移除，见
+ * `singbox-custom-rules.ts`），所以「远端 rule-set 必须带 http_client」这条在真实语料上恒真——
+ * **恒真的断言等于没有断言**。故末尾用合成配置反向证明：把违规形态喂给同一个谓词，必须报出违规。
+ * 语料侧转绿 + 谓词侧有牙，合起来才是有信息量的门。
+ *
+ * # 不要往 local rule_set 上加 http_client
+ *
+ * 真机实测（1.14.0-alpha.45）：`type:'local'` 条目上的 `http_client` / `download_detour` 被按未知字段
+ * 拒绝，`sing-box check` 直接 FATAL。故本门只要求 **remote** 条目带，local 条目带了反而是违规。
+ */
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => '/fake/userData',
+    getVersion: () => '9.9.9',
+    isPackaged: false,
+    getAppPath: () => '/fake/app',
+  },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import { resourceManager } from '../ResourceManager';
+import type { UserConfig, ServerConfig } from '../../../shared/types';
+import type { SingBoxConfig } from '../singbox-config-types';
+
+/** 1.14 才注入 services[]（hasManagementApi 门控）；<1.14 的核没有 services schema。 */
+const CORE_1_14 = '1.14.0';
+
+function makeSvc(coreVersion = CORE_1_14): any {
+  const svc: any = new ProxyManager(undefined, undefined, '/fake/cfg.json', '/fake/sing-box');
+  svc.coreVersion = coreVersion;
+  return svc;
+}
+
+function server(over: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    id: 's1',
+    name: 'HK',
+    protocol: 'vless',
+    address: 'a.example.com',
+    port: 443,
+    uuid: 'uuid-1',
+    ...over,
+  } as ServerConfig;
+}
+
+function cfg(over: Partial<UserConfig> = {}): UserConfig {
+  return {
+    subscriptions: [],
+    servers: [server()],
+    selectedServerId: 's1',
+    proxyMode: 'smart',
+    proxyModeType: 'systemProxy',
+    tunConfig: { mtu: 1350, stack: 'auto', autoRoute: true, strictRoute: true },
+    customRules: [],
+    appRules: [],
+    customAppPresets: [],
+    autoStart: false,
+    silentStart: false,
+    autoConnect: false,
+    minimizeToTray: false,
+    socksPort: 1080,
+    httpPort: 1087,
+    mixedPort: 7890,
+    logLevel: 'info',
+    clashApiSecret: 'testsecret',
+    singboxDashboard: true,
+    ...over,
+  } as unknown as UserConfig;
+}
+
+/**
+ * 谓词：返回该 config 上所有「依赖隐式默认 HTTP client」的违规点。空数组 = 合规。
+ *
+ * 吃 `SingBoxConfig`（= 落到核嘴里的 JSON 形态）而非中间态：门要守的是最终产物，
+ * 走中间变量会把「算出来了但没写进 config」这类失效方式漏掉。
+ */
+function violations(cfg_: SingBoxConfig): string[] {
+  const out: string[] = [];
+
+  // 配置里真实存在的出站 tag 全集（detour 必须命中其一，否则核 "outbound not found" FATAL）。
+  const knownTags = new Set<string>(
+    [
+      ...(cfg_.outbounds ?? []).map((o) => o.tag),
+      ...(cfg_.endpoints ?? []).map((e) => e.tag),
+    ].filter((t): t is string => !!t)
+  );
+
+  // ── 消费点 1：services[].dashboard（核 service/api/dashboard.go 的 resolveTransport）──
+  (cfg_.services ?? []).forEach((svc, i) => {
+    const dash = svc.dashboard;
+    if (!dash || dash.enabled !== true) return;
+    const detour = dash.http_client?.detour;
+    if (detour === undefined) {
+      out.push(`services[${i}].dashboard 缺少 http_client（会落到已弃用的隐式默认 HTTP client）`);
+      return;
+    }
+    // 空串会被核判 IsEmpty() 而重新落回隐式默认——声明了等于没声明。
+    if (detour.trim() === '') out.push(`services[${i}].dashboard.http_client.detour 为空`);
+    else if (!knownTags.has(detour)) {
+      out.push(`services[${i}].dashboard.http_client.detour 指向不存在的出站: ${detour}`);
+    }
+  });
+
+  // ── 消费点 2：type:'remote' 的 rule_set（核 route/rule/rule_set_remote.go）──
+  // local 条目**不得**带这两个键：1.14.0-alpha.45 按未知字段拒绝，check 即 FATAL。
+  (cfg_.route?.rule_set ?? []).forEach((rs, i) => {
+    const raw = rs as unknown as Record<string, unknown>;
+    if (rs.type === 'remote') {
+      const hc = raw.http_client as { detour?: string } | undefined;
+      if (!hc || typeof hc.detour !== 'string' || hc.detour.trim() === '') {
+        out.push(`route.rule_set[${i}](${rs.tag}) 是 remote 但没有非空 http_client.detour`);
+      } else if (!knownTags.has(hc.detour)) {
+        out.push(
+          `route.rule_set[${i}](${rs.tag}).http_client.detour 指向不存在的出站: ${hc.detour}`
+        );
+      }
+    } else if (raw.http_client !== undefined || raw.download_detour !== undefined) {
+      out.push(
+        `route.rule_set[${i}](${rs.tag}) 是 ${rs.type} 却带了 http_client/download_detour（核按未知字段 FATAL）`
+      );
+    }
+  });
+
+  return out;
+}
+
+/** 语料：每条覆盖一个会改变 route.final 或 dashboard 形态的维度。 */
+const CASES: { name: string; config: UserConfig; serveDir: string | null }[] = [
+  { name: 'smart 模式 + 本地 serve 目录', config: cfg(), serveDir: '/fake/dashboard' },
+  { name: 'smart 模式 + 无 serve 目录（联网兜底腿）', config: cfg(), serveDir: null },
+  {
+    name: 'global 模式（final = 选中节点/selector）',
+    config: cfg({ proxyMode: 'global' } as Partial<UserConfig>),
+    serveDir: '/fake/dashboard',
+  },
+  {
+    name: 'direct 模式（final = direct）',
+    config: cfg({ proxyMode: 'direct' } as Partial<UserConfig>),
+    serveDir: null,
+  },
+  {
+    name: 'direct 模式 + 本地 serve 目录',
+    config: cfg({ proxyMode: 'direct' } as Partial<UserConfig>),
+    serveDir: '/fake/dashboard',
+  },
+  {
+    name: '自定义域名规则（route.rules 扩张）',
+    config: cfg({
+      customRules: [
+        { id: 'r1', type: 'domainSuffix', values: ['example.com'], action: 'proxy', enabled: true },
+      ],
+    } as unknown as Partial<UserConfig>),
+    serveDir: null,
+  },
+];
+
+function generate(config: UserConfig, serveDir: string | null): SingBoxConfig {
+  jest.spyOn(resourceManager, 'resolveDashboardServeDir').mockReturnValue(serveDir);
+  return makeSvc().generateSingBoxConfig(config) as SingBoxConfig;
+}
+
+describe('显式 HTTP client 门（sing-box 1.16.0 将移除隐式默认）', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it.each(CASES)('$name → 无隐式默认 HTTP client 消费点', ({ config, serveDir }) => {
+    expect(violations(generate(config, serveDir))).toEqual([]);
+  });
+
+  it.each(CASES)(
+    '$name → dashboard.http_client.detour 逐字等于 route.final',
+    ({ config, serveDir }) => {
+      const out = generate(config, serveDir);
+      const dash = out.services?.[0]?.dashboard;
+      expect(dash?.enabled).toBe(true);
+      // 等价性断言：被替换掉的隐式回落在核里就是「走默认出站」，而默认出站正是 route.final 指的 tag。
+      // 有人把它改成写死 'direct' 时本条必红（那会把 path 省略时的联网下载腿从走代理改成走直连）。
+      expect(dash?.http_client?.detour).toBe(out.route?.final);
+    }
+  );
+
+  it('dashboard 关闭 → 不注入 dashboard，也就没有这个消费点', () => {
+    const out = generate(
+      cfg({ singboxDashboard: false } as Partial<UserConfig>),
+      '/fake/dashboard'
+    );
+    expect(out.services?.[0]?.dashboard).toBeUndefined();
+    expect(violations(out)).toEqual([]);
+  });
+
+  it('本仓不生成任何 remote rule_set（故消费点 2 在真实语料上恒真——见下条谓词有牙对照）', () => {
+    const out = generate(cfg(), '/fake/dashboard');
+    expect((out.route?.rule_set ?? []).filter((rs) => rs.type === 'remote')).toEqual([]);
+  });
+
+  // ── 谓词有牙：合成违规形态逐个喂给同一个谓词，必须都被抓到 ──
+  describe('谓词有牙（防恒真断言）', () => {
+    const base = (): SingBoxConfig =>
+      ({
+        log: { level: 'info' },
+        inbounds: [],
+        outbounds: [
+          { type: 'direct', tag: 'direct' },
+          { type: 'selector', tag: 'proxy-selector' },
+        ],
+        route: { final: 'proxy-selector', rule_set: [] },
+        services: [{ type: 'api', listen: '127.0.0.1', listen_port: 9091 }],
+      }) as unknown as SingBoxConfig;
+
+    it('dashboard 缺 http_client → 抓到', () => {
+      const c = base();
+      c.services![0].dashboard = { enabled: true, path: '/x' };
+      expect(violations(c)).toHaveLength(1);
+      expect(violations(c)[0]).toContain('缺少 http_client');
+    });
+
+    it('detour 为空串 → 抓到（核判 IsEmpty 后重新落回隐式默认）', () => {
+      const c = base();
+      c.services![0].dashboard = { enabled: true, http_client: { detour: '' } };
+      expect(violations(c)[0]).toContain('为空');
+    });
+
+    it('detour 指向不存在的出站 → 抓到（核 outbound not found FATAL）', () => {
+      const c = base();
+      c.services![0].dashboard = { enabled: true, http_client: { detour: 'ghost' } };
+      expect(violations(c)[0]).toContain('不存在的出站');
+    });
+
+    it('remote rule_set 无 http_client → 抓到', () => {
+      const c = base();
+      c.route!.rule_set = [
+        { tag: 'rs', type: 'remote', format: 'binary', url: 'https://example.com/a.srs' },
+      ] as never;
+      expect(violations(c)[0]).toContain('remote 但没有非空 http_client.detour');
+    });
+
+    it('local rule_set 带 http_client → 抓到（核按未知字段 FATAL）', () => {
+      const c = base();
+      c.route!.rule_set = [
+        {
+          tag: 'rs',
+          type: 'local',
+          format: 'source',
+          path: '/x.json',
+          http_client: { detour: 'direct' },
+        },
+      ] as never;
+      expect(violations(c)[0]).toContain('却带了 http_client/download_detour');
+    });
+
+    it('合规形态 → 零违规（防谓词恒报错）', () => {
+      const c = base();
+      c.services![0].dashboard = { enabled: true, http_client: { detour: 'proxy-selector' } };
+      c.route!.rule_set = [
+        { tag: 'rs', type: 'local', format: 'source', path: '/x.json' },
+      ] as never;
+      expect(violations(c)).toEqual([]);
+    });
+  });
+});

--- a/src/main/services/__tests__/singbox-check-gate.test.ts
+++ b/src/main/services/__tests__/singbox-check-gate.test.ts
@@ -254,6 +254,24 @@ describe('sing-box check 门 — 生成的全量 config', () => {
     expect(dnsTags(c)).toContain('dns-node');
     expectCheckOk(c, 'race-off-dnspod');
   });
+
+  it('开 dashboard（显式 http_client）→ 内核识别该字段且 check 通过', () => {
+    const c = svcFor().gen(
+      cfg({ servers: [domainNode()], singboxDashboard: true } as Partial<UserConfig>)
+    );
+    // ① 验的是不是声称的对象：产物必须真的含 http_client，否则 check 绿只证明「没写这个字段也合法」。
+    //    path 是否存在取决于本机 resources/dashboard 是否已 fetch（本门跑在 fetch:dashboard 之前），
+    //    故只钉 enabled + http_client 两项，不把「有没有 path」写死进断言。
+    const dash = c.services?.[0]?.dashboard;
+    expect(dash?.enabled).toBe(true);
+    expect(dash?.http_client).toEqual({ detour: c.route?.final });
+    // ② 引用完整性先验：detour 必须是真实出站 tag（check 的 "outbound not found" 是最终裁判）。
+    expect([
+      ...(c.outbounds ?? []).map((o) => o.tag),
+      ...(c.endpoints ?? []).map((e) => e.tag),
+    ]).toContain(dash?.http_client?.detour);
+    expectCheckOk(c, 'dashboard-http-client');
+  });
 });
 
 // 变异自检：证明本 harness 真的抓得到内核 FATAL（恒绿的 harness = 没门）。
@@ -284,5 +302,30 @@ describe('sing-box check 门 — 门自身的牙（变异自检）', () => {
     ob.domain_resolver = { server, stratgy: 'prefer_ipv4' } as unknown as SingBoxDomainResolver;
     // 该断言若哪天变红 = 内核开始严格校验未知键 → 届时本注释与「不得省略单测」的结论需重估。
     expect(runCheck(c, 'mut-key-typo').code).toBe(0);
+  });
+
+  it('变异：dashboard 的 http_client 写成 http_clientt → check 必须 FATAL（证明该字段是真被识别的）', () => {
+    // 负向对照：`services[].dashboard` 这一层走 DisallowUnknownFields，故上面那条「键名无牙」的边界
+    // **不适用于这里**。没有这条对照，「加了 http_client 后 check 仍通过」就可能只是「这个键被静默丢弃」。
+    const c = svcFor().gen(
+      cfg({ servers: [domainNode()], singboxDashboard: true } as Partial<UserConfig>)
+    );
+    const dash = c.services![0].dashboard as unknown as Record<string, unknown>;
+    dash.http_clientt = dash.http_client;
+    delete dash.http_client;
+    expect(runCheck(c, 'mut-dashboard-key-typo').code).not.toBe(0);
+  });
+
+  it('能力边界（负面事实）：dashboard.http_client.detour 指向不存在的出站 → check 仍 exit=0', () => {
+    // **与 domain_resolver 不同**：那条引用在 check 期解析（"domain resolver not found" FATAL），
+    // 而 dashboard 的 detour 是**运行期**才解析的（核 `resolveTransport()` 在 service start 时才跑）。
+    // ⇒ 悬空 detour 逃得过 check、只在真机起核时炸。守它的只能是 JS 侧谓词
+    // （`explicit-http-client-gate.test.ts` 的「detour 必须在出站/endpoint tag 集合里」）。
+    // 该断言若哪天变红 = 内核把这条引用提前到 check 期 → 届时 JS 侧那条可降级为冗余。
+    const c = svcFor().gen(
+      cfg({ servers: [domainNode()], singboxDashboard: true } as Partial<UserConfig>)
+    );
+    c.services![0].dashboard!.http_client!.detour = 'no-such-outbound';
+    expect(runCheck(c, 'mut-dashboard-dangling-detour').code).toBe(0);
   });
 });

--- a/src/main/services/singbox-config-types.ts
+++ b/src/main/services/singbox-config-types.ts
@@ -400,7 +400,33 @@ export interface SingBoxApiService {
   // path（dashboard #55）：指向**随包内置/运行时下载覆盖**目录 → 核「serving user-provided files，auto-update disabled」，
   //   零联网下载、打开即时、离线可用（实证 1.14-alpha.32：dashboard:{enabled,path} → /dashboard/ HTTP 200 本地 serve）。
   //   省略 path 时核回落联网下载（异常打包/无内置时的兜底）。external_ui 等字段属 experimental.clash_api，非本 service。
-  dashboard?: { enabled: boolean; path?: string };
+  //   http_client（1.14 新增，见 SingBoxHttpClient）：**必填**——缺省会落到已弃用的「隐式默认 HTTP client」。
+  dashboard?: { enabled: boolean; path?: string; http_client?: SingBoxHttpClient };
+}
+
+/**
+ * 显式 HTTP client 声明（sing-box 1.14 `http_client`）。
+ *
+ * **为什么必须显式**：1.14.0 起「隐式默认 HTTP client（走默认出站）」被标弃用，**计划 1.16.0 移除**
+ * （上游 `experimental/deprecated/constants.go` 的 `OptionImplicitDefaultHTTPClient`：
+ * DeprecatedVersion 1.14.0 / ScheduledVersion 1.16.0）。移除后 `httpClientManager.DefaultTransport()`
+ * 返回 nil，消费点拿不到 transport 即报错——对 dashboard 是 `create dashboard http client` → api service
+ * 起不来，**是启动失败而非静默降级**。
+ *
+ * 核里只有两个消费点索取那个默认 transport（1.14.0-alpha.45 全仓 `DefaultTransport()` 调用面：
+ * `service/api/dashboard.go` 与 `route/rule/rule_set_remote.go`）。本仓 rule_set 全 `type:'local'`
+ * （远程能力已 fail-closed 移除，见 singbox-custom-rules），故 dashboard 是唯一触发者。
+ *
+ * **绝不要把本字段挂到 local rule_set 上**：1.14.0-alpha.45 对 `type:'local'` 条目上的 `http_client` /
+ * `download_detour` 按未知字段拒绝，`sing-box check` 直接 FATAL（真机实测）。
+ *
+ * **只声明 `detour` 一个键**：上游 `HTTPClientOptions` 还有 engine/version/tls/headers/dial 全套，
+ * 但隐式回落等价的只有「走默认出站」这一条语义（核的回落工厂只设 `DefaultOutbound = true`，其余取核默认）。
+ * 多写一个键就是多一条与核默认漂移的风险面。
+ */
+export interface SingBoxHttpClient {
+  /** 上游出站 tag。取 `route.final`（= 核的默认出站）以逐字保持隐式回落时的拨号路径。**不可为空串**（核判 `IsEmpty()` 会重新落回隐式默认）。 */
+  detour: string;
 }
 
 export interface SingBoxConfig {


### PR DESCRIPTION
## 缺陷

生成的 sing-box 配置里，`services[].dashboard` 没有声明 `http_client`。

sing-box 1.14.0 起「隐式默认 HTTP client（走默认出站）」被标弃用、**计划 1.16.0 移除**（上游 `experimental/deprecated/constants.go` 的 `OptionImplicitDefaultHTTPClient`：DeprecatedVersion `1.14.0` / ScheduledVersion `1.16.0`）。核在 `service/api/dashboard.go` 的 `start()` 里**无条件** `resolveTransport()`，`http_client` 缺省即落到 `httpClientManager.DefaultTransport()`；该回落被移除后返回 nil，dashboard 拿不到 transport ⇒ `create dashboard http client`，api service 起不来。

新装默认 `singboxDashboard: true`，故**影响面是全量新装用户**，且是**启动失败不是静默降级**。

不是「分流规则整段失效」——分流走的是 local rule-set，与 HTTP client 无关。

## 修法

```jsonc
"dashboard": {
  "enabled": true,
  "path": "…",
  "http_client": { "detour": "proxy-selector" }   // = 该配置的 route.final
}
```

**为什么 `detour` 取 `route.final` 而不是写死 `direct`**：被替换掉的隐式回落在核里是 `DefaultOutbound = true` → `NewDefaultOutboundDetour` → `outboundManager.Default()`，而默认出站正是 `route.final` 指的 tag。写死 `direct` 会把 `path` 省略时的联网下载腿从走代理改成走直连（墙内拉不动 GitHub），是用户可见的行为回退。

**`detour` 也不能为空串**：核判 `IsEmpty()` 后会重新落回隐式默认，等于改动失效，故缺省兜底给非空的 `"direct"`。

**为什么只写 `detour` 一个键**：上游 `HTTPClientOptions` 还有 engine/version/tls/headers/dial 全套，但隐式回落等价的只有「走默认出站」这一条语义（回落工厂只设 `DefaultOutbound`），多写一个键就是多一条与核默认漂移的风险面。

**为什么不用顶层 `http_clients` + `route.default_http_client`**（上游文档的通用写法）：① 它给**每一份**配置加顶层键；② `httpclient.Manager.Start()` 在 `defaultTag` 非空时**急切**建 transport，而 dashboard 关着的用户本来一个都不建。作用域收在真实消费点上，两笔成本都不付。

**不要往 `type:"local"` 的 rule_set 上加 `http_client` / `download_detour`**：内核按未知字段拒绝，`sing-box check` 直接 FATAL（实测）。本仓 rule_set 全为 local（远程能力已 fail-closed 移除），故 dashboard 是唯一消费点。

## 改动

- `singbox-config-types`：新增 `SingBoxHttpClient`，`dashboard` 增可选 `http_client`
- `ProxyManager`：dashboard 注入的两条腿（有/无 `serveDir`）都带 `http_client`
- 新增 `explicit-http-client-gate` 单测：按核里**仅有的两个** `DefaultTransport()` 调用面（`service/api/dashboard.go` / `route/rule/rule_set_remote.go`）逐条断言，6 例语料 × {零违规, `detour` 逐字等于 `route.final`}
- `singbox-check-gate` 增 dashboard 用例与两条边界事实
- 顺带修正 `ConfigManager` 注释：新装种子是 `true`、sanitize 的回落才是 `undefined`(=关)，原注释把两个「默认」写成了同一个

## 验证

随包核 **1.14.0-beta.2** 实测：

| 变体 | 结果 |
|---|---|
| 生成物（开 dashboard） | `check` 通过 |
| `http_client` → `http_clientt` | **FATAL** ⇒ 证明该字段是真被识别的，不是被静默丢弃 |
| `detour` 指向不存在的出站 | **`check` 仍 exit=0** |

第 3 行是本轮的关键边界：与 `domain_resolver` 不同（那条在 check 期解析、悬空即 FATAL），dashboard 的 `detour` 是**运行期** `resolveTransport()` 才解析 ⇒ 悬空 detour 逃得过 `check`、只在真机起核炸。故「`detour` 必须在出站/endpoint tag 集合里」这条只能由 JS 侧谓词把守，已写进门里。

**门有牙（变异实跑，非推理）**：删掉 `http_client` 注入 → 12 条转红；把 `detour` 写死 `direct` → 4 条「`detour ≡ route.final`」转红。

「远端 rule-set 必须带 `http_client`」这条在真实语料上恒真（本仓不生成 remote rule-set），故门里配了合成配置反证谓词能抓到违规，避免恒真断言。

## 抓不到什么（如实）

- **真机起核是否真的不再刷该弃用警告**：`sing-box check` 对它**完全静默**（Report 发生在 `DefaultTransport()` 被惰性索取时，`check` 只 `New()` 不 `Start()`），要证只能 `sing-box run`。
- **1.16.0 的最终形态**：上游只写了 `ScheduledVersion: "1.16.0"`，移除后是返 nil 还是 parse-time 硬报错未载明。方向可确定：是启动失败，不是静默降级。
- **`services[].dashboard` 之外是否还有隐式消费者**：以 1.14 源码 `DefaultTransport()` 调用面为准（2 处）；**换核后这个调用面要重新核一遍**。
