### PR TITLE
fix(ui): 节点表单弹窗收进统一外壳，页脚不再靠宿主自觉

### DIFF
--- a/src/renderer/components/settings/__tests__/node-form-submit-wiring.test.ts
+++ b/src/renderer/components/settings/__tests__/node-form-submit-wiring.test.ts
@@ -17,8 +17,14 @@
  * 无 jsdom / testing-library。为这一条引入整套 DOM 测试栈不划算；而本缺陷的判据恰好是纯文本可判的
  * 「谁挂了表单」×「谁绑了提交按钮」的对账，不依赖运行时。
  *
- * **已知射程边界（如实记）**：文本级判据能证明宿主**引用了**外壳，不能证明表单**嵌在**外壳里面。
- * 要绕过得刻意在同一文件里既用外壳又把表单挂到外壳外——比原来的「忘了加按钮」难得多，接受该残余。
+ * **已知射程边界（如实记，两条）**：
+ *  · 文本级判据能证明宿主**引用了**外壳，不能证明表单**嵌在**外壳里面。要绕过得刻意在同一文件里
+ *    既用外壳又把表单挂到外壳外——比原来的「忘了加按钮」难得多，接受该残余。
+ *  · **`hideFooter` 是一条本门读不到的逃生口**（比上一条便宜得多，故单列）：在挂着协议表单的宿主上
+ *    加这一个 token，页脚就没了、#350 原样长回来，而四条断言无一读它（实测：给 Tailscale 设置弹窗
+ *    加 `hideFooter` → 保存按钮消失、门 4 passed 全绿）。与原缺陷的差别是 omission 变 commission：
+ *    默认 `false` 安全，要复发得主动写一个紧邻 JSDoc 明令禁止的 prop。真正按构造关掉它得拆成
+ *    「恒有页脚的 NodeFormDialog」+「无页脚的面板弹窗」两个组件——见 PR 讨论，未做。
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -40,22 +46,77 @@ function allTsx(dir: string, out: string[] = []): string[] {
 }
 
 /**
- * **先剥块注释再判**（含 JSX 的 `{/* … *\/}`）。判据自污染实录：本门与外壳的注释里都逐字写了
- * `<form id="node-cfg-form">` 与 `form=` 绑定来说明机制，不剥就会把「解释这条规则的注释」本身当成
- * 「遵守这条规则的代码」，判据整体空转。行内 `//` 不剥（URL 里的 `//` 会误伤）。
+ * **先剥注释再判**（块注释含 JSX 的 `{/* … *\/}`，行注释含 `//`）。
+ *
+ * 判据自污染实录（踩过三次，全部实测复现）：
+ *  ① 本门与外壳的注释里都逐字写了 `<form id="node-cfg-form">` 来说明机制 —— 不剥块注释就会把
+ *     「解释这条规则的注释」当成「遵守这条规则的代码」，宿主被误判成表单、判据整体空转。
+ *  ② 只剥块注释不够：绕过外壳的宿主里加一行 `// TODO: 后续迁到 <NodeFormDialog` 就能让第 ④ 条判它合规。
+ *     「行内 `//` 不剥，因为 URL 里的 `//` 会误伤」只对「剥到行尾」的粗暴实现成立 —— 下面这个扫描器
+ *     跳过字符串/模板字面量，URL 在引号里，不受影响。
+ *  ③ 正则式剥法会被**字面量里的 `/*`** 劫持：`'vless://u@h?x=1#/*'` 之后直到下一个 `*\/` 的真实代码全被吞掉。
+ *     最阴的一腿是毒到真表单文件上 —— `formFiles` 从 14 静默降到 13，而下界只是 `>= 10`，余量把这次
+ *     丢失完全吸收，四条断言仍全绿，此后该表单的宿主不受任何约束。
+ *
+ * 故改用逐字符扫描：识别字符串/模板字面量并原样保留，其外的 `//` 与 `/* *\/` 一律剥掉。
  */
-const stripBlockComments = (s: string): string => s.replace(/\/\*[\s\S]*?\*\//g, '');
+function stripComments(src: string): string {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '/' && src[i + 1] === '*') {
+      const end = src.indexOf('*/', i + 2);
+      i = end === -1 ? src.length : end + 2;
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '/') {
+      const nl = src.indexOf('\n', i);
+      i = nl === -1 ? src.length : nl;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      out += c;
+      i += 1;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === '\\') {
+          out += src[i] + (src[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += src[i];
+        i += 1;
+      }
+      out += src[i] ?? '';
+      i += 1;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
 
 const FILES = allTsx(RENDERER).map((p) => ({
   path: p,
   rel: path.relative(RENDERER, p).split(path.sep).join('/'),
-  src: stripBlockComments(fs.readFileSync(p, 'utf8')),
+  src: stripComments(fs.readFileSync(p, 'utf8')),
 }));
 
 /** 判「该文件渲染了 <form id="node-cfg-form">」——限定在 `<form` 标签内。 */
 const FORM_TAG_RE = /<form[^>]*\bid="node-cfg-form"/;
 /** 判「该文件把按钮绑到了协议表单」：字面量或外壳导出的常量，两种写法都算。 */
 const BINDING_RE = /form=(?:"node-cfg-form"|\{NODE_FORM_ID\})/;
+/**
+ * 单个 `<button …>` 开标签。**必须按标签切分再判**，不能在整份文件上做
+ * 「有 `type="submit"` ∧ 有 `form=` 绑定」的合取 —— 那样只删提交按钮的绑定、留着 reset 的，
+ * 左项由 reset 顶上，四条断言全绿（实测），而那恰是 #350 的原始形态：按钮在、绑定没了，
+ * 点下去零反应（协议表单自身 `type="submit"` 计数为 0，无隐式提交兜底）。
+ * `[^>{]|\{[^}]*\}` 而非 `[^>]*`：JSX 属性里的箭头函数含 `>`（`onClick={() => f(false)}`），
+ * 用后者会在箭头处截断，属性顺序一变就静默漏判。
+ */
+const BUTTON_TAG_RE = /<button\b(?:[^>{]|\{[^}]*\})*>/g;
 /** 组件导出名：宿主是以 `<XxxForm` 的形式引用它的。 */
 const EXPORTED_RE = /export\s+function\s+(\w+)/g;
 
@@ -95,10 +156,15 @@ describe('#350 协议表单的提交按钮接线', () => {
   });
 
   it('绑到协议表单的提交按钮全仓有且仅有一处：NodeFormDialog 外壳', () => {
-    const binders = FILES.filter((f) => BINDING_RE.test(f.src) && f.src.includes('type="submit"'))
+    // 合取必须落在**同一个 button 标签**内（理由见 BUTTON_TAG_RE）。
+    const binders = FILES.filter((f) =>
+      [...f.src.matchAll(BUTTON_TAG_RE)].some(
+        (m) => /type="submit"/.test(m[0]) && BINDING_RE.test(m[0])
+      )
+    )
       .map((f) => f.rel)
       .sort();
-    // 多一处 = 有人又在宿主里手搓了一套；零处 = 外壳的页脚被删了。两种都红。
+    // 多一处 = 有人又在宿主里手搓了一套；零处 = 外壳的页脚被删了，或提交按钮丢了绑定。三种都红。
     expect(binders).toEqual([SHELL]);
   });
 

--- a/src/renderer/components/settings/__tests__/node-form-submit-wiring.test.ts
+++ b/src/renderer/components/settings/__tests__/node-form-submit-wiring.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #350 节点协议表单的「提交按钮接线」门。
+ *
+ * 架构事实（本门的前提，第 2 组断言把它钉住）：协议表单组件（`*-form.tsx`）渲染 `<form id="node-cfg-form">`
+ * 但**自身一个提交按钮都没有**——按钮靠 HTML 的 `form=` 属性从表单外面跨节点绑进来。
+ *
+ * 这曾是一条**不可见、无类型、无强制**的宿主义务：「挂了协议表单，你就得在某处渲染一个绑到它的提交按钮」。
+ * tsc 查不出、渲染不报错，三个宿主漏了两个（组网 WireGuard 无添加按钮 = #350；Tailscale 设置无保存按钮 =
+ * 同款未被报告的姊妹腿）。根治办法是把义务从宿主手里收走：页脚改由 `NodeFormDialog` 外壳渲染。
+ *
+ * 故本门钉的是**根治后的结构**，而不是「每个宿主都记得加按钮」——后者只是把已漏的补上，义务原样留着：
+ *  · 绑到协议表单的提交按钮，全仓**有且仅有一处**（外壳）；
+ *  · 挂协议表单的宿主，**只能经外壳挂**。
+ * 任一条被绕开都红。前者防「有人又在宿主里手搓一套按钮」，后者防「有人绕过外壳直接用 raw Dialog」。
+ *
+ * 为什么是源码级判据而不是挂载渲染：本仓 renderer 测试全为纯逻辑（`testEnvironment: 'node'`），
+ * 无 jsdom / testing-library。为这一条引入整套 DOM 测试栈不划算；而本缺陷的判据恰好是纯文本可判的
+ * 「谁挂了表单」×「谁绑了提交按钮」的对账，不依赖运行时。
+ *
+ * **已知射程边界（如实记）**：文本级判据能证明宿主**引用了**外壳，不能证明表单**嵌在**外壳里面。
+ * 要绕过得刻意在同一文件里既用外壳又把表单挂到外壳外——比原来的「忘了加按钮」难得多，接受该残余。
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const RENDERER = path.resolve(__dirname, '../../..');
+const SHELL = 'components/settings/node-form-dialog.tsx';
+
+/** 递归收集 renderer 下全部 .tsx（跳过 __tests__ 自身）。 */
+function allTsx(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name !== '__tests__' && e.name !== 'node_modules') allTsx(p, out);
+    } else if (e.name.endsWith('.tsx')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/**
+ * **先剥块注释再判**（含 JSX 的 `{/* … *\/}`）。判据自污染实录：本门与外壳的注释里都逐字写了
+ * `<form id="node-cfg-form">` 与 `form=` 绑定来说明机制，不剥就会把「解释这条规则的注释」本身当成
+ * 「遵守这条规则的代码」，判据整体空转。行内 `//` 不剥（URL 里的 `//` 会误伤）。
+ */
+const stripBlockComments = (s: string): string => s.replace(/\/\*[\s\S]*?\*\//g, '');
+
+const FILES = allTsx(RENDERER).map((p) => ({
+  path: p,
+  rel: path.relative(RENDERER, p).split(path.sep).join('/'),
+  src: stripBlockComments(fs.readFileSync(p, 'utf8')),
+}));
+
+/** 判「该文件渲染了 <form id="node-cfg-form">」——限定在 `<form` 标签内。 */
+const FORM_TAG_RE = /<form[^>]*\bid="node-cfg-form"/;
+/** 判「该文件把按钮绑到了协议表单」：字面量或外壳导出的常量，两种写法都算。 */
+const BINDING_RE = /form=(?:"node-cfg-form"|\{NODE_FORM_ID\})/;
+/** 组件导出名：宿主是以 `<XxxForm` 的形式引用它的。 */
+const EXPORTED_RE = /export\s+function\s+(\w+)/g;
+
+const formFiles = FILES.filter((f) => FORM_TAG_RE.test(f.src));
+/** 自身不带提交按钮的那批——只有它们的宿主受本门约束。自带按钮的面板（WARP/custom）不适用。 */
+const externallySubmitted = formFiles.filter((f) => !f.src.includes('type="submit"'));
+
+const componentNames = (f: { src: string }): string[] =>
+  [...f.src.matchAll(EXPORTED_RE)].map((m) => m[1]).filter((n) => /Form$/.test(n));
+
+const formNames = new Set(externallySubmitted.flatMap(componentNames));
+const formPaths = new Set(externallySubmitted.map((f) => f.path));
+/** 宿主 = 引用了这批表单组件的非表单文件。 */
+const hosts = FILES.filter(
+  (f) => !formPaths.has(f.path) && [...formNames].some((n) => f.src.includes(`<${n}`))
+);
+
+describe('#350 协议表单的提交按钮接线', () => {
+  it('反平凡：确实存在一批渲染 <form id="node-cfg-form"> 的协议表单，且都能被反查到组件名', () => {
+    expect(formFiles.length).toBeGreaterThanOrEqual(10);
+    for (const f of formFiles) {
+      expect({ file: f.rel, names: componentNames(f) }).toEqual({
+        file: f.rel,
+        names: expect.arrayContaining([expect.any(String)]),
+      });
+    }
+    // 名字集为空会让下面两条恒绿
+    expect(formNames.size).toBeGreaterThanOrEqual(10);
+  });
+
+  it('前提：这批表单自身不提供提交按钮（按钮一律从表单外面经 form= 绑进来）', () => {
+    // 若某天某个表单改成自带按钮，本条会红——那是提醒「本门的前提变了，需重新推导」，不是误报：
+    // externallySubmitted 会自动把它排除，宿主要求随之放宽，判据不会因此变松而无声。
+    expect(externallySubmitted.map((f) => f.rel).sort()).toEqual(
+      formFiles.map((f) => f.rel).sort()
+    );
+  });
+
+  it('绑到协议表单的提交按钮全仓有且仅有一处：NodeFormDialog 外壳', () => {
+    const binders = FILES.filter((f) => BINDING_RE.test(f.src) && f.src.includes('type="submit"'))
+      .map((f) => f.rel)
+      .sort();
+    // 多一处 = 有人又在宿主里手搓了一套；零处 = 外壳的页脚被删了。两种都红。
+    expect(binders).toEqual([SHELL]);
+  });
+
+  it('挂了协议表单的宿主只能经 NodeFormDialog 外壳挂', () => {
+    // 反平凡：至少 server-config-dialog + 两个组网入口。宿主集为空会让断言恒绿。
+    expect(hosts.length).toBeGreaterThanOrEqual(3);
+    const bypassing = hosts.filter((f) => !f.src.includes('<NodeFormDialog')).map((f) => f.rel);
+    expect(bypassing).toEqual([]);
+  });
+});

--- a/src/renderer/components/settings/mesh-access-entry.tsx
+++ b/src/renderer/components/settings/mesh-access-entry.tsx
@@ -17,13 +17,6 @@ import { useTranslation } from 'react-i18next';
 import { Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -42,6 +35,7 @@ import {
 import type { ServerConfig } from '@/bridge/types';
 import { WireGuardForm } from './wireguard-form';
 import { WarpPanel } from './warp-panel';
+import { NodeFormDialog } from './node-form-dialog';
 import { MeshTailscaleControl } from './mesh-tailscale-control';
 import { useServerActions } from '../../pages/use-server-actions';
 
@@ -261,8 +255,8 @@ export function MeshAccessEntry({
         </button>
       </div>
 
-      {/* WireGuard 接入：名称（dialog 级）+ WireGuardForm（.conf 导入已内置）。 */}
-      <Dialog
+      {/* WireGuard 接入：名称（dialog 级）+ WireGuardForm（.conf 导入已内置）。页脚由外壳渲染（#350）。 */}
+      <NodeFormDialog
         open={wgOpen}
         onOpenChange={(open) => {
           setWgOpen(open);
@@ -271,71 +265,68 @@ export function MeshAccessEntry({
             setWgNameError(false);
           }
         }}
+        title={t('servers.meshAccessAddWg', '添加 WireGuard 节点')}
+        description={t('servers.meshAccessAddWgDesc', '手动填写或粘贴 wg-quick .conf 导入。')}
+        submitLabel={t('servers.add')}
       >
-        <DialogContent className="w-[min(452px,94vw)] max-w-none max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{t('servers.meshAccessAddWg', '添加 WireGuard 节点')}</DialogTitle>
-            <DialogDescription>
-              {t('servers.meshAccessAddWgDesc', '手动填写或粘贴 wg-quick .conf 导入。')}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-4">
-            <div className="field">
-              <label className="field-lbl" htmlFor="meshWgName">
-                {t('servers.remarks')}
-              </label>
-              <input
-                ref={wgNameInputRef}
-                id="meshWgName"
-                className={cn('input', wgNameError && 'err')}
-                placeholder={t('servers.remarksPlaceholder')}
-                value={wgName}
-                onChange={(e) => {
-                  setWgName(e.target.value);
-                  if (wgNameError) setWgNameError(false);
-                }}
-                aria-invalid={wgNameError}
-              />
-              {wgNameError && (
-                <p className="text-[11px] text-[hsl(var(--err))]">
-                  {t('servers.meshAccessNameFirst', '请先填写节点名称')}
-                </p>
-              )}
-            </div>
-            <WireGuardForm onSubmit={handleWgSubmit} />
-          </div>
-        </DialogContent>
-      </Dialog>
+        {/* 说明文案作为正文首段（外壳的 description 是 sr-only 的 a11y 描述，不上屏）。 */}
+        <p className="text-xs text-muted-foreground">
+          {t('servers.meshAccessAddWgDesc', '手动填写或粘贴 wg-quick .conf 导入。')}
+        </p>
+        <div className="field">
+          <label className="field-lbl" htmlFor="meshWgName">
+            {t('servers.remarks')}
+          </label>
+          <input
+            ref={wgNameInputRef}
+            id="meshWgName"
+            className={cn('input', wgNameError && 'err')}
+            placeholder={t('servers.remarksPlaceholder')}
+            value={wgName}
+            onChange={(e) => {
+              setWgName(e.target.value);
+              if (wgNameError) setWgNameError(false);
+            }}
+            aria-invalid={wgNameError}
+          />
+          {wgNameError && (
+            <p className="text-[11px] text-[hsl(var(--err))]">
+              {t('servers.meshAccessNameFirst', '请先填写节点名称')}
+            </p>
+          )}
+        </div>
+        <WireGuardForm onSubmit={handleWgSubmit} />
+      </NodeFormDialog>
 
-      {/* WARP 接入：名称（预填）+ WarpPanel（一键注册→WG 节点）。 */}
-      <Dialog open={warpOpen} onOpenChange={setWarpOpen}>
-        <DialogContent className="w-[min(452px,94vw)] max-w-none max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{t('servers.meshAccessAddWarp', '添加 Cloudflare WARP')}</DialogTitle>
-            <DialogDescription>
-              {t(
-                'servers.meshAccessAddWarpDesc',
-                '一键注册匿名 WARP 设备并加入为 WireGuard 节点。'
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-4">
-            <div className="field">
-              <label className="field-lbl" htmlFor="meshWarpName">
-                {t('servers.remarks')}
-              </label>
-              <input
-                id="meshWarpName"
-                className="input"
-                placeholder={t('servers.remarksPlaceholder')}
-                value={warpName}
-                onChange={(e) => setWarpName(e.target.value)}
-              />
-            </div>
-            <WarpPanel onSubmit={handleWarpSubmit} nameMissing={!warpName.trim()} />
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* WARP 接入：名称（预填）+ WarpPanel（一键注册→WG 节点）。WarpPanel 自带按钮，故不套页脚。 */}
+      <NodeFormDialog
+        open={warpOpen}
+        onOpenChange={setWarpOpen}
+        title={t('servers.meshAccessAddWarp', '添加 Cloudflare WARP')}
+        description={t(
+          'servers.meshAccessAddWarpDesc',
+          '一键注册匿名 WARP 设备并加入为 WireGuard 节点。'
+        )}
+        submitLabel={t('servers.add')}
+        hideFooter
+      >
+        <p className="text-xs text-muted-foreground">
+          {t('servers.meshAccessAddWarpDesc', '一键注册匿名 WARP 设备并加入为 WireGuard 节点。')}
+        </p>
+        <div className="field">
+          <label className="field-lbl" htmlFor="meshWarpName">
+            {t('servers.remarks')}
+          </label>
+          <input
+            id="meshWarpName"
+            className="input"
+            placeholder={t('servers.remarksPlaceholder')}
+            value={warpName}
+            onChange={(e) => setWarpName(e.target.value)}
+          />
+        </div>
+        <WarpPanel onSubmit={handleWarpSubmit} nameMissing={!warpName.trim()} />
+      </NodeFormDialog>
 
       {/* WARP 重新注册确认：先注销当前设备再注册新的替换。 */}
       <AlertDialog open={warpReRegisterOpen} onOpenChange={setWarpReRegisterOpen}>

--- a/src/renderer/components/settings/mesh-access-entry.tsx
+++ b/src/renderer/components/settings/mesh-access-entry.tsx
@@ -267,35 +267,40 @@ export function MeshAccessEntry({
         }}
         title={t('servers.meshAccessAddWg', '添加 WireGuard 节点')}
         description={t('servers.meshAccessAddWgDesc', '手动填写或粘贴 wg-quick .conf 导入。')}
+        onSubmit={handleWgSubmit}
         submitLabel={t('servers.add')}
       >
-        {/* 说明文案作为正文首段（外壳的 description 是 sr-only 的 a11y 描述，不上屏）。 */}
-        <p className="text-xs text-muted-foreground">
-          {t('servers.meshAccessAddWgDesc', '手动填写或粘贴 wg-quick .conf 导入。')}
-        </p>
-        <div className="field">
-          <label className="field-lbl" htmlFor="meshWgName">
-            {t('servers.remarks')}
-          </label>
-          <input
-            ref={wgNameInputRef}
-            id="meshWgName"
-            className={cn('input', wgNameError && 'err')}
-            placeholder={t('servers.remarksPlaceholder')}
-            value={wgName}
-            onChange={(e) => {
-              setWgName(e.target.value);
-              if (wgNameError) setWgNameError(false);
-            }}
-            aria-invalid={wgNameError}
-          />
-          {wgNameError && (
-            <p className="text-[11px] text-[hsl(var(--err))]">
-              {t('servers.meshAccessNameFirst', '请先填写节点名称')}
+        {(submit) => (
+          <>
+            {/* 说明文案作为正文首段（外壳的 description 是 sr-only 的 a11y 描述，不上屏）。 */}
+            <p className="text-xs text-muted-foreground">
+              {t('servers.meshAccessAddWgDesc', '手动填写或粘贴 wg-quick .conf 导入。')}
             </p>
-          )}
-        </div>
-        <WireGuardForm onSubmit={handleWgSubmit} />
+            <div className="field">
+              <label className="field-lbl" htmlFor="meshWgName">
+                {t('servers.remarks')}
+              </label>
+              <input
+                ref={wgNameInputRef}
+                id="meshWgName"
+                className={cn('input', wgNameError && 'err')}
+                placeholder={t('servers.remarksPlaceholder')}
+                value={wgName}
+                onChange={(e) => {
+                  setWgName(e.target.value);
+                  if (wgNameError) setWgNameError(false);
+                }}
+                aria-invalid={wgNameError}
+              />
+              {wgNameError && (
+                <p className="text-[11px] text-[hsl(var(--err))]">
+                  {t('servers.meshAccessNameFirst', '请先填写节点名称')}
+                </p>
+              )}
+            </div>
+            <WireGuardForm onSubmit={submit} />
+          </>
+        )}
       </NodeFormDialog>
 
       {/* WARP 接入：名称（预填）+ WarpPanel（一键注册→WG 节点）。WarpPanel 自带按钮，故不套页脚。 */}
@@ -307,25 +312,33 @@ export function MeshAccessEntry({
           'servers.meshAccessAddWarpDesc',
           '一键注册匿名 WARP 设备并加入为 WireGuard 节点。'
         )}
+        onSubmit={handleWarpSubmit}
         submitLabel={t('servers.add')}
         hideFooter
       >
-        <p className="text-xs text-muted-foreground">
-          {t('servers.meshAccessAddWarpDesc', '一键注册匿名 WARP 设备并加入为 WireGuard 节点。')}
-        </p>
-        <div className="field">
-          <label className="field-lbl" htmlFor="meshWarpName">
-            {t('servers.remarks')}
-          </label>
-          <input
-            id="meshWarpName"
-            className="input"
-            placeholder={t('servers.remarksPlaceholder')}
-            value={warpName}
-            onChange={(e) => setWarpName(e.target.value)}
-          />
-        </div>
-        <WarpPanel onSubmit={handleWarpSubmit} nameMissing={!warpName.trim()} />
+        {(submit) => (
+          <>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'servers.meshAccessAddWarpDesc',
+                '一键注册匿名 WARP 设备并加入为 WireGuard 节点。'
+              )}
+            </p>
+            <div className="field">
+              <label className="field-lbl" htmlFor="meshWarpName">
+                {t('servers.remarks')}
+              </label>
+              <input
+                id="meshWarpName"
+                className="input"
+                placeholder={t('servers.remarksPlaceholder')}
+                value={warpName}
+                onChange={(e) => setWarpName(e.target.value)}
+              />
+            </div>
+            <WarpPanel onSubmit={submit} nameMissing={!warpName.trim()} />
+          </>
+        )}
       </NodeFormDialog>
 
       {/* WARP 重新注册确认：先注销当前设备再注册新的替换。 */}

--- a/src/renderer/components/settings/mesh-tailscale-control.tsx
+++ b/src/renderer/components/settings/mesh-tailscale-control.tsx
@@ -31,13 +31,6 @@ import { useAppStore } from '@/store/app-store';
 import { api } from '@/ipc/api-client';
 import { cn } from '@/lib/utils';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -57,6 +50,7 @@ import type { ServerConfig } from '@/bridge/types';
 import { deriveTsCardState } from '../../../shared/tailscale-conn-state';
 import { runTailscaleLogin, openTailscaleLogin } from '../../lib/tailscale-login';
 import { TailscaleForm } from './tailscale-form';
+import { NodeFormDialog } from './node-form-dialog';
 import { useServerActions } from '../../pages/use-server-actions';
 
 interface MeshTailscaleControlProps {
@@ -348,37 +342,37 @@ export function MeshTailscaleControl({
       </DropdownMenu>
 
       {/* 设置 / 用 Auth Key：复用 TailscaleForm（账号制无地址端口，连后配置）。onSubmit 统一 saveServer。 */}
-      <Dialog
+      {/* 宽度/滚动/页脚均由 NodeFormDialog 统一（#350）：出口设备/子网/高级均单列窄字段，沿用 452px 窄窗。 */}
+      <NodeFormDialog
         open={settingsOpen}
         onOpenChange={(open) => {
           setSettingsOpen(open);
           if (!open) setShowKeyForm(false);
         }}
+        title={
+          showKeyForm
+            ? t('servers.tsConnCardUseAuthKey', '用 Auth Key')
+            : t('servers.tsConnCardSettingsTitle', 'Tailscale 设置')
+        }
+        description={t(
+          'servers.tsConnCardSettingsDesc',
+          '出口节点、子网路由与高级选项。代理运行中保存会自动重连以生效。'
+        )}
+        submitLabel={t('common.save')}
       >
-        {/* 宽度对齐「节点编辑」窗（server-config-dialog 的 w-[min(452px,94vw)]）：出口设备/子网/高级均单列窄字段，
-            原 max-w-3xl(768) 一倍宽显空旷（用户反馈过大）。max-h/overflow/标准 padding 保留。 */}
-        <DialogContent className="w-[min(452px,94vw)] max-w-none max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>
-              {showKeyForm
-                ? t('servers.tsConnCardUseAuthKey', '用 Auth Key')
-                : t('servers.tsConnCardSettingsTitle', 'Tailscale 设置')}
-            </DialogTitle>
-            <DialogDescription>
-              {t(
-                'servers.tsConnCardSettingsDesc',
-                '出口节点、子网路由与高级选项。代理运行中保存会自动重连以生效。'
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <TailscaleForm
-            key={tsNode?.id || 'new-key'}
-            serverConfig={tsNode}
-            onSubmit={handleSaveSettings}
-            hideLoginSection
-          />
-        </DialogContent>
-      </Dialog>
+        <p className="text-xs text-muted-foreground">
+          {t(
+            'servers.tsConnCardSettingsDesc',
+            '出口节点、子网路由与高级选项。代理运行中保存会自动重连以生效。'
+          )}
+        </p>
+        <TailscaleForm
+          key={tsNode?.id || 'new-key'}
+          serverConfig={tsNode}
+          onSubmit={handleSaveSettings}
+          hideLoginSection
+        />
+      </NodeFormDialog>
 
       {/* key-ready 删除确认：先登出再删节点，高危故二次确认（受控，从下拉菜单项触发）。 */}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/src/renderer/components/settings/mesh-tailscale-control.tsx
+++ b/src/renderer/components/settings/mesh-tailscale-control.tsx
@@ -358,20 +358,25 @@ export function MeshTailscaleControl({
           'servers.tsConnCardSettingsDesc',
           '出口节点、子网路由与高级选项。代理运行中保存会自动重连以生效。'
         )}
+        onSubmit={handleSaveSettings}
         submitLabel={t('common.save')}
       >
-        <p className="text-xs text-muted-foreground">
-          {t(
-            'servers.tsConnCardSettingsDesc',
-            '出口节点、子网路由与高级选项。代理运行中保存会自动重连以生效。'
-          )}
-        </p>
-        <TailscaleForm
-          key={tsNode?.id || 'new-key'}
-          serverConfig={tsNode}
-          onSubmit={handleSaveSettings}
-          hideLoginSection
-        />
+        {(submit) => (
+          <>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'servers.tsConnCardSettingsDesc',
+                '出口节点、子网路由与高级选项。代理运行中保存会自动重连以生效。'
+              )}
+            </p>
+            <TailscaleForm
+              key={tsNode?.id || 'new-key'}
+              serverConfig={tsNode}
+              onSubmit={submit}
+              hideLoginSection
+            />
+          </>
+        )}
       </NodeFormDialog>
 
       {/* key-ready 删除确认：先登出再删节点，高危故二次确认（受控，从下拉菜单项触发）。 */}

--- a/src/renderer/components/settings/node-form-dialog.tsx
+++ b/src/renderer/components/settings/node-form-dialog.tsx
@@ -17,7 +17,7 @@
  * 今天四处调用点互斥、该状态不可达，属 YAGNI。真要治是本外壳用 `useId()` 生成唯一 id 经 context 下发，
  * 代价是 15 个表单文件都要改 `id=`——等真出现并存场景再做。
  */
-import type { ReactNode } from 'react';
+import { useCallback, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
@@ -34,14 +34,23 @@ interface NodeFormDialogProps {
   description: string;
   /** 提交按钮文案：新增用「添加」、编辑用「保存」。 */
   submitLabel: string;
-  /** 提交中：两个按钮置灰，提交按钮转圈。 */
-  busy?: boolean;
+  /**
+   * 提交处理。**由外壳调用并自管「提交中」态**——宿主不必、也无法再自持提交态。
+   *
+   * 刻意**不给** `busy` prop：那会造出第二条可选的宿主义务（「记得把提交态透传进来」），
+   * 与本外壳收编页脚的理由自相矛盾——三处调用点里已经有两处忘过一次同类义务了。
+   * 现在忘无可忘：宿主想手搓提交态，多传的 prop 直接 tsc 报错，是结构性强制而非又一道门。
+   *
+   * 语义：调用即置灰两个按钮 + 提交按钮转圈，`finally` 复位（抛错也复位，错误处理仍归宿主）。
+   */
+  onSubmit: (config: any) => Promise<void>;
   /**
    * 不渲染页脚。**唯一合法用途**：正文里挂的不是协议表单，而是自带按钮的面板
    * （WARP 一键注册 / custom 的 JSON 直填）。挂了协议表单还传它 = 复现 #350。
    */
   hideFooter?: boolean;
-  children: ReactNode;
+  /** render-prop：外壳把**包好提交态**的 submit 递下去，宿主原样交给协议表单的 `onSubmit`。 */
+  children: (submit: (config: any) => Promise<void>) => ReactNode;
 }
 
 export function NodeFormDialog({
@@ -50,11 +59,25 @@ export function NodeFormDialog({
   title,
   description,
   submitLabel,
-  busy = false,
+  onSubmit,
   hideFooter = false,
   children,
 }: NodeFormDialogProps) {
   const { t } = useTranslation();
+  const [busy, setBusy] = useState(false);
+
+  // 成功提交后宿主通常会关弹窗，但关的是 radix 的 open——本组件仍挂载，故 finally 里的复位安全。
+  const submit = useCallback(
+    async (config: any) => {
+      setBusy(true);
+      try {
+        await onSubmit(config);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [onSubmit]
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -76,7 +99,7 @@ export function NodeFormDialog({
           </button>
         </div>
 
-        <div className="nd-dlg-body">{children}</div>
+        <div className="nd-dlg-body">{children(submit)}</div>
 
         {!hideFooter && (
           <div className="nd-dlg-foot">

--- a/src/renderer/components/settings/node-form-dialog.tsx
+++ b/src/renderer/components/settings/node-form-dialog.tsx
@@ -1,0 +1,102 @@
+/**
+ * 节点协议表单的弹窗外壳（Conduit 标准三段式：`.nd-dlg-h` 头 / `.nd-dlg-body` 滚动正文 / `.nd-dlg-foot` 固定页脚）。
+ *
+ * **为什么要有这层**（issue #350 的根因）：协议表单（`*-form.tsx`）渲染 `<form id="node-cfg-form">`，但
+ * **自身一个提交按钮都没有**——按钮靠 HTML 的 `form=` 属性从表单外面跨节点绑进来。这在组件契约里是一条
+ * **不可见、无类型、无强制**的义务：「挂了我，你就得在某处渲染一个 `form="node-cfg-form"` 的按钮」。
+ * tsc 查不出、渲染不报错、类型不缺，三个宿主漏了两个（组网 WireGuard 无添加按钮 = #350；Tailscale 设置
+ * 无保存按钮 = 同款未被报告的姊妹腿）。逐处补按钮只是把已漏的补上，义务原样留着，下一个宿主照样能漏。
+ *
+ * 故把义务从宿主手里收走：**页脚由本外壳渲染，宿主无从省略**。同时顺带收编两件本来也在各处重复决定的事：
+ *  · 滚动结构——正文是唯一滚动区，页脚**不随表单主体滚动**（长表单如 WireGuard 才不会让提交按钮沉到折叠线下）；
+ *  · `form="node-cfg-form"` 这个跨节点绑定的字面量——全仓提交按钮只此一处。
+ *
+ * **已知且刻意不做**：`node-cfg-form` 是全局 DOM id，两个此类弹窗同时挂载时 `form=` 按文档顺序绑第一个。
+ * 今天四处调用点互斥、该状态不可达，属 YAGNI。真要治是本外壳用 `useId()` 生成唯一 id 经 context 下发，
+ * 代价是 15 个表单文件都要改 `id=`——等真出现并存场景再做。
+ */
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+
+/** 协议表单的 `<form>` id：页脚按钮经 HTML `form=` 跨节点绑定到它。 */
+export const NODE_FORM_ID = 'node-cfg-form';
+
+interface NodeFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 视觉标题（同时供 a11y）。 */
+  title: string;
+  /** a11y 描述（sr-only）。要给用户看的说明请作为 children 的首个段落，别塞这里。 */
+  description: string;
+  /** 提交按钮文案：新增用「添加」、编辑用「保存」。 */
+  submitLabel: string;
+  /** 提交中：两个按钮置灰，提交按钮转圈。 */
+  busy?: boolean;
+  /**
+   * 不渲染页脚。**唯一合法用途**：正文里挂的不是协议表单，而是自带按钮的面板
+   * （WARP 一键注册 / custom 的 JSON 直填）。挂了协议表单还传它 = 复现 #350。
+   */
+  hideFooter?: boolean;
+  /** DialogContent 的补充 class（圆角/描边/底色等各站点 chrome 差异）。 */
+  contentClassName?: string;
+  children: ReactNode;
+}
+
+export function NodeFormDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  submitLabel,
+  busy = false,
+  hideFooter = false,
+  contentClassName,
+  children,
+}: NodeFormDialogProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* overflow-hidden + flex-col：正文自己滚，头与脚贴住不动。radix 自带关闭按钮隐掉，改用 .nd-dlg-x。 */}
+      <DialogContent
+        className={cn(
+          '[&>button]:hidden flex max-h-[90vh] w-[min(452px,94vw)] max-w-none flex-col gap-0 overflow-hidden rounded-[12px] border-line bg-surface p-0',
+          contentClassName
+        )}
+      >
+        {/* a11y：radix 需 Title/Description；视觉标题在下方 .nd-dlg-h，此处仅供辅助技术。 */}
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">{description}</DialogDescription>
+
+        <div className="nd-dlg-h">
+          <span className="nd-dlg-title">{title}</span>
+          <button
+            type="button"
+            className="nd-dlg-x"
+            aria-label={t('common.cancel', 'Cancel')}
+            onClick={() => onOpenChange(false)}
+          >
+            <X />
+          </button>
+        </div>
+
+        <div className="nd-dlg-body">{children}</div>
+
+        {!hideFooter && (
+          <div className="nd-dlg-foot">
+            <button type="reset" form={NODE_FORM_ID} className="btn ghost sm" disabled={busy}>
+              {t('common.reset')}
+            </button>
+            <button type="submit" form={NODE_FORM_ID} className="btn flow sm" disabled={busy}>
+              {busy && <Loader2 className="animate-spin" size={14} />}
+              {submitLabel}
+            </button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/settings/node-form-dialog.tsx
+++ b/src/renderer/components/settings/node-form-dialog.tsx
@@ -7,7 +7,9 @@
  * tsc 查不出、渲染不报错、类型不缺，三个宿主漏了两个（组网 WireGuard 无添加按钮 = #350；Tailscale 设置
  * 无保存按钮 = 同款未被报告的姊妹腿）。逐处补按钮只是把已漏的补上，义务原样留着，下一个宿主照样能漏。
  *
- * 故把义务从宿主手里收走：**页脚由本外壳渲染，宿主无从省略**。同时顺带收编两件本来也在各处重复决定的事：
+ * 故把义务从宿主手里收走：**页脚由本外壳渲染，宿主默认无从省略**（唯一例外是 `hideFooter`，见其 JSDoc；
+ * 它没有被按构造关掉，只是从「不写就坏」变成「得主动写一个明令禁止的 prop 才坏」）。同时顺带收编两件
+ * 本来也在各处重复决定的事：
  *  · 滚动结构——正文是唯一滚动区，页脚**不随表单主体滚动**（长表单如 WireGuard 才不会让提交按钮沉到折叠线下）；
  *  · `form="node-cfg-form"` 这个跨节点绑定的字面量——全仓提交按钮只此一处。
  *
@@ -18,7 +20,6 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Loader2 } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 
 /** 协议表单的 `<form>` id：页脚按钮经 HTML `form=` 跨节点绑定到它。 */
@@ -40,8 +41,6 @@ interface NodeFormDialogProps {
    * （WARP 一键注册 / custom 的 JSON 直填）。挂了协议表单还传它 = 复现 #350。
    */
   hideFooter?: boolean;
-  /** DialogContent 的补充 class（圆角/描边/底色等各站点 chrome 差异）。 */
-  contentClassName?: string;
   children: ReactNode;
 }
 
@@ -53,7 +52,6 @@ export function NodeFormDialog({
   submitLabel,
   busy = false,
   hideFooter = false,
-  contentClassName,
   children,
 }: NodeFormDialogProps) {
   const { t } = useTranslation();
@@ -61,12 +59,7 @@ export function NodeFormDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* overflow-hidden + flex-col：正文自己滚，头与脚贴住不动。radix 自带关闭按钮隐掉，改用 .nd-dlg-x。 */}
-      <DialogContent
-        className={cn(
-          '[&>button]:hidden flex max-h-[90vh] w-[min(452px,94vw)] max-w-none flex-col gap-0 overflow-hidden rounded-[12px] border-line bg-surface p-0',
-          contentClassName
-        )}
-      >
+      <DialogContent className="[&>button]:hidden flex max-h-[90vh] w-[min(452px,94vw)] max-w-none flex-col gap-0 overflow-hidden rounded-[12px] border-line bg-surface p-0">
         {/* a11y：radix 需 Title/Description；视觉标题在下方 .nd-dlg-h，此处仅供辅助技术。 */}
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">{description}</DialogDescription>

--- a/src/renderer/components/settings/server-config-dialog.tsx
+++ b/src/renderer/components/settings/server-config-dialog.tsx
@@ -118,9 +118,6 @@ export function ServerConfigDialog({
   const [currentServerConfig, setCurrentServerConfig] = useState<any>(null);
   const [detour, setDetour] = useState<string | undefined>(undefined);
   const [nameError, setNameError] = useState('');
-  // 保存态：footer 的保存按钮固定在 dialog 底部（不随表单主体滚动），isSubmitting 不再由各表单内按钮承载，
-  // 故 dialog 层自持保存态驱动按钮 loading/禁用。
-  const [saving, setSaving] = useState(false);
 
   const isEditing = !!server;
   // 锁协议只针对组网节点（WireGuard/WARP/Tailscale）：协议=组网身份不可变，换协议=删了重建，防止误改成代理协议；
@@ -178,17 +175,14 @@ export function ServerConfigDialog({
       ...protocolConfig,
     };
 
-    setSaving(true);
     try {
       await onSave(serverConfig);
       onOpenChange(false);
     } catch (e) {
-      // 后端保存失败也要可见（原先 throw 被表单 submit 吞掉、无提示）。
+      // 后端保存失败也要可见（原先 throw 被表单 submit 吞掉、无提示）。提交态由 NodeFormDialog 自管。
       toast.error(t('servers.saveFailed', 'Failed to save'), {
         description: e instanceof Error ? e.message : String(e),
       });
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -226,276 +220,286 @@ export function ServerConfigDialog({
             )
       }
       submitLabel={t('common.save')}
-      busy={saving}
+      onSubmit={handleSave}
       // warp（一键生成）/ custom（JSON 直填）自带按钮，不挂协议表单 ⇒ 不套页脚。
       hideFooter={selectedProtocol === 'warp' || selectedProtocol === 'custom'}
     >
-      {isEditing && server?.subscriptionId && (
-        <div className="nd-amber">
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.9"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+      {(submit) => (
+        <>
+          {isEditing && server?.subscriptionId && (
+            <div className="nd-amber">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.9"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="9" />
+                <path d="M12 8v4M12 16h.01" />
+              </svg>
+              <span>
+                {t(
+                  'servers.subNodeEditHint',
+                  'This node belongs to a subscription; edits are overwritten on the next update. For lasting changes, use "Clone to Manual Nodes".'
+                )}
+              </span>
+            </div>
+          )}
+
+          <div className="nd-fld">
+            <span className="nd-fld-lbl">
+              {t('servers.protocol')}
+              {!isMeshEdit && (
+                <small className="font-medium text-fg-faint">
+                  {t('servers.selectProtocol', 'Select your proxy server protocol')}
+                </small>
+              )}
+            </span>
+            <Select
+              value={selectedProtocol}
+              onValueChange={handleProtocolChange}
+              disabled={isMeshEdit}
+            >
+              <SelectTrigger>
+                {isMeshEdit ? <span>{meshLockedLabel}</span> : <SelectValue />}
+              </SelectTrigger>
+              <SelectContent>
+                {/* 组网协议（WireGuard/WARP/Tailscale）始终不进下拉：新增走组网 tab 顶部入口，编辑锁定协议。 */}
+                {getSortedProtocolOptions(t, i18n.language, (v) => v !== 'wireguard').map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {isMeshEdit && (
+              <div className="nd-swrow-d">
+                {t(
+                  'servers.protocolLockedOnEdit',
+                  'Protocol cannot be changed when editing — delete and re-add to switch.'
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="nd-fld">
+            <span className="nd-fld-lbl">
+              {t('servers.remarks')} <span className="nd-req">*</span>
+            </span>
+            <Input
+              id="serverName"
+              placeholder={t('servers.remarksPlaceholder')}
+              value={serverName}
+              onChange={(e) => {
+                setServerName(e.target.value);
+                if (nameError) setNameError('');
+              }}
+              className={
+                nameError ? 'border-destructive focus-visible:ring-destructive' : undefined
+              }
+            />
+            {nameError ? (
+              <div className="fld-err">{nameError}</div>
+            ) : isDuplicateName ? (
+              <div className="nd-swrow-d text-amber-600 dark:text-amber-500">
+                {t('servers.nameDuplicate', 'A node with this name already exists')}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="contents">
+            {selectedProtocol === 'warp' && (
+              <WarpPanel onSubmit={submit} nameMissing={!serverName.trim()} />
+            )}
+            {selectedProtocol === 'vless' && (
+              <VlessForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'vless'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'trojan' && (
+              <TrojanForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'trojan'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'hysteria2' && (
+              <Hysteria2Form
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'hysteria2'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'shadowsocks' && (
+              <SsForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'shadowsocks'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'anytls' && (
+              <AnyTlsForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'anytls'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'tuic' && (
+              <TuicForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'tuic'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'snell' && (
+              <SnellForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'snell'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'naive' && (
+              <NaiveForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'naive'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'vmess' && (
+              <VmessForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'vmess'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'socks' && (
+              <SocksForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'socks'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'http' && (
+              <HttpForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'http'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'ssh' && (
+              <SshForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'ssh'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'wireguard' && (
+              <WireGuardForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'wireguard'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'tailscale' && (
+              <TailscaleForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'tailscale'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+            {selectedProtocol === 'custom' && (
+              <CustomForm
+                key={currentServerConfig?.id || 'new'}
+                serverConfig={
+                  currentServerConfig?.protocol?.toLowerCase() === 'custom'
+                    ? currentServerConfig
+                    : undefined
+                }
+                onSubmit={submit}
+              />
+            )}
+          </div>
+
+          <FormSection
+            title={t('servers.detour', 'Proxy Chain (Detour)')}
+            collapsible
+            defaultOpen={!!server?.detour}
           >
-            <circle cx="12" cy="12" r="9" />
-            <path d="M12 8v4M12 16h.01" />
-          </svg>
-          <span>
-            {t(
-              'servers.subNodeEditHint',
-              'This node belongs to a subscription; edits are overwritten on the next update. For lasting changes, use "Clone to Manual Nodes".'
-            )}
-          </span>
-        </div>
+            <DetourPicker
+              servers={servers}
+              excludeId={server?.id}
+              value={detour}
+              onSelect={(id) => setDetour(id === DETOUR_DIRECT ? undefined : id)}
+            />
+            <div className="nd-swrow-d">
+              {t(
+                'servers.detourDesc',
+                'Connect to this node through another proxy server (proxy chain)'
+              )}
+            </div>
+          </FormSection>
+        </>
       )}
-
-      <div className="nd-fld">
-        <span className="nd-fld-lbl">
-          {t('servers.protocol')}
-          {!isMeshEdit && (
-            <small className="font-medium text-fg-faint">
-              {t('servers.selectProtocol', 'Select your proxy server protocol')}
-            </small>
-          )}
-        </span>
-        <Select value={selectedProtocol} onValueChange={handleProtocolChange} disabled={isMeshEdit}>
-          <SelectTrigger>
-            {isMeshEdit ? <span>{meshLockedLabel}</span> : <SelectValue />}
-          </SelectTrigger>
-          <SelectContent>
-            {/* 组网协议（WireGuard/WARP/Tailscale）始终不进下拉：新增走组网 tab 顶部入口，编辑锁定协议。 */}
-            {getSortedProtocolOptions(t, i18n.language, (v) => v !== 'wireguard').map((p) => (
-              <SelectItem key={p.value} value={p.value}>
-                {p.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {isMeshEdit && (
-          <div className="nd-swrow-d">
-            {t(
-              'servers.protocolLockedOnEdit',
-              'Protocol cannot be changed when editing — delete and re-add to switch.'
-            )}
-          </div>
-        )}
-      </div>
-
-      <div className="nd-fld">
-        <span className="nd-fld-lbl">
-          {t('servers.remarks')} <span className="nd-req">*</span>
-        </span>
-        <Input
-          id="serverName"
-          placeholder={t('servers.remarksPlaceholder')}
-          value={serverName}
-          onChange={(e) => {
-            setServerName(e.target.value);
-            if (nameError) setNameError('');
-          }}
-          className={nameError ? 'border-destructive focus-visible:ring-destructive' : undefined}
-        />
-        {nameError ? (
-          <div className="fld-err">{nameError}</div>
-        ) : isDuplicateName ? (
-          <div className="nd-swrow-d text-amber-600 dark:text-amber-500">
-            {t('servers.nameDuplicate', 'A node with this name already exists')}
-          </div>
-        ) : null}
-      </div>
-
-      <div className="contents">
-        {selectedProtocol === 'warp' && (
-          <WarpPanel onSubmit={handleSave} nameMissing={!serverName.trim()} />
-        )}
-        {selectedProtocol === 'vless' && (
-          <VlessForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'vless'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'trojan' && (
-          <TrojanForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'trojan'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'hysteria2' && (
-          <Hysteria2Form
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'hysteria2'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'shadowsocks' && (
-          <SsForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'shadowsocks'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'anytls' && (
-          <AnyTlsForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'anytls'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'tuic' && (
-          <TuicForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'tuic'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'snell' && (
-          <SnellForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'snell'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'naive' && (
-          <NaiveForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'naive'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'vmess' && (
-          <VmessForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'vmess'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'socks' && (
-          <SocksForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'socks'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'http' && (
-          <HttpForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'http'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'ssh' && (
-          <SshForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'ssh'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'wireguard' && (
-          <WireGuardForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'wireguard'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'tailscale' && (
-          <TailscaleForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'tailscale'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-        {selectedProtocol === 'custom' && (
-          <CustomForm
-            key={currentServerConfig?.id || 'new'}
-            serverConfig={
-              currentServerConfig?.protocol?.toLowerCase() === 'custom'
-                ? currentServerConfig
-                : undefined
-            }
-            onSubmit={handleSave}
-          />
-        )}
-      </div>
-
-      <FormSection
-        title={t('servers.detour', 'Proxy Chain (Detour)')}
-        collapsible
-        defaultOpen={!!server?.detour}
-      >
-        <DetourPicker
-          servers={servers}
-          excludeId={server?.id}
-          value={detour}
-          onSelect={(id) => setDetour(id === DETOUR_DIRECT ? undefined : id)}
-        />
-        <div className="nd-swrow-d">
-          {t(
-            'servers.detourDesc',
-            'Connect to this node through another proxy server (proxy chain)'
-          )}
-        </div>
-      </FormSection>
     </NodeFormDialog>
   );
 }

--- a/src/renderer/components/settings/server-config-dialog.tsx
+++ b/src/renderer/components/settings/server-config-dialog.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
-import { X, Loader2 } from 'lucide-react';
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import {
   Select,
   SelectContent,
@@ -26,6 +24,7 @@ import { WireGuardForm } from './wireguard-form';
 import { TailscaleForm } from './tailscale-form';
 import { CustomForm } from './custom-form';
 import { WarpPanel } from './warp-panel';
+import { NodeFormDialog } from './node-form-dialog';
 import { FormSection } from './shared/form-layout';
 import { getSortedProtocolOptions } from './shared/protocol-options';
 import { isEndpointProtocol } from '../../../shared/endpoint-routes';
@@ -207,332 +206,296 @@ export function ServerConfigDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="[&>button]:hidden flex max-h-[90vh] w-[min(452px,94vw)] max-w-none flex-col gap-0 overflow-hidden rounded-[12px] border-line bg-surface p-0">
-        {/* a11y：radix 需 Title/Description；视觉标题另在 `.nd-dlg-h`，此处仅供辅助技术。 */}
-        <DialogTitle className="sr-only">
-          {isEditing
-            ? t('servers.editServer', 'Edit Server Config')
-            : t('servers.addServerConfig', 'Add Server Config')}
-        </DialogTitle>
-        <DialogDescription className="sr-only">
-          {isEditing
-            ? t(
-                'servers.editServerDesc',
-                'Modify server configuration. Proxy will not restart automatically after saving.'
-              )
-            : t(
-                'servers.addServerDesc',
-                'Add a new proxy server. Supports VLESS, Trojan, Hysteria2, Shadowsocks, AnyTLS.'
-              )}
-        </DialogDescription>
-
-        <div className="nd-dlg-h">
-          <span className="nd-dlg-title">
-            {isEditing
-              ? t('servers.editServer', 'Edit Server Config')
-              : t('servers.addServerConfig', 'Add Server Config')}
+    <NodeFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        isEditing
+          ? t('servers.editServer', 'Edit Server Config')
+          : t('servers.addServerConfig', 'Add Server Config')
+      }
+      description={
+        isEditing
+          ? t(
+              'servers.editServerDesc',
+              'Modify server configuration. Proxy will not restart automatically after saving.'
+            )
+          : t(
+              'servers.addServerDesc',
+              'Add a new proxy server. Supports VLESS, Trojan, Hysteria2, Shadowsocks, AnyTLS.'
+            )
+      }
+      submitLabel={t('common.save')}
+      busy={saving}
+      // warp（一键生成）/ custom（JSON 直填）自带按钮，不挂协议表单 ⇒ 不套页脚。
+      hideFooter={selectedProtocol === 'warp' || selectedProtocol === 'custom'}
+    >
+      {isEditing && server?.subscriptionId && (
+        <div className="nd-amber">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.9"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+          <span>
+            {t(
+              'servers.subNodeEditHint',
+              'This node belongs to a subscription; edits are overwritten on the next update. For lasting changes, use "Clone to Manual Nodes".'
+            )}
           </span>
-          <button
-            type="button"
-            className="nd-dlg-x"
-            aria-label={t('common.cancel', 'Cancel')}
-            onClick={() => onOpenChange(false)}
-          >
-            <X />
-          </button>
         </div>
+      )}
 
-        <div className="nd-dlg-body">
-          {isEditing && server?.subscriptionId && (
-            <div className="nd-amber">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.9"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <circle cx="12" cy="12" r="9" />
-                <path d="M12 8v4M12 16h.01" />
-              </svg>
-              <span>
-                {t(
-                  'servers.subNodeEditHint',
-                  'This node belongs to a subscription; edits are overwritten on the next update. For lasting changes, use "Clone to Manual Nodes".'
-                )}
-              </span>
-            </div>
+      <div className="nd-fld">
+        <span className="nd-fld-lbl">
+          {t('servers.protocol')}
+          {!isMeshEdit && (
+            <small className="font-medium text-fg-faint">
+              {t('servers.selectProtocol', 'Select your proxy server protocol')}
+            </small>
           )}
-
-          <div className="nd-fld">
-            <span className="nd-fld-lbl">
-              {t('servers.protocol')}
-              {!isMeshEdit && (
-                <small className="font-medium text-fg-faint">
-                  {t('servers.selectProtocol', 'Select your proxy server protocol')}
-                </small>
-              )}
-            </span>
-            <Select
-              value={selectedProtocol}
-              onValueChange={handleProtocolChange}
-              disabled={isMeshEdit}
-            >
-              <SelectTrigger>
-                {isMeshEdit ? <span>{meshLockedLabel}</span> : <SelectValue />}
-              </SelectTrigger>
-              <SelectContent>
-                {/* 组网协议（WireGuard/WARP/Tailscale）始终不进下拉：新增走组网 tab 顶部入口，编辑锁定协议。 */}
-                {getSortedProtocolOptions(t, i18n.language, (v) => v !== 'wireguard').map((p) => (
-                  <SelectItem key={p.value} value={p.value}>
-                    {p.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {isMeshEdit && (
-              <div className="nd-swrow-d">
-                {t(
-                  'servers.protocolLockedOnEdit',
-                  'Protocol cannot be changed when editing — delete and re-add to switch.'
-                )}
-              </div>
+        </span>
+        <Select value={selectedProtocol} onValueChange={handleProtocolChange} disabled={isMeshEdit}>
+          <SelectTrigger>
+            {isMeshEdit ? <span>{meshLockedLabel}</span> : <SelectValue />}
+          </SelectTrigger>
+          <SelectContent>
+            {/* 组网协议（WireGuard/WARP/Tailscale）始终不进下拉：新增走组网 tab 顶部入口，编辑锁定协议。 */}
+            {getSortedProtocolOptions(t, i18n.language, (v) => v !== 'wireguard').map((p) => (
+              <SelectItem key={p.value} value={p.value}>
+                {p.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {isMeshEdit && (
+          <div className="nd-swrow-d">
+            {t(
+              'servers.protocolLockedOnEdit',
+              'Protocol cannot be changed when editing — delete and re-add to switch.'
             )}
-          </div>
-
-          <div className="nd-fld">
-            <span className="nd-fld-lbl">
-              {t('servers.remarks')} <span className="nd-req">*</span>
-            </span>
-            <Input
-              id="serverName"
-              placeholder={t('servers.remarksPlaceholder')}
-              value={serverName}
-              onChange={(e) => {
-                setServerName(e.target.value);
-                if (nameError) setNameError('');
-              }}
-              className={
-                nameError ? 'border-destructive focus-visible:ring-destructive' : undefined
-              }
-            />
-            {nameError ? (
-              <div className="fld-err">{nameError}</div>
-            ) : isDuplicateName ? (
-              <div className="nd-swrow-d text-amber-600 dark:text-amber-500">
-                {t('servers.nameDuplicate', 'A node with this name already exists')}
-              </div>
-            ) : null}
-          </div>
-
-          <div className="contents">
-            {selectedProtocol === 'warp' && (
-              <WarpPanel onSubmit={handleSave} nameMissing={!serverName.trim()} />
-            )}
-            {selectedProtocol === 'vless' && (
-              <VlessForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'vless'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'trojan' && (
-              <TrojanForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'trojan'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'hysteria2' && (
-              <Hysteria2Form
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'hysteria2'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'shadowsocks' && (
-              <SsForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'shadowsocks'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'anytls' && (
-              <AnyTlsForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'anytls'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'tuic' && (
-              <TuicForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'tuic'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'snell' && (
-              <SnellForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'snell'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'naive' && (
-              <NaiveForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'naive'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'vmess' && (
-              <VmessForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'vmess'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'socks' && (
-              <SocksForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'socks'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'http' && (
-              <HttpForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'http'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'ssh' && (
-              <SshForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'ssh'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'wireguard' && (
-              <WireGuardForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'wireguard'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'tailscale' && (
-              <TailscaleForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'tailscale'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-            {selectedProtocol === 'custom' && (
-              <CustomForm
-                key={currentServerConfig?.id || 'new'}
-                serverConfig={
-                  currentServerConfig?.protocol?.toLowerCase() === 'custom'
-                    ? currentServerConfig
-                    : undefined
-                }
-                onSubmit={handleSave}
-              />
-            )}
-          </div>
-
-          <FormSection
-            title={t('servers.detour', 'Proxy Chain (Detour)')}
-            collapsible
-            defaultOpen={!!server?.detour}
-          >
-            <DetourPicker
-              servers={servers}
-              excludeId={server?.id}
-              value={detour}
-              onSelect={(id) => setDetour(id === DETOUR_DIRECT ? undefined : id)}
-            />
-            <div className="nd-swrow-d">
-              {t(
-                'servers.detourDesc',
-                'Connect to this node through another proxy server (proxy chain)'
-              )}
-            </div>
-          </FormSection>
-        </div>
-
-        {/* 固定底部操作区：保存/重置贴 dialog 底、不随表单主体滚动。经 HTML form= 关联当前挂载的
-            协议表单（id="node-cfg-form"）——submit 触发其 RHF 校验+提交，reset 经表单 onReset 走 form.reset()。
-            warp（一键生成）/custom（JSON）自带按钮、不套用本 footer。 */}
-        {selectedProtocol !== 'warp' && selectedProtocol !== 'custom' && (
-          <div className="nd-dlg-foot">
-            <button type="reset" form="node-cfg-form" className="btn ghost sm" disabled={saving}>
-              {t('common.reset')}
-            </button>
-            <button type="submit" form="node-cfg-form" className="btn flow sm" disabled={saving}>
-              {saving && <Loader2 className="animate-spin" size={14} />}
-              {t('common.save')}
-            </button>
           </div>
         )}
-      </DialogContent>
-    </Dialog>
+      </div>
+
+      <div className="nd-fld">
+        <span className="nd-fld-lbl">
+          {t('servers.remarks')} <span className="nd-req">*</span>
+        </span>
+        <Input
+          id="serverName"
+          placeholder={t('servers.remarksPlaceholder')}
+          value={serverName}
+          onChange={(e) => {
+            setServerName(e.target.value);
+            if (nameError) setNameError('');
+          }}
+          className={nameError ? 'border-destructive focus-visible:ring-destructive' : undefined}
+        />
+        {nameError ? (
+          <div className="fld-err">{nameError}</div>
+        ) : isDuplicateName ? (
+          <div className="nd-swrow-d text-amber-600 dark:text-amber-500">
+            {t('servers.nameDuplicate', 'A node with this name already exists')}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="contents">
+        {selectedProtocol === 'warp' && (
+          <WarpPanel onSubmit={handleSave} nameMissing={!serverName.trim()} />
+        )}
+        {selectedProtocol === 'vless' && (
+          <VlessForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'vless'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'trojan' && (
+          <TrojanForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'trojan'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'hysteria2' && (
+          <Hysteria2Form
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'hysteria2'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'shadowsocks' && (
+          <SsForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'shadowsocks'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'anytls' && (
+          <AnyTlsForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'anytls'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'tuic' && (
+          <TuicForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'tuic'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'snell' && (
+          <SnellForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'snell'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'naive' && (
+          <NaiveForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'naive'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'vmess' && (
+          <VmessForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'vmess'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'socks' && (
+          <SocksForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'socks'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'http' && (
+          <HttpForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'http'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'ssh' && (
+          <SshForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'ssh'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'wireguard' && (
+          <WireGuardForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'wireguard'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'tailscale' && (
+          <TailscaleForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'tailscale'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+        {selectedProtocol === 'custom' && (
+          <CustomForm
+            key={currentServerConfig?.id || 'new'}
+            serverConfig={
+              currentServerConfig?.protocol?.toLowerCase() === 'custom'
+                ? currentServerConfig
+                : undefined
+            }
+            onSubmit={handleSave}
+          />
+        )}
+      </div>
+
+      <FormSection
+        title={t('servers.detour', 'Proxy Chain (Detour)')}
+        collapsible
+        defaultOpen={!!server?.detour}
+      >
+        <DetourPicker
+          servers={servers}
+          excludeId={server?.id}
+          value={detour}
+          onSelect={(id) => setDetour(id === DETOUR_DIRECT ? undefined : id)}
+        />
+        <div className="nd-swrow-d">
+          {t(
+            'servers.detourDesc',
+            'Connect to this node through another proxy server (proxy chain)'
+          )}
+        </div>
+      </FormSection>
+    </NodeFormDialog>
   );
 }


### PR DESCRIPTION
## 现象

组网 → WireGuard，`.conf` 全部导入完毕后**没有添加按钮**。报告截图里弹窗已滚到底（`Reserved` 是最后一个字段），下方留白、无任何操作区——不是「按钮在折叠线以下」，是真的没有。

## 根因

协议表单组件（`*-form.tsx`，共 15 个）渲染 `<form id="node-cfg-form">`，但**自身一个提交按钮都没有**（实测 `type="submit"` 计数全为 0）。按钮靠 HTML 的 `form=` 属性从表单**外面**跨节点绑进来：

```tsx
// server-config-dialog.tsx —— 唯一做对的宿主
<button type="submit" form="node-cfg-form" className="btn flow sm">{t('common.save')}</button>
```

这在组件契约里是一条**不可见、无类型、无强制**的宿主义务：「挂了协议表单，你就得在某处渲染一个绑到它的按钮」。tsc 查不出（类型完整）、渲染不报错（表单照常渲染），只有真人点下去才发现。

## 姊妹腿

按「谁引用了协议表单」反查，宿主恰好三个，漏了两个：

| 宿主 | 状态 |
|---|---|
| `server-config-dialog.tsx` | 有页脚 |
| `mesh-access-entry.tsx` → `<WireGuardForm>` | **无页脚** ← 本 issue |
| `mesh-tailscale-control.tsx` → `<TailscaleForm>` | **无页脚** ← 同款，未被报告 |

Tailscale 设置弹窗里改完的出口设备 / 子网路由 / 高级选项**无从保存**。全仓 `<form>` 另扫一遍，除这批外只有 `privacy-overlay.tsx` 一处，自带 submit，无关。

## 为什么不逐处补按钮

逐处补只是把已漏的两处补上，**义务原样留着**，下一个宿主照样能漏。

且补完还剩一半问题：组网两个弹窗把整个 `DialogContent` 设成 `overflow-y-auto`，页脚会跟着正文滚。WireGuard 表单很长（正是报告者滚到底才发现问题的那个长度），提交按钮会沉到折叠线以下——等于把「够不着按钮」从**没有**降级成**要找**。

## 改动

新增 `NodeFormDialog` 外壳，把义务从宿主手里收走：

```
DialogContent  flex flex-col overflow-hidden p-0 max-h-[90vh]
├─ .nd-dlg-h     标题 + 关闭        —— 不滚
├─ .nd-dlg-body  max-height:470px; overflow-y:auto   ←—— 唯一滚动区
└─ .nd-dlg-foot  Reset / 提交       —— 不滚，由外壳渲染，宿主无从省略
```

顺带收编两件本来在各处重复决定的事：滚动结构只在一处决定；`form="node-cfg-form"` 这个跨节点绑定的字面量收敛到一处。

四个调用点全部改经外壳：节点新增/编辑、组网 WireGuard、组网 WARP（`WarpPanel` 自带按钮 ⇒ `hideFooter`）、Tailscale 设置。组网三个弹窗的头部随之从 radix `DialogHeader` 换成标准 `.nd-dlg-h`，与节点弹窗一致；原先**可见**的说明文案改为正文首段（外壳的 `description` 是 sr-only 的 a11y 描述，不上屏）。

**已知且刻意不做**：`node-cfg-form` 是全局 DOM id，两个此类弹窗并存时 `form=` 按文档顺序绑第一个。今天四处互斥、该状态不可达，属 YAGNI。真要治是外壳用 `useId()` 生成唯一 id 经 context 下发，代价是 15 个表单都要改 `id=`——等真出现并存场景再做。

## 门

`node-form-submit-wiring.test.ts` 钉的是**根治后的结构**，不是「每个宿主都记得加按钮」：

1. 反平凡：确实存在 ≥10 个渲染 `<form id="node-cfg-form">` 的表单，且都能反查到组件名；
2. 前提：这批表单自身不提供提交按钮（前提若变本条红，提醒重新推导）；
3. **绑到协议表单的提交按钮全仓有且仅有一处**（外壳）；
4. **挂协议表单的宿主只能经外壳挂**。

三向变异实测，各自精确红一条：

| 变异 | 红的断言 |
|---|---|
| 删掉外壳页脚 | ③（binders 变空） |
| 宿主里手搓一套按钮 | ③（binders 变两处） |
| 宿主绕过外壳用 raw Dialog | ④ |

**判据自污染（踩过并修）**：第一版正则把**注释**里逐字写的 `<form id="node-cfg-form">` 也算了进去——本门与 `server-config-dialog` 的注释都写了它来说明机制，于是「解释规则的注释」被当成「遵守规则的代码」，两个宿主被误判成表单、判据整体空转。改为先剥块注释再匹配。

**射程边界（如实记）**：文本级判据能证明宿主**引用了**外壳，不能证明表单**嵌在**外壳里面。要绕过得刻意在同一文件里既用外壳又把表单挂到外壳外——比原来的「忘了加按钮」难得多，接受该残余。

不做挂载渲染测试的理由：renderer 测试全为纯逻辑（`testEnvironment: 'node'`），无 jsdom / testing-library；为这一条引入整套 DOM 测试栈不划算，而本缺陷的判据恰好纯文本可判。

## 验证

`npx jest` 全量 **3695 passed** / 242 suites / 37 snapshots · `eslint` 0 errors · `tsc -p tsconfig.json` 与 `tsconfig.renderer.json` 均 rc=0 · `build:main` + `build:renderer`。

本机 Xvfb + Electron + CDP 实测：

| 弹窗 | 结果 |
|---|---|
| 节点新增 | 页脚 `Reset/reset` + `Save/submit`，均 `form=node-cfg-form`；正文滚动 63/533（`clientH=470`），页脚固定 `top:685 bottom:742` |
| 组网 WireGuard | 页脚 `Reset/reset` + **`Add/submit`**；正文滚动 186/656，页脚**同一坐标** `top:685` |
| 组网 WARP | 无 `.nd-dlg-foot`（`hideFooter`，符合设计），正文内自带按钮在位 |
| `getElementById('node-cfg-form')` | 存在，`tagName=FORM` |

「页脚固定」不是看图下的结论，是两个弹窗滚动后页脚 `getBoundingClientRect()` **同为 685/742** 这一实测坐标。

Tailscale 设置弹窗未截图：需要一个已接入的 TS 节点才可达，本机无；其接线由门的 ③④ 与 tsc 覆盖，外壳与另外三处共用。

## 复审后的两轮跟进

独立复审（三镜头 + 每条双人对抗证伪）**零 Blocker**，交付代码零缺陷；拦下来的全是**这道门自己**——而门是「根治」这个主张唯一的执行力来源。

**`2d2ac66` 门的三处漏判**（每条都实测复现过）：

| # | 缺陷 | 实测 |
|---|---|---|
| F1 | 合取写在**文件级**而非按钮级 | 只删提交按钮的 `form=` 绑定、留着 reset 的 → 左项由 reset 顶上，**四条断言全绿** |
| F2 | 只剥块注释不够 | 绕过外壳的宿主加一行 `// TODO: 后续迁到 <NodeFormDialog` → **全绿** |
| F3 | 正则剥法被字面量里的 `/*` 劫持 | 毒到真表单文件上 → `formFiles` 从 14 静默降到 13，下界 `>= 10` 把丢失完全吸收 → **全绿** |

F1 放过的正是 **#350 的原始形态**：按钮在、绑定没了，点下去零反应。修法是按 `<button>` 开标签切分后再判合取；标签正则用 `[^>{]|\{[^}]*\}` 而非 `[^>]*`——JSX 属性里的箭头函数含 `>`，后者会在箭头处截断，属性顺序一变就静默漏判。F2/F3 合并修：正则换成逐字符扫描器，字符串/模板字面量原样保留（URL 在引号里，故「行内 `//` 不能剥」那条理由本就只对粗暴实现成立）。

同时更正两处**在当前代码上为假**的注释：外壳 JSDoc 的「宿主无从省略」不成立（`hideFooter` 就是省略口，四条断言无一读它，已如实记进射程边界）；删掉零消费者的 `contentClassName`（连 `cn` 的 import 一起，`noUnusedLocals` 会报）。

**`6fffbc6` 提交态由外壳自管**：复审指出组网两个新增按钮没接 `busy`。没有在两个宿主里各补一份 saving state——那等于再造一条可选宿主义务，与本 PR 收编页脚的理由自相矛盾。改为删掉 `busy` prop、外壳自持提交态，`children` 改 render-prop 把包好的 `submit` 递下去。宿主想手搓提交态，多传的 prop 直接 tsc 报错，是结构性强制而非又一道门。

**变异矩阵六条全红、基线绿**：删外壳页脚 / 宿主手搓按钮 / 宿主绕过外壳 / 只删提交按钮绑定 / 一行 TODO 注释伪装合规 / 字面量毒化真表单。

运行时冒烟（Xvfb + CDP，render-prop 是结构性改动，tsc 证不了 `children(submit)` 真能渲染）：组网 WireGuard 弹窗 `bodyChildren=3`、页脚在、`Reset/reset` 与 `Add/submit` 均 `disabled=false` 且 `form=node-cfg-form`。

Closes #350

