### PR TITLE
fix(ci): PR 打包冒烟显式用 bash，修 Windows 上中间步骤失败被吞

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -92,21 +92,30 @@ jobs:
       # PR 冒烟：完整 prep（helper 编译 + 资产 fetch + build）+ `electron-builder --dir`——验证打包链能过，
       # 跳过 nsis/portable/压缩/签名/上传（省 PR 时长且语义诚实：冒烟就是冒烟，不假装出安装包）。
       #
-      # ⚠️ `shell: bash` 不可删：多行 run 块在 **Windows 上默认走 pwsh**，原生命令的非零退出码既不中断
-      # 脚本、也不决定步骤成败——步骤退出码只取**最后一条**命令。实测后果（PR #342 → run 30936437582）：
-      # `fetch:cronet` 已打印 `0 ready, 2 failed` 并退 1，却被后续 `electron-builder --dir` 的 0 覆盖，
-      # 该步骤报 SUCCESS、PR 全绿合入，缺陷直到 main push 跑单命令 `npm run package:win` 才炸出来。
-      # 即这块冒烟当时对「资产 fetch 失败」是零信息量的绿。GitHub 的 bash 默认带 `-eo pipefail`，中间
-      # 任一条失败即整步失败，这正是冒烟该有的语义。新增多行 run 块时同样要显式指定。
+      # ⚠️ 各行之间的 `&&` 不可删（两处实测踩坑，都别再踩回去）：
+      #
+      # 1) 多行 run 块在 **Windows 上默认走 pwsh**，原生命令的非零退出码既不中断脚本、也不决定步骤成败
+      #    ——步骤退出码只取**最后一条**命令。后果（PR #342 → run 30936437582）：`fetch:cronet` 已打印
+      #    `0 ready, 2 failed` 并退 1，却被随后 `electron-builder --dir` 的 0 覆盖，该步骤报 SUCCESS、
+      #    PR 全绿合入；缺陷直到 main push 跑单命令 `npm run package:win` 才炸出来。即这块冒烟当时对
+      #    「资产 fetch 失败」是零信息量的绿——比没有这道门更糟，它给了「已验证过」的错觉。
+      #
+      # 2) 但**不能改用 `shell: bash` 来拿 `-e`**：换 shell 会连带换掉工具解析。实测（run 30966966135）
+      #    pwsh 下 `tar` 取到 Windows 自带 `system32\tar.exe`（bsdtar，认 `C:\...` 路径），而 Git-bash 下
+      #    PATH 里 GNU tar 优先，它把 `C:\Users\...` 当成 `host:path` 远程语法 → `Cannot connect to C:
+      #    resolve failed`，`fetch:core` 变成 1 ready / 3 failed。
+      #
+      # 故保持各平台默认 shell（Windows 侧与 main push 走 npm script 时的解析一致），改用 `&&` 串联拿
+      # fail-fast：pwsh 7 与 bash 都支持该操作符，前一条非零即短路，$LASTEXITCODE 由 GitHub 包装器带出。
+      # 新增多行 run 块时照此串联。
       - name: Package smoke (PR, --dir, no artifact)
         if: github.event_name == 'pull_request'
-        shell: bash
         run: |
-          npm run build:helper
-          npm run fetch:core
-          npm run fetch:cronet
-          npm run fetch:dashboard
-          npm run build
+          npm run build:helper &&
+          npm run fetch:core &&
+          npm run fetch:cronet &&
+          npm run fetch:dashboard &&
+          npm run build &&
           npx electron-builder --${{ matrix.platform }} --dir
 
       # main push / 手动：完整打包（与 release.yml 同源脚本，含正确 arch flag）。

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -91,8 +91,16 @@ jobs:
 
       # PR 冒烟：完整 prep（helper 编译 + 资产 fetch + build）+ `electron-builder --dir`——验证打包链能过，
       # 跳过 nsis/portable/压缩/签名/上传（省 PR 时长且语义诚实：冒烟就是冒烟，不假装出安装包）。
+      #
+      # ⚠️ `shell: bash` 不可删：多行 run 块在 **Windows 上默认走 pwsh**，原生命令的非零退出码既不中断
+      # 脚本、也不决定步骤成败——步骤退出码只取**最后一条**命令。实测后果（PR #342 → run 30936437582）：
+      # `fetch:cronet` 已打印 `0 ready, 2 failed` 并退 1，却被后续 `electron-builder --dir` 的 0 覆盖，
+      # 该步骤报 SUCCESS、PR 全绿合入，缺陷直到 main push 跑单命令 `npm run package:win` 才炸出来。
+      # 即这块冒烟当时对「资产 fetch 失败」是零信息量的绿。GitHub 的 bash 默认带 `-eo pipefail`，中间
+      # 任一条失败即整步失败，这正是冒烟该有的语义。新增多行 run 块时同样要显式指定。
       - name: Package smoke (PR, --dir, no artifact)
         if: github.event_name == 'pull_request'
+        shell: bash
         run: |
           npm run build:helper
           npm run fetch:core


### PR DESCRIPTION
## 问题

`Package smoke (PR)` 是多行 `run: |` 块，**Windows 上默认走 pwsh**：原生命令的非零退出码既不中断脚本、也不决定步骤成败——步骤退出码只取**最后一条**命令。

实测（PR #342 → run 30936437582，windows-2022 job 日志）：

```
downloading linux_amd64 module → resources/linux/libcronet.so ...
caution: filename not matched:  */libcronet.so
  FAILED linux: Command failed: unzip -q -o -j ... */libcronet.so ...
  FAILED win:   Command failed: unzip -q -o -j ... */libcronet.dll ...
cronet libs: 0 ready, 2 failed
```

`fetch:cronet` 退 1，被随后 `electron-builder --dir` 的 0 覆盖 → **该步骤报 SUCCESS，PR 全绿合入**。同一缺陷直到 main push 跑单命令 `npm run package:win`（npm script 内部 `&&` 串联）才炸出来（run 30964765672）。

即这块冒烟当时对「资产 fetch 失败」是**零信息量的绿**——比没有这道门更糟，因为它给了「已经验证过」的错觉。

mac 侧默认 bash 本就 fail-fast，没暴露是因为 macOS 的 unzip 通配符跨 `/`，那格本来就没失败。两个条件叠加才正好漏过。

## 改动

该步骤显式 `shell: bash`（GitHub 的 bash 默认带 `-eo pipefail`），中间任一条失败即整步失败。只动这一步，不改其它步骤的 shell。注释里写明新增多行 run 块要同样显式指定。

仓内其余多行 run 块只在 Linux/mac 上跑（release.yml 的 apt-get / for ARCH 循环），不受此影响；ci.yml 无多行 run 块。

## 验证

`.github/workflows/**` 在本 workflow 的 paths 过滤里，**本 PR 自身就会跑到这个被改的步骤**，windows-2022 + macos-14 双绿即证明 bash 下打包链无回归。

导致失败的 unzip 通配符问题已在 main 单独修掉（`fix(build): cronet 解压写全条目名`），故本 PR 的冒烟应当真绿而非再次被吞。