### PR TITLE
refactor(route): 阻断动作迁移到 action:reject，删除 legacy block 出站

### DIFF
--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -255,10 +255,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -905,10 +901,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -1533,10 +1525,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -2195,10 +2183,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -2808,10 +2792,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -3416,10 +3396,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -3974,10 +3950,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -4531,10 +4503,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -5096,10 +5064,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -5742,10 +5706,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -6375,10 +6335,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -7043,10 +6999,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -7674,10 +7626,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -8298,10 +8246,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -8974,10 +8918,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -9564,10 +9504,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -10172,10 +10108,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -10764,10 +10696,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -11387,10 +11315,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -12037,10 +11961,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -12662,13 +12582,19 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "selector",
       },
       {
+        "default": "proxy-selector",
+        "interrupt_exist_connections": false,
+        "outbounds": [
+          "HK",
+          "proxy-selector",
+        ],
+        "tag": "rule-sel-app-custom-app1",
+        "type": "selector",
+      },
+      {
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -12945,6 +12871,13 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         },
         {
           "action": "route",
+          "outbound": "rule-sel-app-custom-app1",
+          "rule_set": [
+            "geosite-youtube",
+          ],
+        },
+        {
+          "action": "route",
           "ip_cidr": [
             "10.0.0.0/8",
             "100.64.0.0/10",
@@ -13066,7 +12999,12 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
   "idToTagMap": {
     "s1": "HK",
   },
-  "ruleTargetMap": {},
+  "ruleTargetMap": {
+    "app:custom-app1": {
+      "memberTag": "proxy-selector",
+      "selectorTag": "rule-sel-app-custom-app1",
+    },
+  },
 }
 `;
 
@@ -13290,10 +13228,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -13714,6 +13648,629 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
 }
 `;
 
+exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线） smart + 阻断动作（自定义规则 domainSuffix→block + 应用分流 block）→ 锁阻断规则形态 1`] = `
+{
+  "config": {
+    "dns": {
+      "final": "dns-domestic",
+      "rules": [
+        {
+          "domain": [
+            "a.example.com",
+          ],
+          "domain_suffix": [
+            "a.example.com",
+            ".a.example.com",
+          ],
+          "server": "dns-domestic",
+        },
+        {
+          "domain": [
+            "doh.pub",
+            "dns.google",
+            "cloudflare-dns.com",
+            "one.one.one.one",
+          ],
+          "server": "dns-bootstrap",
+        },
+        {
+          "domain_suffix": [
+            ".local",
+            ".arpa",
+            ".lan",
+            ".home.arpa",
+            ".microdone.cn",
+            ".icbc.com.cn",
+            ".boc.cn",
+            ".ccb.com",
+            ".abchina.com",
+            ".abchina.com.cn",
+            ".bankcomm.com",
+            ".cmbchina.com",
+            ".psbc.com",
+            ".spdb.com.cn",
+            ".cebbank.com",
+            ".citicbank.com",
+            ".pingan.com",
+            ".cib.com.cn",
+            ".hxb.com.cn",
+            ".cmbc.com.cn",
+            ".hzbank.com.cn",
+            ".10jqka.com.cn",
+            ".thsi.cn",
+            ".eastmoney.com",
+            ".1234567.com.cn",
+            ".gw.com.cn",
+            ".tdx.com.cn",
+          ],
+          "server": "dns-local",
+        },
+        {
+          "domain": [
+            "captive.apple.com",
+            "connectivitycheck.gstatic.com",
+            "connectivitycheck.android.com",
+            "msftconnecttest.com",
+            "www.msftconnecttest.com",
+            "msftncsi.com",
+            "www.msftncsi.com",
+            "dns.msftncsi.com",
+            "detectportal.firefox.com",
+            "network-test.debian.org",
+            "connect.rom.miui.com",
+          ],
+          "server": "dns-local",
+        },
+        {
+          "domain_keyword": [
+            "ntp",
+            "stun",
+          ],
+          "domain_suffix": [
+            "ntp.org",
+            ".ntp.org",
+            "time.windows.com",
+            ".time.windows.com",
+            "time.apple.com",
+            ".time.apple.com",
+            "time.cloudflare.com",
+            ".time.cloudflare.com",
+            "time.nist.gov",
+            ".time.nist.gov",
+            "time.android.com",
+            ".time.android.com",
+          ],
+          "server": "dns-domestic",
+        },
+        {
+          "query_type": [
+            "A",
+            "AAAA",
+          ],
+          "rewrite_ttl": 60,
+          "server": "fakeip",
+        },
+        {
+          "query_type": [
+            "A",
+            "AAAA",
+          ],
+          "rule_set": "geosite-cn",
+          "server": "dns-domestic",
+        },
+        {
+          "query_type": [
+            "A",
+            "AAAA",
+          ],
+          "server": "dns-remote",
+        },
+      ],
+      "servers": [
+        {
+          "path": "/dns-query",
+          "server": "223.5.5.5",
+          "server_port": 443,
+          "tag": "dns-bootstrap",
+          "type": "https",
+        },
+        {
+          "path": "/dns-query",
+          "server": "1.12.12.12",
+          "server_port": 443,
+          "tag": "dns-node",
+          "type": "https",
+        },
+        {
+          "tag": "dns-local",
+          "type": "local",
+        },
+        {
+          "domain_resolver": "dns-bootstrap",
+          "path": "/dns-query",
+          "server": "doh.pub",
+          "server_port": 443,
+          "tag": "dns-domestic",
+          "type": "https",
+        },
+        {
+          "detour": "proxy-selector",
+          "domain_resolver": "dns-bootstrap",
+          "path": "/dns-query",
+          "server": "dns.google",
+          "server_port": 443,
+          "tag": "dns-remote",
+          "type": "https",
+        },
+        {
+          "inet4_range": "198.18.0.0/15",
+          "tag": "fakeip",
+          "type": "fakeip",
+        },
+      ],
+      "strategy": "ipv4_only",
+    },
+    "experimental": {
+      "cache_file": {
+        "cache_id": "flowz-dns-v2",
+        "enabled": true,
+        "path": "/fake/userData/cache.db",
+        "store_dns": true,
+        "store_fakeip": true,
+      },
+    },
+    "inbounds": [
+      {
+        "listen": "127.0.0.1",
+        "listen_port": 7890,
+        "tag": "mixed-in",
+        "type": "mixed",
+      },
+    ],
+    "log": {
+      "level": "info",
+      "timestamp": true,
+    },
+    "outbounds": [
+      {
+        "domain_resolver": {
+          "server": "dns-bootstrap",
+          "strategy": "prefer_ipv4",
+        },
+        "packet_encoding": "xudp",
+        "server": "a.example.com",
+        "server_port": 443,
+        "tag": "HK",
+        "type": "vless",
+        "uuid": "uuid-1",
+      },
+      {
+        "default": "HK",
+        "interrupt_exist_connections": false,
+        "outbounds": [
+          "HK",
+          "direct",
+        ],
+        "tag": "proxy-selector",
+        "type": "selector",
+      },
+      {
+        "domain_resolver": "dns-bootstrap",
+        "tag": "direct",
+        "type": "direct",
+      },
+    ],
+    "route": {
+      "auto_detect_interface": true,
+      "default_domain_resolver": "dns-bootstrap",
+      "final": "proxy-selector",
+      "rule_set": [
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-cn.srs",
+          "tag": "geosite-cn",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-geolocation-!cn.srs",
+          "tag": "geosite-geolocation-!cn",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geoip-cn.srs",
+          "tag": "geoip-cn",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-youtube.srs",
+          "tag": "geosite-youtube",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-netflix.srs",
+          "tag": "geosite-netflix",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-tiktok.srs",
+          "tag": "geosite-tiktok",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-telegram.srs",
+          "tag": "geosite-telegram",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-twitter.srs",
+          "tag": "geosite-twitter",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-instagram.srs",
+          "tag": "geosite-instagram",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-openai.srs",
+          "tag": "geosite-openai",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-anthropic.srs",
+          "tag": "geosite-anthropic",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-category-ai-!cn.srs",
+          "tag": "geosite-category-ai",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-google.srs",
+          "tag": "geosite-google",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-github.srs",
+          "tag": "geosite-github",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-spotify.srs",
+          "tag": "geosite-spotify",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-steam.srs",
+          "tag": "geosite-steam",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-epicgames.srs",
+          "tag": "geosite-epicgames",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-riot.srs",
+          "tag": "geosite-riot",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-disney.srs",
+          "tag": "geosite-disney",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geosite-private.srs",
+          "tag": "geosite-private",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geoip-netflix.srs",
+          "tag": "geoip-netflix",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geoip-telegram.srs",
+          "tag": "geoip-telegram",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geoip-twitter.srs",
+          "tag": "geoip-twitter",
+          "type": "local",
+        },
+        {
+          "format": "binary",
+          "path": "/fake/userData/rules/geoip-private.srs",
+          "tag": "geoip-private",
+          "type": "local",
+        },
+      ],
+      "rules": [
+        {
+          "action": "sniff",
+        },
+        {
+          "action": "route",
+          "outbound": "direct",
+          "process_name": [
+            "sing-box",
+            "sing-box.exe",
+          ],
+        },
+        {
+          "action": "route",
+          "ip_cidr": [
+            "223.5.5.5/32",
+            "223.6.6.6/32",
+            "1.12.12.12/32",
+            "119.29.29.29/32",
+            "119.28.28.28/32",
+            "114.114.114.114/32",
+          ],
+          "outbound": "direct",
+          "port": [
+            53,
+            443,
+          ],
+        },
+        {
+          "action": "hijack-dns",
+          "port": [
+            53,
+          ],
+        },
+        {
+          "action": "route",
+          "outbound": "direct",
+          "process_name": [
+            "Surge",
+            "Surge 4",
+            "Surge 5",
+            "Clash",
+            "Clash for Windows",
+            "ClashX",
+            "ClashX Pro",
+            "clash-meta",
+            "Quantumult X",
+            "sing-box",
+            "sing-box.exe",
+            "mDNSResponder",
+            "apsd",
+            "nsurlsessiond",
+            "airportd",
+            "syspolicyd",
+            "trustd",
+            "ocspd",
+            "securityd",
+            "taskgated",
+            "findmydeviced",
+            "cloudd",
+          ],
+        },
+        {
+          "action": "reject",
+          "domain_keyword": [
+            "dns.google",
+            "cloudflare-dns.com",
+            "doh.opendns.com",
+            "dns.quad9.net",
+            "one.one.one.one",
+          ],
+          "port": [
+            443,
+            853,
+          ],
+        },
+        {
+          "action": "route",
+          "domain": [
+            "a.example.com",
+          ],
+          "domain_suffix": [
+            ".a.example.com",
+          ],
+          "outbound": "direct",
+        },
+        {
+          "action": "route",
+          "domain_suffix": [
+            ".microdone.cn",
+          ],
+          "outbound": "direct",
+          "override_address": "127.0.0.1",
+        },
+        {
+          "action": "route",
+          "domain_suffix": [
+            ".icbc.com.cn",
+            ".boc.cn",
+            ".ccb.com",
+            ".abchina.com",
+            ".abchina.com.cn",
+            ".bankcomm.com",
+            ".cmbchina.com",
+            ".psbc.com",
+            ".spdb.com.cn",
+            ".cebbank.com",
+            ".citicbank.com",
+            ".pingan.com",
+            ".cib.com.cn",
+            ".hxb.com.cn",
+            ".cmbc.com.cn",
+            ".hzbank.com.cn",
+            ".10jqka.com.cn",
+            ".thsi.cn",
+            ".eastmoney.com",
+            ".1234567.com.cn",
+            ".gw.com.cn",
+            ".tdx.com.cn",
+          ],
+          "outbound": "direct",
+        },
+        {
+          "action": "reject",
+          "domain_suffix": [
+            "ads.example",
+          ],
+        },
+        {
+          "action": "reject",
+          "process_name": [
+            "blocked.exe",
+          ],
+        },
+        {
+          "action": "route",
+          "ip_cidr": [
+            "10.0.0.0/8",
+            "100.64.0.0/10",
+            "127.0.0.0/8",
+            "169.254.0.0/16",
+            "172.16.0.0/12",
+            "192.0.0.0/24",
+            "192.88.99.0/24",
+            "192.168.0.0/16",
+            "224.0.0.0/4",
+            "233.252.0.0/24",
+            "240.0.0.0/4",
+            "fc00::/7",
+            "fe80::/10",
+          ],
+          "outbound": "direct",
+        },
+        {
+          "action": "route",
+          "outbound": "direct",
+          "rule_set": "geosite-private",
+        },
+        {
+          "action": "route",
+          "network": [
+            "icmp",
+          ],
+          "outbound": "direct",
+        },
+        {
+          "action": "reject",
+          "domain_keyword": [
+            "dns.google",
+            "cloudflare-dns.com",
+            "doh.opendns.com",
+            "dns.quad9.net",
+            "one.one.one.one",
+          ],
+          "network": [
+            "udp",
+          ],
+          "port": [
+            443,
+          ],
+        },
+        {
+          "action": "route",
+          "outbound": "direct",
+          "protocol": "dns",
+        },
+        {
+          "action": "route",
+          "ip_cidr": [
+            "223.5.5.5/32",
+            "1.12.12.12/32",
+          ],
+          "outbound": "direct",
+          "port": [
+            53,
+            443,
+          ],
+        },
+        {
+          "action": "route",
+          "domain_suffix": [
+            "doh.pub",
+          ],
+          "outbound": "direct",
+        },
+        {
+          "action": "reject",
+          "domain_suffix": [
+            "gvt2.com",
+            "gvt1.com",
+            "oauthaccountmanager.googleapis.com",
+            "clientservices.googleapis.com",
+            "optimizationguide-pa.googleapis.com",
+            "mtalk.google.com",
+            "android.clients.google.com",
+            "clients1.google.com",
+            "clients2.google.com",
+            "clients3.google.com",
+            "clients4.google.com",
+            "clients5.google.com",
+            "clients6.google.com",
+            "update.googleapis.com",
+          ],
+        },
+        {
+          "action": "route",
+          "domain_keyword": [
+            "google",
+            "gmail",
+            "youtube",
+            "gstatic",
+            "googleapis",
+            "googlevideo",
+          ],
+          "outbound": "proxy-selector",
+        },
+        {
+          "action": "route",
+          "outbound": "proxy-selector",
+          "rule_set": "geosite-geolocation-!cn",
+        },
+        {
+          "action": "route",
+          "outbound": "direct",
+          "rule_set": "geosite-cn",
+        },
+        {
+          "action": "route",
+          "outbound": "direct",
+          "rule_set": "geoip-cn",
+        },
+      ],
+    },
+  },
+  "idToTagMap": {
+    "s1": "HK",
+  },
+  "ruleTargetMap": {},
+}
+`;
+
 exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线） ssh outbound（独立返回路径，无 TLS/传输层）→ 锁 ssh 字段块 1`] = `
 {
   "config": {
@@ -13933,10 +14490,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -14548,10 +15101,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -15192,10 +15741,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -15791,10 +16336,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -16221,10 +16762,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -16876,10 +17413,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "type": "direct",
       },
       {
-        "tag": "block",
-        "type": "block",
-      },
-      {
         "password": "stp",
         "server": "a.example.com",
         "server_port": 443,
@@ -17521,10 +18054,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -18162,10 +18691,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -18792,10 +19317,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -19406,10 +19927,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -20029,10 +20546,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -20642,10 +21155,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -21361,10 +21870,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "tag": "direct",
         "type": "direct",
       },
-      {
-        "tag": "block",
-        "type": "block",
-      },
     ],
     "route": {
       "auto_detect_interface": true,
@@ -21995,10 +22500,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {
@@ -22638,10 +23139,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
         "domain_resolver": "dns-bootstrap",
         "tag": "direct",
         "type": "direct",
-      },
-      {
-        "tag": "block",
-        "type": "block",
       },
     ],
     "route": {

--- a/src/main/services/__tests__/config-snapshot.test.ts
+++ b/src/main/services/__tests__/config-snapshot.test.ts
@@ -219,7 +219,43 @@ describe('generateSingBoxConfig — characterization 快照（抽取前锁基线
               geoipTags: [],
             },
           ],
+          appRoutingEnabled: true,
           appRules: [{ appId: 'custom-app1', action: 'proxy', enabled: true }],
+        } as unknown as Partial<UserConfig>)
+      )
+    ).toMatchSnapshot();
+  });
+
+  // 「阻断」动作的快照覆盖。此前**零覆盖**：上面 customRules 那条用的是 geosite=category-ads-all，
+  // 运行时目录没有该 .srs → 规则被 fail-closed 剪掉，快照里 `category-ads-all` 出现 0 次，
+  // 于是自定义规则与应用分流两个阻断发射点都没被任何快照锁住。这里改用不依赖 rule_set 文件的
+  // domainSuffix / process_name 形态，让阻断规则真的落进产物。
+  it('smart + 阻断动作（自定义规则 domainSuffix→block + 应用分流 block）→ 锁阻断规则形态', () => {
+    expect(
+      snap(
+        cfg({
+          servers: [server({})],
+          customRules: [
+            {
+              id: 'b1',
+              type: 'domainSuffix',
+              values: ['ads.example'],
+              action: 'block',
+              enabled: true,
+            },
+          ],
+          customAppPresets: [
+            {
+              id: 'custom-blocked',
+              name: 'BlockedApp',
+              emoji: '🚫',
+              geositeTags: [],
+              geoipTags: [],
+              processNames: ['blocked.exe'],
+            },
+          ],
+          appRoutingEnabled: true,
+          appRules: [{ appId: 'custom-blocked', action: 'block', enabled: true }],
         } as unknown as Partial<UserConfig>)
       )
     ).toMatchSnapshot();

--- a/src/main/services/__tests__/reject-action-migration.test.ts
+++ b/src/main/services/__tests__/reject-action-migration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * 「阻断」动作迁移门：legacy `outbound: 'block'` → sing-box 1.14 路由动作 `action: 'reject'`。
+ *
+ * 迁移动机（实测，非推断）：真内核 1.14.0-beta.14，两份最小配置只差这一处 —— 客户端侧**行为等价**
+ * （都是立即关闭、curl 502、亚毫秒），差别只在日志：legacy `block` 出站每拦一条打一行 **ERROR**
+ * `operation not permitted`，`reject` 只在 DEBUG 打 `connection closed: rejected`。故收益是
+ * 「阻断规则不再刷 ERROR 淹没真错误」+ 去掉 1.11 起 deprecated 的 legacy 出站，不是失败形态的改变。
+ *
+ * **为什么必须连 `block` 出站一起删，而不是留着不用**：留着就还有第二条能走通的路。删掉之后，若哪天
+ * 又有人发出 `outbound: 'block'`，它会成为死引用被 `ProxyManager.fixRouteDeadReferences` 改写成
+ * `proxy-selector` —— 用户想阻断的流量反被代理，且完全静默。本门把这条路正面钉死：**生成产物里不得
+ * 出现任何 `outbound: 'block'`，也不得再定义 `block` 出站**。
+ *
+ * 门的判据是「产物形态」而不是「某个函数的返回值」，故两条发射腿（自定义规则 / 应用分流）与出站装配
+ * 三处任一回退都判红。三条正向对照防负面断言空过：阻断规则确实生成了、两条腿都生成了、非阻断规则
+ * 仍带 outbound（证明 matcher 不是把所有规则都当成 reject）。
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'flowz-reject-migration-'));
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getAppPath: () => TMP, isPackaged: false },
+  net: {},
+}));
+
+import { buildRouteConfig, type RouteConfigDeps } from '../singbox-route-builder';
+import { buildOutbounds } from '../singbox-outbound-builder';
+import { getRuleSetRuntimeDir } from '../builtin-geo-rulesets';
+import type { ServerConfig, UserConfig } from '../../../shared/types';
+
+{
+  const dir = getRuleSetRuntimeDir();
+  fs.mkdirSync(dir, { recursive: true });
+  for (const f of ['geosite-cn.srs', 'geosite-geolocation-!cn.srs', 'geoip-cn.srs']) {
+    fs.writeFileSync(path.join(dir, f), Buffer.from('SRS'));
+  }
+}
+
+const NODE: ServerConfig = {
+  id: 'p1',
+  name: 'HK',
+  protocol: 'vless',
+  address: 'a.example.com',
+  port: 443,
+  uuid: 'u1',
+} as ServerConfig;
+
+/** 两条阻断腿同时在场：自定义规则（domainSuffix）+ 应用分流（process_name）。 */
+const CONFIG = {
+  proxyMode: 'smart',
+  servers: [NODE],
+  selectedServerId: 'p1',
+  customRules: [
+    { id: 'b1', type: 'domainSuffix', values: ['ads.example'], action: 'block', enabled: true },
+    { id: 'p2', type: 'domainSuffix', values: ['proxied.example'], action: 'proxy', enabled: true },
+  ],
+  appRoutingEnabled: true,
+  customAppPresets: [
+    {
+      id: 'blocked-app',
+      name: 'BlockedApp',
+      emoji: '🚫',
+      geositeTags: [],
+      geoipTags: [],
+      processNames: ['blocked.exe'],
+    },
+  ],
+  appRules: [{ appId: 'blocked-app', action: 'block', enabled: true }],
+} as unknown as UserConfig;
+
+const deps = (): RouteConfigDeps => ({
+  probeDirectPort: null,
+  probeProxyPort: null,
+  updateInPort: null,
+  lanResolverForDns: null,
+  pendingEndpoints: [],
+  log: () => {},
+  onDegraded: () => {},
+});
+
+const idMap = new Map([['p1', 'HK']]);
+const rc: any = buildRouteConfig(CONFIG, idMap, deps());
+const rules: any[] = rc.rules || [];
+
+/** 该规则是否命中给定匹配值（域名后缀 / 进程名任一）。 */
+const matches = (r: any, needle: string): boolean =>
+  (r.domain_suffix ?? []).includes(needle) || (r.process_name ?? []).includes(needle);
+
+describe('阻断动作迁移：outbound:block → action:reject', () => {
+  it('正向对照：两条阻断腿都真的生成了规则（否则下面的断言恒绿）', () => {
+    expect(rules.filter((r) => matches(r, 'ads.example'))).toHaveLength(1);
+    expect(rules.filter((r) => matches(r, 'blocked.exe'))).toHaveLength(1);
+  });
+
+  it.each([
+    ['自定义规则', 'ads.example'],
+    ['应用分流', 'blocked.exe'],
+  ])('%s 的阻断规则是 action:reject 且不带 outbound', (_leg, needle) => {
+    const r = rules.find((x) => matches(x, needle));
+    expect(r.action).toBe('reject');
+    expect(r.outbound).toBeUndefined();
+  });
+
+  it('正向对照：非阻断规则仍带 outbound（证明不是把所有规则都判成 reject）', () => {
+    const r = rules.find((x) => matches(x, 'proxied.example'));
+    expect(r.action).toBe('route');
+    expect(typeof r.outbound).toBe('string');
+  });
+
+  it('全部 route 规则中不存在 outbound:block（否则会被死引用兜底改写成 proxy-selector）', () => {
+    expect(rules.filter((r) => r.outbound === 'block')).toEqual([]);
+  });
+
+  it('outbounds 中不再定义 legacy block 出站', () => {
+    const { outbounds } = buildOutbounds(NODE, CONFIG, idMap, {
+      gateInvalidNodes: new Map(),
+      log: () => {},
+    } as any);
+    const tags = outbounds.map((o: any) => o.tag);
+    // 反平凡：装配确实产出了出站，否则「不含 block」恒成立。
+    expect(tags).toEqual(expect.arrayContaining(['direct', 'proxy-selector']));
+    expect(tags).not.toContain('block');
+    expect(outbounds.filter((o: any) => o.type === 'block')).toEqual([]);
+  });
+});

--- a/src/main/services/__tests__/singbox-check-gate.test.ts
+++ b/src/main/services/__tests__/singbox-check-gate.test.ts
@@ -278,6 +278,52 @@ describe('sing-box check 门 — 生成的全量 config', () => {
     expectCheckOk(c, 'fakeip-off-resolve-on');
   });
 
+  it('阻断动作迁移：自定义规则 + 应用分流的 reject 规则被真核接受，且产物无 legacy block 出站', () => {
+    // 迁移把「阻断」从 legacy `outbound: 'block'` 换成 sing-box 1.14 的 `action: 'reject'`，并删除了
+    // block 出站。单测只能证「生成了什么」，证不了「内核收不收」——若 1.14 对 reject 规则的字段组合
+    // 另有约束（如不允许与某些匹配器共存），或 block 出站还有别处引用，check 会 FATAL。
+    const c = svcFor().gen(
+      cfg({
+        servers: [domainNode()],
+        customRules: [
+          {
+            id: 'r-blk',
+            type: 'domainSuffix',
+            values: ['ads.example'],
+            action: 'block',
+            enabled: true,
+          },
+        ],
+        appRoutingEnabled: true,
+        customAppPresets: [
+          {
+            id: 'blocked-app',
+            name: 'BlockedApp',
+            emoji: '🚫',
+            geositeTags: [],
+            geoipTags: [],
+            processNames: ['blocked.exe'],
+          },
+        ],
+        appRules: [{ appId: 'blocked-app', action: 'block', enabled: true }],
+      } as unknown as Partial<UserConfig>)
+    );
+    // ① 验的是不是声称的对象：两条阻断腿都在，且都是 reject（缺一则 check 绿也无意义）。
+    const legs = (c.route?.rules ?? []).filter((r) => {
+      const x = r as { domain_suffix?: string[]; process_name?: string[] };
+      return (x.domain_suffix ?? []).includes('ads.example') ||
+        (x.process_name ?? []).includes('blocked.exe');
+    }) as { action?: string; outbound?: string }[];
+    expect(legs).toHaveLength(2);
+    for (const leg of legs) {
+      expect(leg.action).toBe('reject');
+      expect(leg.outbound).toBeUndefined();
+    }
+    // ② legacy 出站确已从产物消失（留着就还有第二条能走通的路）。
+    expect((c.outbounds ?? []).map((o) => o.tag)).not.toContain('block');
+    expectCheckOk(c, 'reject-action-migration');
+  });
+
   it('race off + 单上游档 dnspod（tag=dns-node）→ 结构化包裹层与档位正交，check 通过', () => {
     const c = svcFor().gen(
       cfg({

--- a/src/main/services/__tests__/singbox-custom-rules.test.ts
+++ b/src/main/services/__tests__/singbox-custom-rules.test.ts
@@ -58,7 +58,7 @@ describe('buildCustomRules — 出站映射（applyRuleAction）', () => {
     expect(rules[0].rule_set).toEqual(['geosite-youtube']);
   });
 
-  it('direct → outbound=direct；block → outbound=block', () => {
+  it('direct → outbound=direct；block → action=reject（无 outbound）', () => {
     const deps = mkDeps();
     const { rules } = buildCustomRules(
       [
@@ -74,7 +74,10 @@ describe('buildCustomRules — 出站映射（applyRuleAction）', () => {
       deps
     );
     expect(rules.find((r) => r.rule_set?.includes('geoip-cn'))?.outbound).toBe('direct');
-    expect(rules.find((r) => r.rule_set?.includes('geosite-youtube'))?.outbound).toBe('block');
+    // 阻断 = sing-box 1.14 的 `action: 'reject'`，且**不带 outbound**（reject 就地终止、不经出站）。
+    const blocked = rules.find((r) => r.rule_set?.includes('geosite-youtube'))!;
+    expect(blocked.action).toBe('reject');
+    expect(blocked.outbound).toBeUndefined();
   });
 });
 
@@ -219,7 +222,8 @@ describe('buildCustomRules — route TLS spoof（P3a 抗审查）', () => {
       false,
       deps
     );
-    expect(rules[0].outbound).toBe('block');
+    expect(rules[0].action).toBe('reject');
+    expect(rules[0].outbound).toBeUndefined();
     expect(rules[0].tls_spoof).toBeUndefined();
     expect(rules[0].tls_spoof_method).toBeUndefined();
   });
@@ -323,7 +327,8 @@ describe('buildCustomRules — 源设备 MAC / 主机名（P6 LAN 网关）', ()
     );
     expect(rules).toHaveLength(1);
     expect(rules[0].source_mac_address).toEqual(['00:11:22:33:44:55']); // bad-mac 剔除
-    expect(rules[0].outbound).toBe('block');
+    expect(rules[0].action).toBe('reject');
+    expect(rules[0].outbound).toBeUndefined();
   });
 
   it('macOS：sourceHostname → source_hostname（DHCP 名）', () => {

--- a/src/main/services/__tests__/singbox-outbounds-build.test.ts
+++ b/src/main/services/__tests__/singbox-outbounds-build.test.ts
@@ -52,14 +52,16 @@ afterEach(() =>
 );
 
 describe('buildOutbounds — 基础装配 + 载体', () => {
-  it('单节点：节点出站 + proxy-selector(default=节点) + direct + block；载体空', () => {
+  it('单节点：节点出站 + proxy-selector(default=节点) + direct（无 legacy block 出站）；载体空', () => {
     const servers = [vless('s1', '香港')];
     const r = buildOutbounds(servers[0], cfg(servers), idMap(servers), deps());
     const tags = r.outbounds.map((o) => o.tag);
     expect(tags).toContain('香港');
     expect(tags).toContain('proxy-selector');
     expect(tags).toContain('direct');
-    expect(tags).toContain('block');
+    // legacy `block` 出站已删除：阻断改由 route 的 `action: 'reject'` 表达（见 singbox-outbound-builder 原址注释）。
+    // 断言「不存在」而非删掉这行——它是防回归的：谁再把 block 出站加回来，这条即红。
+    expect(tags).not.toContain('block');
     const sel = r.outbounds.find((o) => o.tag === 'proxy-selector')!;
     expect(sel.type).toBe('selector');
     expect(sel.outbounds).toEqual(['香港', 'direct']);

--- a/src/main/services/singbox-custom-rules.ts
+++ b/src/main/services/singbox-custom-rules.ts
@@ -317,7 +317,13 @@ function applyRuleAction(
   } else if (action === 'direct') {
     singboxRule.outbound = 'direct';
   } else if (action === 'block') {
-    singboxRule.outbound = 'block';
+    // sing-box 1.14 路由动作：`reject` 就地终止，不经任何出站；与内置的 QUIC / DoH / STUN reject 同形。
+    // 取代 legacy 的 `outbound: 'block'`（1.11 起 deprecated）。行为等价已实测（真内核 1.14.0-beta.14，
+    // 同一份最小配置只差这一处：两者客户端侧都是立即关闭、502，差别仅在日志——block 出站每拦一条打一行
+    // **ERROR** `operation not permitted`，reject 只在 DEBUG 打 `connection closed: rejected`）。
+    // 故迁移买到的是「阻断规则不再刷 ERROR 日志淹没真错误」+ 去掉 legacy 依赖，不是失败形态的改变。
+    singboxRule.action = 'reject';
+    delete singboxRule.outbound;
   } else {
     singboxRule.outbound = selectedServerTag;
   }

--- a/src/main/services/singbox-outbound-builder.ts
+++ b/src/main/services/singbox-outbound-builder.ts
@@ -1035,10 +1035,16 @@ export function buildOutbounds(
     domain_resolver: getDomesticResolverTag(config, 'dns-bootstrap'),
   });
 
-  outbounds.push({
-    type: 'block',
-    tag: 'block',
-  });
+  // 【已删除：legacy `block` 出站】阻断改由 sing-box 1.14 的 `action: 'reject'` 路由动作表达
+  // （自定义规则与应用分流两处发射点均已迁移），故本出站无任何引用者：
+  //  · 三种 selector 的成员表分别是 [...nodeTags,'direct'] / [...nodeTags,'proxy-selector'] /
+  //    [...nodeTags,'direct']，都不含 block（36 份 config 快照里 `default: "block"` 与裸数组元素
+  //    `"block"` 各 0 处，实测核对）；
+  //  · 用户侧无法产出对它的引用——规则动作经结构化 Rule 生成，用户能提供的 rule-set 文件只含匹配器、
+  //    自定义协议 JSON 提供的是 outbound 定义而非路由规则。
+  // 反向风险已评估：若将来某处又发出 `outbound: 'block'` 而本出站不在，`fixRouteDeadReferences` 会把它
+  // 改写成 `proxy-selector` —— 用户想阻断的流量反被代理，且静默。故本目录的接线门断言「全仓不得再出现
+  // outbound: 'block'」，把这条路彻底关掉，而不是靠保留一个死出站兜底。
 
   // §15 主核测速探测池 selector：K 个 probe-selector-k，成员 = proxy-selector 同款全量 nodeTags + direct。
   // default=direct（sing-box 要求 default ∈ outbounds 成员，direct 恒为成员）；测速时按波 gRPC selectOutbound 把该槽

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -483,11 +483,9 @@ export function buildRouteConfig(
       'rules',
     ]);
     for (const cr of customRules) {
-      const isProxyOut =
-        cr.action === 'route' &&
-        !!cr.outbound &&
-        cr.outbound !== 'direct' &&
-        cr.outbound !== 'block';
+      // 阻断规则不必再排除：迁移到 `action: 'reject'` 后它们的 action 已不是 'route'，首个合取项即淘汰之。
+      // 保留 `!== 'block'` 会是一条**恒真的死条件**——读代码的人会误以为仍有 outbound 为 'block' 的规则存在。
+      const isProxyOut = cr.action === 'route' && !!cr.outbound && cr.outbound !== 'direct';
       if (isProxyOut && blockProxyQuic) {
         if (cr.type === 'logical') {
           // logical 规则顶层不接受 network/port（sing-box 解码会 FATAL）→ 把原 logical matcher 与 udp443
@@ -538,20 +536,25 @@ export function buildRouteConfig(
       const preset = getAppPreset(appRule.appId, config.customAppPresets);
       if (!preset) continue;
 
-      // 确定出站方式
+      // 确定动作：阻断走 sing-box 1.14 的 `reject` 路由动作（就地终止、不经出站），与自定义规则的阻断
+      // 及内置 QUIC/DoH/STUN reject 同形；其余走 `route` + 出站 tag。取代 legacy 的 `outbound: 'block'`。
+      const isBlock = appRule.action === 'block';
       let outbound = 'direct';
       if (appRule.action === 'proxy') {
         // rule-sel-app 恒存在（generateRuleSelectors 为所有 proxy appRule 生成）：outbound 恒指
         // rule-sel-app-<appId>，「默认/跟全局」= default=proxy-selector（嵌套），「指定节点」= default=节点 tag。
         // 使「节点↔默认」= rule-sel-app default 变（PUT 热切换），非 outbound 结构变（重启）。
         outbound = `rule-sel-app-${appRule.appId}`;
-      } else if (appRule.action === 'block') {
-        outbound = 'block';
       }
+      // 每条 app 规则的「动作部分」：两个发射点（process_name / rule_set）共用同一份，防一处漏改后
+      // 两种匹配形态的同一条规则动作不一致。
+      const appAction: Pick<SingBoxRouteRule, 'action' | 'outbound'> = isBlock
+        ? { action: 'reject' }
+        : { action: 'route', outbound };
 
       // 走代理的 app 分流也要配对 udp443 reject（这些是终止规则、在末尾兜底之前命中，否则 blockQuic
-      // 对该应用的 QUIC 失效）。direct/block 不配对。
-      const appOutIsProxy = outbound !== 'direct' && outbound !== 'block';
+      // 对该应用的 QUIC 失效）。direct/阻断 不配对。
+      const appOutIsProxy = !isBlock && outbound !== 'direct';
 
       // a. 基于进程名的规则（最精准，适用于 macOS/Windows TUN 模式）
       if (preset.processNames && preset.processNames.length > 0) {
@@ -561,8 +564,7 @@ export function buildRouteConfig(
         }
         rules.push({
           process_name: preset.processNames,
-          action: 'route',
-          outbound,
+          ...appAction,
         });
       }
 
@@ -581,8 +583,7 @@ export function buildRouteConfig(
         }
         rules.push({
           rule_set: ruleSets,
-          action: 'route',
-          outbound,
+          ...appAction,
         });
       }
     }


### PR DESCRIPTION
## 现状

「阻断」有两种写法并存：

| 来源 | 写法 |
|---|---|
| 自定义规则 `action=block` | `outbound: 'block'`（legacy，1.11 起 deprecated） |
| 应用分流 `action=block` | `outbound: 'block'` |
| 内置 QUIC / DoH / STUN | `action: 'reject'` |

外加一个 `{type:'block', tag:'block'}` 出站。本次统一到 `action: 'reject'` 并删除该出站。

## 行为差异：先实测再改

真内核 1.14.0-beta.14，两份最小配置**只差这一处**，同一条 curl：

| arm | 客户端观察 | 日志 |
|---|---|---|
| `outbound: "block"` | 502，0.66 ms | `INFO outbound/block[block]: blocked connection` + **`ERROR connection: … operation not permitted`** |
| `action: "reject"` | 502，0.55 ms | `DEBUG router: connection closed: rejected` |

**客户端侧行为等价。** 所以迁移买到的是两样，都不是失败形态：

1. **日志噪音** —— legacy `block` 每拦一条打一行 **ERROR**。用户只要有一条「阻断」类应用分流规则，`app.log` 就持续刷 ERROR，诊断报告里真错误被淹没。`reject` 只在 DEBUG 打一行。
2. **去 legacy 依赖** —— `block` 出站迟早会被内核移除。

## 为什么连出站一起删，而不是留着不用

留着就还有第二条能走通的路。删掉之后风险反而**收敛**：`fixRouteDeadReferences` 的兜底是

```ts
if (r.action === 'route' && r.outbound && !validTags.has(r.outbound)) r.outbound = 'proxy-selector';
```

即若将来某处又发出 `outbound: 'block'` 而出站不在，**用户想阻断的流量会被静默改成走代理**。所以靠门正面钉死「全仓不得再出现 `outbound: 'block'`」，而不是靠保留一个死出站兜底。

删除前排除了两条误判：

- **selector 不需要它** —— 三种 selector 的成员表分别是 `[...nodeTags,'direct']` / `[...nodeTags,'proxy-selector']` / `[...nodeTags,'direct']`；36 份 config 快照里 `"default": "block"` 与裸数组元素 `"block"` 各 **0 处**。UI 的「阻断」是**规则动作**（`RuleAction`），不是出口选项。
- **用户也产不出对它的引用** —— route-builder 里那批 `customRules` 是 `buildCustomRules(...)` 的**输出**（本程序自己生成的规则）；用户能提供的 rule-set 文件只含匹配器，自定义协议 JSON 提供的是出站定义而非路由规则。故无需入口归一化。

## 先补覆盖再改：两条 fixture 此前是空的

- `smart + customRules（… geosite→block）`：那条 block 规则用 `geosite=category-ads-all`，运行时无该 `.srs` → fail-closed 剪掉，快照里 `category-ads-all` 出现 **0 次**。
- `smart + appRules … → 锁 rule-sel-app`：`effectiveAppRules` 要求 `appRoutingEnabled === true`，fixture 没设 → 整块应用分流不发射，`rule-sel-app` 出现 **0 次**。**这条快照名叫「锁 rule-sel-app」，实际一直什么都没锁。**

不先补，本次迁移在快照上产生零 diff、没有回归检测。补完后 `rule-sel-app` 0 → 3，阻断规则 2 条落地。

## 门与变异

`reject-action-migration.test.ts` 判**产物形态**而非某函数返回值，三处任一回退都红：两条阻断腿必须 `action:'reject'` 且不带 `outbound`；全部 route 规则无 `outbound === 'block'`；outbounds 不再定义 `block`。配三条正向对照防负面断言空过。

变异实测（全部转红后还原）：① 自定义规则腿回退 → 红；② 应用分流腿回退 → 红；③ `block` 出站复活 → 红。

## 验证

- `tsc --noEmit` rc=0；eslint 无 error
- 全量 `jest`：242 suites / 3698 tests 绿，38 快照绿
- **真内核** `npm run test:core-gate`：新增用例「阻断动作迁移 … 被真核接受」通过（`sing-box check` rc=0）
- 全快照 `"outbound": "block"` 与 `"tag": "block"` 各 0 处
