### PR TITLE
docs(readme): 修复 Star 历史图表，改用 star-history.dera.page

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -278,4 +278,4 @@ This software is for learning and research only. Comply with your local laws and
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dododook/FlowZ&type=Date)](https://star-history.com/#dododook/FlowZ&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dododook/FlowZ&type=Date)](https://star-history.dera.page/#dododook/FlowZ&Date)

--- a/README.fa.md
+++ b/README.fa.md
@@ -278,4 +278,4 @@ MIT License
 
 ## ⭐ تاریخچهٔ Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dododook/FlowZ&type=Date)](https://star-history.com/#dododook/FlowZ&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dododook/FlowZ&type=Date)](https://star-history.dera.page/#dododook/FlowZ&Date)

--- a/README.md
+++ b/README.md
@@ -278,4 +278,4 @@ MIT License
 
 ## ⭐ Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dododook/FlowZ&type=Date)](https://star-history.com/#dododook/FlowZ&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dododook/FlowZ&type=Date)](https://star-history.dera.page/#dododook/FlowZ&Date)

--- a/README.ru.md
+++ b/README.ru.md
@@ -278,4 +278,4 @@ MIT License
 
 ## ⭐ История звёзд
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dododook/FlowZ&type=Date)](https://star-history.com/#dododook/FlowZ&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dododook/FlowZ&type=Date)](https://star-history.dera.page/#dododook/FlowZ&Date)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -278,4 +278,4 @@ MIT License
 
 ## ⭐ Star 趨勢
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dododook/FlowZ&type=Date)](https://star-history.com/#dododook/FlowZ&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dododook/FlowZ&type=Date)](https://star-history.dera.page/#dododook/FlowZ&Date)


### PR DESCRIPTION
当前 README 中的 Star 历史图表已失效，原因是 star-history.com 依赖的 GitHub stargazer API 受到限制。此改动将全部语言 README 的图表迁移到无需 token 的替代数据源 star-history.dera.page，以恢复正常展示。