### PR TITLE
fix(test): 重录阻断快照，去掉已随 #354 删除的 Google reject 表

### DIFF
--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -13798,25 +13798,6 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
           "outbound": "direct",
         },
         {
-          "action": "reject",
-          "domain_suffix": [
-            "gvt2.com",
-            "gvt1.com",
-            "oauthaccountmanager.googleapis.com",
-            "clientservices.googleapis.com",
-            "optimizationguide-pa.googleapis.com",
-            "mtalk.google.com",
-            "android.clients.google.com",
-            "clients1.google.com",
-            "clients2.google.com",
-            "clients3.google.com",
-            "clients4.google.com",
-            "clients5.google.com",
-            "clients6.google.com",
-            "update.googleapis.com",
-          ],
-        },
-        {
           "action": "route",
           "domain_keyword": [
             "google",


### PR DESCRIPTION
## 现象

main 当前红：`config-snapshot.test.ts` 1 failed（其余 3737 passed）。

```
● smart + 阻断动作（自定义规则 domainSuffix→block + 应用分流 block）→ 锁阻断规则形态
    - Snapshot  - 19
    + Received  +  0
    -           "action": "reject",
    -           "domain_suffix": [ "gvt2.com", "gvt1.com", … "update.googleapis.com" ],
```

## 原因

#356 的分支基于 `b476058`，即 **#354 删除 Google reject 表之前**。#356 中新增的「阻断动作」快照因此把当时仍存在的那 14 个域名一并录了进去。

#354 与 #356 各自的 PR CI 都是全绿的 —— 但两者合入 main 后，该快照记录的内容已不再由代码产出。

## 修复

重录该条快照。diff 恰为那 19 行，无其它变化（逐行核对：全部是 `gvt*` / `clients*` / `googleapis` 等域名 + 其 `action`/`domain_suffix` 包裹，零新增内容）。

## 验证

- 全量 `jest`：245 suites / 3738 tests 绿，38 快照绿
- `npm run test:core-gate`（真内核 `sing-box check`）：20 passed

## 教训

栈式 PR 若各自基于不同 base 且都会重录同一份快照，**各自 CI 绿不蕴含合并后绿** —— 基于旧 base 生成的快照会把「另一个 PR 已删除的内容」固化进来。后续应把后一个 PR 基于前一个的分支，或在合并前重录。
