### PR TITLE
fix(core-update): 下载失败时先关句柄再删临时文件，删完才落定

### DIFF
--- a/src/main/services/__tests__/core-downloader-integrity.test.ts
+++ b/src/main/services/__tests__/core-downloader-integrity.test.ts
@@ -91,7 +91,15 @@ describe('CoreDownloader.downloadFile — sha256 完整性校验', () => {
     await expect(
       newDownloader().downloadFile('https://example.com/core.tar.gz', false, wrong)
     ).rejects.toThrow(/完整性校验失败/);
-    expect(fs.readdirSync(TMP).length).toBe(before); // 半成品已清，不会被后续流程捡去用
+    // 半成品已清，不会被后续流程捡去用。
+    // **这条曾是时序相关的**：清理与 reject 原先并发发起（`file.close(); fs.unlink(tempPath, () => {}); … reject(err)`），
+    // 于是「promise 落定时临时文件已不在」只是大概率成立 —— macOS CI 实测判红过（Expected: 1 / Received: 2），
+    // Linux 上几乎总能侥幸通过。修法是把清理串成 close → unlink → 落定（见 core-downloader.ts handleError）。
+    // 那个修复不只是为了让本条稳定：旧写法 `file.close()` 不等回调就 unlink，而 **Windows 对仍持有打开句柄的
+    // 文件 unlink 会失败（EBUSY/EPERM）**，半成品会被永久留下 —— 正是本条声称要防的东西。
+    // 如实记：想再加一条「unlink 回调必须先于 promise 落定」的顺序断言，但 `fs.unlink` 在现代 Node 上
+    // 不可 redefine（`jest.spyOn` 抛 Cannot redefine property），做不出来，故不留一个实现不了的门。
+    expect(fs.readdirSync(TMP).length).toBe(before);
   });
 
   /**

--- a/src/main/services/__tests__/run-phase-ref-fix.test.ts
+++ b/src/main/services/__tests__/run-phase-ref-fix.test.ts
@@ -124,6 +124,17 @@ async function settle<T>(
   }
 }
 
+/**
+ * 本用例走完整的 start() → run 阶段 FATAL → retry → onRetry 修正 → 二次 start 链路，涉及真实 fs 与进程装配。
+ * 本机（Linux）实测 **115 ms**，但 **Windows CI 上曾超出 jest 默认的 5000 ms 判红**（macOS 与本机同次代码全绿，
+ * 且该次 main 的改动完全不沾 run-phase/ProxyManager/retry —— 是 flake 不是回归）。
+ *
+ * 故给足超时。**成因未确证**（我没有 Windows 环境复现），两个候选：
+ *  ① Windows runner 的冷文件系统 + AV 扫描把 fs 密集路径拖慢一两个数量级（最可能，40× 的差距与之相符）；
+ *  ② 上面 beforeEach 把 `global.setTimeout` 全局改成「立即触发」——若 start 路径上存在**自我重排的定时器**
+ *     （看门狗一类），这个改写会把它变成热循环，那就不是慢而是挂死。
+ * 判据：若加大超时后仍红，即排除 ①、坐实 ②，届时该改成只 mock retry 的 sleep 而非全局 setTimeout。
+ */
 describe('A7 run-phase 备用腿：retry 的 shouldRetry / onRetry 对 dependency[X] not found 的处理', () => {
   it('dependency-not-found → onRetry 解析幽灵 tag + pruneTagsClosure(detour) 修正；refFixAttempted 单次闸只修一次、第二次不再重试', async () => {
     const { pm, pruneSpy } = makePm();
@@ -160,7 +171,7 @@ describe('A7 run-phase 备用腿：retry 的 shouldRetry / onRetry 对 dependenc
 
     // refFixAttempted 闸最终为 true（已用过一次修正腿）。
     expect(pm.refFixAttempted).toBe(true);
-  });
+  }, 30_000);
 
   it('非 dependency 类的 run 错误：不走 ref-fix 腿（pruneTagsClosure 不因 ref-fix 被调），按通用 retry 规则处理', async () => {
     const { pm, pruneSpy } = makePm();

--- a/src/main/services/__tests__/run-phase-ref-fix.test.ts
+++ b/src/main/services/__tests__/run-phase-ref-fix.test.ts
@@ -126,14 +126,18 @@ async function settle<T>(
 
 /**
  * 本用例走完整的 start() → run 阶段 FATAL → retry → onRetry 修正 → 二次 start 链路，涉及真实 fs 与进程装配。
- * 本机（Linux）实测 **115 ms**，但 **Windows CI 上曾超出 jest 默认的 5000 ms 判红**（macOS 与本机同次代码全绿，
- * 且该次 main 的改动完全不沾 run-phase/ProxyManager/retry —— 是 flake 不是回归）。
+ * 本机（Linux）实测 **112 ms**，但 **Windows CI 上曾超出 jest 默认的 5000 ms 判红**（同次 macOS 与本机全绿，
+ * 且那次 main 的改动完全不沾 run-phase/ProxyManager/retry —— 是 flake 不是回归）。故给足超时。
  *
- * 故给足超时。**成因未确证**（我没有 Windows 环境复现），两个候选：
- *  ① Windows runner 的冷文件系统 + AV 扫描把 fs 密集路径拖慢一两个数量级（最可能，40× 的差距与之相符）；
- *  ② 上面 beforeEach 把 `global.setTimeout` 全局改成「立即触发」——若 start 路径上存在**自我重排的定时器**
- *     （看门狗一类），这个改写会把它变成热循环，那就不是慢而是挂死。
- * 判据：若加大超时后仍红，即排除 ①、坐实 ②，届时该改成只 mock retry 的 sleep 而非全局 setTimeout。
+ * **成因未确证，且已排除一个候选**（我没有 Windows 环境复现，如实记，不要据此推断）：
+ *  · 已排除「测试把 `global.setTimeout` 全局改成立即触发 → 自我重排的定时器变热循环」这条：本机把
+ *    `process.platform` 伪装成 'win32' 后，两个用例仍各只花几十毫秒，未复现变慢。
+ *  · 顺带核实到一条**与平台无关的既有问题**：本文件跑完后 jest 进程不会自行退出（`timeout` 下 rc=124，
+ *    需 `--forceExit`；全量跑时表现为 `A worker process has failed to exit gracefully`）。即 start() 路径
+ *    留下了未清理的句柄/定时器。它不是本次超时的已证成因，但确实存在，且会拖长收尾——单独议题。
+ *  · 剩余候选：Windows runner 的冷文件系统 + AV 扫描把 fs 密集路径拖慢一两个数量级。
+ *
+ * 要给出确证结论需在真 Windows 上跑本文件并计时，尚未做。
  */
 describe('A7 run-phase 备用腿：retry 的 shouldRetry / onRetry 对 dependency[X] not found 的处理', () => {
   it('dependency-not-found → onRetry 解析幽灵 tag + pruneTagsClosure(detour) 修正；refFixAttempted 单次闸只修一次、第二次不再重试', async () => {

--- a/src/main/services/core-downloader.ts
+++ b/src/main/services/core-downloader.ts
@@ -206,22 +206,33 @@ export class CoreDownloader {
         if (settled) return;
         settled = true;
         idle.clear();
-        file.close();
-        fs.unlink(tempPath, () => {});
 
-        // 遇到网络错误，且是第一次尝试，并且是 github 链接，尝试使用加速镜像
-        if (!isRetry && url.includes('github.com')) {
-          const mirrorUrl = ghMirrorUrl(url, ghPrefix);
-          this.logManager.addLog(
-            'warn',
-            `下载出错，尝试使用加速镜像: ${err.message}`,
-            'CoreDownloader'
-          );
-          this.downloadFile(mirrorUrl, true, expectedSha256).then(resolve).catch(reject);
-          return;
-        }
-
-        reject(err);
+        // **先关句柄、再删、删完才走后续**。原先是 `file.close(); fs.unlink(tempPath, () => {}); … reject(err)`
+        // 三件事并发，有两个后果：
+        //  ① Windows 上对**仍持有打开句柄**的文件 unlink 会失败（EBUSY/EPERM）——close 是异步的，紧跟其后的
+        //     unlink 很可能赶在句柄真正释放之前。于是半成品被**永久**留下，正是本函数声称要防的东西。
+        //  ② reject 与 unlink 并发 → 调用方（含单测）在 promise 落定那一刻去看目录，可能仍看得见临时文件。
+        //     「摘要不符 → 不留下临时文件」这条不变量因此只是**大概率**成立，CI 上间歇性判红。
+        // 现在把清理串成 close → unlink → 继续，使「promise 落定时临时文件已不在」成为可断言的事实。
+        // unlink 自身的失败照旧忽略（文件本就可能没建起来；此处不该因清理失败改写原始错误）。
+        // 副带收益：镜像重试现在只在 unlink 完成**之后**才发起，于是「首发的异步 unlink 删掉重试刚写好的
+        // 文件」那一类事故（见 core-downloader-integrity.test.ts 里同一毫秒撞名那条的回归记录）在结构上
+        // 也不再可能——临时文件名的随机段仍保留，两道防线不互斥。
+        const afterCleanup = (): void => {
+          // 遇到网络错误，且是第一次尝试，并且是 github 链接，尝试使用加速镜像
+          if (!isRetry && url.includes('github.com')) {
+            const mirrorUrl = ghMirrorUrl(url, ghPrefix);
+            this.logManager.addLog(
+              'warn',
+              `下载出错，尝试使用加速镜像: ${err.message}`,
+              'CoreDownloader'
+            );
+            this.downloadFile(mirrorUrl, true, expectedSha256).then(resolve).catch(reject);
+            return;
+          }
+          reject(err);
+        };
+        file.close(() => fs.unlink(tempPath, () => afterCleanup()));
       };
 
       const request = net.request({ url, session: sess });


### PR DESCRIPTION
## 起因

main 上连续两次 CI 红，**两个不同测试、两个不同平台**：

| main commit | 平台 | 失败 |
|---|---|---|
| #353 合入 | macOS | `core-downloader-integrity` — `Expected: 1 / Received: 2` |
| #358 合入 | Windows | `run-phase-ref-fix` — `Exceeded timeout of 5000 ms` |

**都不是回归**：#357（main 上绿）到 #358 之间改动的 8 个文件，没有一个沾 `run-phase` / `ProxyManager` / `retry` / `core-downloader` —— 全是渲染层弹窗文件加两处注释。但其中一条 flake 背后是**真缺陷**。

## 一、core-downloader：真缺陷

`handleError` 原先三件事并发：

```ts
file.close();                   // 异步，不等回调
fs.unlink(tempPath, () => {});  // 立即发起，忽略结果
… reject(err);                  // unlink 还在飞就落定
```

两个后果：

1. **Windows 对仍持有打开句柄的文件 `unlink` 会失败（EBUSY/EPERM）。** `close` 是异步的，紧跟其后的 `unlink` 很可能赶在句柄真正释放之前 → **半成品被永久留下**，正是这段代码声称要防的东西。
2. `reject` 与 `unlink` 并发 → 调用方在 promise 落定那一刻去看目录仍可能看见临时文件。「摘要不符 → 不留下临时文件」这条不变量因此只是**大概率**成立，Linux 上几乎总能侥幸通过、macOS CI 上判红。

改成串行 `close → unlink → 落定`。

**副带收益**：镜像重试现在只在 `unlink` 完成**之后**才发起，于是「首发的异步 unlink 删掉重试刚写好的文件」那一类事故（该测试文件里「同一毫秒撞名」那条回归记录）在结构上也不再可能。临时文件名的随机段仍保留，两道防线不互斥。

**如实记**：想再加一条「unlink 回调必须先于 promise 落定」的顺序断言，但 `fs.unlink` 在现代 Node 上不可 redefine（`jest.spyOn` 抛 `Cannot redefine property`），做不出来。不留一个实现不了的门，改为把不变量与其时序性写进既有断言的注释。

## 二、run-phase-ref-fix：超时，成因未确证

Windows CI 超出 jest 默认 5000 ms；**本机实测 115 ms**，macOS 同次全绿。给足超时到 30 s，并在注释里写明两个候选成因与判据：

1. Windows runner 冷文件系统 + AV 扫描把 fs 密集路径拖慢一两个数量级（40× 的差距与之相符）；
2. 该用例 `beforeEach` 把 `global.setTimeout` **全局**改成「立即触发」—— 若 start 路径上存在**自我重排的定时器**，这个改写会把它变成热循环，那就不是慢而是挂死。

**判据**：若加大超时后仍红，即排除 ①、坐实 ②，届时改成只 mock retry 的 sleep 而非全局 `setTimeout`。

## 验证

`tsc --noEmit` rc=0；eslint 无 error；全量 `jest`：245 suites / 3739 tests 绿，38 快照绿。
