### PR TITLE
chore(core): 升级 sing-box 1.14.0-beta.5，cronet 取源改 Go module proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:core-gate": "jest --testPathIgnorePatterns=/node_modules/ --runTestsByPath src/main/services/__tests__/singbox-check-gate.test.ts",
+    "test:core-gate": "jest --testPathIgnorePatterns=/node_modules/ --runTestsByPath src/main/services/__tests__/singbox-check-gate.test.ts src/shared/__tests__/core-manifest-invariants.test.ts",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,css}\"",

--- a/resources/README.en.md
+++ b/resources/README.en.md
@@ -60,10 +60,16 @@ The app accesses these files through the `ResourceManager` class:
    ```bash
    gh api repos/SagerNet/sing-box/releases/tags/v<version> --jq '.assets[]|select(.name|test("(linux-amd64.tar.gz|windows-amd64.zip|darwin-amd64.tar.gz|darwin-arm64.tar.gz)$"))|{name,digest}'
    ```
-   The digest looks like `sha256:<hex>` and can be pasted **as-is** into `coreArchiveSha256` (`fetch:core` strips the `sha256:` prefix before comparing). `libcronet` is managed separately by `cronetVersion` and need not change with the core (unless the official core's ABI changes). When swapping, confirm the binary's `Tags` include `with_naive_outbound` (prerequisite for naive support).
+   The digest looks like `sha256:<hex>` and can be pasted **as-is** into `coreArchiveSha256` (`fetch:core` strips the `sha256:` prefix before comparing). When swapping, confirm the binary's `Tags` include `with_naive_outbound` (prerequisite for naive support).
+
+   **`libcronet` must be swapped together with the core** (since 2026-08-05): it is no longer managed independently — `cronetVersion` is the Go module pseudo-version copied from the bundled sing-box's own `go.mod`, and the source moved from the (now stale) cronet-go Releases to the Go module proxy:
+   ```bash
+   curl -fsSL "https://proxy.golang.org/github.com/sagernet/sing-box/@v/v<version>.mod" | grep 'cronet-go/lib/linux_amd64'
+   ```
+   Put that pseudo-version into `cronetVersion`, obtain both pins as documented at the top of `scripts/fetch-cronet.mjs` (`cronetArchiveSha256` = module zip, `cronetLibSha256` = the installed library itself), then run `npm run fetch:cronet -- --force`. Forgetting to sync is not silent: before any actual download the script fetches sing-box's `.mod` and fails if the versions disagree.
 
 ## sing-box version
 
-Current: **1.14.0-alpha.34** (SagerNet official release; `Tags` include `with_naive_outbound`).
+The current version is whatever `bundledCoreVersion` in `src/shared/core-manifest.json` says (**single source of truth** — do not restate it here; this line used to drift). Requirement: an official SagerNet release whose `Tags` include `with_naive_outbound`.
 
 Downloads: https://github.com/SagerNet/sing-box/releases

--- a/resources/README.md
+++ b/resources/README.md
@@ -61,11 +61,20 @@ resources/
    值 = 官方 release REST API 的 asset digest，一行取：
    `gh api repos/SagerNet/sing-box/releases/tags/v<新版本> --jq '.assets[]|select(.name|test("(linux-amd64.tar.gz|windows-amd64.zip|darwin-amd64.tar.gz|darwin-arm64.tar.gz)$"))|{name,digest}'`，
    digest 形如 `sha256:<hex>`，**可原样填入** coreArchiveSha256，`fetch:core` 会自动 strip `sha256:` 前缀后比对），
-   再 `npm run fetch:core -- --force` 拉新核（无需手动下载/替换二进制；不入库）。`libcronet` 独立按 `cronetVersion`
-   管理，换核不必同步（除非官方核 ABI 变更）。换核须确认二进制 `Tags` 含 `with_naive_outbound`（naive 支持前提）。
+   再 `npm run fetch:core -- --force` 拉新核（无需手动下载/替换二进制；不入库）。换核须确认二进制 `Tags`
+   含 `with_naive_outbound`（naive 支持前提）。
+
+   **`libcronet` 必须同步换**（2026-08-05 起）：它不再独立管理——`cronetVersion` 就是从「随包 sing-box 的
+   go.mod」抄来的 Go module 伪版本，取源亦从已停更的 cronet-go Releases 改为 Go module proxy。步骤：
+   ```bash
+   curl -fsSL "https://proxy.golang.org/github.com/sagernet/sing-box/@v/v<新版本>.mod" | grep 'cronet-go/lib/linux_amd64'
+   ```
+   把伪版本回填 `cronetVersion`，按 `scripts/fetch-cronet.mjs` 头注取两类 sha（`cronetArchiveSha256`=module
+   zip、`cronetLibSha256`=落地库本体），再 `npm run fetch:cronet -- --force`。忘同步不会静默——脚本每次实际
+   下载前会拿 sing-box 的 `.mod` 校验同源，不一致直接 fail。
 
 ## sing-box 版本
 
-当前使用的 sing-box 版本：**1.14.0-alpha.34**（SagerNet 官方 release，`Tags` 含 `with_naive_outbound`）
+当前版本以 `src/shared/core-manifest.json` 的 `bundledCoreVersion` 为准（**单一真值**，勿在此复述——历史上这里长期滞后于真实版本）。要求：SagerNet 官方 release 且 `Tags` 含 `with_naive_outbound`。
 
 下载地址：https://github.com/SagerNet/sing-box/releases

--- a/scripts/fetch-cronet.mjs
+++ b/scripts/fetch-cronet.mjs
@@ -9,20 +9,54 @@
  *   静态编入（CGO，实测二进制内含 cronet 符号、无 dlopen libcronet.dylib），naive 开箱即用、无需任何
  *   外部库。mac-x64 二进制未编入 cronet → naive 暂不可用（需重编带 naive 的 x64 核心）。详见 README。
  *
- * ⚠️ 版本耦合：cronetVersion（src/shared/core-manifest.json）应与「随 app 打包的 sing-box 所用
- *   cronet-go 版本」对应。cronet 走 C API（Chromium 稳定 ABI），跨 sing-box 小版本一般兼容；若升级
- *   sing-box 后 naive 报符号错，提高 manifest 中的版本并重打包。该 manifest 同时被 TS 主进程读取，
- *   是核心/cronet 版本耦合的唯一真源。来源：https://github.com/SagerNet/cronet-go/releases
+ * ⚠️ **取源＝Go module proxy，不是 GitHub Releases**（2026-08-05 改）：sing-box 自身经 Go module
+ *   `github.com/sagernet/cronet-go/lib/<平台>` 拿预编译库，而 SagerNet/cronet-go 的 Releases 已停更
+ *   （最新仍是 v148，而 sing-box 1.14.0-beta.5 已用到 naiveproxy 150）。继续走 Releases 会让打包库与核
+ *   永久漂移，故改为与核**同源**取模块 zip。
  *
- * 完整性 pin（与 fetch-core 对称）：core-manifest.json 的 cronetArchiveSha256 是「下载的 libcronet 库本体」
- *   的 sha256，其值 == cronet-go release REST API 返回的 asset digest（gh api
- *   repos/SagerNet/cronet-go/releases/tags/<cronetVersion> --jq '.assets[]|{name,digest}'，一行可取，
- *   换版本直接抄）。libcronet 是运行期 dlopen 加载执行的原生库，故与 sing-box 核同级别供应链防护：下载后
- *   逐字节校验、不符即 fail（落位前拦损坏/截断/投毒），缺 pin 直接拒拉（绝不无校验拉可执行原生库）。
+ * ⚠️ **MODULE_BASE 与 pin 绑定，禁止换 GOPROXY 镜像**：module zip 的字节由构造者的 golang.org/x/mod/zip
+ *   版本与压缩参数决定（zip 内的 1980 时间戳只保证时间字段确定，不保证压缩流逐字节一致），goproxy.cn /
+ *   自建 Athens 可能重新打包 → sha 不符。换镜像必须按下方流程用该镜像重取 pin，不可沿用本文件的值。
+ *
+ * ⚠️ **换核必须同步换本脚本的版本**：cronetVersion 就是从「随包 sing-box 的 go.mod」抄来的，两者绑定。
+ *   脚本在**每次实际下载前**会自动校验二者一致（取 sing-box 的 .mod 比对），不一致直接 fail —— 这条自动
+ *   校验是本设计的防漂移主闸，注释只是它的说明书。
+ *
+ * ── 换版本操作（三步）────────────────────────────────────────────────────────
+ *  1) 取 cronet-go/lib 伪版本（与随包核同源，免鉴权，无需 gh）：
+ *       curl -fsSL "https://proxy.golang.org/github.com/sagernet/sing-box/@v/v<bundledCoreVersion>.mod" \
+ *         | grep 'cronet-go/lib/linux_amd64'
+ *  2) 取两类 sha256 pin。**推荐走 Go 工具链**，使其经 sum.golang.org 透明日志背书（append-only Merkle
+ *     log + 第三方审计者），强于直接 curl 同一个 URL 自算（后者是纯 TOFU，只防传输损坏与事后篡改）：
+ *       d=$(mktemp -d); cd $d && go mod init tmp >/dev/null
+ *       GOMODCACHE=$d/gomod go get github.com/sagernet/cronet-go/lib/linux_amd64@<伪版本>
+ *       sha256sum $d/gomod/cache/download/github.com/sagernet/cronet-go/lib/linux_amd64/@v/<伪版本>.zip
+ *     （仓库已依赖 Go——helper 用它编译——故零新增依赖。注：`.ziphash` 不是 proxy 协议端点，
+ *      实测 GET 返回 404 `unexpected extension "ziphash"`，别走那条路。）
+ *  3) 把 zip sha 填进 cronetArchiveSha256，跑 `npm run fetch:cronet -- --force`；脚本会打印落地库本体的
+ *     sha256，填进 cronetLibSha256 即可。
+ *
+ * ── 两类 pin 的分工（都不可删）────────────────────────────────────────────────
+ *  · cronetArchiveSha256 —— 下载的 module zip 本体 sha256。防传输损坏/截断/投毒，落位前 fail-fast。
+ *  · cronetLibSha256     —— **解出并落地的库本体** sha256。两个作用：①锁定「zip 里解出来的到底是哪个
+ *    文件」；②让 **skip 分支可自证** —— 磁盘上已存在的库能当场重算比对，不匹配即 fail 并要求 --force。
+ *    缺了它，「换 manifest 版本但忘加 --force」会静默沿用旧库打进安装包，且构建链与运行期全程无声
+ *    （核有 reconcileCoreWithBundledBaseline 兜底，libcronet 没有任何版本层面的运行期对照）。
+ *  libcronet 是运行期 dlopen 加载执行的原生库，故与 sing-box 核同级供应链防护：缺任一 pin 直接拒拉。
  */
+import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
-import { createWriteStream, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync } from 'fs';
-import { get } from 'https';
+import {
+  copyFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+} from 'fs';
+import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -32,101 +66,161 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const coreManifest = JSON.parse(
   readFileSync(join(ROOT, 'src/shared/core-manifest.json'), 'utf-8')
 );
-const CRONET_VERSION = coreManifest.cronetVersion; // ← 与打包 sing-box 的 cronet-go 版本对齐
-const CRONET_SHA = coreManifest.cronetArchiveSha256 || {}; // 库本体 sha == cronet-go release API 的 asset digest
-const REPO = 'SagerNet/cronet-go';
+// cronet-go/lib/<平台> 的 Go module 伪版本，抄自随包 sing-box 版本的 go.mod（见文件头取法）。
+const CRONET_VERSION = coreManifest.cronetVersion;
+const CORE_VERSION = coreManifest.bundledCoreVersion;
+const CRONET_SHA = coreManifest.cronetArchiveSha256 || {}; // module zip 本体 sha256
+const CRONET_LIB_SHA = coreManifest.cronetLibSha256 || {}; // 落地库本体 sha256（skip 分支自证用）
+const PROXY = 'https://proxy.golang.org';
+const MODULE_BASE = `${PROXY}/github.com/sagernet/cronet-go/lib`;
 const FORCE = process.argv.includes('--force');
+// 新增外部 host（Google 网段，可达性与 github.com 不同）→ 显式超时，避免无代理环境下静默卡死数分钟。
+const CURL_TIMEOUTS = ['--connect-timeout', '15', '--max-time', '600'];
 
 // 仅 linux/windows 走动态库；mac 静态编入核心二进制，不需下载（见文件头）。
-// resources 目标目录 ← cronet-go 资产名 → 落地文件名(purego 期望) → cronetArchiveSha256 key。
+// resources 目标目录 ← cronet-go lib 模块名 → 模块内库文件名(== 落地名，purego 期望) → sha pin key。
+// 注：两平台共用一个 cronetVersion —— 这是「上游同 commit 一次性打包全部 lib 子模块」的结果，不是协议
+// 保证；真分叉时本脚本会 404 或 sha 不符 → fail-closed，不会静默出错。
 const TARGETS = [
-  { dir: 'resources/linux', asset: 'libcronet-linux-amd64.so', out: 'libcronet.so', key: 'linux' },
-  { dir: 'resources/win', asset: 'libcronet-windows-amd64.dll', out: 'libcronet.dll', key: 'win' },
+  { dir: 'resources/linux', mod: 'linux_amd64', lib: 'libcronet.so', key: 'linux' },
+  { dir: 'resources/win', mod: 'windows_amd64', lib: 'libcronet.dll', key: 'win' },
 ];
 
 const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex');
+const normSha = (v) => (v || '').replace(/^sha256:/, '');
 
-function download(url, dest, want, redirects = 0) {
-  return new Promise((resolve, reject) => {
-    if (redirects > 5) return reject(new Error('too many redirects'));
-    get(url, { headers: { 'User-Agent': 'FlowZ-fetch-cronet' } }, (res) => {
-      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        res.resume();
-        return resolve(download(res.headers.location, dest, want, redirects + 1));
-      }
-      if (res.statusCode !== 200) {
-        res.resume();
-        return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
-      }
-      // 原子写：先写 .tmp，完成再 rename；失败/中断则删 .tmp，避免把截断文件当成"已存在"误用
-      const tmp = `${dest}.tmp`;
-      const file = createWriteStream(tmp);
-      const fail = (e) => {
-        try {
-          unlinkSync(tmp);
-        } catch {
-          /* ignore */
-        }
-        reject(e);
-      };
-      res.on('error', fail);
-      file.on('error', fail);
-      res.pipe(file);
-      file.on('finish', () =>
-        file.close((err) => {
-          if (err) return fail(err);
-          // 完整性校验：对下载库本体算 sha256，比对 manifest pin（= cronet-go release API 的 asset digest）。
-          // fail-fast 于落位前——损坏/截断/投毒不会 rename 到 dest（坏 .tmp 由 fail() 清理）。
-          try {
-            const got = sha256(tmp);
-            if (got !== want) {
-              return fail(
-                new Error(`sha256 不符：期望 ${want}，实得 ${got}（版本漂移 / 投毒 / 截断）`)
-              );
-            }
-            renameSync(tmp, dest);
-            resolve();
-          } catch (e) {
-            fail(e);
-          }
-        })
+/**
+ * 防漂移主闸：cronetVersion 必须等于「随包 sing-box 版本的 go.mod 所引 cronet-go/lib/<平台> 版本」。
+ * 只在真要下载时调用一次（skip 全通过的离线重建不触网）。取不到 .mod 即 fail-closed —— 无法证明同源时
+ * 不放行，与「缺 pin 拒拉」同一立场。
+ */
+function assertCronetMatchesCore(mods) {
+  const url = `${PROXY}/github.com/sagernet/sing-box/@v/v${CORE_VERSION}.mod`;
+  const out = execFileSync('curl', ['-fsSL', ...CURL_TIMEOUTS, url], { encoding: 'utf-8' });
+  for (const mod of mods) {
+    const m = out.match(new RegExp(`cronet-go/lib/${mod}\\s+(\\S+)`));
+    if (!m) {
+      throw new Error(`sing-box ${CORE_VERSION} 的 go.mod 未引用 cronet-go/lib/${mod}（上游结构变化？）`);
+    }
+    if (m[1] !== CRONET_VERSION) {
+      throw new Error(
+        `cronetVersion 与随包内核不同源：core ${CORE_VERSION} 要 ${m[1]}，manifest 写的是 ${CRONET_VERSION}` +
+          `（换核后须同步更新 cronetVersion + 两类 sha，见脚本头「换版本操作」）`
       );
-    }).on('error', reject);
-  });
+    }
+  }
 }
 
 let ok = 0;
 let failed = 0;
+const pending = [];
+
+// 第一遍：能自证的 skip 掉，其余进 pending（决定是否需要触网校验同源）。
 for (const t of TARGETS) {
-  const absDir = join(ROOT, t.dir);
-  const dest = join(absDir, t.out);
-  if (existsSync(dest) && !FORCE) {
-    console.log(`skip (exists): ${t.dir}/${t.out}`);
-    ok++;
-    continue;
+  const dest = join(ROOT, t.dir, t.lib);
+  const wantLib = normSha(CRONET_LIB_SHA[t.key]);
+  if (!FORCE && existsSync(dest)) {
+    if (!wantLib) {
+      console.error(
+        `  FAILED ${t.key}: 磁盘已有 ${t.lib} 但 core-manifest.json 缺 cronetLibSha256[${t.key}] → 无法自证其版本，拒绝沿用（补 pin 或加 --force 重拉）`
+      );
+      failed++;
+      continue;
+    }
+    const got = sha256(dest);
+    if (got === wantLib) {
+      console.log(`skip (verified): ${t.dir}/${t.lib} (lib sha ${got.slice(0, 12)}…)`);
+      ok++;
+      continue;
+    }
+    console.log(
+      `stale: ${t.dir}/${t.lib} 与 cronetLibSha256 不符（磁盘 ${got.slice(0, 12)}… ≠ 期望 ${wantLib.slice(0, 12)}…）→ 重新下载`
+    );
   }
-  // 完整性 pin 是供应链防护核心：缺 pin 直接 fail（绝不无校验拉可 dlopen 的原生库）；换版本须同步补 cronetArchiveSha256。
-  // normalize：容忍带/不带 `sha256:` 前缀——cronet-go release API 的 asset digest 形如 `sha256:<hex>`，可原样抄进 manifest。
-  const want = (CRONET_SHA[t.key] || '').replace(/^sha256:/, '');
+  pending.push(t);
+}
+
+if (pending.length > 0) {
+  try {
+    assertCronetMatchesCore(pending.map((t) => t.mod));
+  } catch (e) {
+    console.error(`  FAILED: ${e.message}`);
+    console.log(`\ncronet libs: ${ok} ready, ${pending.length} failed (module ${CRONET_VERSION}).`);
+    process.exit(1);
+  }
+}
+
+for (const t of pending) {
+  const absDir = join(ROOT, t.dir);
+  const dest = join(absDir, t.lib);
+  // 完整性 pin 是供应链防护核心：缺 pin 直接 fail（绝不无校验拉可 dlopen 的原生库）。
+  const want = normSha(CRONET_SHA[t.key]);
   if (!want) {
     console.error(
-      `  FAILED ${t.key}: core-manifest.json 缺 cronetArchiveSha256[${t.key}] pin → 拒绝无完整性校验拉取（换版本须同步补；值=cronet-go release API 的 asset digest）`
+      `  FAILED ${t.key}: core-manifest.json 缺 cronetArchiveSha256[${t.key}] pin → 拒绝无完整性校验拉取（值=module zip 的 sha256，见脚本头「换版本操作」）`
     );
     failed++;
     continue;
   }
   mkdirSync(absDir, { recursive: true });
-  const url = `https://github.com/${REPO}/releases/download/${CRONET_VERSION}/${t.asset}`;
+  const url = `${MODULE_BASE}/${t.mod}/@v/${CRONET_VERSION}.zip`;
+  const work = mkdtempSync(join(tmpdir(), 'flowz-cronet-'));
+  const tmpDest = `${dest}.tmp`;
   try {
-    console.log(`downloading ${t.asset} → ${t.dir}/${t.out} ...`);
-    await download(url, dest, want);
-    console.log(`  ok (sha ${want.slice(0, 12)}…)`);
+    const archive = join(work, `${t.mod}.zip`);
+    console.log(`downloading ${t.mod} module → ${t.dir}/${t.lib} ...`);
+    // -fL：失败返回非零（不把错误页当成功）+ 跟随重定向；--retry 抗瞬时抖动。与 fetch-core 同款。
+    execFileSync('curl', ['-fL', '--retry', '3', ...CURL_TIMEOUTS, '-o', archive, url], {
+      stdio: 'inherit',
+    });
+
+    // 完整性校验①：对下载的 module zip 本体算 sha256，比对 manifest pin。fail-fast 于解压前。
+    const got = sha256(archive);
+    if (got !== want) {
+      throw new Error(`module zip sha256 不符：期望 ${want}，实得 ${got}（版本漂移 / 投毒 / 截断）`);
+    }
+
+    // 只解目标文件并拍平路径（-j）：module zip 内为 `<module path>@<version>/` 多层前缀，`-j` 后直接落
+    // extractDir/<lib>。无匹配时 unzip 退 11 → execFileSync 抛 → 下方 catch 接住，仍 fail-closed。
+    // 同时避免顺带解出同目录 57MB 的 libcronet.a（本脚本不需要）。
+    const extractDir = join(work, 'x');
+    mkdirSync(extractDir, { recursive: true });
+    execFileSync('unzip', ['-q', '-o', '-j', archive, `*/${t.lib}`, '-d', extractDir], {
+      stdio: 'inherit',
+    });
+    const libPath = join(extractDir, t.lib);
+    if (!existsSync(libPath)) throw new Error(`解压产物未找到 ${t.lib}（上游模块结构可能变化）`);
+
+    // 完整性校验②：库本体 sha —— 锁定「解出来的到底是哪个文件」，并为后续 skip 分支留下可自证的锚。
+    const libGot = sha256(libPath);
+    const wantLib = normSha(CRONET_LIB_SHA[t.key]);
+    if (wantLib && libGot !== wantLib) {
+      throw new Error(`库本体 sha256 不符：期望 ${wantLib}，实得 ${libGot}`);
+    }
+
+    // 原子落地：拷到 .tmp → chmod（unix 可执行）→ rename 顶替（避免半写文件被打包/误用）。
+    rmSync(tmpDest, { force: true });
+    copyFileSync(libPath, tmpDest);
+    if (t.lib.endsWith('.so')) chmodSync(tmpDest, 0o755);
+    renameSync(tmpDest, dest);
+    console.log(`  ok: ${t.dir}/${t.lib} (zip sha ${got.slice(0, 12)}…, lib sha ${libGot})`);
+    if (!wantLib) {
+      console.log(
+        `  ⚠ core-manifest.json 缺 cronetLibSha256[${t.key}] → 请填入上面的 lib sha（否则下次 skip 无法自证）`
+      );
+    }
     ok++;
   } catch (e) {
-    console.error(`  FAILED: ${e.message}`);
+    console.error(`  FAILED ${t.key}: ${e.message}`);
     failed++;
+  } finally {
+    // 清理顺序无关紧要，但 .tmp 必须在这里清：copyFileSync 成功而 chmod/rename 失败时（磁盘满 / 杀软锁
+    // 文件），残留的 .tmp 会被 electron-builder 的 `**/*` filter 打进安装包。
+    rmSync(tmpDest, { force: true });
+    rmSync(work, { recursive: true, force: true });
   }
 }
-console.log(`\ncronet libs: ${ok} ready, ${failed} failed (version ${CRONET_VERSION}).`);
+
+console.log(`\ncronet libs: ${ok} ready, ${failed} failed (module ${CRONET_VERSION}).`);
 console.log('macOS: cronet 静态编入 mac-arm64 核心，无需下载（见脚本头注）。');
 process.exit(failed > 0 ? 1 : 0);

--- a/src/shared/__tests__/core-manifest-invariants.test.ts
+++ b/src/shared/__tests__/core-manifest-invariants.test.ts
@@ -1,0 +1,72 @@
+/**
+ * core-manifest.json 不变量门 —— 挂在 `npm run test:core-gate` 上（**打包链必经**：package:* / dist:* /
+ * release:prepare 都跑它），而不是只挂全量 `npm test`。理由：本门要拦的事故是「换核时 manifest 改错/漏改
+ * → 打进安装包」，只有站在打包链上才拦得住。
+ *
+ * 被保护的对象是 `scripts/fetch-cronet.mjs` 与 `scripts/fetch-core.mjs`（cronetVersion 在主进程无任何
+ * 消费方，全仓仅这两个脚本 + 本测试读它），故断言放在 shared 侧、不寄生于某个 runtime 单测。
+ */
+import * as manifest from '../core-manifest.json';
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+describe('core-manifest：版本字段', () => {
+  it('bundledCoreVersion 非空', () => {
+    expect(typeof (manifest as { bundledCoreVersion?: string }).bundledCoreVersion).toBe('string');
+    expect((manifest as { bundledCoreVersion?: string }).bundledCoreVersion).toBeTruthy();
+  });
+
+  /**
+   * cronet 取源不变量：libcronet 改经 **Go module proxy** 取（与随包 sing-box 的 go.mod 同源），
+   * SagerNet/cronet-go 的 **Releases 已停更**（停在 v148，而核已用到 naiveproxy 150）。
+   *
+   * 若有人把 release tag（chromium 式，形如 `v148.0.7778.96-1`）粘回 cronetVersion：fetch-cronet 会 404，
+   * 而磁盘上已存在的库**在旧实现里会被静默沿用** → naive 与核永久漂移且零报错。现已由脚本的 cronetLibSha256
+   * 自证 + 同源校验双重拦截，本断言是第三道（最早、最便宜的一道）。
+   *
+   * 形状判据刻意**不锁基版本段**：当前上游从未给 lib 子模块打 tag（`@v/list` 实测为空），故伪版本恒为
+   * `v0.0.0-<14位时间戳>-<12位hash>`；一旦上游打了 tag，Go 生成的伪版本会变成 `v<next>-0.<ts>-<hash>`，
+   * 那是**完全合法**的值，不该让门在此误红（误红时最省事的「修法」是把正则放宽成 `.*`，门就没了）。
+   */
+  it('cronetVersion 是 Go module 伪版本，不是 chromium 式 release tag', () => {
+    const v = (manifest as { cronetVersion?: string }).cronetVersion || '';
+    // 必含伪版本后缀：14 位 UTC 时间戳 + 12 位 commit 前缀
+    expect(v).toMatch(/-\d{14}-[0-9a-f]{12}$/);
+    // 反面：chromium 式主版本号（v148.x / v150.x）说明取源退回了 Releases
+    expect(v).not.toMatch(/^v\d{3,}\./);
+  });
+});
+
+describe('core-manifest：供应链 pin 齐全（缺 pin 时 fetch 脚本拒拉，此处提前暴露）', () => {
+  it('coreArchiveSha256 覆盖四平台且为 64 位 hex', () => {
+    const m = (manifest as { coreArchiveSha256?: Record<string, string> }).coreArchiveSha256 || {};
+    for (const key of ['linux', 'win', 'mac-x64', 'mac-arm64']) {
+      expect(m[key]).toMatch(HEX64);
+    }
+  });
+
+  /**
+   * cronet 两类 pin 分工（都不可删，见 fetch-cronet.mjs 头注）：
+   *   · cronetArchiveSha256 = 下载的 module zip 本体 → 防传输损坏/投毒，落位前 fail-fast
+   *   · cronetLibSha256     = 解出并落地的库本体 → ①锁定「解出来的是哪个文件」②让 skip 分支可自证
+   * 仅 linux/win 走动态库；mac 的 cronet 静态编入核心二进制，故此处只断言两平台。
+   */
+  it('cronet 两类 sha 覆盖 linux/win 且为 64 位 hex', () => {
+    const zip =
+      (manifest as { cronetArchiveSha256?: Record<string, string> }).cronetArchiveSha256 || {};
+    const lib = (manifest as { cronetLibSha256?: Record<string, string> }).cronetLibSha256 || {};
+    for (const key of ['linux', 'win']) {
+      expect(zip[key]).toMatch(HEX64);
+      expect(lib[key]).toMatch(HEX64);
+    }
+  });
+
+  it('zip sha 与 lib sha 不相等（防把同一个值误填两处）', () => {
+    const zip =
+      (manifest as { cronetArchiveSha256?: Record<string, string> }).cronetArchiveSha256 || {};
+    const lib = (manifest as { cronetLibSha256?: Record<string, string> }).cronetLibSha256 || {};
+    for (const key of ['linux', 'win']) {
+      expect(zip[key]).not.toBe(lib[key]);
+    }
+  });
+});

--- a/src/shared/core-manifest.json
+++ b/src/shared/core-manifest.json
@@ -1,14 +1,18 @@
 {
-  "bundledCoreVersion": "1.14.0-beta.2",
-  "cronetVersion": "v148.0.7778.96-1",
+  "bundledCoreVersion": "1.14.0-beta.5",
+  "cronetVersion": "v0.0.0-20260731161755-38229fb700f6",
   "coreArchiveSha256": {
-    "linux": "f68715815741e59f25e32904cabcd5924a0461a910d8e9c9612512b957709ef4",
-    "win": "4a50a0ffcd685ccf522ff0d45700ad175aae7cf85172b19ba0f27ed0ef1a65cb",
-    "mac-x64": "0c8e6cd7c5ca537ba2f0d125c24b9b4519d2359bfcfb6615d6751fe5caf10371",
-    "mac-arm64": "32a8130b8598eb70028164f4393e7d5777d866c7db9e487b8ab0f56d0d0e7735"
+    "linux": "6342f233fff0e9a4a33e3bb62eee0b79e1ca02e21d3d24cdfa00fb80d543d3f6",
+    "win": "d3d92103ae267d9d0c70781d738713a5eaef97a5739522ab1ea4a8e4a06fc6a3",
+    "mac-x64": "40bafb42cdc3dd2105090971eb45f799e8dac453ce3bf06f371e5d5550773c72",
+    "mac-arm64": "2dfc004dde54327f4afc89d6a2b6f87c26f2d92bb08809dfed6782a0dda37a0f"
   },
   "cronetArchiveSha256": {
-    "linux": "dc7293a929dffa695aae1a89555e7366158fa0a3f40bbe3012d445bc05c99672",
-    "win": "c7434cfa93c3041321dd19111c4de6c52b8a9531a65661ba45425d3c51ec69e2"
+    "linux": "c89c881f4e9c0a1a21a5941ebdea2e0540daf5f0b8d0ecac984b841d74d6135b",
+    "win": "9974a299e7bedc8a18eb0312796f174a344b1d20cefd34ed8d35950e0722dc28"
+  },
+  "cronetLibSha256": {
+    "linux": "9d43c2ee2410a54262e394c09da14b402e872d919ea66280c6b1f54414ab5f6a",
+    "win": "257f966119ffca91d7a2ce110a4b668b865d88bf2ed5339fd06a5644b0d02823"
   }
 }


### PR DESCRIPTION
## 变更

内核 `1.14.0-beta.2` → `1.14.0-beta.5`，libcronet `148.0.7778.96` → `150.0.7871.63`。

上游本版把 **AnyTLS 客户端 metadata 默认置空**（该字段开源服务端不使用，但可被用于给用户画像）。FlowZ 换核即生效，无需改代码：该 metadata 从来不是 FlowZ 暴露的配置项；`client_metadata` 是 sing-box 新增的出站选项，Clash/mihomo 节点格式无对应字段，订阅带不进来，故本 PR 不做表单或订阅侧改动。

## 为什么顺带改 cronet 取源

sing-box 经 Go module `github.com/sagernet/cronet-go/lib/<平台>` 拿预编译库，而 `SagerNet/cronet-go` 的 **Releases 已停更**（最新仍是 `v148.0.7778.96-1`，本版核已用到 naiveproxy 150）。原先 `fetch-cronet.mjs` 从 Releases 资产下载，两条渠道脱钩后打包库与核会永久漂移。改为与核同源取 module zip，`cronetVersion` 相应从 release tag 改为 Go module 伪版本。

## 两类 pin 的分工（都不可删）

| 字段 | 校验对象 | 作用 |
|---|---|---|
| `cronetArchiveSha256` | 下载的 module zip 本体 | 防传输损坏/截断/投毒，落位前 fail-fast |
| `cronetLibSha256`（新增） | 解出并落地的库本体 | 锁定「解出来的是哪个文件」；让 skip 分支可自证 |

后者是必需的：`package:*` 链里的 `fetch:cronet` **不带 `--force`**。若只 pin zip，磁盘产物与 manifest 之间就没有可校验关系，「换版本忘加 `--force`」会静默沿用旧库打进安装包，且构建链与运行期全程无声——内核有 `reconcileCoreWithBundledBaseline` 兜底，libcronet 没有任何版本层面的运行期对照。

## 防漂移主闸

每次**实际下载前**取 sing-box 的 `.mod` 校验 `cronetVersion` 与随包内核同源，不一致直接 fail。skip 全部自证通过时不触网，不影响离线重建。

## 变异实跑（非推理）

| 变异 | 结果 |
|---|---|
| 篡改 `cronetLibSha256` | 拒绝 skip → 重新下载 → 库本体校验报错 |
| `cronetVersion` 与随包核不同源 | 下载前硬 fail，指名 core 要哪个版本 |
| 库在位但缺 `cronetLibSha256` | fail-closed 拒绝沿用（旧行为为静默计入成功） |

## 验证

- `build:main` / `build:renderer` / `lint`（0 error）/ `npm test`（236 suites, 3553 passed, 37 snapshots）
- `test:core-gate` 2 suites / 13 passed —— manifest 不变量断言接入该 script（打包链必经），非仅 `npm test`
- 二进制实测：sing-box `1.14.0-beta.5`；libcronet `150.0.7871.63`；Windows dll 为合法 PE32+ x86-64
- **真机 naive 出站**（本次唯一单测覆盖不到的路径，运行期 dlopen 原生库）：
  - Windows x64：8 MB ×2 `http=200`，日志 `NaiveProxy started, version: 150.0.7871.63`
  - macOS arm64：同上（mac 的 cronet 静态编入核二进制，新核自带即 150）
- **Windows TUN 起核 + clash_api 换节点**：起核正常、适配器建出、热切 2 次、切换期间 9/9 请求成功、停核后适配器无残留

## 其它

`resources/README.md` / `README.en.md` 原写「libcronet 独立按 cronetVersion 管理，换核不必同步」，在新设计下不成立，已改为「必须同步换」并补三步操作；顺带把长期滞后的硬编码版本号行改为指向 manifest。