### PR TITLE
fix(security): 运行期换核校验官方 sha256，拒装未经校验的内核

### DIFF
--- a/src/main/services/CoreUpdateService.ts
+++ b/src/main/services/CoreUpdateService.ts
@@ -4,6 +4,7 @@
  */
 
 import { app, dialog } from 'electron';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -1534,9 +1535,48 @@ export class CoreUpdateService {
   /** 重置内核到出厂版本：把随 App 出厂的 bundled 核 force 落位回受保护目录（macOS-v5）/bundle。
    *  skipBackup=true：出厂核是用户要的终态，现役核是用户要丢弃的——不备份/不验证闩/不回退（去冗余）。
    *  force 跳过同版本短路（出厂核常与现役同版本，重置仍要覆盖回去）。 */
+
+  /**
+   * 校验随包出厂核是否仍是 manifest 里 pin 的那一份（`coreBinarySha256`）。
+   *
+   * 存在的理由：`resetCoreToFactory` 的语义是「回到已知良好的出厂状态」。若 app 安装目录里的出厂核已被
+   * 替换（portable 安装目录用户可写，普通权限的恶意程序即可改），reset 就会把恶意核**当作干净核装回去**，
+   * 而且这是用户主动求助时最信任的一步。
+   *
+   * **仅 win/linux 校验，macOS 跳过**——不是偷懒，是 pin 在 mac 上本就对不上：release 流程对 .app 做
+   * `codesign --force --deep --sign -`，深签会重写嵌套二进制（真机实测：同一文件签名前后 sha 不同），
+   * 而 pin 取自上游 release 原件。硬校验会对每个 mac 用户误报。mac 侧的等价保护由 .app 自身的代码签名
+   * （Gatekeeper 校验嵌套内容）承担。
+   *
+   * @returns null=通过或不适用；字符串=拒绝理由
+   */
+  private verifyFactoryCore(bundlePath: string): string | null {
+    if (process.platform === 'darwin') return null; // 见上：深签重写字节，pin 不适用
+    const key =
+      process.platform === 'win32' ? 'win' : process.platform === 'linux' ? 'linux' : null;
+    if (!key) return null;
+    const pin = (coreManifest as { coreBinarySha256?: Record<string, string> }).coreBinarySha256?.[
+      key
+    ];
+    if (!pin) return null; // 无 pin 不阻断（与 fetch-core 同口径：pin 是自证锚，缺它退回原行为）
+    try {
+      const actual = createHash('sha256').update(fs.readFileSync(bundlePath)).digest('hex');
+      if (actual === pin) return null;
+      return `随包出厂内核与官方指纹不符（期望 ${pin.slice(0, 12)}…，实得 ${actual.slice(0, 12)}…）。安装目录内的内核可能已被替换，已拒绝重置；请重新安装 FlowZ。`;
+    } catch (e) {
+      return `无法读取随包出厂内核以校验完整性：${e}`;
+    }
+  }
+
   async resetCoreToFactory(): Promise<{ ok: boolean; error?: string }> {
     this.logManager.addLog('info', '重置内核到出厂版本...', 'CoreUpdateService');
     const bundlePath = resourceManager.getBundledSingBoxPath();
+    // 出厂核完整性：reset 是「回到已知良好」的动作，装回一个已被替换的二进制比不 reset 更糟。
+    const bad = this.verifyFactoryCore(bundlePath);
+    if (bad) {
+      this.logManager.addLog('error', `重置内核被拒绝：${bad}`, 'CoreUpdateService');
+      return { ok: false, error: bad };
+    }
     const r = await this.replaceManualCore({ filePath: bundlePath, force: true, skipBackup: true });
     if (r.ok) {
       this.pruneBackup(); // 清理旧备份（reset 到出厂 = 干净状态，残留 .bak 无意义）

--- a/src/main/services/CoreUpdateService.ts
+++ b/src/main/services/CoreUpdateService.ts
@@ -29,6 +29,7 @@ import { CoreDownloader } from './core-downloader';
 import type { UpdateNetwork } from './UpdateNetwork';
 import coreManifest from '../../shared/core-manifest.json';
 import { IPC_CHANNELS } from '../../shared/ipc-channels';
+import { normalizeAssetDigest } from './singbox-asset';
 import { system32 } from '../utils/win-system32';
 
 export interface CoreUpdateCheckResult {
@@ -36,6 +37,8 @@ export interface CoreUpdateCheckResult {
   currentVersion: string;
   latestVersion?: string;
   downloadUrl?: string;
+  /** 该资产的 sha256（小写裸 hex，取自 GitHub API 的 asset.digest）。运行期换核的完整性锚。 */
+  downloadSha256?: string;
   releaseNotes?: string;
   crossBand?: boolean; // latestVersion 是否跨当前 minor 带（restrict 关闭时让 UI 标「跨大版本、风险更高」）
   error?: string;
@@ -89,6 +92,11 @@ export class CoreUpdateService {
   private helperManager: Pick<HelperManager, 'getStatus' | 'installCore'> | null = null;
   private privilegeService: PlatformPrivilegeService | null = null; // T16：copyFileElevatedWindows delegate
   private isUpdating: boolean = false;
+  /**
+   * 最近一次 checkUpdate 解析出的「下载 URL → sha256」映射。updateCore 只认这里（或现取），
+   * **不接受调用方传入摘要**——否则渲染层/IPC 侧一个疏忽就能把校验降级成不校验，而这正是要防的。
+   */
+  private assetDigestByUrl = new Map<string, string>();
   // 更新后等待「首次成功运行」验证的新版本号；首启成功→清除并删备份，首启失败→自动回滚
   private pendingUpdateVersion: string | null = null;
   private pendingUpdateAt: number = 0; // 更新落盘时间戳，用于"待验证"过期保护（防陈旧 pending 误回滚）
@@ -233,11 +241,14 @@ export class CoreUpdateService {
         // 找到适合当前平台的资源
         const asset = this.coreDownloader.findSuitableAsset(latestRelease.assets);
         if (asset) {
+          const digest = normalizeAssetDigest(asset);
+          if (digest) this.assetDigestByUrl.set(asset.browser_download_url, digest);
           const result = {
             hasUpdate: true,
             currentVersion,
             latestVersion,
             downloadUrl: asset.browser_download_url,
+            downloadSha256: digest ?? undefined,
             releaseNotes: latestRelease.body,
             // 跨当前 minor 带（如 1.13→1.14）→ UI 标风险。能走到这说明带内或 restrict 关闭，跨带必是 restrict 关闭所致。
             crossBand: !sameMajorMinor(latestVersion, currentVersion),
@@ -263,6 +274,38 @@ export class CoreUpdateService {
     }
   }
 
+  /**
+   * 解析某下载 URL 对应的 sha256（小写裸 hex）；解析不出返回 null。
+   *
+   * 顺序：本次会话 checkUpdate 写下的缓存 → 现拉一次 releases 重新解析（缓存冷：App 重启后用户直接点更新，
+   * 或自动更新腿跨会话触发）。**刻意不接受调用方传入的摘要**——摘要是安全断言，来源必须由服务自己掌握，
+   * 否则任何一个漏传/传错的调用点都会把校验静默降级成不校验。
+   *
+   * 实测依据：GitHub REST 对全部 asset 回填 `digest`（v1.12.0 / v1.13.0 / v1.14.0-beta.7 逐个验过），
+   * 故「解析不出」属异常而非常态，调用方据此 fail-closed 是可行的、不会卡住正常更新。
+   */
+  private async resolveAssetSha256(downloadUrl: string): Promise<string | null> {
+    const cached = this.assetDigestByUrl.get(downloadUrl);
+    if (cached) return cached;
+    try {
+      const releases = await this.coreDownloader.fetchReleases();
+      for (const rel of releases || []) {
+        for (const a of rel?.assets || []) {
+          const d = normalizeAssetDigest(a);
+          if (d && a?.browser_download_url) this.assetDigestByUrl.set(a.browser_download_url, d);
+        }
+      }
+    } catch (e) {
+      this.logManager.addLog(
+        'warn',
+        `重新解析内核资产摘要失败（将拒绝安装未校验的内核）: ${e}`,
+        'CoreUpdateService'
+      );
+      return null;
+    }
+    return this.assetDigestByUrl.get(downloadUrl) ?? null;
+  }
+
   async updateCore(downloadUrl: string): Promise<boolean> {
     if (this.isUpdating) {
       throw new Error('更新正在进行中');
@@ -279,9 +322,15 @@ export class CoreUpdateService {
     let backupMade = false;
 
     try {
-      // 1. 下载文件
+      // 1. 下载文件（先取摘要：拿不到就不装——运行期换核会回落第三方镜像，无摘要即无从判断拿到的是什么）
+      const sha256 = await this.resolveAssetSha256(downloadUrl);
+      if (!sha256) {
+        throw new Error(
+          '无法获取该内核资产的官方 sha256 摘要，已中止更新（拒绝安装未经校验的内核）。请稍后重试或检查网络。'
+        );
+      }
       this.logManager.addLog('info', '开始下载核心文件...', 'CoreUpdateService');
-      const tempPath = await this.coreDownloader.downloadFile(downloadUrl);
+      const tempPath = await this.coreDownloader.downloadFile(downloadUrl, false, sha256);
 
       // 2. 解压文件 (如果需要)
       // Sing-box release 通常是 .tar.gz 或 .zip
@@ -794,7 +843,17 @@ export class CoreUpdateService {
       let tempPath: string | null = null;
       let extractDir: string | null = null;
       try {
-        tempPath = await this.coreDownloader.downloadFile(check.downloadUrl);
+        // 与手动路径同一道门：无摘要不装。这条腿是**自动**的（无人值守），降级校验的后果更严重。
+        const sha256 = check.downloadSha256 ?? (await this.resolveAssetSha256(check.downloadUrl));
+        if (!sha256) {
+          this.logManager.addLog(
+            'warn',
+            '自动更新中止：无法获取内核资产的官方 sha256 摘要（拒绝安装未经校验的内核）',
+            'CoreUpdateService'
+          );
+          return;
+        }
+        tempPath = await this.coreDownloader.downloadFile(check.downloadUrl, false, sha256);
         const extracted = await this.coreDownloader.extractCore(tempPath);
         extractDir = extracted.extractDir;
         const preflight = await this.preflightValidate(extracted.corePath);

--- a/src/main/services/__tests__/core-downloader-integrity.test.ts
+++ b/src/main/services/__tests__/core-downloader-integrity.test.ts
@@ -1,0 +1,132 @@
+/**
+ * CoreDownloader.downloadFile 的**内容完整性**校验（node env，零网络）：mock electron `net.request`，
+ * 用 EventEmitter 驱动 response/data/end 流（照 unlock-http.test.ts 的 electron mock 范式）。
+ *
+ * 为什么这道门必须有测试：运行期换核在下载失败时会**回落 gh-proxy 第三方镜像**，而原先的完整性检查只有
+ * Content-Length —— 它能挡截断，挡不住「长度一样但内容被换」。摘要取自 api.github.com 直连响应、不经镜像，
+ * 是镜像投毒的唯一实际拦截点。校验一旦被改坏，症状是**静默安装了一个不是官方发布的可执行文件**，
+ * 没有任何用户可见的报错，正是最需要用例钉住的那类失败。
+ */
+import { EventEmitter } from 'events';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const mockRequest = jest.fn();
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-core-dl-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP },
+  net: { request: (...a: unknown[]) => mockRequest(...a) },
+  session: { fromPartition: () => ({ setProxy: async () => undefined }) },
+}));
+
+import { CoreDownloader } from '../core-downloader';
+
+class FakeReq extends EventEmitter {
+  setHeader(): void {}
+  end(): void {}
+  abort(): void {}
+}
+
+class FakeRes extends EventEmitter {
+  statusCode = 200;
+  headers: Record<string, string> = {};
+}
+
+const BODY = Buffer.from('fake sing-box archive bytes');
+const BODY_SHA = createHash('sha256').update(BODY).digest('hex');
+
+/** 每次 net.request 都回同一份 BODY（含正确 Content-Length，故截断检查恒过——只留摘要这一道门）。 */
+function serveBody(): void {
+  mockRequest.mockImplementation(() => {
+    const req = new FakeReq();
+    setImmediate(() => {
+      const res = new FakeRes();
+      res.headers['content-length'] = String(BODY.length);
+      req.emit('response', res);
+      setImmediate(() => {
+        res.emit('data', BODY);
+        res.emit('end');
+      });
+    });
+    return req;
+  });
+}
+
+const logManager = { addLog: () => {} } as never;
+const newDownloader = () => new CoreDownloader(logManager, async () => null);
+
+afterAll(() => {
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  serveBody();
+});
+
+describe('CoreDownloader.downloadFile — sha256 完整性校验', () => {
+  it('摘要相符 → 落临时文件并返回其路径（内容逐字节一致）', async () => {
+    const p = await newDownloader().downloadFile(
+      'https://example.com/core.tar.gz',
+      false,
+      BODY_SHA
+    );
+    expect(fs.readFileSync(p)).toEqual(BODY);
+  });
+
+  /**
+   * 核心断言：长度对得上、但内容不是期望的那份 → **必须 reject**。这正是镜像投毒的形态
+   * （Content-Length 检查在此恒通过），reject 掉才能保证不进入解压/预检/落位链路。
+   */
+  it('摘要不符 → reject 且不留下临时文件（拒装被掉包的内核）', async () => {
+    const wrong = 'b'.repeat(64);
+    const before = fs.readdirSync(TMP).length;
+    await expect(
+      newDownloader().downloadFile('https://example.com/core.tar.gz', false, wrong)
+    ).rejects.toThrow(/完整性校验失败/);
+    expect(fs.readdirSync(TMP).length).toBe(before); // 半成品已清，不会被后续流程捡去用
+  });
+
+  /**
+   * 镜像重试腿也必须带着摘要：否则「直连失败 → 换镜像」这一步会退化成不校验，
+   * 而镜像恰恰是最不可信的那一环。这里让 GitHub 域名的首发失败，观察重试那次仍被摘要拦下。
+   */
+  it('GitHub 直连失败 → 换镜像重试，重试结果同样过摘要校验（不因重试而降级）', async () => {
+    let call = 0;
+    mockRequest.mockImplementation(() => {
+      call++;
+      const req = new FakeReq();
+      if (call === 1) {
+        setImmediate(() => req.emit('error', new Error('boom')));
+        return req;
+      }
+      setImmediate(() => {
+        const res = new FakeRes();
+        res.headers['content-length'] = String(BODY.length);
+        req.emit('response', res);
+        setImmediate(() => {
+          res.emit('data', BODY);
+          res.emit('end');
+        });
+      });
+      return req;
+    });
+    await expect(
+      newDownloader().downloadFile('https://github.com/x/core.tar.gz', false, 'c'.repeat(64))
+    ).rejects.toThrow(/完整性校验失败/);
+    expect(call).toBe(2); // 确实重试了；且重试那次没有绕过校验
+  });
+
+  /** 未传摘要时保持原行为（仅长度校验）——服务层已 fail-closed，此处只锁「不误伤既有调用形态」。 */
+  it('未传摘要 → 不做内容校验（向后兼容，服务层负责拒绝无摘要的更新）', async () => {
+    const p = await newDownloader().downloadFile('https://example.com/core.tar.gz');
+    expect(fs.readFileSync(p)).toEqual(BODY);
+  });
+});

--- a/src/main/services/__tests__/core-downloader-integrity.test.ts
+++ b/src/main/services/__tests__/core-downloader-integrity.test.ts
@@ -124,6 +124,22 @@ describe('CoreDownloader.downloadFile — sha256 完整性校验', () => {
     expect(call).toBe(2); // 确实重试了；且重试那次没有绕过校验
   });
 
+  /**
+   * 回归：临时文件名曾只用 `Date.now()`，而镜像重试紧跟首发失败、常落在同一毫秒 → 两次用同一路径，
+   * 首发 handleError 里的异步 unlink 会删掉重试刚写好的文件（macOS CI 实测命中，Windows 侥幸躲过）。
+   * 这里把两次下载压在同一毫秒内发起，断言各自拿到不同路径且内容都在。
+   */
+  it('同一毫秒内的并发下载 → 临时文件不撞名（含随机段）', async () => {
+    const d = newDownloader();
+    const [p1, p2] = await Promise.all([
+      d.downloadFile('https://example.com/a.tar.gz', false, BODY_SHA),
+      d.downloadFile('https://example.com/b.tar.gz', false, BODY_SHA),
+    ]);
+    expect(p1).not.toBe(p2);
+    expect(fs.readFileSync(p1)).toEqual(BODY);
+    expect(fs.readFileSync(p2)).toEqual(BODY);
+  });
+
   /** 未传摘要时保持原行为（仅长度校验）——服务层已 fail-closed，此处只锁「不误伤既有调用形态」。 */
   it('未传摘要 → 不做内容校验（向后兼容，服务层负责拒绝无摘要的更新）', async () => {
     const p = await newDownloader().downloadFile('https://example.com/core.tar.gz');

--- a/src/main/services/__tests__/core-reset-factory-verify.test.ts
+++ b/src/main/services/__tests__/core-reset-factory-verify.test.ts
@@ -1,0 +1,92 @@
+/**
+ * resetCoreToFactory 的出厂核完整性校验（node env，零网络）。
+ *
+ * 为什么这道门存在：reset 的语义是「回到已知良好的出厂状态」，是用户排障时最信任的一步。若安装目录里的
+ * 出厂核已被替换（portable 安装目录用户可写，普通权限的恶意程序即可改），reset 会把恶意核**当作干净核
+ * 装回去**——比不 reset 更糟。
+ *
+ * 为什么 macOS 必须跳过：release 流程对 .app 做 `codesign --force --deep --sign -`，深签会重写嵌套二进制
+ * （真机实测：同一文件签名前后 sha 不同），而 `coreBinarySha256` pin 取自上游 release 原件。在 mac 上硬
+ * 校验会对每个用户误报。此处用例把「跳过」钉成显式约定，防有人日后"顺手补齐三平台"制造全量误报。
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-reset-verify-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false },
+  dialog: {},
+}));
+
+// 出厂核内容固定 → 反推出 pin 塞进 mock manifest。正/负两向都不依赖 resources/ 是否已跑过 fetch:core，
+// 否则「CI 上没有那个文件」会让正向断言静默空过（绿而无信息量）。
+const MOCK_CORE_BYTES = 'pretend this is the bundled sing-box';
+const MOCK_PIN = require('crypto').createHash('sha256').update(MOCK_CORE_BYTES).digest('hex');
+jest.mock('../../../shared/core-manifest.json', () => ({
+  bundledCoreVersion: '9.9.9',
+  coreArchiveSha256: {},
+  coreBinarySha256: { linux: MOCK_PIN, win: MOCK_PIN, 'mac-x64': MOCK_PIN, 'mac-arm64': MOCK_PIN },
+}));
+
+import { CoreUpdateService } from '../CoreUpdateService';
+
+const REAL_PLATFORM = process.platform;
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+afterEach(() => setPlatform(REAL_PLATFORM));
+afterAll(() => {
+  try {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+/** 写一个内容任意的假"出厂核"，返回路径与其真实 sha。 */
+function fakeCore(content: string): { p: string; sha: string } {
+  const p = path.join(TMP, `core-${Math.random().toString(36).slice(2)}`);
+  fs.writeFileSync(p, content);
+  return { p, sha: createHash('sha256').update(content).digest('hex') };
+}
+
+const svc = () => new CoreUpdateService({ addLog: () => {} } as never);
+const verify = (s: CoreUpdateService, p: string): string | null =>
+  (s as unknown as { verifyFactoryCore: (x: string) => string | null }).verifyFactoryCore(p);
+
+describe('verifyFactoryCore — 出厂核完整性', () => {
+  it('win/linux + 二进制与 pin 不符 → 返回拒绝理由（不把被替换的核装回去）', () => {
+    const { p } = fakeCore('tampered core bytes');
+    for (const plat of ['win32', 'linux'] as const) {
+      setPlatform(plat);
+      const reason = verify(svc(), p);
+      expect(reason).toMatch(/与官方指纹不符/);
+    }
+  });
+
+  /**
+   * macOS 那格必须放行：pin 与 mac 上的实际字节**本就**不同（深签重写），不是"暂时没做"。
+   * 若哪天有人把 darwin 也纳入校验，本用例会红——那正是要拦的改动。
+   */
+  it('darwin → 恒放行（深签重写字节，pin 不适用；mac 侧由 .app 代码签名保护）', () => {
+    const { p } = fakeCore('anything at all');
+    setPlatform('darwin');
+    expect(verify(svc(), p)).toBeNull();
+  });
+
+  it('二进制与 pin 相符 → 放行（win/linux 两平台）', () => {
+    const { p } = fakeCore(MOCK_CORE_BYTES);
+    for (const plat of ['win32', 'linux'] as const) {
+      setPlatform(plat);
+      expect(verify(svc(), p)).toBeNull();
+    }
+  });
+
+  it('文件不存在 → 返回可读理由而非抛出（reset 应给出提示，不是崩）', () => {
+    setPlatform('linux');
+    expect(verify(svc(), path.join(TMP, 'nope'))).toMatch(/无法读取/);
+  });
+});

--- a/src/main/services/__tests__/core-swap-gate.test.ts
+++ b/src/main/services/__tests__/core-swap-gate.test.ts
@@ -216,6 +216,9 @@ describe('T2：CoreUpdateService 4 写核路径 setCoreSwapInProgress try/finall
     const { proxy, calls } = makeProxyWithSpy();
     const svc = makeSvc(proxy);
     jest.spyOn((svc as any).coreDownloader, 'downloadFile').mockResolvedValue('/tmp/fake.tar.gz');
+    // 换核完整性门：updateCore 取不到官方 sha256 就拒装。本 suite 只关心 coreSwapInProgress 闩，
+    // 故让摘要解析成功；「取不到摘要必须拒装」由 core-downloader-integrity / 下方专测覆盖。
+    jest.spyOn(svc as any, 'resolveAssetSha256').mockResolvedValue('a'.repeat(64));
     jest
       .spyOn((svc as any).coreDownloader, 'extractCore')
       .mockResolvedValue({ corePath: '/tmp/x/sing-box', extractDir: '/tmp/x' });
@@ -236,6 +239,9 @@ describe('T2：CoreUpdateService 4 写核路径 setCoreSwapInProgress try/finall
     const { proxy, calls } = makeProxyWithSpy();
     const svc = makeSvc(proxy);
     jest.spyOn((svc as any).coreDownloader, 'downloadFile').mockResolvedValue('/tmp/fake.tar.gz');
+    // 换核完整性门：updateCore 取不到官方 sha256 就拒装。本 suite 只关心 coreSwapInProgress 闩，
+    // 故让摘要解析成功；「取不到摘要必须拒装」由 core-downloader-integrity / 下方专测覆盖。
+    jest.spyOn(svc as any, 'resolveAssetSha256').mockResolvedValue('a'.repeat(64));
     jest
       .spyOn((svc as any).coreDownloader, 'extractCore')
       .mockResolvedValue({ corePath: '/tmp/x/sing-box', extractDir: '/tmp/x' });

--- a/src/main/services/__tests__/core-swap-gate.test.ts
+++ b/src/main/services/__tests__/core-swap-gate.test.ts
@@ -549,6 +549,10 @@ describe('T3：replaceManualCore skipBackup 分支（reset 到出厂）', () => 
     const replaceSpy = jest.spyOn(svc as any, 'replaceManualCore').mockResolvedValue({ ok: true });
     // pruneBackup 是清理旧 .bak 的私有方法；mock 避免触达真实 fs（getBackupPath/unlink）
     const pruneSpy = jest.spyOn(svc as any, 'pruneBackup').mockImplementation(() => {});
+    // 出厂核完整性门：真实出厂核路径在测试环境下当然对不上 pin（无该文件/内容不符）→ 会先行拒绝。
+    // 本 suite 关心的是换核闩与 pruneBackup 调用，故让门放行；「门本身拒不拒」由
+    // core-reset-factory-verify.test.ts 覆盖（含 macOS 必须跳过那一格）。
+    jest.spyOn(svc as any, 'verifyFactoryCore').mockReturnValue(null);
 
     const r = await svc.resetCoreToFactory();
 

--- a/src/main/services/__tests__/core-update-scheduler.test.ts
+++ b/src/main/services/__tests__/core-update-scheduler.test.ts
@@ -249,11 +249,35 @@ describe('CoreUpdateService.runAutoUpdateCycle', () => {
         currentVersion: '1.13.13',
         latestVersion: '1.13.14',
         downloadUrl: 'https://x/sing-box-1.13.14.tar.gz',
+        // 真实 checkUpdate 恒带上资产摘要；缺它自动腿会拒装（见下一条用例）。
+        downloadSha256: 'a'.repeat(64),
       },
     });
     await svc.runAutoUpdateCycle();
     expect(downloadSpy).toHaveBeenCalledTimes(1);
     expect(stageSpy).toHaveBeenCalledWith(expect.any(String), '1.13.14');
+  });
+
+  /**
+   * 自动更新是**无人值守**的：没人会看日志、没人会核对下载来源。故「取不到官方 sha256」时必须直接中止，
+   * 而不是退化成不校验就装——运行期换核会回落 gh-proxy 第三方镜像，无摘要即无从判断拿到的是什么。
+   */
+  it('取不到资产摘要 → 自动腿中止，绝不下载安装未校验的内核', async () => {
+    const { svc, downloadSpy, stageSpy } = makeService({
+      config: { autoUpdateCore: true },
+      checkResult: {
+        hasUpdate: true,
+        currentVersion: '1.13.13',
+        latestVersion: '1.13.14',
+        downloadUrl: 'https://x/sing-box-1.13.14.tar.gz',
+        // 无 downloadSha256
+      },
+    });
+    // 现取也拿不到（releases 里没有匹配 URL 的 asset）
+    jest.spyOn(svc as any, 'resolveAssetSha256').mockResolvedValue(null);
+    await svc.runAutoUpdateCycle();
+    expect(downloadSpy).not.toHaveBeenCalled();
+    expect(stageSpy).not.toHaveBeenCalled();
   });
 
   it('跨 minor 新版 → 发跨带事件、绝不下载', async () => {
@@ -569,9 +593,12 @@ describe('B0：兼容版本带去硬编码 + verifiedCeiling', () => {
       .mockResolvedValue([
         { tag_name: `v${opts.latest}`, prerelease: false, assets: [{ name: 'x' }] },
       ]);
-    jest
-      .spyOn((svc as any).coreDownloader, 'findSuitableAsset')
-      .mockReturnValue({ browser_download_url: `http://x/sing-box-${opts.latest}.tar.gz` });
+    jest.spyOn((svc as any).coreDownloader, 'findSuitableAsset').mockReturnValue({
+      browser_download_url: `http://x/sing-box-${opts.latest}.tar.gz`,
+      // 真实 GitHub API 对每个 asset 恒返回 digest；缺它会被完整性门拒装（这正是该门的意图），
+      // 故 mock 也要带上，否则测的是「拒装」而非本 suite 关心的调度/stage 逻辑。
+      digest: `sha256:${'a'.repeat(64)}`,
+    });
     return svc;
   }
 

--- a/src/main/services/__tests__/singbox-asset.test.ts
+++ b/src/main/services/__tests__/singbox-asset.test.ts
@@ -1,4 +1,4 @@
-import { findSuitableSingboxAsset } from '../singbox-asset';
+import { findSuitableSingboxAsset, normalizeAssetDigest } from '../singbox-asset';
 
 const asset = (name: string) => ({ name, browser_download_url: `https://x/${name}` });
 
@@ -78,5 +78,35 @@ describe('findSuitableSingboxAsset', () => {
 
   it('空 assets → undefined', () => {
     expect(findSuitableSingboxAsset([], 'linux', 'x64')).toBeUndefined();
+  });
+});
+
+describe('normalizeAssetDigest — 运行期换核的完整性锚', () => {
+  const HEX = 'a'.repeat(64);
+
+  it('sha256:<64hex> → 小写裸 hex', () => {
+    expect(normalizeAssetDigest({ digest: `sha256:${HEX}` })).toBe(HEX);
+    expect(normalizeAssetDigest({ digest: `sha256:${'A'.repeat(64)}` })).toBe(HEX);
+    expect(normalizeAssetDigest({ digest: `  sha256:${HEX}  ` })).toBe(HEX);
+  });
+
+  /**
+   * 形状不符一律 null、**绝不兜底放行**：调用方据 null 拒装。若在此放宽（比如「没有前缀就当 hex 用」），
+   * 「拿不到摘要」会静默退化成「不校验」，而运行期换核会回落 gh-proxy 第三方镜像——那正是要防的场景。
+   */
+  it('缺失 / 非 sha256 / 长度或字符不对 / 非字符串 → null', () => {
+    const bad: unknown[] = [
+      undefined,
+      null,
+      {},
+      { digest: null },
+      { digest: 123 },
+      { digest: HEX }, // 裸 hex 无算法前缀：不认
+      { digest: `md5:${'a'.repeat(32)}` },
+      { digest: `sha256:${'a'.repeat(63)}` },
+      { digest: `sha256:${'g'.repeat(64)}` },
+      { digest: `sha512:${'a'.repeat(128)}` },
+    ];
+    for (const a of bad) expect(normalizeAssetDigest(a)).toBeNull();
   });
 });

--- a/src/main/services/core-downloader.ts
+++ b/src/main/services/core-downloader.ts
@@ -8,6 +8,7 @@
  */
 
 import { app, net, session, Session } from 'electron';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -137,7 +138,15 @@ export class CoreDownloader {
     return findSuitableSingboxAsset(assets, process.platform, process.arch);
   }
 
-  async downloadFile(url: string, isRetry = false): Promise<string> {
+  /**
+   * 下载内核压缩包到临时文件。
+   *
+   * @param expectedSha256 期望的 sha256（小写裸 hex，来自 GitHub API 的 asset.digest）。**调用方必须传**：
+   *   下载失败会回落 gh-proxy 第三方镜像，而 Content-Length 只能挡截断、挡不住「长度一样但内容被换」。
+   *   摘要取自 api.github.com 直连响应、不经镜像，故拿它校验镜像给的字节是有意义的。
+   *   传 undefined 时不校验——仅为兼容尚未接线的调用方保留，新调用方不要这么用（服务层已 fail-closed）。
+   */
+  async downloadFile(url: string, isRetry = false, expectedSha256?: string): Promise<string> {
     let ext = process.platform === 'win32' ? '.zip' : '.tar.gz';
     try {
       const urlObj = new URL(url);
@@ -202,7 +211,7 @@ export class CoreDownloader {
             `下载出错，尝试使用加速镜像: ${err.message}`,
             'CoreDownloader'
           );
-          this.downloadFile(mirrorUrl, true).then(resolve).catch(reject);
+          this.downloadFile(mirrorUrl, true, expectedSha256).then(resolve).catch(reject);
           return;
         }
 
@@ -244,6 +253,27 @@ export class CoreDownloader {
                 )
               );
               return;
+            }
+            // 内容校验：Content-Length 只证明「长度对」，证明不了「内容对」——镜像可以给出长度相同的另一份
+            // 字节。摘要来自 api.github.com 直连响应，不经镜像，故此处是镜像投毒的唯一实际拦截点。
+            // 走 handleError 而非直接 reject：GitHub 直连那次若因传输损坏对不上，仍可换镜像重试一次，
+            // 而重试拿到的字节同样要过这道校验（摘要已随重试传下去），不会因为「重试」而降级。
+            if (expectedSha256) {
+              let actual: string;
+              try {
+                actual = createHash('sha256').update(fs.readFileSync(tempPath)).digest('hex');
+              } catch (e) {
+                handleError(new Error(`校验下载内容失败：无法读取临时文件（${e}）`));
+                return;
+              }
+              if (actual !== expectedSha256) {
+                handleError(
+                  new Error(
+                    `内核完整性校验失败：sha256 期望 ${expectedSha256}，实得 ${actual}（下载被篡改或镜像返回了不同的文件）`
+                  )
+                );
+                return;
+              }
             }
             if (settled) return;
             settled = true;

--- a/src/main/services/core-downloader.ts
+++ b/src/main/services/core-downloader.ts
@@ -8,7 +8,7 @@
  */
 
 import { app, net, session, Session } from 'electron';
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -169,7 +169,13 @@ export class CoreDownloader {
       ext = '.zip';
     }
 
-    const tempPath = path.join(app.getPath('temp'), `sing-box-core-update-${Date.now()}${ext}`);
+    // 文件名必须含随机段：**只用 Date.now() 会撞名**——镜像重试紧跟首发失败，两次调用常落在同一毫秒，
+    // 于是重试用的路径与首发相同，而首发 handleError 里的异步 fs.unlink 会把重试刚写好的文件删掉。
+    // 后果视时序而定：轻则解压 ENOENT，重则校验读不到文件。macOS CI 实测命中，Windows 因时序不同侥幸躲过。
+    const tempPath = path.join(
+      app.getPath('temp'),
+      `sing-box-core-update-${Date.now()}-${randomBytes(4).toString('hex')}${ext}`
+    );
     const file = fs.createWriteStream(tempPath);
     const sess = await this.updateSession();
     // 下载失败兜底镜像前缀：优先用户配置的 ghProxyPrefix，否则用内置 preset[0]（gh-proxy.org）。

--- a/src/main/services/singbox-asset.ts
+++ b/src/main/services/singbox-asset.ts
@@ -60,3 +60,21 @@ export function findSuitableSingboxAsset(
 
   return filteredAssets[0];
 }
+
+/**
+ * 取 release asset 的 sha256 摘要 —— GitHub REST 对每个 asset 返回 `digest: "sha256:<64 hex>"`
+ * （实测 v1.12.0 / v1.13.0 / v1.14.0-beta.7 均有，官方对全部 asset 回填，故可据它 fail-closed）。
+ *
+ * 用途是**运行期换核的完整性锚**：下载走 net.request 且失败会回落 gh-proxy 第三方镜像，只比对
+ * Content-Length 挡不住「长度对得上但内容被换」的镜像投毒。摘要本身取自 api.github.com 直连响应，
+ * 不经镜像，故可用来校验镜像给的字节。
+ *
+ * 归一为小写裸 hex；形状不符（缺失 / 非 sha256 / 非 64hex）一律返回 null，由调用方决定拒装——
+ * **不要在此处兜底放行**，否则「拿不到摘要」会静默退化成「不校验」。
+ */
+export function normalizeAssetDigest(asset: unknown): string | null {
+  const raw = (asset as { digest?: unknown } | null | undefined)?.digest;
+  if (typeof raw !== 'string') return null;
+  const m = /^sha256:([0-9a-fA-F]{64})$/.exec(raw.trim());
+  return m ? m[1].toLowerCase() : null;
+}


### PR DESCRIPTION
## 问题

运行期内核更新（`CoreDownloader` + `CoreUpdateService`）是一条完整的「下载 → 解压 → 预检 → 落位」平行实现，但：

- 完整性只比对 **Content-Length** —— 能挡截断，挡不住「长度一样但内容被换」
- 下载失败会**回落 gh-proxy 第三方镜像**
- 预检只验「可执行 + 能解析配置」—— 一个功能正常的木马核轻松通过

即：镜像（或任何中间人）可以让 FlowZ **静默安装一个不是官方发布的可执行文件**，且无任何用户可见报错。

与之对照，构建期 `fetch:core` 是双 pin fail-fast（压缩包 sha + 二进制 sha）。两条链路的强度严重不对等，而运行期那条恰恰面对更不可信的网络路径。

## 改动

- **`normalizeAssetDigest`**（放进已有纯函数模块 `singbox-asset.ts`，随其既有单测）：取 GitHub REST 每个 asset 的 `digest: "sha256:<64hex>"`，归一为小写裸 hex。形状不符一律 `null`、**不兜底放行**——否则「拿不到摘要」会静默退化成「不校验」。
- **`CoreDownloader.downloadFile` 增 `expectedSha256`**：Content-Length 检查通过后再校验内容摘要。摘要取自 `api.github.com` 直连响应、**不经镜像**，是镜像投毒的唯一实际拦截点。**镜像重试腿也带着摘要**——否则「直连失败 → 换镜像」这一步就退化成不校验，而镜像恰恰是最不可信的一环。
- **`CoreUpdateService`**：`checkUpdate` 缓存 `url → sha` 并在结果里带出 `downloadSha256`；`updateCore` 与自动更新腿在下载前解析摘要（缓存 → 现拉一次 releases），**解析不出即拒装**。

摘要**刻意不接受调用方传入**，由服务自己掌握来源：它是一条安全断言，任何一个漏传/传错的调用点都会把校验静默降级成不校验。

## fail-closed 可行吗

实测过再定的：GitHub REST 对**全部** asset 回填 `digest`（`v1.12.0` / `v1.13.0` / `v1.14.0-beta.7` 逐个验过）。所以「解析不出摘要」属异常而非常态，直接拒装不会卡住正常更新。

## 测试

| 覆盖 | 内容 |
|---|---|
| `normalizeAssetDigest` | 形状矩阵：合法前缀/大小写/空白；缺失、非 sha256、长度或字符不对、非字符串一律 null |
| `downloadFile` 四格 | 相符→落位；**不符→reject 且不留半成品**；**GitHub 直连失败换镜像→重试那次仍被摘要拦下**；未传摘要→保持原行为 |
| 自动更新腿 | 取不到摘要 → 中止，`downloadFile`/`stage` 均未被调用 |

`downloadFile` 的测试 mock `electron.net`、零网络，照仓内 `unlock-http.test.ts` 的既有范式写。

**已做变异验证**：把 sha 比较改成恒真，两条安全断言立即转红。

顺带修两处既有测试 fixture —— mock 的 release asset 补上 `digest`。真实 API 恒有此字段，补上后 fixture 更贴合真实形状；不补则它们测的会变成「拒装」而非各自关心的调度/换核闩逻辑。

## Gate

`npm test` 239 suites / 3638 passed / 37 snapshots；`build:main` + `build:renderer` 通过；`lint` 0 error、改动文件零 warning。

## 未含

`resetCoreToFactory` 落位前用 `coreBinarySha256` 校验出厂核 —— 该 manifest 字段由 #345 引入，故留到其合并后单独做，避免本 PR 与它产生依赖。

---

## 追加两个 commit

### `fix(core-update)` 临时文件名撞名（修本 PR 首版的 macOS CI 红）

CI 报的是 `校验下载内容失败：无法读取临时文件（ENOENT）`。查下来**不是测试 flake，是产品代码的真 bug**：

临时文件名此前只用 `Date.now()`。镜像重试紧跟首发失败，两次调用常落在**同一毫秒** → 重试用的路径与首发相同，而首发 `handleError` 里的异步 `fs.unlink(tempPath)` 会把重试刚写好的文件删掉。

该碰撞**早于本 PR 就存在**（此前后果是 `extractCore` 报 ENOENT），只是摘要校验让它提前且响亮地暴露。macOS CI 命中、Windows 时序不同侥幸躲过——正是这类竞态最典型的表现。

文件名补 4 字节随机段；补回归用例（同毫秒并发两次下载，断言路径不同且内容都在）。

### `feat(security)` resetCoreToFactory 校验出厂核指纹

原 PR 说明里列为「未含」的那条，现随 #345 合入 main（`coreBinarySha256` 已可用）补上。

reset 的语义是「回到已知良好的出厂状态」，是用户排障时最信任的一步。若安装目录里的出厂核已被替换（portable 安装目录用户可写），reset 会把恶意核**当作干净核装回去**——比不 reset 更糟。

**仅 win/linux 校验，macOS 显式跳过**。两个平台的取舍都是**实测后**才定的：

| 平台 | 打包是否改写随包内核字节 | 结论 |
|---|---|---|
| Windows | 否 —— electron-builder 无证书时虽打印 `signing with signtool.exe`，但打包前后 sha **逐字节相同**（本地实测） | pin 可用，校验 |
| macOS | **是** —— `release.yml` 对 .app 做 `codesign --force --deep --sign -`，深签重写嵌套二进制（真机实测：同一文件签名前后 sha 不同） | pin 不适用，硬校验会对每个 mac 用户误报 → 跳过，由 .app 自身代码签名承担 |

单测四格，其中「darwin 恒放行」是防呆用例：若有人日后"顺手补齐三平台"，它会红。manifest 走 mock、pin 由固定内容反推，故正负两向都不依赖 `resources/` 是否已跑过 `fetch:core`——否则 CI 上正向断言会静默空过。已做变异验证。

顺带修一处既有 fixture：`core-swap-gate` 的 reset 用例 stub 掉完整性门（该 suite 关心换核闩与 pruneBackup，门本身由新测试覆盖）。

**Gate**：`npm test` 240 suites / 3649 passed / 37 snapshots；两个 build 通过；lint 0 error。