### PR TITLE
docs(route): 更正「block 出站已 deprecated」这句未核实断言

### DIFF
--- a/src/main/services/__tests__/reject-action-migration.test.ts
+++ b/src/main/services/__tests__/reject-action-migration.test.ts
@@ -4,7 +4,12 @@
  * 迁移动机（实测，非推断）：真内核 1.14.0-beta.14，两份最小配置只差这一处 —— 客户端侧**行为等价**
  * （都是立即关闭、curl 502、亚毫秒），差别只在日志：legacy `block` 出站每拦一条打一行 **ERROR**
  * `operation not permitted`，`reject` 只在 DEBUG 打 `connection closed: rejected`。故收益是
- * 「阻断规则不再刷 ERROR 淹没真错误」+ 去掉 1.11 起 deprecated 的 legacy 出站，不是失败形态的改变。
+ * 「阻断规则不再刷 ERROR 淹没真错误」+ 把同一语义的两种写法收敛成一种，不是失败形态的改变。
+ *
+ * **一处曾写错的断言，如实留证**：本门初版与 PR #356 文案都写了「`block` 出站 1.11 起 deprecated、迟早移除」。
+ * 后续同核实测证伪 —— `reject`/`drop`/`blackhole` 均 `unknown outbound type`（无替代丢包出站）、
+ * `dns` 出站是硬 FATAL 且带明确 deprecation 文案，而 `block` **rc=0、加载期零告警**。内核有这套告警机制
+ * 却没对 `block` 用，故「迟早移除」是推断不是事实。迁移依据不依赖它（见上段），但别再据此推广到别处。
  *
  * **为什么必须连 `block` 出站一起删，而不是留着不用**：留着就还有第二条能走通的路。删掉之后，若哪天
  * 又有人发出 `outbound: 'block'`，它会成为死引用被 `ProxyManager.fixRouteDeadReferences` 改写成

--- a/src/main/services/singbox-custom-rules.ts
+++ b/src/main/services/singbox-custom-rules.ts
@@ -318,7 +318,7 @@ function applyRuleAction(
     singboxRule.outbound = 'direct';
   } else if (action === 'block') {
     // sing-box 1.14 路由动作：`reject` 就地终止，不经任何出站；与内置的 QUIC / DoH / STUN reject 同形。
-    // 取代 legacy 的 `outbound: 'block'`（1.11 起 deprecated）。行为等价已实测（真内核 1.14.0-beta.14，
+    // 取代 legacy 的 `outbound: 'block'`。行为等价已实测（真内核 1.14.0-beta.14，
     // 同一份最小配置只差这一处：两者客户端侧都是立即关闭、502，差别仅在日志——block 出站每拦一条打一行
     // **ERROR** `operation not permitted`，reject 只在 DEBUG 打 `connection closed: rejected`）。
     // 故迁移买到的是「阻断规则不再刷 ERROR 日志淹没真错误」+ 去掉 legacy 依赖，不是失败形态的改变。


### PR DESCRIPTION
## 问题

#356 的代码注释与 PR 文案都写了「`block` 出站 1.11 起 deprecated、迟早移除」。这句是**推断**，不是有源事实。

## 实测证伪

同一随包核 1.14.0-beta.14：

| 出站类型 | `sing-box check` |
|---|---|
| `reject` / `drop` / `blackhole` | `FATAL: unknown outbound type` —— 不存在替代的丢包出站 |
| `dns` | `FATAL: dns outbound is deprecated in sing-box 1.11.0 and …` |
| **`block`** | **rc=0，加载期零告警** |

即：内核有一整套 deprecation 报错机制，但**没对 `block` 用**。`dns` 出站已是硬 FATAL 且带明确文案，`block` 连一句提示都没有 —— 两者不在同一条淘汰轨道上。

## 处理

只改表述，不动实现 —— 迁移的真实依据是「每条阻断连接打一行 ERROR 的日志噪音」+「同一语义两种写法收敛成一种」，不依赖「即将被移除」这个前提。

同时在门的注释里如实留证，避免这条推断被当作事实推广到别处。**尤其是把「阻断」实现为「selector 的 `default` 指向 block 出站」的客户端**：那里 selector 的成员与 `default` 按 schema 只能填 outbound tag，`action` 是规则级概念填不进去，且无替代丢包出站 ⇒ 删掉 `block` 会把「切出阻断」从毫秒级热切变成整核重启（连带断掉阻断期间仍活着的 LAN/NAS/SSH 直连）。

> 顺带记一条已被排除的替代路：用 `socks` 出站指向本地关闭端口可以做到「非 legacy + 可热切 + 立即失败」（实测 `check` rc=0、502、0.87 ms），但**日志仍是每条一行 ERROR**（`connection refused`）—— sing-box 对任何出站层拨号失败都打 ERROR，只有规则级 `reject` 才是 DEBUG。所以换出站类型解决不了噪音，这条路是死的。

## 验证

`tsc --noEmit` rc=0；`reject-action-migration.test.ts` 6 passed。纯注释改动，无行为变化。
