### PR TITLE
perf(win-tun): Windows TUN 起核 12.1s → 5.2s（分阶段埋点 + 五处优化）

### DIFF
--- a/src/main/services/DiagnosticService.ts
+++ b/src/main/services/DiagnosticService.ts
@@ -313,6 +313,8 @@ export class DiagnosticService {
             ageSec: Math.max(0, Math.round((Date.now() - f.at) / 1000)),
           };
         })(),
+        // B0：最近一次起核的分阶段耗时。「启动慢」类报告的第一手依据——没有它只能对着总时长猜。
+        lastStartTimeline: this.proxyManager.getLastStartTimeline() ?? undefined,
       },
       redactedUserConfig,
       redactedSingboxConfig: redactedSingbox,

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -135,6 +135,7 @@ import {
   sampleProcessRssMb,
   type MemoryTimelineFrame,
 } from './process-sampler';
+import { StartTimeline } from './start-timeline';
 import {
   probeWinTunAdapterPresent,
   waitForAdapterReleased,
@@ -607,18 +608,31 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
   // issue #159：Windows TUN 重启前等自家 wintun 适配器释放的门控参数。8s 上限覆盖硬杀后驱动回收滞后，
   // 250ms 轮询；探测到消失即早退（常见 1-3s），超时 fail-open 放行交启动 retry（绝不卡死代理）。
-  private static readonly TUN_ADAPTER_RELEASE_TIMEOUT_MS = 8000;
+  // 复审实测：改造前这个门的**真实**墙钟不是 8s 而是 ~24s（预算按轮数算，而每轮的 PowerShell probe 要 ~950ms）。
+  //   `waitForAdapterReleased` 已改成单调 deadline，8000 会把门**收紧 3 倍**——而「#159 至今没复发」这个事实
+  //   恰恰建立在那 24s 之上。故常量同步提到 24000 保持行为等价：先让实现与声明对齐（纯 bug 修复），
+  //   8s 到底够不够交真机数据决定，不拿一次没有数据支撑的收紧去赌一个已知 P1。
+  private static readonly TUN_ADAPTER_RELEASE_TIMEOUT_MS = 24000;
   // 500ms 轮询：每轮 probe 一次 Get-NetAdapter（spawn powershell，冷启 ~百 ms），间隔放宽控最坏 spawn 次数（≤~16）。
   // 常见 1-3 轮即检出释放、早退。若真机证明 PS spawn 仍过重，可改单次长轮询 PS 脚本（内部 while+Start-Sleep）只付一次冷启。
   private static readonly TUN_ADAPTER_RELEASE_POLL_MS = 500;
   // wintun 适配器存在性探测（默认 Get-NetAdapter，零提权，按本名匹配）；注入式便于单测替换桩。
   private adapterProbe: (name: string) => Promise<boolean> = probeWinTunAdapterPresent;
+  // B1：**第一条**起核腿的释放门预热 promise（win32+TUN）。门本身语义不变（每腿都必须过），只是把首腿那次探测
+  //   提前到 killOrphans 之后立刻发起，与配置生成/写盘/`sing-box check` 并行跑——那些步骤本就是异步等待，白等不如并行。
+  //   一次性消费：首腿取走并置 null，重试腿一律现场重探（残留是**当下**的事实，不能吃陈旧结论）。
+  //   每次 startInternal 入口先清，杜绝上一次失败的 start 遗留的过期 promise 被下一次首腿吃掉。
+  private pendingAdapterReleaseGate: Promise<void> | null = null;
 
   // issue #159 纵深网：helper 起核后等核真就绪（管理 API 绑定）的门控。成功路径早退（API 通常 <1s 绑定）不加延迟；
   // 12s 上限仅在「进程活但 API 始终不绑」的卡死态触顶，进程死则即时捕获。
   private static readonly CORE_READY_TIMEOUT_MS = 12000;
-  // 500ms 轮询：成功路径 isReady(异步TCP) 早退、不触发 isAlive(execSync 探活阻塞)；仅失败路径每轮探活，放宽间隔控阻塞次数。
-  private static readonly CORE_READY_POLL_MS = 500;
+  // B4：就绪轮询 500→50ms。判据是本地 loopback TCP connect（近乎免费），500ms 粒度带来的是**纯空等**——
+  //   Polaris 同常量同值，其真机实测「API 口 97–221ms 就已 listen，门到 504ms 才宣布就绪」，每次固定浪费 ~300–400ms。
+  private static readonly CORE_READY_POLL_MS = 50;
+  // 探活节拍单独给，仍为 500ms：探活是子进程（Windows `tasklist`），跟着 50ms 走会把 spawn 次数放大 10 倍。
+  //   两个节拍解耦后：就绪检出快 10 倍，探活开销与改动前持平。
+  private static readonly CORE_READY_ALIVE_POLL_MS = 500;
   // 管理 API 可连探测（默认 TCP 直连）；注入式便于单测替换桩。
   private coreReadyProbe: (host: string, port: number) => Promise<boolean> = probeTcpReachable;
 
@@ -629,7 +643,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // 就绪窗/grace 内的适配器观测轮询间隔（1s）。就绪窗 ≤12s → ≤~12 次 PS spawn；见到即停观测省 spawn。真机项 #2 校准。
   private static readonly TUN_READY_OBSERVE_POLL_MS = 1000;
   // 就绪（API 绑定）后再给适配器出现的 grace 上限（8s）：适配器晚于 API bind 出现属正常时序，避免误杀 #159/#176 瞬态。真机项 #2 校准。
-  private static readonly TUN_READY_GRACE_TIMEOUT_MS = 8000;
+  //   同上（姊妹腿）：8000/1000 的真实墙钟是 ~16.6s，deadline 化后 8000 会把 #324 硬闸的判定窗口砍掉一半 →
+  //   更早判 absent-timeout → 更多「永久拒连」误报。故提到 17000 保持等价。
+  private static readonly TUN_READY_GRACE_TIMEOUT_MS = 17000;
   // issue #324 分类 tracker（start-scoped，win32+TUN 时于 startInternal 置对象、否则 null）。跨所有重试腿 sticky 累计观测：
   //   adapterEverSeen=任一腿曾见适配器（→ 瞬态释放竞态族）；probeEverConclusive=探测链路曾给出 clean present/absent
   //   （排除杀软拦 PS 的全 unknown 误判）。预算耗尽 && !adapterEverSeen && probeEverConclusive → 持续性 TUN 失败终态。
@@ -649,6 +665,11 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // 重启争用下 wintun 适配器未及时释放），与「核崩溃自动重启」（restartCount/AUTO_RESTARTING）是不同轴，纳入诊断
   // 区分「核崩」vs「争用慢起」。每次 startInternal 复位。
   private lastStartReadyRetries = 0;
+  // B0 起核阶段耗时埋点：本次 start 在飞的收集器（由 public start() 建、finally 收），非启动期恒 null。
+  //   起核路径各步在其后打标记；null 时全链路 no-op（防未经 start() 的直调路径 NPE）。
+  private startTimeline: StartTimeline | null = null;
+  // 最近一次 start 的阶段耗时汇总行（成功/失败/让位都留）。供诊断报告直接带走，不必让用户去 app.log 里翻。
+  private lastStartTimeline: string | null = null;
 
   // 自动重启相关
   private autoRestartEnabled: boolean = true;
@@ -666,6 +687,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   private static readonly RESTART_COOLDOWN = 60000; // 重启冷却时间（1分钟内最多重启3次）
   private isRestarting: boolean = false;
   private coreVersion: string = 'unknown';
+  // B5：`coreVersion` / `coreVersionLine` 所对应二进制的指纹（path|size|mtimeMs）。启动路径的 `getCoreVersion(true)`
+  //   据此判「核没换过就别重 spawn」——那是每次 start 对 45MB 内核的一次 execve，Windows 上还要过 AV 扫描。
+  //   null（stat 失败）恒不命中 → 回落每次重探，与改动前逐字相同。
+  private coreVersionFingerprint: string | null = null;
   // `sing-box version` 原始第一行（含 fork 后缀，不截 X.Y.Z）；供内核来源判定（classifyCoreBuild）。
   // 由 getCoreVersion 的同一次 spawn 顺带写入，避免「关于/内核」页二次 spawn（Windows 45MB 核加载慢）。
   private coreVersionLine: string | null = null;
@@ -712,13 +737,20 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
    */
   async start(config: UserConfig, options: { interactive?: boolean } = {}): Promise<void> {
     this.beginLifecycleOp();
+    // B0：阶段耗时收集器在此建（而非 startInternal 内）——public 包装是 start 的唯一入口，且它的 finally 是
+    //   成功/失败/让位三条出口的共同收口，收集器的生死与这次 start 严格同域。
+    const timeline = new StartTimeline();
+    this.startTimeline = timeline;
+    let outcome = 'failed';
     try {
       await this.startInternal(config, options);
+      outcome = 'ok';
     } catch (e) {
       // issue #176：本腿在就绪等待期被更新的 start/stop 接管 → 静默让位，**绝不 cleanup**（接管方已拥有/正在
       //   建立进程与系统代理状态，cleanup 会清掉它的 refs）。镜像 attemptAutoRestart「自动重启已让位」语义。
       if (e instanceof CoreStartSupersededError) {
         this.lastStartSuperseded = true; // 供 attemptAutoRestart 判别，跳过让位时的多余 started 事件
+        outcome = 'superseded';
         this.logToManager('info', '启动已让位（检测到更新的启动/停止操作接管）');
         return;
       }
@@ -729,8 +761,51 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       await this.ensureSystemProxyCleared();
       throw e;
     } finally {
+      // B0：三条出口（成功/失败/让位）共用的收口——出一行汇总并留给诊断报告。
+      //   仅当 this.startTimeline 仍是本次的对象时才清：被更新的 start 接管后该字段已属接管方，清它会让接管方
+      //   后续标记全部落空（与 lifecycleGeneration 让位守卫同一条纪律）。
+      const summary = timeline.summarize(outcome);
+      this.logToManager('info', summary);
+      // 守卫要同时管住 lastStartTimeline（诊断报告读的是它）。原先它是无条件写：让位腿若卡在**没有世代检查**的
+      //   前置腿上（释放门 24s / 地址预检 4s / waitForPidFile 60s），会在接管方之后才 settle，把接管方那条成功
+      //   汇总覆盖成自己的让位残行——而要回传给用户的恰恰是接管方那条。日志行不受此限（按时间顺序追加，两条都留）。
+      if (this.startTimeline === timeline) {
+        this.lastStartTimeline = summary;
+        this.startTimeline = null;
+      }
       this.endLifecycleOp('start');
     }
+  }
+
+  /**
+   * B0 埋点：记一个起核阶段（label 表示「从上一个标记到此刻」的耗时）。非 start() 语境下 startTimeline 为 null
+   * → no-op。**绝不影响控制流**：只做数组 push。
+   *
+   * 起核腿内的打点一律走 `markStartLeg`（带世代守卫），不要用本方法——理由见其头注。
+   */
+  private markStart(label: string): void {
+    this.startTimeline?.mark(label);
+  }
+
+  /**
+   * 腿内打点：仅当本腿仍是当前世代（未被更新的 start/stop 接管）时才记。
+   *
+   * 原先这里是一条自我豁免：「交错时旧腿的标记落进接管方 timeline，表现为同名 label 重复出现，是**可见**信号
+   * 而非静默错值」。复审推翻了它——`shouldRetryStartError` 只对 `CoreStartSupersededError` 拒绝重试，而 supersede
+   * 的检测点只有 `waitForCoreReady` / `waitForAdapterPresent` 两处；若旧腿在就绪门**之前**以可重试错误失败
+   * （如 `helper.startCore` 返回 !ok），它退避后照常进下一腿，此时接管方可能已就位 → 接管方的第一腿被标成 `L2.`，
+   * **没有任何重复 label**，那条「可见信号」在这条路上根本不存在；而且旧腿插入的格还会重置 `last` 基准，
+   * 把接管方相邻那格的数字静默改小。埋点不作判据，但给出**静默错值**与给出可见噪声是两回事。
+   */
+  private markStartLeg(startGen: number, label: string): void {
+    if (this.lifecycleGeneration !== startGen) return;
+    this.startTimeline?.mark(label);
+  }
+
+  /** 腿边界：同 markStartLeg 的世代守卫（被接管的旧腿绝不给接管方的时间轴插入新腿）。 */
+  private beginStartLeg(startGen: number): void {
+    if (this.lifecycleGeneration !== startGen) return;
+    this.startTimeline?.beginLeg();
   }
 
   private async startInternal(
@@ -741,6 +816,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // 被拒时不污染世代。updateCore/applyStagedNow 自身的 start 在 installCoreFromDir 返回后调用（coreSwapInProgress
     // 已清），不受此闸影响。
     this.rejectIfCoreSwapInProgress('启动代理');
+    // B1：清掉上一次 start 可能遗留的释放门预热（那次 start 若在首腿之前就抛错，promise 会没人消费）。
+    //   必须在本方法**入口**清、且在下方重新 arm 之前——否则首腿会吃到一个早于本次 stop/killOrphans 的陈旧结论。
+    this.pendingAdapterReleaseGate = null;
     // issue #176：本次 start 让位标记从干净态开始（被接管时 start() 包装置 true）。
     this.lastStartSuperseded = false;
     // 生命周期世代 +1：标记一次新的 start 接管（供退避中的 attemptAutoRestart 比对让位，M-2′）。
@@ -769,6 +847,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     if (this.singboxProcess || this.singboxPid) {
       await this.stop();
     }
+    this.markStart('stopOld'); // 未在跑时 ≈0，正在跑时 = 拆旧核耗时（重启路径的前半段）
 
     // 复位自动重启取消标记：必须在上面的内部 stop() 之后（stop 会置 true）——真正开始一次启动即清掉，
     // 否则 start 的内部 stop poison 该标记会让此后所有崩溃自动重启被误拦（M3 回归防护）。
@@ -815,15 +894,20 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     // macOS 提权 helper 引导门控（收敛单点，先于一切重活；abort 直接抛出、不留半启动态）。
     await this.maybePromptHelperGate(config, isTunMode, options);
+    this.markStart('helperGate'); // 含 win 的 sc query / mac 的 SMAppService 探测；弹窗等待也计在这里
 
     await this.killOrphanedSingBoxProcesses(isTunMode);
+    this.markStart('killOrphans'); // win: helper 管道 cleanup + tasklist/taskkill（execSync，阻塞 event loop）
 
     // 孤儿清理后仍占 9090 → 按端口清掉占用者（helper freePort / osascript），否则明确终态（L2，含外部/旧路径
     // sing-box）。把「裸 spawn 撞 9090 占用 → retry 风暴」收敛为一次明确、可定位的失败。
     await this.resolveClashApiPortConflict();
+    this.markStart('portConflict');
 
     // 0. 获取核心版本（用于后续生成兼容的配置文件）。force=true：内核可能已更新，启动时强制重检测刷新缓存。
     this.coreVersion = await this.getCoreVersion(true);
+    // 每次 start 恒 force=true 重 spawn 45MB 内核（Windows 上还要过一遍 AV 扫描）——这一格就是量它值不值。
+    this.markStart('coreVersion');
     this.logToManager('info', `检测到 sing-box 核心版本: ${this.coreVersion}`);
 
     // §5 核覆盖 reconcile + 最低版本守卫：内置核是种子（强制落位），决策只针对本机在用的【非内置】核。
@@ -832,6 +916,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // 配置已硬切 1.14，<1.14 核会 unknown-field FATAL，故覆盖决策后仍 <1.14 → 明确报错（含 fork 专属引导）。
     // §5 核覆盖 reconcile 抽为公共方法（供启动期 reseedBundledCoreOnStartup 复用，单一真值）：连接期发渲染端基线警告事件。
     await this.reconcileCoreWithBundledBaseline({ emitRendererEvents: true });
+    this.markStart('coreReconcile'); // 常态 ≈0；命中重播种时含拷核 + 二次 version spawn
     // 覆盖决策后仍 <1.14（仅 fork/unknown 旧核会到此；官方旧核已重播种到 ≥内置≥1.14）→ 配置 FATAL 前明确报错。
     // 此版本闸 throw 只在连接路径（startInternal）——启动期 reconcile 绝不 throw（不阻断启动），故留在此处、不进抽取方法。
     if (!coreVersionAtLeast(this.coreVersion, 1, 14)) {
@@ -845,9 +930,11 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     // 1.14 管理 API 端口：解析一个空闲本地端口（排除 clash/用户端口），避免硬编 clash+1 撞占致 services bind FATAL（A1）。
     this.tailscaleApiPort = await this.resolveTailscaleApiPort(config);
+    this.markStart('apiPort');
 
     // 修复可能被 root 创建的文件权限（从 TUN 模式切换到系统代理模式时）
     await this.fixFilePermissions();
+    this.markStart('filePerm');
 
     // 3.2 issue #324：TUN 地址冲突预检**在此发起**，与下面的节点域名预解析 / race server 启动并行跑，
     //   到生成配置前才 await。探测是 PowerShell spawn（4s 超时封顶，候选连撞时串行多次），串在起核关键
@@ -870,10 +957,25 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       throw new Error('Selected server not found');
     }
 
+    // B1（Polaris R3 点名的那条）：wintun 释放门首腿探测在此并行发起，与上面的地址预检同址同理由。
+    //   **必须在 killOrphanedSingBoxProcesses 之后**——孤儿被硬杀才是适配器开始释放的起点，早于它发起等于探一个
+    //   还没开始释放的状态。门的语义（每腿必过、fail-open、按本名匹配）一字未改，改的只是首腿的付款时机。
+    //   **也必须在 selectedServerId / selectedServer 两处早退校验之后**：arm 之后到消费点之间的任何 throw 都会
+    //   留下一条无人 await 的后台轮询（Windows 上最长 17 次 PowerShell spawn），下一次 start 只在入口丢引用、
+    //   不取消它——用户看到报错立刻重连时，这条孤儿会与新 start 自己的探测和 `sing-box check` 抢资源，
+    //   正好砸在本批要优化的那段关键路径上。放在这里可以砍掉最常见的两条早退分支。
+    if (process.platform === 'win32' && isTunMode) {
+      this.pendingAdapterReleaseGate = this.waitForOwnTunAdapterReleased(config);
+    }
+
     // 3. 准备规则文件（必须在生成配置前完成）
     await this.copyRuleSetsToUserData();
+    // 真机实测这两步合计 7.5s、占一次起核的 62%（2026-08-26 首条时间轴），而 28 个 .srs 总共只有 0.4MB
+    // 且第二次起核不重写——耗时不在文件量上。合成一格看不出是谁，故拆开。
+    this.markStart('seedRules');
     // 3.1 落盘外化自定义规则文件 + 孤儿对账清扫（必须在 generateSingBoxConfig 前——缺文件 sing-box 启动 FATAL）
     await this.writeCustomRuleFiles(config);
+    this.markStart('customRules');
 
     // 3.5. 预解析所有节点的域名为 IP（仅针对 TUN 模式），防止 Windows 下回流死循环
     // 【待真机验证 / CDN 风险】：对"域名节点"预解析得到的 IP 会进 route_exclude_address，若节点在
@@ -910,9 +1012,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       });
       await Promise.all(resolvePromises);
     }
+    // 仅 win32+TUN 非零：全节点域名并行 dns.lookup。系统 DNS 此刻可能仍是上一会话 TUN 拆完的残态，慢在意料内 → 必须量。
+    this.markStart('winDnsPreresolve');
 
     // 3.6. 为出口 IP 探针分配端口（失败不阻断启动，仅探针不可用）
     await this.allocateProbePorts(config);
+    this.markStart('probePorts');
 
     // 3.7. 复位启动前配置校验 gate 状态（必须在 generateSingBoxConfig→generateOutbounds 消费 gateInvalidNodes
     //      之前）：每次 start 重新判定坏节点，换核 / 修好配置后自动复活，不跨会话残留。
@@ -940,25 +1045,32 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         );
       }
     }
+    this.markStart('lanResolver'); // 含 3.7.1 的 tailscale state 属主归一（同步 fs）+ scutil/netsh 读解析器
 
     // 3.9 issue #147：节点 outbound.server 恒用域名（buildProxyOutbound）→ 内核 resolveDialer 运行时解析多 A →
     //     DialSerial 逐 IP 重试（取代旧 resolve-ahead 烧单 IP，那会关闭内核多 IP 容错，见设计 §1.1）。多上游 race
     //     的本地 server 起停 + effective config 降级见下（startNodeDnsRaceServer）。
     await this.startNodeDnsRaceServer(config);
+    this.markStart('dnsRace');
 
     // 3.9.5 issue #324：收 3.2 发起的地址冲突预检结果（此刻必须落定：地址要随本次配置下发给核）。
+    // 这一格量的是**并行是否真的把它藏住了**：预检 3.2 就发起，若这里仍为正数，说明前面的准备步骤不够长
+    // （或候选连撞导致多次 PowerShell 串行），并行化的收益名存实亡。
     await this.applyTunAddressPreflight(tunAddressPick);
+    this.markStart('tunAddrPreflightWait');
 
     // 4. 生成 sing-box 配置文件
     const singboxConfig = this.generateSingBoxConfig(config, resolvedServerIps);
 
     // 写入配置文件
     await this.writeSingBoxConfig(singboxConfig);
+    this.markStart('configGen'); // 生成 + 写盘
     this.logToManager('info', 'sing-box 配置文件已生成');
 
     // 4.5 启动前配置校验 gate：剔除会致整体启动 FATAL 的坏节点后重写盘（插在写盘后、retry 前 →
     //     gate 抛错由 start() catch 收口，不进 retry；选中节点被剔/全部剔光/降级 → throw 不启动）。
     await this.checkAndPruneConfig(singboxConfig, config);
+    this.markStart('configCheck'); // `sing-box check`：本次 start 对 45MB 内核的第 2 次 spawn
 
     // TUN 模式下，删除旧的 PID 文件，确保不会读到旧的 PID
     if (this.needsOsascript() || this.needsWindowsUAC()) {
@@ -969,6 +1081,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     //     （缺失/0 字节/截断/版本错位 → 从内置重拷）。覆盖 Windows 常规启动不补的盲区（Linux 既有 ensureWritableCore
     //     内的 beside 保留，此处对其幂等）；mac 静态编入 cronet，ensureCronetReadyForLaunch 内部跳过。热路径仅 stat。
     await this.ensureCronetReadyForLaunch();
+    this.markStart('cronetCheck'); // 含上面的 deletePidFile；热路径应仅 stat
 
     // issue #176 L1.2：快照本次起核世代——就绪/重试腿据此判 supersede 让位。捕获点在本方法上方内部 stop()
     //   （它会 lifecycleGeneration++）之后，故此值即本次 start 的稳定基线；之后任一外部 start/stop 接管即令其变化。
@@ -1066,6 +1179,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // macOS 停核断网安全网：与上面同属「起核前快照」——记录系统全局默认路由网关，供停核后检测被 sing-tun
     // setRoutes EEXIST 善后误删的 default 并补回（system WG 全隧道场景）。必须在 sing-box 起核前跑。非 macOS no-op。
     await this.captureDefaultRoute();
+    this.markStart('routeSnapshot'); // 非 macOS 恒 ≈0（两个 no-op）
 
     // T2 libcronet 启动失败冷路径闭环：起核失败且命中 cronet 缺库 FATAL（linux/win）→ strong（hash 强校验）
     // 重拷 → 若 restored 则整体重启内核一次（一次性 cronetHealAttempted 闸，防抖动循环）→ 仍失败/未恢复 →
@@ -1108,6 +1222,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
     // issue #176 诊断：起核成功（含经数次就绪重试）。落 lastStartReadyRetries，>0 时记一行——便于把「争用下起得慢
     //   但已自愈」与「核崩溃自动重启」（restartCount/AUTO_RESTARTING 另一轴）在诊断里区分开。
+    // 起核收口：从最后一条腿的末个标记到此刻——含 startViaHelper 尾部（写 PID 文件 / 起 log watcher / 起健康
+    // 检查 / 发 started 事件），以及 cronet 自愈冷路径若触发的整轮重起。
+    this.markStart('startTail');
+
     this.lastStartReadyRetries = readyRetries;
     if (readyRetries > 0) {
       this.logToManager('info', `sing-box 经 ${readyRetries} 次就绪重试后启动成功`);
@@ -1155,6 +1273,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       }
     }
 
+    this.markStart('systemProxySync'); // systemProxy 模式=置代理（mac 上的 networksetup 风暴在这一格）；TUN=反向清
+
     // 系统 DNS 接管收口（治本 DNS，与系统代理 reconcile 正交）：仅 TUN 模式接管——on-link 的 LAN/ISP DNS 不进
     // TUN → hijack-dns 看不到 → 需代理的域名被系统解析器解析成真实/错族 IP。故 TUN 启动把系统 DNS 改为受控、
     // 可路由、不在 bootstrap-direct 的 8.8.8.8，使其经 TUN 被 hijack（真进 sing-box → FakeIP/远程解析）。
@@ -1173,6 +1293,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
         `系统 DNS 接管状态同步失败: ${e instanceof Error ? e.message : String(e)}`
       );
     }
+
+    this.markStart('dnsTakeover'); // Windows 不接管系统 DNS（见 SystemDnsManager）→ 该平台应恒 ≈0
 
     // 核已成功起动、DNS 接管状态已收口 → best-effort 刷 OS DNS 缓存（fire-and-forget，不阻塞启动；让位
     // CoreStartSupersededError 与失败路径在更早处已抛、到不了这里）。清掉接管边界前系统解析器缓存的陈旧记录
@@ -3010,6 +3132,21 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     if (!force && this.coreVersion && this.coreVersion !== 'unknown') {
       return this.coreVersion;
     }
+    // B5：force 的本意是「内核可能已换，别信旧缓存」——那就直接问二进制换没换，而不是无条件重 spawn。
+    //   指纹（path|size|mtimeMs）一致 ⟹ 同一个文件 ⟹ 版本不可能变；换核（CoreUpdateService 写盘 / 重播种 /
+    //   路径改指）三者都必然改变指纹 → 未命中 → 照常重探。指纹取不到（stat 失败）→ 不命中，行为同改动前。
+    //   注意：`getCoreVersionLine(true)` **有意不吃这条缓存**——它是换核后「诚实重读活二进制」的验证腿（issue #150），
+    //   缓存会把「重读失败」伪装成「换核成功」。两者语义不同，勿合并。
+    const fingerprint = this.coreBinaryFingerprint();
+    if (
+      force &&
+      fingerprint !== null &&
+      fingerprint === this.coreVersionFingerprint &&
+      this.coreVersion &&
+      this.coreVersion !== 'unknown'
+    ) {
+      return this.coreVersion;
+    }
     try {
       // 版本号恒在第一行（`sing-box version X.Y.Z ...`）；用第一行解析既复用 coreVersionLine 的同一次 spawn，
       // 又避免在全量 stdout 上误匹配后续行（如 Environment 的 `go1.25.10` 含 `1.25.10`）。
@@ -3025,6 +3162,8 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
           ? secondMatch[1]
           : coreManifest.bundledCoreVersion;
       this.coreVersion = detected; // 写缓存：供后续查询命中 + config 生成 coreVersionAtLeast 复用
+      // B5：指纹只在**探测成功后**写——失败路径不写，下次仍会重探（与既有「不写 unknown 缓存」同一取向）。
+      this.coreVersionFingerprint = fingerprint;
       return detected;
     } catch (error) {
       this.logToManager('error', `获取核心版本失败: ${(error as any).message}`);
@@ -3044,6 +3183,21 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       .then(() => this.doSpawnCoreVersionFirstLine());
     this.versionProbeChain = run.catch(() => undefined);
     return run;
+  }
+
+  /**
+   * B5：现役核二进制指纹 `path|size|mtimeMs`。用于判「核换没换」——比再 spawn 一次 45MB 二进制便宜四个数量级。
+   * 不用内容 hash：45MB 全量读盘本身就比一次 version spawn 贵，而 size+mtime 已能覆盖全部真实换核路径
+   * （CoreUpdateService 写盘 / 随包重播种 / 路径改指），代价是理论上「同长度且强制保留 mtime 的原地改写」测不出——
+   * FlowZ 没有这样的写侧。stat 失败返 null（调用方按未命中处理）。
+   */
+  private coreBinaryFingerprint(): string | null {
+    try {
+      const st = require('fs').statSync(this.singboxPath);
+      return `${this.singboxPath}|${st.size}|${st.mtimeMs}`;
+    } catch {
+      return null;
+    }
   }
 
   /** 实际 spawn `sing-box version`（不含串行排队）；仅供 spawnCoreVersionFirstLine 经 versionProbeChain 调用。 */
@@ -4482,6 +4636,7 @@ rm -f "$STOPFLAG"
     );
 
     const res = await helper.startCore(this.configPath, startupLogFile, forward);
+    this.markStartLeg(startGen, 'spawn'); // 管道 RPC 往返 + helper 侧 CreateProcess 返回，**不含**核自身初始化
     if (!res.ok || !res.pid) {
       throw new Error(res.error || 'helper 启动 sing-box 失败');
     }
@@ -4552,16 +4707,29 @@ rm -f "$STOPFLAG"
       : Promise.resolve();
 
     const outcome = await waitForCoreReady(
-      { timeoutMs: ProxyManager.CORE_READY_TIMEOUT_MS, pollMs: ProxyManager.CORE_READY_POLL_MS },
       {
-        isAlive: () => this.isProcessAlive(pid),
+        timeoutMs: ProxyManager.CORE_READY_TIMEOUT_MS,
+        pollMs: ProxyManager.CORE_READY_POLL_MS,
+        alivePollMs: ProxyManager.CORE_READY_ALIVE_POLL_MS,
+      },
+      {
+        // B4：换异步探活——同步版是 execSync，起核窗内每轮阻塞主进程 50–100ms（拖拽/动画可感）。
+        //   判定逻辑与 isProcessAlive 严格一致（见其头注），仅是不再堵 event loop。
+        isAlive: () => this.isProcessAliveAsync(pid),
         isReady: () => this.coreReadyProbe('127.0.0.1', port),
         sleep,
         isSuperseded: () => this.lifecycleGeneration !== startGen,
       }
     ).catch(() => 'timeout' as const);
+    // B0 复审 High：这一格必须在 drain **之前**打。observerDone 要等在途的适配器 probe 回来（PowerShell，
+    //   execFile 4s 封顶）或在途 sleep(1s) 走完——放在 drain 之后，格值恒被摊上 ~1s，与 B4 要省的 300–400ms
+    //   同量级，等于这颗埋点度量不出它被加进来要回答的那个问题（复审推演：两条路径都落在 ~1s）。
+    //   让位腿不打点的不变量靠 `measured` 保住（原先靠「放在 superseded 出口之后」，现在出口在下面）。
+    const measured = outcome !== 'superseded';
+    if (measured) this.markStartLeg(startGen, `coreReady:${outcome}`);
     observing = false; // 停就绪窗观测，等其 drain（在途 sleep 至多 1s；若卡在在途 probe，Get-NetAdapter 的 execFile timeout 4s 封顶）
     await observerDone.catch(() => {});
+    if (measured) this.markStartLeg(startGen, 'observerDrain'); // drain 本身单独一格：它是真实成本，只是不该混进就绪耗时
 
     // issue #176：被接管 → 静默让位，绝不 stopCore（接管方拥有拆核权，避免抢放适配器）。由 start() 包装吞掉。优先于一切。
     if (outcome === 'superseded') {
@@ -4591,6 +4759,8 @@ rm -f "$STOPFLAG"
       if (res.outcome === 'superseded') {
         throw new CoreStartSupersededError();
       }
+      // 同上，放在 superseded 出口之后。三态都记：present 是「多付一次 PS 探测」的成本，absent-timeout 是硬闸耗时。
+      this.markStartLeg(startGen, `tunAdapter:${res.outcome}`);
       if (res.outcome === 'present') {
         recordPresence('present');
         return;
@@ -4920,6 +5090,9 @@ rm -f "$STOPFLAG"
   }
 
   private async startSingBoxProcess(startGen: number): Promise<void> {
+    // B0：进入一条起核腿。产出的 `L<n>.begin` 格 = 上一个标记到本腿开始之间的耗时（第 1 腿≈0，第 2 腿起 = retry 退避）。
+    //   放在方法最顶端 → helper / UAC / osascript 三条支路与每次重试腿都被同一条时间轴覆盖。
+    this.beginStartLeg(startGen);
     // 复位 helper 启动标志：本次启动尚未确定走 helper 还是直起，由实际启动路径置位（startViaHelper 成功置 true，
     //   直起 UAC/osascript 路径保持 false）。修复 issue #159 就绪门控失败、重试腿回退直起时 startedViaHelper 残留 true
     //   → 后续 stop() 误走 helper 停核分支（停不动→回退提权 taskkill/osascript，降级但自愈）。每次启动腿都从干净态判定。
@@ -4943,7 +5116,13 @@ rm -f "$STOPFLAG"
     //   runStartWithRetry 重启腿、以及下方 helper / UAC 两条启动支路都经此门控（不止首次），杜绝重试立刻再撞僵尸适配器。
     const launchCfg = this.currentConfig;
     if (launchCfg && process.platform === 'win32' && launchCfg.proxyModeType === 'tun') {
-      await this.waitForOwnTunAdapterReleased(launchCfg);
+      // B1：首腿吃 startInternal 并行预热的那次探测（多半已跑完 → 这一格 ≈0）；重试腿 pending 为 null → 现场重探
+      //   （残留是当下的事实，重试腿绝不能吃首腿的陈旧结论）。取走即置 null，保证「一次性」。
+      const pending = this.pendingAdapterReleaseGate;
+      this.pendingAdapterReleaseGate = null;
+      await (pending ?? this.waitForOwnTunAdapterReleased(launchCfg));
+      // 首腿 ≈0 说明并行真藏住了；重试腿这一格才是一次 Get-NetAdapter 的净开销（有残留则最坏 8s）。
+      this.markStartLeg(startGen, 'adapterRelease');
     }
 
     // macOS TUN 模式 + helper 就绪 → 走零提权路径（避免每次启停弹 osascript 授权框）。
@@ -6089,11 +6268,15 @@ rm -f "$STOPFLAG"
   private async isProcessAliveAsync(pid: number): Promise<boolean> {
     try {
       if (process.platform === 'win32') {
-        const { stdout } = await healthProbeExecFile(system32('tasklist.exe'), [
-          '/FI',
-          `PID eq ${pid}`,
-          '/NH',
-        ]);
+        // `windowsHide` 与 `timeout` 缺一不可（复审实测：Node 的 execFile 是 `windowsHide: !!options.windowsHide`
+        //   → 缺省 **false**；仓内另 9 处 Windows exec 全部显式传 true）。同步孪生 isProcessAlive 一直带着它，
+        //   本方法漏了——B4 把 Windows 起核路径接到这条腿上之后，射程从「10s 一次健康检查」扩大到「起核期每 500ms」，
+        //   一个原本低频的缺陷变成了正对着本批优化目标的高频闪窗 + 无上限阻塞。
+        const { stdout } = await healthProbeExecFile(
+          system32('tasklist.exe'),
+          ['/FI', `PID eq ${pid}`, '/NH'],
+          { windowsHide: true, timeout: 3000 }
+        );
         const result = String(stdout);
         return !result.includes('No tasks') && result.includes(String(pid));
       } else {
@@ -8023,6 +8206,14 @@ rm -f "$STOPFLAG"
    */
   getLastStartReadyRetries(): number {
     return this.lastStartReadyRetries;
+  }
+
+  /**
+   * B0：最近一次 start 的阶段耗时汇总行（成功/失败/让位都留；从未启动过 → null）。进诊断报告，使「启动慢」
+   * 类报告自带分阶段分布，不必让用户回 app.log 里翻那一行。
+   */
+  getLastStartTimeline(): string | null {
+    return this.lastStartTimeline;
   }
 
   /**

--- a/src/main/services/__tests__/core-readiness.test.ts
+++ b/src/main/services/__tests__/core-readiness.test.ts
@@ -171,3 +171,170 @@ describe('probeTcpReachable', () => {
     expect(await probeTcpReachable('127.0.0.1', port, 500)).toBe(false);
   });
 });
+
+/**
+ * B4：就绪节拍与探活节拍解耦。把 pollMs 调细（500→50）是为了少空等，但探活是子进程
+ * （Windows `tasklist` ~50-100ms），若跟着细节拍走就是拿一个开销换一个更大的开销。
+ */
+describe('waitForCoreReady — alivePollMs 双节拍（B4）', () => {
+  /** 第 n 次调用才 ready 的桩（n 从 1 计）。 */
+  function readyAt(n: number): { isReady: () => Promise<boolean>; calls: () => number } {
+    let c = 0;
+    return {
+      isReady: async () => ++c >= n,
+      calls: () => c,
+    };
+  }
+
+  it('缺省 alivePollMs = pollMs → 每轮探活（改动前行为逐字保持）', async () => {
+    let aliveCalls = 0;
+    const ready = readyAt(4);
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 500 },
+      {
+        isAlive: () => {
+          aliveCalls++;
+          return true;
+        },
+        isReady: ready.isReady,
+        sleep: noSleep,
+      }
+    );
+    expect(r).toBe('ready');
+    // 前 3 轮 isReady 假 → 各探活一次；第 4 轮 ready 早退（不探活）
+    expect(aliveCalls).toBe(3);
+  });
+
+  it('alivePollMs=500 / pollMs=50 → 每 10 轮探一次活，且首轮必探（瞬死检出不变差）', async () => {
+    let aliveCalls = 0;
+    const ready = readyAt(21); // 前 20 轮不 ready
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 50, alivePollMs: 500 },
+      {
+        isAlive: () => {
+          aliveCalls++;
+          return true;
+        },
+        isReady: ready.isReady,
+        sleep: noSleep,
+      }
+    );
+    expect(r).toBe('ready');
+    // i=0 与 i=10 两轮探活（i=20 那轮 isReady 已真、早退）——而非 20 次
+    expect(aliveCalls).toBe(2);
+  });
+
+  it('细节拍让就绪检出更快：ready 出现在第 3 轮 → 只 sleep 2 次', async () => {
+    let sleeps = 0;
+    const ready = readyAt(3);
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 50, alivePollMs: 500 },
+      {
+        isAlive: () => true,
+        isReady: ready.isReady,
+        sleep: async () => {
+          sleeps++;
+        },
+      }
+    );
+    expect(r).toBe('ready');
+    expect(sleeps).toBe(2);
+  });
+
+  it('异步 isAlive 被 await：循环内首轮即判 dead，不是耗尽预算后靠末轮兜底', async () => {
+    // 只断言 outcome='dead' 挡不住「忘了 await」——Promise 恒真值 → 循环里永不 dead，但**末轮**那次判定
+    // 仍是 await 的，最终照样返回 dead。故判据必须是「多快判出来」：真 await 时首轮即退，一次 sleep 都没有。
+    let sleeps = 0;
+    const r = await waitForCoreReady(
+      { timeoutMs: 1000, pollMs: 50, alivePollMs: 500 },
+      {
+        isAlive: async () => false,
+        isReady: async () => false,
+        sleep: async () => {
+          sleeps++;
+        },
+      }
+    );
+    expect(r).toBe('dead');
+    expect(sleeps).toBe(0);
+  });
+
+  it('alivePollMs 小于 pollMs 时被夹到 pollMs（不产生「每轮探多次」的荒谬节拍）', async () => {
+    let aliveCalls = 0;
+    const ready = readyAt(3);
+    await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 500, alivePollMs: 10 },
+      {
+        isAlive: () => {
+          aliveCalls++;
+          return true;
+        },
+        isReady: ready.isReady,
+        sleep: noSleep,
+      }
+    );
+    expect(aliveCalls).toBe(2);
+  });
+});
+
+/**
+ * B4 复审 Med：`maxPolls` 只是轮数封顶，`timeoutMs` 必须是**时间**预算。原有 5 条用例全部注入 no-op sleep、
+ * 断言的是轮数与调用次数，破坏墙钟这一维（如把 maxPolls 乘 10）是 0 红。此处用计账式时钟把预算本身立成判据。
+ */
+describe('waitForCoreReady — timeoutMs 是时间预算而非轮数（B4）', () => {
+  /** 计账式时钟：sleep 与探测各自把耗时累加进虚拟时间，`now` 读它。 */
+  function accountant(opts: { probeMs: number }) {
+    let t = 0;
+    return {
+      now: (): number => t,
+      sleep: async (ms: number): Promise<void> => {
+        t += ms;
+      },
+      isReady: async (): Promise<boolean> => {
+        t += opts.probeMs; // 模拟 probeTcpReachable 的真实成本（自带 1000ms 上限）
+        return false;
+      },
+      elapsed: (): number => t,
+    };
+  }
+
+  it('每轮探测远超 pollMs 时，仍在 timeoutMs 附近收口（不按轮数超支）', async () => {
+    // 复审实测的病态场景：connect 打满 1000ms、pollMs=50 → 按轮数会跑到 ~255s
+    const acc = accountant({ probeMs: 1000 });
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 50, alivePollMs: 500 },
+      { isAlive: () => true, isReady: acc.isReady, sleep: acc.sleep, now: acc.now }
+    );
+    expect(r).toBe('timeout');
+    // 变异守卫：去掉 `now() < deadline` 判据 → elapsed 会跑到 ~250s → 红
+    expect(acc.elapsed()).toBeLessThanOrEqual(12000 * 1.2);
+  });
+
+  it('探测很便宜时预算同样成立（不因 deadline 改造而提前收口）', async () => {
+    const acc = accountant({ probeMs: 1 });
+    const r = await waitForCoreReady(
+      { timeoutMs: 12000, pollMs: 50, alivePollMs: 500 },
+      { isAlive: () => true, isReady: acc.isReady, sleep: acc.sleep, now: acc.now }
+    );
+    expect(r).toBe('timeout');
+    expect(acc.elapsed()).toBeGreaterThan(12000 * 0.8);
+    expect(acc.elapsed()).toBeLessThanOrEqual(12000 * 1.2);
+  });
+
+  it('不注入 now 时退化为轮数封顶（既有注入式用例行为不变）', async () => {
+    let polls = 0;
+    const r = await waitForCoreReady(
+      { timeoutMs: 1000, pollMs: 250 },
+      {
+        isAlive: () => true,
+        isReady: async () => {
+          polls++;
+          return false;
+        },
+        sleep: noSleep,
+      }
+    );
+    expect(r).toBe('timeout');
+    expect(polls).toBe(5); // 4 轮 + 末轮补探
+  });
+});

--- a/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
+++ b/src/main/services/__tests__/diagnostic-service-log-sources.test.ts
@@ -38,6 +38,9 @@ afterAll(() => {
   }
 });
 
+/** B0 汇总行样本：既做桩返回值，也做报告文本断言的靶。 */
+const TIMELINE_LINE = '起核阶段耗时 total=1234ms outcome=ok | killOrphans=181 startTail=44';
+
 function makeSvc(opts: { startedViaHelper?: boolean; lastDnsFlush?: unknown } = {}): any {
   const configManager: any = { loadConfig: jest.fn().mockResolvedValue({ logLevel: 'info' }) };
   const logManager: any = { flush: jest.fn().mockResolvedValue(undefined) };
@@ -50,6 +53,9 @@ function makeSvc(opts: { startedViaHelper?: boolean; lastDnsFlush?: unknown } = 
     getLastStartReadyRetries: jest.fn().mockReturnValue(0),
     // issue #367：诊断报告读取最近一次 DNS 缓存刷新结果；null=本会话从未触发（多数用例不覆盖该段内容）。
     getLastDnsFlush: jest.fn().mockReturnValue(opts.lastDnsFlush ?? null),
+    // 返回真串而非 null：桩返 null 时渲染分支恒不进入 ⇒ 这个桩**结构上不可能有检出力**，
+    // 删掉 DiagnosticService 里那行接线也照样绿（复审 M10b 实测）。下方 describe 用它钉住接线。
+    getLastStartTimeline: jest.fn().mockReturnValue(TIMELINE_LINE),
   };
   const systemProxyManager: any = { getProxyStatus: jest.fn().mockResolvedValue(null) };
   return new DiagnosticService(configManager, logManager, proxyManager, systemProxyManager) as any;
@@ -182,5 +188,31 @@ describe('DiagnosticService — lastDnsFlush 字段接线', () => {
       return (await svc.buildReport()) as string;
     });
     expect(skippedMd).toContain('已跳过');
+  });
+});
+
+/**
+ * B0 接线：`getLastStartTimeline()` 的返回值必须真的进报告。这条链路的另一半（渲染）由
+ * `src/shared/__tests__/diagnostic-redact.test.ts` 守；此处守 service → 报告这一跳。
+ */
+describe('DiagnosticService — 起核阶段耗时汇总行接线（B0）', () => {
+  it('汇总行出现在报告里', async () => {
+    const md = await withPlatformAsync('linux', async () => {
+      const svc = makeSvc();
+      jest.spyOn(svc, 'readTail').mockResolvedValue('x');
+      return (await svc.buildReport()) as string;
+    });
+    // 变异守卫：删掉 DiagnosticService 里 `lastStartTimeline: …` 那行 → 红
+    expect(md).toContain(TIMELINE_LINE);
+  });
+
+  it('从未启动过（返回 null）→ 报告不出现该段，也不出现占位符', async () => {
+    const md = await withPlatformAsync('linux', async () => {
+      const svc = makeSvc();
+      svc.proxyManager.getLastStartTimeline = jest.fn().mockReturnValue(null);
+      jest.spyOn(svc, 'readTail').mockResolvedValue('x');
+      return (await svc.buildReport()) as string;
+    });
+    expect(md).not.toContain('起核阶段耗时');
   });
 });

--- a/src/main/services/__tests__/proxy-manager-adapter-release-gate.test.ts
+++ b/src/main/services/__tests__/proxy-manager-adapter-release-gate.test.ts
@@ -1,0 +1,215 @@
+/**
+ * B1：wintun 释放门「首腿并行预热 + 每腿必过」的接线单测。
+ *
+ * 门的语义一字未改（issue #159：**每一次** start 尝试、含 retry 每轮都必须按本名探测过才放行；fail-open）。
+ * 本批只改首腿的**付款时机**——把那次 ~950ms 的 PowerShell 提前到 killOrphans 之后与配置生成并行跑。
+ * 会被误改坏的正是这两条，故逐条钉住：
+ *  1. 首腿吃预热结果，且**取走即置 null**（一次性）；
+ *  2. 重试腿 pending 已空 → **现场重探**（绝不吃首腿的陈旧结论——残留是「当下」的事实）。
+ *
+ * 私有方法/字段经 `(svc as any)` 直调注入，不启动 sing-box。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-b1gate-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import { withPlatformAsync } from './platform-test-utils';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+/**
+ * 构造一个「走到释放门就收工」的实例：helper 就绪 + startViaHelper 桩化，使 startSingBoxProcess 在门之后
+ * 立刻返回，不触碰进程/网卡/PowerShell。
+ */
+function makeSvc(mode: 'tun' | 'systemProxy' = 'tun'): any {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  const svc: any = new ProxyManager(undefined, undefined, configPath, '/fake/sing-box');
+  svc.currentConfig = { proxyModeType: mode, servers: [], selectedServerId: 'x', tunConfig: {} };
+  svc.helperManager = { isReady: jest.fn().mockResolvedValue(true) };
+  svc.startViaHelper = jest.fn().mockResolvedValue(undefined);
+  svc.waitForOwnTunAdapterReleased = jest.fn().mockResolvedValue(undefined);
+  return svc;
+}
+
+describe('B1 — 释放门首腿预热的一次性消费', () => {
+  it('首腿必须 await 预热腿：预热未兑现前不得起核', async () => {
+    await withPlatformAsync('win32', async () => {
+      const svc = makeSvc();
+      // 判据必须立在**顺序**上，不能立在终值上。曾写成 `let warmed=false; pending=Promise.resolve().then(()=>warmed=true)`
+      // 再断言 `warmed===true`——那是无牙的：`.then` 的回调在微任务里自行执行，与本腿有没有 await 它毫无关系，
+      // 且门之后还有 `await helperManager.isReady()` 让出一次微任务，故把整条门删掉该断言照样绿（A 面复审实测）。
+      let release!: () => void;
+      const gate = new Promise<void>((r) => (release = r));
+      svc.pendingAdapterReleaseGate = gate;
+
+      const p = svc.startSingBoxProcess(svc.lifecycleGeneration ?? 0);
+      await Promise.resolve(); // 让出几轮微任务：若门被删，起核此刻就已发生
+      await Promise.resolve();
+      expect(svc.startViaHelper).not.toHaveBeenCalled(); // ← 真正的判据：门未放行前不得起核
+
+      release();
+      await p;
+
+      expect(svc.startViaHelper).toHaveBeenCalled(); // 门放行后才起核
+      expect(svc.waitForOwnTunAdapterReleased).not.toHaveBeenCalled(); // 首腿零重探
+      expect(svc.pendingAdapterReleaseGate).toBeNull(); // 一次性
+    });
+  });
+
+  it('重试腿（pending 已空）现场重探——绝不复用首腿结论', async () => {
+    await withPlatformAsync('win32', async () => {
+      const svc = makeSvc();
+      svc.pendingAdapterReleaseGate = Promise.resolve();
+
+      await svc.startSingBoxProcess(0); // 首腿：吃预热
+      await svc.startSingBoxProcess(0); // 重试腿：应现场重探
+      await svc.startSingBoxProcess(0); // 再一腿：仍重探
+
+      expect(svc.waitForOwnTunAdapterReleased).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('无预热（pending 本就为 null）→ 首腿也现场重探，行为等同改动前', async () => {
+    await withPlatformAsync('win32', async () => {
+      const svc = makeSvc();
+      expect(svc.pendingAdapterReleaseGate).toBeNull();
+
+      await svc.startSingBoxProcess(0);
+
+      expect(svc.waitForOwnTunAdapterReleased).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // 非 TUN / 非 Windows 走不到 helper 支路，会一路落到直起分支；核路径是假的 → 以「找不到可执行文件」收尾。
+  // 那正是本用例要的：证明**门没跑**，而不是证明起核成功。
+  it('非 TUN 模式：门整条不跑，预热字段不被消费', async () => {
+    await withPlatformAsync('win32', async () => {
+      const svc = makeSvc('systemProxy');
+      svc.ensureLinuxTunCapabilities = jest.fn().mockResolvedValue(undefined);
+      const sentinel = Promise.resolve();
+      svc.pendingAdapterReleaseGate = sentinel;
+
+      await expect(svc.startSingBoxProcess(0)).rejects.toThrow(/找不到 sing-box/);
+
+      expect(svc.waitForOwnTunAdapterReleased).not.toHaveBeenCalled();
+      expect(svc.pendingAdapterReleaseGate).toBe(sentinel);
+    });
+  });
+
+  it('非 Windows：门整条不跑（macOS/Linux 零改动）', async () => {
+    await withPlatformAsync('darwin', async () => {
+      const svc = makeSvc();
+      svc.needsOsascript = () => false; // 不走 mac 提权支路，直接落到下方直起判定
+      svc.ensureLinuxTunCapabilities = jest.fn().mockResolvedValue(undefined);
+      const sentinel = Promise.resolve();
+      svc.pendingAdapterReleaseGate = sentinel;
+
+      await expect(svc.startSingBoxProcess(0)).rejects.toThrow(/找不到 sing-box/);
+
+      expect(svc.waitForOwnTunAdapterReleased).not.toHaveBeenCalled();
+      expect(svc.pendingAdapterReleaseGate).toBe(sentinel);
+    });
+  });
+});
+
+/**
+ * B1 另外两条不变量在 `startInternal` 层，上面那组用例（直调 `startSingBoxProcess`）够不到它们——
+ * A 面复审实测：把 arm 整块上移到 killOrphans 之前、以及删掉入口清除那行，在补这组之前都是 **0 红**。
+ *
+ * 手法：让 arm **之后**的第一步（`copyRuleSetsToUserData`）抛一个哨兵错误，从而在不碰配置生成/起核的前提下
+ * 走完 arm 及其之前的全部前置步骤。
+ *
+ * 注意 arm 的位置本身是被复审改过的（原在 `selectedServerId` 校验之前 → 早退分支会留下无人 await 的孤儿轮询），
+ * 故这里用 `__direct__` 让两处早退校验都通过，停靠点取 arm 的紧后一步——停靠点必须跟着 arm 走，
+ * 否则这条门会在 arm 再次搬家时静默失效（变成「arm 根本没执行」也能绿）。
+ */
+function stubPrelude(svc: any, order: string[]): void {
+  svc.getSingBoxPath = () => '/fake/sing-box';
+  svc.maybePromptHelperGate = jest.fn().mockResolvedValue(undefined);
+  svc.killOrphanedSingBoxProcesses = jest.fn(async () => {
+    order.push('killOrphans');
+  });
+  svc.resolveClashApiPortConflict = jest.fn().mockResolvedValue(undefined);
+  svc.getCoreVersion = jest.fn().mockResolvedValue('1.14.0');
+  svc.reconcileCoreWithBundledBaseline = jest.fn().mockResolvedValue(undefined);
+  svc.resolveTailscaleApiPort = jest.fn().mockResolvedValue(9099);
+  svc.fixFilePermissions = jest.fn().mockResolvedValue(undefined);
+  svc.startTunAddressPreflight = jest.fn().mockResolvedValue(null);
+  svc.waitForOwnTunAdapterReleased = jest.fn(async () => {
+    order.push('armGate');
+  });
+  // arm 的紧后一步：抛哨兵停下。同时它自己也进 order —— 若 arm 被搬到它之后，顺序断言会直接翻红。
+  svc.copyRuleSetsToUserData = jest.fn(async () => {
+    order.push('afterArm');
+    throw new Error('STOP_AFTER_ARM');
+  });
+  svc.logToManager = jest.fn();
+  // 经 public start() 进入（埋点收集器在那儿建），故失败收口的两步要桩掉，免得碰进程/系统代理。
+  svc.cleanup = jest.fn();
+  svc.ensureSystemProxyCleared = jest.fn().mockResolvedValue(undefined);
+}
+
+/** `__direct__` 让 selectedServerId / selectedServer 两处早退都通过，走到 arm。 */
+const DIRECT_CFG: any = {
+  proxyModeType: 'tun',
+  servers: [],
+  selectedServerId: '__direct__',
+  tunConfig: {},
+};
+
+describe('B1 — startInternal 层的两条不变量', () => {
+  it('arm 必须发生在 killOrphans 之后：孤儿被硬杀才是适配器开始释放的起点', async () => {
+    await withPlatformAsync('win32', async () => {
+      const svc = makeSvc();
+      const order: string[] = [];
+      stubPrelude(svc, order);
+
+      await expect(svc.start(DIRECT_CFG)).rejects.toThrow(/STOP_AFTER_ARM/);
+
+      // 变异守卫：把 arm 那块上移到 killOrphans 之前 → 顺序翻转 → 红；arm 被删/搬到停靠点之后 → 缺项 → 红
+      expect(order).toEqual(['killOrphans', 'armGate', 'afterArm']);
+
+      // 顺带钉住 B0 埋点的**生产路径**（复审 Low）：此前 25 处 markStart + beginLeg 全无断言——
+      // `proxy-manager-start-timeline.test.ts` 把 startInternal 整个桩掉，验的是被调函数而不是调用点。
+      // 这里真跑了一遍前置链路，那些格必须出现在汇总行里。
+      const summary = svc.getLastStartTimeline() as string;
+      expect(summary).toContain('outcome=failed');
+      for (const label of ['stopOld=', 'helperGate=', 'killOrphans=', 'coreVersion=', 'apiPort=']) {
+        expect(summary).toContain(label);
+      }
+    });
+  });
+
+  it('startInternal 入口清掉上一次 start 遗留的预热（否则下一次首腿吃陈旧结论）', async () => {
+    // 非 Windows 跑：入口清除是无条件的，而 arm 有 win32 守卫 → 清完不会被重新 arm，
+    // 故「结束时为 null」这一条只可能来自入口那次清除。
+    await withPlatformAsync('darwin', async () => {
+      const svc = makeSvc();
+      stubPrelude(svc, []);
+      const stale = Promise.resolve();
+      svc.pendingAdapterReleaseGate = stale; // 模拟上一次 start 在首腿之前抛错留下的遗留
+
+      await expect(svc.start(DIRECT_CFG)).rejects.toThrow(/STOP_AFTER_ARM/);
+
+      // 变异守卫：删掉入口那行 `this.pendingAdapterReleaseGate = null` → 这里仍是 stale → 红
+      expect(svc.pendingAdapterReleaseGate).toBeNull();
+    });
+  });
+});

--- a/src/main/services/__tests__/proxy-manager-core-version-cache.test.ts
+++ b/src/main/services/__tests__/proxy-manager-core-version-cache.test.ts
@@ -1,0 +1,234 @@
+/**
+ * B5：`getCoreVersion(force)` 的二进制指纹缓存单测。
+ *
+ * 背景：启动路径每次 start 都 `force=true` 重 spawn 一次 45MB 内核（Windows 上还要过 AV 扫描）。force 的本意是
+ * 「核可能换了，别信旧缓存」——那就直接问二进制换没换，而不是无条件重探。
+ *
+ * 要钉住的四条（错一条就是「换了核还报旧版本」或「缓存白加」）：
+ *  1. 同一文件 + force → 不重 spawn；
+ *  2. 文件变了（mtime/size/路径）→ 必重 spawn；
+ *  3. 探测失败不写指纹（下次仍重探）；
+ *  4. `getCoreVersionLine(true)` **不**吃这条缓存——它是换核后「诚实重读活二进制」的验证腿（issue #150）。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-b5ver-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ProxyManager } from '../ProxyManager';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+/** 造一个真实存在的假核文件（指纹要靠 statSync 取真值）。 */
+function makeCoreFile(content = 'core-v1'): string {
+  const p = path.join(TMP, `sing-box-${Math.random().toString(36).slice(2)}`);
+  fsSync.writeFileSync(p, content);
+  return p;
+}
+
+function makeSvc(corePath: string): {
+  svc: any;
+  spawns: () => number;
+  setLine: (l: string) => void;
+} {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  const svc: any = new ProxyManager(undefined, undefined, configPath, corePath);
+  let line = 'sing-box version 1.14.0';
+  let n = 0;
+  // 桩掉真实 spawn（execve 一个假文件必失败），只数调用次数。
+  svc.doSpawnCoreVersionFirstLine = async () => {
+    n++;
+    return line;
+  };
+  return { svc, spawns: () => n, setLine: (l: string) => (line = l) };
+}
+
+describe('B5 — getCoreVersion(force) 指纹缓存', () => {
+  it('同一二进制未变 → force 也不重 spawn', async () => {
+    const { svc, spawns } = makeSvc(makeCoreFile());
+
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+    expect(spawns()).toBe(1);
+
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+    expect(spawns()).toBe(1); // 变异守卫：删掉指纹分支这里会变成 3
+  });
+
+  it('二进制被换掉（内容+mtime 变）→ 重 spawn 并拿到新版本', async () => {
+    const corePath = makeCoreFile();
+    const { svc, spawns, setLine } = makeSvc(corePath);
+
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+    expect(spawns()).toBe(1);
+
+    // 模拟 CoreUpdateService 换核：内容变长 + mtime 前移一小时（size / mtime 任一变即失配）
+    fsSync.writeFileSync(corePath, 'core-v2-longer-content');
+    const future = new Date(Date.now() + 3600_000);
+    fsSync.utimesSync(corePath, future, future);
+    setLine('sing-box version 1.15.0');
+
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.15.0');
+    expect(spawns()).toBe(2);
+  });
+
+  it('现役核路径改指（同会话换核/换目录）→ 指纹含路径，必重 spawn', async () => {
+    const { svc, spawns, setLine } = makeSvc(makeCoreFile());
+    await svc.getCoreVersion(true);
+    expect(spawns()).toBe(1);
+
+    svc.singboxPath = makeCoreFile('another'); // 另一个文件
+    setLine('sing-box version 1.16.0');
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.16.0');
+    expect(spawns()).toBe(2);
+  });
+
+  it('二进制不存在（stat 失败）→ 指纹取不到，每次都重探（回落改动前行为）', async () => {
+    const { svc, spawns } = makeSvc(path.join(TMP, 'does-not-exist'));
+
+    await svc.getCoreVersion(true);
+    await svc.getCoreVersion(true);
+    expect(spawns()).toBe(2);
+  });
+
+  it('探测失败不写指纹：下一次仍重探（不把失败缓存成结论）', async () => {
+    const corePath = makeCoreFile();
+    const { svc } = makeSvc(corePath);
+    let n = 0;
+    svc.doSpawnCoreVersionFirstLine = async () => {
+      n++;
+      if (n === 1) throw new Error('spawn 炸了');
+      return 'sing-box version 1.14.0';
+    };
+
+    await svc.getCoreVersion(true); // 失败 → 回落随包基线，不写指纹
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+    expect(n).toBe(2);
+  });
+
+  it('换核后探测失败 → 不得把旧版本连同新指纹一起缓存（否则新核永远报旧版本）', async () => {
+    const corePath = makeCoreFile();
+    const { svc } = makeSvc(corePath);
+    let n = 0;
+    svc.doSpawnCoreVersionFirstLine = async () => {
+      n++;
+      if (n === 1) return 'sing-box version 1.14.0'; // 旧核探测成功
+      if (n === 2) throw new Error('新核刚写完，execve 撞上了'); // 换核后首探失败
+      return 'sing-box version 1.15.0'; // 重探成功
+    };
+
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+
+    fsSync.writeFileSync(corePath, 'core-v2-longer-content');
+    const future = new Date(Date.now() + 3600_000);
+    fsSync.utimesSync(corePath, future, future);
+    await svc.getCoreVersion(true); // 失败：绝不能把新指纹配旧版本写进缓存
+
+    // 变异守卫：若失败路径也写指纹，这里会命中缓存直接返回陈旧的 1.14.0
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.15.0');
+    expect(n).toBe(3);
+  });
+
+  it('非 force 的老缓存路径不受影响（有缓存即返回，零 spawn）', async () => {
+    const { svc, spawns } = makeSvc(makeCoreFile());
+    await svc.getCoreVersion(true);
+    expect(spawns()).toBe(1);
+
+    await expect(svc.getCoreVersion()).resolves.toBe('1.14.0');
+    expect(spawns()).toBe(1);
+  });
+
+  it('getCoreVersionLine(true) 不吃指纹缓存——换核后的诚实重读腿必须真的重读', async () => {
+    const { svc, spawns } = makeSvc(makeCoreFile());
+    await svc.getCoreVersion(true);
+    expect(spawns()).toBe(1);
+
+    await svc.getCoreVersionLine(true);
+    await svc.getCoreVersionLine(true);
+    expect(spawns()).toBe(3); // 每次都真去问二进制
+  });
+});
+
+/**
+ * 指纹三分量的**隔离**用例。原有夹具同时改内容长度和 mtime、换文件时 mtime 又天然不同，无法隔离任一分量——
+ * 复审实测：把 path 从指纹里删掉、把 mtimeMs 删掉、甚至只剩 mtimeMs，原套件全绿（M8a/M8b/M8c）。
+ * 覆盖面继承自夹具而不是从判据（path ∨ size ∨ mtime 任一变即失配）生成，故按判据逐分量补齐。
+ */
+describe('B5 — 指纹三分量各自都必须参与失配', () => {
+  it('只改 mtime（path 与 size 均不变）→ 必重 spawn', async () => {
+    const corePath = makeCoreFile('same-length');
+    const { svc, spawns, setLine } = makeSvc(corePath);
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.14.0');
+    expect(spawns()).toBe(1);
+
+    // 等长覆写 → size 不变；再显式把 mtime 推到未来 → 只有 mtime 变了
+    fsSync.writeFileSync(corePath, 'SAME-LENGTH');
+    const t = new Date(Date.now() + 7200_000);
+    fsSync.utimesSync(corePath, t, t);
+    setLine('sing-box version 1.15.0');
+
+    // 变异守卫：指纹丢掉 mtimeMs → 命中缓存 → 仍返 1.14.0 → 红
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.15.0');
+    expect(spawns()).toBe(2);
+  });
+
+  it('只改 size（path 与 mtime 均不变）→ 必重 spawn', async () => {
+    const corePath = makeCoreFile('short');
+    // 先把 mtime 归整到整毫秒再取基准：`utimesSync` 只有毫秒精度，直接拿 statSync 的带小数 mtime 去复原
+    // 会把小数截掉 ⇒ mtime 其实变了 ⇒ 这条用例就不再是「只改 size」（首版即栽在这里）。
+    const FIXED = new Date(Date.now() - 60_000);
+    fsSync.utimesSync(corePath, FIXED, FIXED);
+
+    const { svc, spawns, setLine } = makeSvc(corePath);
+    await svc.getCoreVersion(true);
+    const before = fsSync.statSync(corePath);
+    expect(spawns()).toBe(1);
+
+    fsSync.writeFileSync(corePath, 'a-much-longer-content');
+    fsSync.utimesSync(corePath, FIXED, FIXED); // 同一个时刻 → mtime 逐位复原，只有 size 变了
+    expect(fsSync.statSync(corePath).mtimeMs).toBe(before.mtimeMs);
+    expect(fsSync.statSync(corePath).size).not.toBe(before.size);
+    setLine('sing-box version 1.15.0');
+
+    // 变异守卫：指纹丢掉 size → 命中缓存 → 红
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.15.0');
+    expect(spawns()).toBe(2);
+  });
+
+  it('只改 path（size 与 mtime 均不变）→ 必重 spawn', async () => {
+    const FIXED = new Date(Date.now() - 60_000); // 同上：先归整到整毫秒，两个文件才对得齐
+    const first = makeCoreFile('identical');
+    fsSync.utimesSync(first, FIXED, FIXED);
+
+    const { svc, spawns, setLine } = makeSvc(first);
+    await svc.getCoreVersion(true);
+    const st = fsSync.statSync(first);
+    expect(spawns()).toBe(1);
+
+    const second = makeCoreFile('identical'); // 同长度
+    fsSync.utimesSync(second, FIXED, FIXED); // 同一时刻 → size 与 mtime 都相同，只有 path 不同
+    expect(fsSync.statSync(second).size).toBe(st.size);
+    expect(fsSync.statSync(second).mtimeMs).toBe(st.mtimeMs);
+    svc.singboxPath = second;
+    setLine('sing-box version 1.15.0');
+
+    // 变异守卫：指纹丢掉 path → 命中缓存 → 红（这正是「同会话换核到另一目录」的形态）
+    await expect(svc.getCoreVersion(true)).resolves.toBe('1.15.0');
+    expect(spawns()).toBe(2);
+  });
+});

--- a/src/main/services/__tests__/proxy-manager-start-timeline.test.ts
+++ b/src/main/services/__tests__/proxy-manager-start-timeline.test.ts
@@ -1,0 +1,140 @@
+/**
+ * B0 起核阶段耗时埋点的**接线**单测（不是 StartTimeline 本体的逻辑测，那在 start-timeline.test.ts）。
+ *
+ * 这一层要钉住的是「方法体对了但没接上」那类缺陷：收集器有没有在 public start() 建、三条出口（成功/失败/让位）
+ * 是不是都出汇总行、字段有没有被接管方的 start 误清、非启动语境打标记会不会炸。
+ *
+ * 私有方法/字段经 `(svc as any)` 直调注入，不启动 sing-box。
+ */
+const os = require('os');
+const path = require('path');
+const fsSync = require('fs');
+
+const TMP = fsSync.mkdtempSync(path.join(os.tmpdir(), 'flowz-b0tl-'));
+
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP, getVersion: () => '9.9.9', isPackaged: false, getAppPath: () => TMP },
+  BrowserWindow: class {},
+  Notification: class {},
+  net: {},
+  session: {},
+}));
+
+import { ProxyManager } from '../ProxyManager';
+import { CoreStartSupersededError } from '../core-readiness';
+import { StartTimeline } from '../start-timeline';
+
+afterAll(() => {
+  try {
+    fsSync.rmSync(TMP, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+const CFG: any = { proxyModeType: 'tun', servers: [], selectedServerId: 'x' };
+
+function makeSvc(): any {
+  const configPath = path.join(TMP, `sb-${Math.random().toString(36).slice(2)}.json`);
+  const svc: any = new ProxyManager(undefined, undefined, configPath, '/fake/sing-box');
+  // 失败腿收口会真跑清理，桩掉避免碰进程/系统代理。
+  svc.cleanup = jest.fn();
+  svc.ensureSystemProxyCleared = jest.fn(async () => {});
+  return svc;
+}
+
+/** 捕获 logToManager 的全部行。 */
+function captureLogs(svc: any): string[] {
+  const lines: string[] = [];
+  jest.spyOn(svc, 'logToManager').mockImplementation((...args: unknown[]) => {
+    lines.push(String(args[1]));
+  });
+  return lines;
+}
+
+function timelineLine(lines: string[]): string | undefined {
+  return lines.find((l) => l.startsWith('起核阶段耗时 '));
+}
+
+describe('B0 埋点接线 — 三条出口都出汇总行', () => {
+  it('成功：outcome=ok，且带至少一格阶段', async () => {
+    const svc = makeSvc();
+    const lines = captureLogs(svc);
+    svc.startInternal = jest.fn(async () => {
+      svc.markStart('fakePhase');
+    });
+
+    await svc.start(CFG);
+
+    const line = timelineLine(lines);
+    expect(line).toBeDefined();
+    expect(line).toContain('outcome=ok');
+    expect(line).toContain('fakePhase=');
+  });
+
+  it('失败：仍出汇总行且 outcome=failed（原异常照常上抛）', async () => {
+    const svc = makeSvc();
+    const lines = captureLogs(svc);
+    svc.startInternal = jest.fn(async () => {
+      svc.markStart('beforeBoom');
+      throw new Error('boom');
+    });
+
+    await expect(svc.start(CFG)).rejects.toThrow('boom');
+
+    const line = timelineLine(lines);
+    expect(line).toContain('outcome=failed');
+    expect(line).toContain('beforeBoom=');
+  });
+
+  it('让位：outcome=superseded（让位是静默返回，但耗时依然要看得见）', async () => {
+    const svc = makeSvc();
+    const lines = captureLogs(svc);
+    svc.startInternal = jest.fn(async () => {
+      throw new CoreStartSupersededError();
+    });
+
+    await expect(svc.start(CFG)).resolves.toBeUndefined();
+
+    expect(timelineLine(lines)).toContain('outcome=superseded');
+    // 让位不应被 cleanup（既有 #176 语义，顺带守住不被本改动破坏）
+    expect(svc.cleanup).not.toHaveBeenCalled();
+  });
+});
+
+describe('B0 埋点接线 — 字段生命周期', () => {
+  it('start 收尾清空在飞收集器，并把汇总行留给诊断报告', async () => {
+    const svc = makeSvc();
+    captureLogs(svc);
+    svc.startInternal = jest.fn(async () => {
+      expect(svc.startTimeline).toBeInstanceOf(StartTimeline); // 在飞期间必须已就位
+    });
+
+    await svc.start(CFG);
+
+    expect(svc.startTimeline).toBeNull();
+    expect(svc.getLastStartTimeline()).toContain('起核阶段耗时 ');
+  });
+
+  it('被更新的 start 接管后，旧腿的收尾**不得**清掉接管方的收集器', async () => {
+    const svc = makeSvc();
+    captureLogs(svc);
+    const taker = new StartTimeline();
+    svc.startInternal = jest.fn(async () => {
+      // 模拟接管方在旧腿还没收尾时装上了自己的收集器
+      svc.startTimeline = taker;
+    });
+
+    await svc.start(CFG);
+
+    // 变异守卫：若收尾无条件 `this.startTimeline = null`，接管方此后所有 markStart 会全部落空
+    expect(svc.startTimeline).toBe(taker);
+  });
+
+  it('非启动语境打标记是 no-op，不抛', () => {
+    const svc = makeSvc();
+    expect(svc.startTimeline).toBeNull();
+    expect(() => svc.markStart('孤儿标记')).not.toThrow();
+    expect(svc.getLastStartTimeline()).toBeNull();
+  });
+});

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -47,6 +47,9 @@ function makeSvc(): any {
   svc.tailscaleApiPort = 9099; // 有管理 API 端口 → 不走 fail-open 早退
   svc.currentConfig = { proxyModeType: 'tun', servers: [], tunConfig: {} };
   svc.helperManager = { stopCore: jest.fn().mockResolvedValue(undefined) };
+  // B4：就绪门的探活腿已从 isProcessAlive（execSync，阻塞 event loop）换成异步版。默认委托到同一个同步桩，
+  //   使各用例既有的 `svc.isProcessAlive = …` 意图逐字保留；个别用例直接改 isProcessAliveAsync 的照旧覆盖本默认。
+  svc.isProcessAliveAsync = async () => svc.isProcessAlive();
   return svc;
 }
 
@@ -930,5 +933,51 @@ describe('issue #324 M-1 — prev 的捕获与复位归属预检方法本身（�
 
     const pick = await svc.startTunAddressPreflight(tunCfg, true);
     expect(pick?.address).toBe('172.31.0.1');
+  });
+});
+
+/**
+ * B4 的全部收益就是三个接线值：就绪节拍 50ms、探活节拍 500ms、探活走异步腿。
+ * 复审实测：这三处在全仓 3786 条测试里**零覆盖**，逐个回退全绿（M1/M2/M3）——门建在了被调函数
+ * （`core-readiness` 纯函数层自己传参）上，没建在生产调用点上，典型「两扇门之间的缝」。
+ */
+describe('B4 接线 — 就绪门必须按这三个值调用（复审 High）', () => {
+  it('waitForCoreReadyOrThrow 传给 waitForCoreReady 的 opts 恒为 {12000, 50, 500}', async () => {
+    const svc = makeSvc();
+    svc.coreReadyProbe = async () => true; // 首轮即就绪，尽快收束
+    const mod = require('../core-readiness');
+    const spy = jest.spyOn(mod, 'waitForCoreReady');
+
+    try {
+      await svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+      expect(spy).toHaveBeenCalledTimes(1);
+      // 变异守卫：CORE_READY_POLL_MS 回 500 / CORE_READY_ALIVE_POLL_MS 回 50 / 删 alivePollMs → 任一即红
+      expect(spy.mock.calls[0][0]).toEqual({
+        timeoutMs: 12000,
+        pollMs: 50,
+        alivePollMs: 500,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('探活腿必须走异步版 isProcessAliveAsync（同步版会用 execSync 堵住 event loop）', async () => {
+    const svc = makeSvc();
+    const asyncProbe = jest.fn(async () => true);
+    svc.isProcessAliveAsync = asyncProbe;
+    svc.isProcessAlive = jest.fn(() => {
+      throw new Error('就绪门不得触碰同步探活腿');
+    });
+    svc.coreReadyProbe = jest
+      .fn()
+      .mockResolvedValueOnce(false) // 首轮未就绪 → 触发一次探活
+      .mockResolvedValue(true);
+
+    await svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+
+    // 变异守卫：接线换回 `this.isProcessAlive(pid)` → 同步桩抛错 → 红
+    expect(asyncProbe).toHaveBeenCalled();
+    expect(svc.isProcessAlive).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/start-timeline.test.ts
+++ b/src/main/services/__tests__/start-timeline.test.ts
@@ -1,0 +1,178 @@
+/**
+ * StartTimeline 纯逻辑单测（B0 起核阶段耗时埋点）。
+ *
+ * 时钟经 deps 注入，零真实计时器；断言全部针对「增量语义 / 腿前缀 / 上限行为 / 汇总格式」这四条会被误改的性质。
+ */
+import { StartTimeline, START_TIMELINE_MAX_PHASES } from '../start-timeline';
+
+/** 可编排的假时钟：每次读取吐出队列里的下一个值，耗尽后维持最后一个值。 */
+function fakeClock(values: number[]): () => number {
+  let i = 0;
+  return () => {
+    const v = values[Math.min(i, values.length - 1)];
+    i++;
+    return v;
+  };
+}
+
+describe('StartTimeline — 增量语义', () => {
+  it('每格记的是「相对上一个标记」的增量，不是自 start 起的绝对耗时', () => {
+    // 构造读 0；三次 mark 分别读 100 / 250 / 300
+    const tl = new StartTimeline({ now: fakeClock([0, 100, 250, 300]) });
+    tl.mark('a');
+    tl.mark('b');
+    tl.mark('c');
+    // 变异守卫：若实现改成绝对耗时，这里会是 100/250/300
+    expect(tl.phases()).toEqual([
+      { label: 'a', ms: 100 },
+      { label: 'b', ms: 150 },
+      { label: 'c', ms: 50 },
+    ]);
+  });
+
+  it('首格的基准是构造时刻（不是 0，也不是第一次 mark）', () => {
+    const tl = new StartTimeline({ now: fakeClock([40, 100]) });
+    tl.mark('first');
+    expect(tl.phases()).toEqual([{ label: 'first', ms: 60 }]);
+  });
+
+  it('增量四舍五入到整毫秒', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 0.4, 2.0]) });
+    tl.mark('tiny'); // 0.4 → 0
+    tl.mark('next'); // 1.6 → 2
+    expect(tl.phases().map((p) => p.ms)).toEqual([0, 2]);
+  });
+
+  it('totalMs 是自构造起的绝对耗时（与逐格增量之和相互独立）', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 10, 30, 999]) });
+    tl.mark('a');
+    tl.mark('b');
+    expect(tl.totalMs()).toBe(999);
+  });
+
+  it('phases() 返回副本——调用方改不动内部状态', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 5]) });
+    tl.mark('a');
+    tl.phases().push({ label: '注入', ms: 12345 });
+    expect(tl.phases()).toHaveLength(1);
+  });
+});
+
+describe('StartTimeline — 起核腿前缀', () => {
+  it('beginLeg 之前无前缀，之后带 L<n>. 前缀且逐腿递增', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 10, 20, 30, 40, 50]) });
+    tl.mark('prep');
+    tl.beginLeg();
+    tl.mark('adapterRelease');
+    tl.beginLeg();
+    tl.mark('adapterRelease');
+    expect(tl.phases().map((p) => p.label)).toEqual([
+      'prep',
+      'L1.begin',
+      'L1.adapterRelease',
+      'L2.begin',
+      'L2.adapterRelease',
+    ]);
+  });
+
+  it('L<n>.begin 这一格 = 上一个标记到本腿开始的耗时（第 2 腿起即 retry 退避）', () => {
+    // 0 构造 → mark prep@10 → beginLeg@15 → mark ready@20 → beginLeg@3020（退避 3s）
+    const tl = new StartTimeline({ now: fakeClock([0, 10, 15, 20, 3020]) });
+    tl.mark('prep');
+    tl.beginLeg();
+    tl.mark('coreReady');
+    tl.beginLeg();
+    const byLabel = Object.fromEntries(tl.phases().map((p) => [p.label, p.ms]));
+    expect(byLabel['L1.begin']).toBe(5);
+    expect(byLabel['L2.begin']).toBe(3000);
+  });
+});
+
+describe('StartTimeline — 上限与汇总', () => {
+  // 注：「丢格时是否仍推进时钟基准」在公开 API 上**不可观测**——一旦触顶就再不推入任何格，`last` 此后不影响
+  // 任何输出（实测：把 `this.last = at` 挪到 cap 检查之后，本文件 11 条全绿 ⇒ 等价变异）。故此处只断言真正能
+  // 观测到的三条：触顶后不再增长、dropped 计数、已入格的历史不被回溯改写。不写「变异守卫」以免立一个无牙的判据。
+  it('触顶后只计数不再入格，且不回溯改写已记录的格', () => {
+    let t = 0;
+    const tl = new StartTimeline({ now: () => t });
+    for (let i = 0; i < START_TIMELINE_MAX_PHASES; i++) {
+      t += 1;
+      tl.mark(`p${i}`);
+    }
+    expect(tl.phases()).toHaveLength(START_TIMELINE_MAX_PHASES);
+    expect(tl.dropped()).toBe(0);
+    // 再来两格：都被丢，但基准必须跟着走
+    t += 100;
+    tl.mark('dropped-1');
+    t += 7;
+    tl.mark('dropped-2');
+    expect(tl.dropped()).toBe(2);
+    expect(tl.phases()).toHaveLength(START_TIMELINE_MAX_PHASES);
+    // 触顶后的两次 mark 不得回头改写末格
+    expect(tl.phases()[START_TIMELINE_MAX_PHASES - 1]).toEqual({
+      label: `p${START_TIMELINE_MAX_PHASES - 1}`,
+      ms: 1,
+    });
+  });
+
+  it('summarize 含 total / outcome / 逐格', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 100, 300, 350]) });
+    tl.mark('killOrphans');
+    tl.mark('coreVersion');
+    expect(tl.summarize('ok')).toBe(
+      '起核阶段耗时 total=350ms outcome=ok | killOrphans=100 coreVersion=200'
+    );
+  });
+
+  it('summarize 在有丢格时自曝，不静默截断', () => {
+    let t = 0;
+    const tl = new StartTimeline({ now: () => t });
+    for (let i = 0; i < START_TIMELINE_MAX_PHASES + 3; i++) {
+      t += 1;
+      tl.mark(`p${i}`);
+    }
+    expect(tl.summarize('failed')).toContain('(+3 格超限未记)');
+  });
+
+  it('一格没记时不留空尾巴 `| `（那是条零信息量的行，却每次 start 都进 app.log 与诊断报告）', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 12]) });
+    expect(tl.summarize('superseded')).toBe('起核阶段耗时 total=12ms outcome=superseded');
+  });
+});
+
+/**
+ * 汇总行整行原文会被 push 进诊断报告且**不过脱敏**——「不含用户数据」是它免脱敏的唯一理由。
+ * 该不变量原先只写在设计文档里、零判据（复审 Low）；此处把它落成门。
+ */
+describe('StartTimeline — label 形状约束（免脱敏的前提）', () => {
+  it('越界字符被替成 ?：节点名/域名不会经 label 漏进诊断报告', () => {
+    const tl = new StartTimeline({ now: fakeClock([0, 5]) });
+    tl.mark('probe:香港节点 01.example.com');
+    // 「香港节点」4 字 + 1 空格 = 5 个越界字符；ASCII 部分（含 `.` `:`）原样保留
+    expect(tl.phases()[0].label).toBe('probe:?????01.example.com');
+  });
+
+  it('今天在用的 label 形态一律原样保留（约束不得误伤合法标签）', () => {
+    const tl = new StartTimeline({ now: () => 0 });
+    for (const l of ['killOrphans', 'coreReady:ready', 'tunAdapter:absent-timeout', 'startTail']) {
+      tl.mark(l);
+    }
+    tl.beginLeg();
+    tl.mark('adapterRelease');
+    expect(tl.phases().map((p) => p.label)).toEqual([
+      'killOrphans',
+      'coreReady:ready',
+      'tunAdapter:absent-timeout',
+      'startTail',
+      'L1.begin',
+      'L1.adapterRelease',
+    ]);
+  });
+
+  it('腿前缀在约束之外拼接：`L<n>.` 不被自身规则吃掉', () => {
+    const tl = new StartTimeline({ now: () => 0 });
+    tl.beginLeg();
+    tl.mark('spawn');
+    expect(tl.phases()[1].label).toBe('L1.spawn');
+  });
+});

--- a/src/main/services/__tests__/win-tun-adapter.test.ts
+++ b/src/main/services/__tests__/win-tun-adapter.test.ts
@@ -8,11 +8,20 @@ jest.mock('child_process', () => ({
   execFile: jest.fn(),
 }));
 
+// B3 快检读 os.networkInterfaces()，而 Node 的 os 模块属性不可重定义（jest.spyOn 会抛
+// `Cannot redefine property`）→ 只能整模块 mock。默认实现即真实实现，故其余用例行为不变。
+jest.mock('os', () => {
+  const actual = jest.requireActual('os');
+  return { ...actual, networkInterfaces: jest.fn(actual.networkInterfaces) };
+});
+
 import { execFile } from 'child_process';
+import * as os from 'os';
 import {
   probeWinIpv4AddressUsage,
   probeWinTunAdapterPresence,
   probeWinTunAdapterPresent,
+  nodeSeesInterface,
   waitForAdapterReleased,
   waitForAdapterPresent,
   recordAdapterPresence,
@@ -376,6 +385,10 @@ try {
 exit 0`;
 
 describe('PowerShell 探测脚本形态（#324 真机契约）', () => {
+  // 姊妹腿：与 `describe('probeWinTunAdapterPresence')` 同一条理由——本组守的是**外部进程契约文本**
+  // （PowerShell 全文 `toBe`），被 B3 快检短路掉的话连脚本都不会生成，失效代价比那组更高。
+  beforeEach(() => mockIfaces(() => ({})));
+
   beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
 
   it('地址探测（无别名）生成的脚本逐字等于真机实证过的原文', async () => {
@@ -498,6 +511,10 @@ describe('probeWinIpv4AddressUsage', () => {
  */
 describe('probeWinTunAdapterPresence', () => {
   beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
+  // 本组验的是 **PowerShell 契约**（哨兵/退出码/三态），必须让 B3 快检恒不命中，否则判据会被短路吃掉。
+  // 不加这行的话：本机 Linux 无 `flowz-tun0` 恰好全绿，但在真跑着 FlowZ 的 Windows 开发机上（那里确实存在
+  // 同名接口）这 8 条会集体短路成 present —— 一个只在特定机器上失效的门，比没有门更坏。
+  beforeEach(() => mockIfaces(() => ({})));
 
   it('哨兵在、命中本名 → present', async () => {
     stubExecFile(null, okStdout('flowz-tun0'));
@@ -539,5 +556,83 @@ describe('probeWinTunAdapterPresence', () => {
     await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(false);
     stubExecFile(null, okStdout('flowz-tun0'));
     await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(true);
+  });
+});
+
+/**
+ * B3：零 spawn 快检。合同的全部要害在于**它只被允许产出肯定结论**——看不见一律回落 PowerShell，
+ * 绝不据此判 absent（否则 #159 释放门恒放行、#324 正向门把健康机器判成终态失败）。
+ */
+/** 把 os.networkInterfaces 换成给定实现；用完 restoreIfaces 还原到真实实现。 */
+function mockIfaces(impl: () => unknown): void {
+  (os.networkInterfaces as unknown as jest.Mock).mockImplementation(impl);
+}
+function restoreIfaces(): void {
+  (os.networkInterfaces as unknown as jest.Mock).mockImplementation(
+    jest.requireActual('os').networkInterfaces
+  );
+}
+
+describe('nodeSeesInterface（B3 快检）', () => {
+  afterEach(restoreIfaces);
+
+  const withAddr = [{ address: '172.19.0.1' }] as unknown as ReturnType<
+    typeof os.networkInterfaces
+  >[string];
+
+  it('枚举里有本名且带地址 → true', () => {
+    expect(nodeSeesInterface('flowz-tun0', { 'flowz-tun0': withAddr })).toBe(true);
+  });
+
+  it('枚举里没有本名 → false（含义是「说不了」，由调用方回落 PowerShell）', () => {
+    expect(nodeSeesInterface('flowz-tun0', { 以太网: withAddr })).toBe(false);
+  });
+
+  it('键在但无地址（空数组 / undefined）→ false：无地址不构成肯定结论', () => {
+    expect(nodeSeesInterface('flowz-tun0', { 'flowz-tun0': [] as never })).toBe(false);
+    expect(nodeSeesInterface('flowz-tun0', { 'flowz-tun0': undefined })).toBe(false);
+  });
+
+  it('名字为空 → false（不拿空串去撞枚举）', () => {
+    expect(nodeSeesInterface('', { '': withAddr })).toBe(false);
+  });
+
+  it('枚举本身抛错 → false（说不了，绝不冒充结论）', () => {
+    mockIfaces(() => {
+      throw new Error('boom');
+    });
+    expect(nodeSeesInterface('flowz-tun0')).toBe(false);
+  });
+});
+
+describe('probeWinTunAdapterPresence — B3 短路接线', () => {
+  afterEach(restoreIfaces);
+
+  it('Node 看得见 → 直接 present，且**零 spawn**（省掉真机实测 ~950ms 的那次 PowerShell）', async () => {
+    (execFile as unknown as jest.Mock).mockClear();
+    mockIfaces(() => ({ 'flowz-tun0': [{ address: '172.19.0.1' }] }));
+
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('present');
+    expect(execFile as unknown as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('Node 看不见 → 仍回落 PowerShell 由它给权威结论（absent 只能来自 PS）', async () => {
+    (execFile as unknown as jest.Mock).mockClear();
+    mockIfaces(() => ({}));
+    (execFile as unknown as jest.Mock).mockImplementation(
+      (_c: string, _a: string[], _o: unknown, cb: (e: unknown, out: string) => void) =>
+        cb(null, 'PROBE_OK\n')
+    );
+
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('absent');
+    expect(execFile as unknown as jest.Mock).toHaveBeenCalled();
+  });
+
+  it('布尔版（#159 释放门）继承短路：Node 看见 → true 且零 spawn', async () => {
+    (execFile as unknown as jest.Mock).mockClear();
+    mockIfaces(() => ({ 'flowz-tun0': [{ address: '172.19.0.1' }] }));
+
+    await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(true);
+    expect(execFile as unknown as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/win-tun-adapter.test.ts
+++ b/src/main/services/__tests__/win-tun-adapter.test.ts
@@ -315,12 +315,10 @@ function stubExecFile(
   return {
     lastBin: () => lastBin,
     lastOpts: () => lastOpts,
-    // 脚本经 -EncodedCommand（UTF-16LE base64）传入，还原回文本供断言。
+    // 脚本作为单个 argv 元素经 -Command 传入，直接取回供断言。
     lastCommand: () => {
-      const i = lastArgs.indexOf('-EncodedCommand');
-      return i < 0 || i + 1 >= lastArgs.length
-        ? ''
-        : Buffer.from(lastArgs[i + 1], 'base64').toString('utf16le');
+      const i = lastArgs.indexOf('-Command');
+      return i < 0 || i + 1 >= lastArgs.length ? '' : lastArgs[i + 1];
     },
     lastArgs: () => lastArgs,
   };
@@ -409,12 +407,44 @@ describe('PowerShell 探测脚本形态（#324 真机契约）', () => {
     expect(h.lastCommand()).toBe(SCRIPT_ADAPTER);
   });
 
-  it('走 -EncodedCommand 而非 -Command（命令行转义面 + 脚本可含多行/exit）', async () => {
-    // 这条不在脚本文本里，故仍需单独断言 argv 形态。
+  /**
+   * argv 形态门（脚本文本里没有，故单独断言）。
+   *
+   * **判据改写记录（2026-08-26）**：原门断言的是「必须走 `-EncodedCommand`」，理由写的是「命令行转义面 +
+   * 脚本可含多行/exit」。真机实测推翻了它的性价比——`-EncodedCommand` 让 `CreateProcessW` **同步阻塞主线程**
+   * 2.3–4.7s/次（同脚本改 `-Command` 后 8–10ms，见 runPsProbe 头注）。改判据前先核对新旧判据的强弱：
+   *
+   * | 输入 | 旧判据（-EncodedCommand） | 新判据（单 argv 元素 + 校验器） | 差 |
+   * |---|---|---|---|
+   * | `flowz-tun0`（合法） | 正常探测 | 正常探测 | 无 |
+   * | 别名含 `'` | 调用方 `''` 转义后落单引号串 | 同左（转义逻辑未动） | 无 |
+   * | 别名含 `"` / 空格 / 换行 | base64 后不经命令行解析 | `execFile` 不过 shell，仍是**一个** argv 元素，不经命令行解析 | 无 |
+   * | 别名含 PowerShell 语法（`$(...)`） | **不拦**（编码只消命令行层，语法层照旧） | **不拦**（同左） | 无 |
+   * | 非法 IP 字面量 | 校验器早退 unknown，不 spawn | 同左 | 无 |
+   *
+   * 结论：编码传参消掉的只有**命令行层**，而 `execFile`（无 shell）本来就没有那一层——两者对输入的约束
+   * 逐格相同，故换传参方式**不放宽任何东西**。下面三条把「逐格相同」落成门。
+   */
+  it('脚本以单个 argv 元素经 -Command 传入（argv 边界即转义边界）', async () => {
     const h = stubExecFile(null, okStdout());
     await probeWinIpv4AddressUsage('172.19.0.1');
-    expect(h.lastArgs()).toContain('-EncodedCommand');
-    expect(h.lastArgs()).not.toContain('-Command');
+    // 变异守卫：若脚本被按行/按空格拆成多个参数，argv 长度会变，且 PowerShell 会按命令行规则重新解析它们。
+    expect(h.lastArgs()).toEqual(['-NoProfile', '-NonInteractive', '-Command', SCRIPT_IP_PLAIN]);
+  });
+
+  it('不得回退 -EncodedCommand（真机实测：每次 2.3–4.7s 主进程同步冻结）', async () => {
+    // 这条守的是**性能**性质，单测测不出耗时，故按传参形态钉。数据与理由见 runPsProbe 头注。
+    const h = stubExecFile(null, okStdout());
+    await probeWinIpv4AddressUsage('172.19.0.1');
+    expect(h.lastArgs()).not.toContain('-EncodedCommand');
+  });
+
+  it('恶意别名：引号被转义、其余字符原样落在单引号串内，且 argv 仍是一个元素', async () => {
+    const h = stubExecFile(null, okStdout());
+    // 同时含单引号、双引号、空格、换行——覆盖上表「别名含 `"` / 空格 / 换行」与「含 `'`」两行。
+    await probeWinTunAdapterPresence('a\'b"c d\ne');
+    expect(h.lastArgs()).toHaveLength(4);
+    expect(h.lastCommand()).toContain(`Get-NetAdapter -Name 'a''b"c d\ne'`);
   });
 
   it('spawn 的是 powershellPath() 的绝对路径，且带 timeout / windowsHide', async () => {

--- a/src/main/services/core-readiness.ts
+++ b/src/main/services/core-readiness.ts
@@ -107,13 +107,21 @@ export type CoreReadyOutcome = 'ready' | 'dead' | 'timeout' | 'superseded';
 
 /** waitForCoreReady 注入依赖（单测可替换为桩）。 */
 export interface CoreReadyDeps {
-  /** 核进程是否存活。 */
-  isAlive: () => boolean;
+  /**
+   * 核进程是否存活。允许返回 Promise（B4）：Windows 上这条腿是 `tasklist` 子进程，同步版会阻塞 event loop，
+   * 起核窗内每轮一次足以让主进程可感卡顿。同步桩（返回 boolean）照常可用——`await` 对非 Promise 是恒等。
+   */
+  isAlive: () => boolean | Promise<boolean>;
   /** 管理 API 是否可连（就绪信号）。 */
   isReady: () => Promise<boolean>;
   sleep: (ms: number) => Promise<void>;
   /** 本次起核是否已被更新的 start/stop 接管（issue #176，可选；缺省视作未接管）。 */
   isSuperseded?: () => boolean;
+  /**
+   * 单调毫秒时钟，缺省 `Date.now`。用于把 timeoutMs 落成**真的时间预算**（见 waitForCoreReady 头注）。
+   * 单测想验预算本身时注入一个跟着 sleep 走的假时钟；不注入则退化为「轮数封顶」的旧行为，既有用例零改动。
+   */
+  now?: () => number;
 }
 
 /**
@@ -122,22 +130,37 @@ export interface CoreReadyDeps {
  * 早退使成功路径仅等到 API 绑定（通常 <1s），不加额外延迟。
  */
 export async function waitForCoreReady(
-  opts: { timeoutMs: number; pollMs: number },
+  opts: { timeoutMs: number; pollMs: number; alivePollMs?: number },
   deps: CoreReadyDeps
 ): Promise<CoreReadyOutcome> {
   const pollMs = Math.max(1, opts.pollMs);
+  // B4：探活与就绪**解耦成两个节拍**。把 pollMs 调细是为了少空等（就绪判据是本地 TCP connect，近乎免费），
+  //   但探活是子进程（Windows `tasklist` ~50-100ms），跟着细节拍走会把 spawn 次数放大同样的倍数——那是拿一个
+  //   开销换另一个更大的开销。故 alivePollMs 单独给：缺省 = pollMs（逐字保持旧行为），调用方按需放宽。
+  //   注：这里**不**对 alivePollMs 做「不得小于 pollMs」的下夹——下一行的 `Math.max(1, …)` 已把 aliveEvery 兜到
+  //   至少 1 轮，任何更小的 alivePollMs 都产生同一结果，夹了也观测不到（复审实测：删掉下夹全量 0 红 = 死代码）。
+  const alivePollMs = opts.alivePollMs ?? pollMs;
+  const aliveEvery = Math.max(1, Math.round(alivePollMs / pollMs)); // 每 N 轮探一次活（下限 1 轮）
   const maxPolls = Math.max(1, Math.ceil(opts.timeoutMs / pollMs));
+  // timeoutMs 必须是**时间**预算，不能只是轮数封顶。`maxPolls` 假设每轮成本 ≈ pollMs，而 isReady 是 TCP connect
+  //   （`probeTcpReachable` 自带 1000ms 上限）、isAlive 是子进程——单轮真实成本可以远超 pollMs。pollMs 越细，
+  //   这个假设错得越离谱：500ms→50ms 使单轮固定开销被摊 24 次变成摊 241 次，connect 打满时实测墙钟从 38.9s
+  //   膨胀到 254.9s（复审实测）。故以单调时钟的 deadline 为主判据，maxPolls 退居为「时钟不前进时」的兜底
+  //   （注入式假 sleep 的单测正是这种情形，故既有用例行为不变）。
+  const now = deps.now ?? Date.now;
+  const deadline = now() + opts.timeoutMs;
   // supersede 先于一切判定：被更新的 start/stop 接管后，本腿继续等就绪/重试毫无意义且有害（抢适配器/撞端口），立即让位。
-  // isReady（异步 TCP）先于 isAlive（execSync 探活，阻塞 event loop）：成功路径（API 早绑）即返回，绝不触发阻塞探活。
+  // isReady（异步 TCP）先于 isAlive（子进程探活）：成功路径（API 早绑）即返回，绝不触发探活。
   // 顺序安全：API 监听随核进程而生灭，端口可连 ⟹ 核存活（端口不会在核死后仍被本核监听）。
-  for (let i = 0; i < maxPolls; i++) {
+  for (let i = 0; i < maxPolls && now() < deadline; i++) {
     if (deps.isSuperseded?.()) return 'superseded';
     if (await deps.isReady()) return 'ready';
-    if (!deps.isAlive()) return 'dead';
+    // i=0 必探（`0 % N === 0`）：核瞬死的检出延迟不因细化就绪节拍而变差。
+    if (i % aliveEvery === 0 && !(await deps.isAlive())) return 'dead';
     await deps.sleep(pollMs);
   }
   if (deps.isSuperseded?.()) return 'superseded';
   if (await deps.isReady()) return 'ready';
-  if (!deps.isAlive()) return 'dead';
+  if (!(await deps.isAlive())) return 'dead';
   return 'timeout';
 }

--- a/src/main/services/start-timeline.ts
+++ b/src/main/services/start-timeline.ts
@@ -1,0 +1,118 @@
+/**
+ * 起核阶段耗时埋点（B0：先量化再优化）。
+ *
+ * 背景：Windows TUN 起核慢的**分阶段耗时目前没有任何实测数据**——已知的两个真机数字（PowerShell 探测单次
+ * ~950ms、sing-box 自报 `started (2.12s)`）来自两次不同排查，其余全是按代码路径静态推算的。在没有分布之前
+ * 按推算去改，重演的就是「嫌疑清单 5 条错 3 条、真因不在清单里」那类返工。
+ *
+ * 本模块只做一件事：把一次 start 的各阶段墙钟增量攒起来，收尾时输出**一行**汇总进 app.log（并进诊断报告），
+ * 使真机跑一次即可拿到分布。**零新增 syscall / 零 spawn / 不改控制流**——只有数组 push 与减法。
+ *
+ * 设计取舍：
+ *  - [选：一行汇总] 每阶段各记一行会刷屏，且与「状态未变化禁重复进度提示」冲突；一行汇总便于用户一次性回传。
+ *  - [不选：只在 debug 级输出] 起核慢是用户主动报的问题，等他先去调日志级别再复现一次，等于多一轮往返。
+ *    单行 INFO 的代价可忽略。
+ *  - [选：单调时钟 `performance.now()`] 起核跨秒级窗口，`Date.now()` 遇系统时钟跳变/NTP 校正会给出负增量或
+ *    离谱值，而这个数据的用途正是判断某阶段是否异常——被污染就失去意义。
+ *  - [选：注入 now] 纯逻辑可单测，无需假计时器。
+ *
+ * 重试腿：起核失败重试时每腿的耗时必须可分辨（同名阶段在 3 条腿上各出现一次），故 `beginLeg()` 之后所有
+ * 标记自动带 `L<n>.` 前缀；`L<n>.begin` 这一格本身即「上一腿失败 → 本腿开始」之间的退避等待。
+ */
+import { performance } from 'perf_hooks';
+
+/** 单个阶段：label + 相对上一个标记的毫秒增量（已取整）。 */
+export interface StartPhase {
+  label: string;
+  ms: number;
+}
+
+/** 注入依赖（单测替换时钟用）。 */
+export interface StartTimelineDeps {
+  /** 单调毫秒时钟。缺省 `performance.now()`。 */
+  now?: () => number;
+}
+
+/**
+ * 阶段数硬上限。正常一次 start ≤ ~40 格；设上限是防「起核失败 → 无界重试」的病态路径把数组撑大
+ * （每腿约 5 格，200 格 ≈ 30+ 腿，真实预算远达不到）。触顶后只累加 dropped 计数、不再入格；`mark` 仍推进
+ * 时钟基准，但那之后已无任何格会被推入，故这一点在输出上不可观测（单测里不为它立判据）。
+ */
+export const START_TIMELINE_MAX_PHASES = 200;
+
+/**
+ * 一次 start 的阶段耗时收集器。**绝不抛异常**（调用点遍布起核关键路径，埋点自身出错代价远大于收益）。
+ */
+export class StartTimeline {
+  private readonly now: () => number;
+  private readonly t0: number;
+  /** 上一个标记的时刻——增量基准。 */
+  private last: number;
+  /** 当前起核腿序号；0 = 尚未进入起核（前置准备阶段），≥1 = 第 n 条 startSingBoxProcess 腿。 */
+  private legIndex = 0;
+  private droppedCount = 0;
+  private readonly items: StartPhase[] = [];
+
+  constructor(deps: StartTimelineDeps = {}) {
+    this.now = deps.now ?? ((): number => performance.now());
+    this.t0 = this.now();
+    this.last = this.t0;
+  }
+
+  /**
+   * 记一个阶段：label 记录的是「从上一个标记到现在」的耗时，故调用点应放在被测步骤**之后**。
+   * 进入起核腿后自动加 `L<n>.` 前缀。
+   */
+  mark(label: string): void {
+    const at = this.now();
+    // 汇总行整行原文会被 push 进诊断报告且**不过脱敏**——「不含用户数据」这条不变量是它免脱敏的唯一理由，
+    // 故必须落成代码而不是只写在文档里。今天所有调用点传的都是字面量或受控枚举，本行是防将来某处写出
+    // `markStart(\`x:${serverName}\`)`：越界字符一律替成 `?`，宁可让标签变难看也不让节点名/域名漏进报告。
+    const safe = label.replace(/[^A-Za-z0-9_.:-]/g, '?');
+    const ms = Math.round(at - this.last);
+    this.last = at;
+    if (this.items.length >= START_TIMELINE_MAX_PHASES) {
+      this.droppedCount++;
+      return;
+    }
+    this.items.push({ label: this.legIndex > 0 ? `L${this.legIndex}.${safe}` : safe, ms });
+  }
+
+  /**
+   * 进入下一条起核腿。产出的 `L<n>.begin` 格 = 上一个标记到本腿开始之间的耗时：
+   * 第 1 腿是起核前最后一步到 spawn 前的间隙，第 2 腿起则是 retry 退避。
+   */
+  beginLeg(): void {
+    this.legIndex++;
+    this.mark('begin');
+  }
+
+  /** 自 start 起的总墙钟毫秒（取整）。 */
+  totalMs(): number {
+    return Math.round(this.now() - this.t0);
+  }
+
+  /** 已记录的阶段快照（副本，调用方改不动内部状态）。 */
+  phases(): StartPhase[] {
+    return this.items.slice();
+  }
+
+  /** 因超上限被丢弃的阶段数（正常恒 0）。 */
+  dropped(): number {
+    return this.droppedCount;
+  }
+
+  /**
+   * 一行汇总，形如：
+   * `起核阶段耗时 total=8421ms outcome=ok | killOrphans=181 coreVersion=642 … L1.adapterRelease=962 …`
+   * @param outcome 本次 start 的终态（ok / failed / superseded），便于把失败腿的分布与成功的分开看。
+   */
+  summarize(outcome: string): string {
+    const body = this.items.map((p) => `${p.label}=${p.ms}`).join(' ');
+    const tail = this.droppedCount > 0 ? ` (+${this.droppedCount} 格超限未记)` : '';
+    const head = `起核阶段耗时 total=${this.totalMs()}ms outcome=${outcome}`;
+    // 一格没记时（如 rejectIfCoreSwapInProgress 在首个标记之前就抛）不留空尾巴 `| `——那是条零信息量的行，
+    // 而它每次 start 都会进 app.log 与诊断报告。
+    return body || tail ? `${head} | ${body}${tail}` : head;
+  }
+}

--- a/src/main/services/win-tun-adapter.ts
+++ b/src/main/services/win-tun-adapter.ts
@@ -49,8 +49,16 @@ interface PsProbeResult {
  *   地址空闲 / 网卡不存在 → `ObjectNotFound`（`CmdletizationQuery_NotFound_*`）；CIM 会话不可用 → `ResourceUnavailable`。
  * 故哨兵的发放条件是「零错误，或被吞的错误**全部**是 ObjectNotFound」。
  *
- * 脚本经 `-EncodedCommand`（UTF-16LE base64）传入，消掉命令行层的转义面；PowerShell 语法层仍靠调用方的
- * 单引号转义 + 输入校验（IP 正则 / 网卡名字符集）把关。
+ * 脚本作为**单个 argv 元素**经 `-Command` 传入：`execFile` 不过 shell，argv 边界即转义边界，故命令行层没有
+ * 可注入面；PowerShell 语法层仍靠调用方的单引号转义 + 输入校验（IP 正则 / 网卡名字符集）把关。
+ *
+ * **为什么不是 `-EncodedCommand`**（原实现，2026-08-26 真机实测推翻）：base64 编码的 PowerShell 是恶意脚本的
+ * 典型形态，杀软要在进程创建回调里深扫，于是 `execFile` 的 `CreateProcessW` **同步阻塞主线程**。Windows 11
+ * 26200 实测，同一段脚本只换传参方式（每次插 nonce 保证内容都是冷的，排除按哈希缓存）：
+ *   `-EncodedCommand` 同步段 2298 / 2328 / 2336 / 4729 ms；`-Command` 同步段 8.2 / 8.3 / 8.5 / 9.9 ms。
+ * 这不是延迟而是**主进程冻结**——起核路径上两次探测的同步段合计 ~7.2s，占一次 TUN 冷启（12.1s）的六成，
+ * 期间 UI 完全无响应，且任何「并行预热」都吃不掉它（B1 只兑现 130ms 的真因）。编码传参消掉的那层命令行
+ * 转义面，由「脚本是单个 argv 元素」这条性质等价提供，故换回明文**不放宽任何输入约束**。
  *
  * **stdout 只可用来比对 ASCII**：中文 Windows 的 PowerShell 按 OEM codepage（936）写 stdout，Node execFile
  * 默认按 utf8 解码 → 非 ASCII 输出必成乱码（真机实测：网卡名「以太网」回传即乱码）。本模块的比对对象全是
@@ -70,11 +78,10 @@ function runPsProbe(pipeline: string): Promise<PsProbeResult> {
     `} catch { }`,
     `exit 0`,
   ].join('\n');
-  const encoded = Buffer.from(script, 'utf16le').toString('base64');
   return new Promise((resolve) => {
     execFile(
       powershellPath(),
-      ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+      ['-NoProfile', '-NonInteractive', '-Command', script],
       { timeout: 4000, windowsHide: true },
       (err, stdout) => {
         if (err) return resolve({ ok: false, lines: [] });

--- a/src/main/services/win-tun-adapter.ts
+++ b/src/main/services/win-tun-adapter.ts
@@ -11,6 +11,7 @@
  *  - 纯逻辑 waitForAdapterReleased 注入 probe/sleep，便于无真实计时器/无真实网卡的单测。
  */
 import { execFile } from 'child_process';
+import * as os from 'os';
 import { powershellPath } from '../utils/win-system32';
 import type { AddressUsage } from '../../shared/tun-address';
 
@@ -104,6 +105,8 @@ export function probeWinTunAdapterPresent(name: string): Promise<boolean> {
 export interface AdapterWaitDeps {
   probe: (name: string) => Promise<boolean>;
   sleep: (ms: number) => Promise<void>;
+  /** 单调毫秒时钟，缺省 `Date.now`（把 timeoutMs 落成真的时间预算，见 waitForAdapterReleased 头注）。 */
+  now?: () => number;
 }
 
 /** 等待结果：released=true 已确认网卡消失；false=超时仍在（调用方放行交 retry）。polls=实际探测次数。 */
@@ -114,7 +117,11 @@ export interface AdapterWaitResult {
 
 /**
  * 有界轮询等名为 `name` 的网卡消失。早退：一旦探测到消失立即返回。
- * maxPolls = ceil(timeoutMs/pollMs)，每轮 probe→（仍在则）sleep；循环末再 probe 一次覆盖最后窗口。
+ * 每轮 probe→（仍在则）sleep；循环末再 probe 一次覆盖最后窗口。
+ *
+ * **预算是时间不是轮数**：`maxPolls = ceil(timeoutMs/pollMs)` 隐含「每轮成本 ≈ pollMs」，而这里的 probe 是
+ * PowerShell（真机实测单次 ~950ms）→ 8000/500 名义 8s，真实墙钟 17×0.95+16×0.5 ≈ **24s**（复审实测）。
+ * 故以单调时钟 deadline 为主判据，maxPolls 退居兜底（时钟不前进的注入式单测走这条，行为与改动前逐字相同）。
  */
 export async function waitForAdapterReleased(
   name: string,
@@ -123,7 +130,9 @@ export async function waitForAdapterReleased(
 ): Promise<AdapterWaitResult> {
   const pollMs = Math.max(1, opts.pollMs);
   const maxPolls = Math.max(1, Math.ceil(opts.timeoutMs / pollMs));
-  for (let i = 0; i < maxPolls; i++) {
+  const now = deps.now ?? Date.now;
+  const deadline = now() + opts.timeoutMs;
+  for (let i = 0; i < maxPolls && now() < deadline; i++) {
     if (!(await deps.probe(name))) return { released: true, polls: i + 1 };
     await deps.sleep(pollMs);
   }
@@ -147,10 +156,44 @@ export async function waitForAdapterReleased(
 export type AdapterPresence = 'present' | 'absent' | 'unknown';
 
 /**
+ * B3 零 spawn 快检：Node 的接口枚举里是否有本名接口。
+ *
+ * **只允许产出肯定结论**——这是本函数唯一的设计约束，也是它敢在没有 Windows 真机的情况下上线的全部理由：
+ *  - 看见 → `true`，可直接判 present（Node 枚举的是 `GetAdaptersAddresses` 的 FriendlyName，与 `Get-NetAdapter -Name`
+ *    同一个名字空间；能看见就是真的存在）。
+ *  - 看不见 → `false`，含义是**「本法说不了」而不是「不存在」**，调用方一律回落 PowerShell 由它给权威结论。
+ *
+ * 为什么不能反过来用它判 absent（issue #324 §5.6 的教训）：libuv 只返回**带地址**的接口，
+ * 而 #159 要等的那种硬杀后滞留的 wintun 网卡、以及 #324 的冲突源 TAP 残留网卡，恰恰常处于 Disconnected/无地址态
+ * ——Node 看不见它们。据此判 absent 会让 #159 释放门恒放行、#324 正向门把健康机器判成「TUN 从未创建」的终态失败。
+ *
+ * 最坏情况（Node 在某些 Windows 版本上压根看不见 wintun 适配器）：本函数恒 false → 行为与改动前逐字相同，
+ * 只是省不到那次 spawn。**没有产生假 absent 的路径**，故不需要 Windows 真机才能上线。
+ *
+ * @param list 注入点（单测用）；缺省读 `os.networkInterfaces()`。
+ */
+export function nodeSeesInterface(
+  name: string,
+  list?: ReturnType<typeof os.networkInterfaces>
+): boolean {
+  if (!name) return false;
+  try {
+    const map = list ?? os.networkInterfaces();
+    const entry = map[name];
+    // 键存在但值为 undefined/空数组 → 当作没看见（无地址的接口不构成肯定结论）。
+    return Array.isArray(entry) && entry.length > 0;
+  } catch {
+    return false; // 枚举本身失败 → 说不了，交回 PowerShell
+  }
+}
+
+/**
  * 三态探测名为 `name` 的网卡是否存在（issue #324）。与 probeWinTunAdapterPresent 同一 Get-NetAdapter 机制，
  * 仅返回值语义更细：err（spawn/执行失败）→ 'unknown'；命中本名 → 'present'；查询成功但空 → 'absent'。
  */
 export function probeWinTunAdapterPresence(name: string): Promise<AdapterPresence> {
+  // B3 快路径：Node 看得见本名接口 → 直接 'present'，省掉一次 PowerShell（真机实测单次 ~950ms）。
+  if (nodeSeesInterface(name)) return Promise.resolve('present');
   const psName = name.replace(/'/g, "''");
   // 哨兵在、命中本名 → present；哨兵在、无命中 → absent（查询确实跑过，可据此判「从未创建」）；
   // 哨兵不在 → unknown（fail-open）。见 runPsProbe 头注：退出码不再参与「空结果」判定。
@@ -166,6 +209,8 @@ export function probeWinTunAdapterPresence(name: string): Promise<AdapterPresenc
 export interface AdapterPresenceWaitDeps {
   probe: (name: string) => Promise<AdapterPresence>;
   sleep: (ms: number) => Promise<void>;
+  /** 单调毫秒时钟，缺省 `Date.now`（把 timeoutMs 落成真的时间预算，见 waitForAdapterPresent 头注）。 */
+  now?: () => number;
   /**
    * issue #176/#324 High#1：本腿是否已被更新的 start/stop 接管（可选；缺省视作未接管）。每轮先判——接管后本腿继续
    * 验适配器/停核/发 started 都会抢放接管方的核，故立即让位（outcome='superseded'），调用方绝不 stopCore/emit started。
@@ -199,6 +244,12 @@ export async function waitForAdapterPresent(
 ): Promise<AdapterPresentResult> {
   const pollMs = Math.max(1, opts.pollMs);
   const maxPolls = Math.max(1, Math.ceil(opts.timeoutMs / pollMs));
+  // 与 waitForAdapterReleased 同一条纪律（**姊妹腿，同根因一起改**）：8000/1000 名义 8s，probe 为 PowerShell 时
+  //   真实墙钟 8×(0.95+1.0)+0.95 ≈ **16.6s**。这条腿的形态更糟——它是 #324 的硬闸，判 absent-timeout 要先耗完
+  //   整个预算，三腿耗尽的路径上光这个门就吃掉 ~50s。B3 快检只在**真 present** 时救得了它；真出故障那条路上
+  //   Node 恒看不见，每轮都得付 PowerShell，正是最需要预算准确的场景。
+  const now = deps.now ?? Date.now;
+  const deadline = now() + opts.timeoutMs;
   // 一次 clean absent 即证明 Get-NetAdapter 探测链路可用；据此把「确实没建起」（→ 硬闸/终态）与「探测本身失败」
   // （全 unknown → fail-open）区分开。零星 unknown 被一次 clean absent 压过。
   let sawAbsent = false;
@@ -209,7 +260,7 @@ export async function waitForAdapterPresent(
       return 'unknown'; // probe 抛错 → fail-open（按 unknown 处理，绝不据此判失败）
     }
   };
-  for (let i = 0; i < maxPolls; i++) {
+  for (let i = 0; i < maxPolls && now() < deadline; i++) {
     if (deps.isSuperseded?.()) return { outcome: 'superseded', polls: i }; // #176：接管先于一切，立即让位
     const p = await step();
     if (p === 'present') return { outcome: 'present', polls: i + 1 };

--- a/src/shared/__tests__/diagnostic-redact.test.ts
+++ b/src/shared/__tests__/diagnostic-redact.test.ts
@@ -198,6 +198,26 @@ describe('buildDiagnosticReport', () => {
     singboxLogTail: '',
   };
 
+  /**
+   * B0：起核阶段耗时汇总行必须真的出现在报告里。整条链路（`DiagnosticService` 喂字段 → 本函数渲染）此前
+   * 零判据——复审实测把渲染块和接线各自删掉都全绿，而「真机跑一次就能从诊断报告读到分阶段分布」正是本批的
+   * 完成标准，全押在这条无门链路上。
+   */
+  it('runtime.lastStartTimeline 必须渲染进报告（B0 完成标准所系）', () => {
+    const line = '起核阶段耗时 total=8421ms outcome=ok | killOrphans=181 L1.coreReady:ready=2311';
+    const md = buildDiagnosticReport({
+      ...base,
+      runtime: { ...base.runtime, lastStartTimeline: line },
+    });
+    // 变异守卫：删掉 diagnostic-redact 里那三行渲染 → 红
+    expect(md).toContain(line);
+  });
+
+  it('未启动过（字段缺席）时不产出空行/占位符', () => {
+    const md = buildDiagnosticReport(base);
+    expect(md).not.toContain('起核阶段耗时');
+  });
+
   it('含核心区块与脱敏 JSON', () => {
     const md = buildDiagnosticReport(base);
     expect(md).toContain('# FlowZ 诊断报告');

--- a/src/shared/diagnostic-redact.ts
+++ b/src/shared/diagnostic-redact.ts
@@ -309,6 +309,7 @@ export interface DiagnosticReportInput {
       context: string; // start | stop | link-change
       ageSec: number;
     };
+    lastStartTimeline?: string; // B0：最近一次起核的分阶段耗时汇总行（`起核阶段耗时 total=… | 阶段=ms …`）
   };
   redactedUserConfig: unknown;
   redactedSingboxConfig: unknown;
@@ -483,6 +484,9 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): string {
     }
   } else {
     lines.push('- 系统 DNS 缓存刷新：本会话从未触发');
+  }
+  if (runtime.lastStartTimeline) {
+    lines.push(`- ${runtime.lastStartTimeline}`);
   }
   lines.push('');
 


### PR DESCRIPTION
## 背景

Windows TUN 起核慢一直只有零星印象，没有分阶段实测数据。本 PR 先补埋点把耗时量化，再按实测数据做优化——其中最大的一处是实测之后才发现的，与最初的猜测完全不同。

真机（Windows 11 26200，TUN + 全局直连）实测：**起核总耗时 12065ms → 5004 / 5715 / 5378ms**。

## 两个 commit

### 1. B0 埋点 + B1/B3/B4/B5

**B0 起核阶段耗时埋点**：新增 `StartTimeline`，把一次 start 各阶段的墙钟增量攒起来，收尾输出一行汇总进 app.log 与诊断报告。零新增 syscall、零 spawn、不改控制流，只有数组 push 与减法。重试腿带 `L<n>.` 前缀，同名阶段在多条腿上可分辨。三条出口（成功 / 失败 / 让位）都出汇总行。

汇总行整行进诊断报告且不过脱敏，故 label 的字符集约束落成了代码（越界字符替成 `?`）而不是只写在注释里。

**B1**：Windows TUN 的 wintun 释放门首腿探测提前到 `killOrphanedSingBoxProcesses` 之后发起，与后续配置生成/写盘/`sing-box check` 并行。门的语义一字未改（每腿必过、fail-open、按本名匹配），改的只是首腿的付款时机。arm 点必须在 `selectedServerId` / `selectedServer` 两处早退校验之后——否则中途 throw 会留下一条无人 await 的后台轮询，与下一次 start 抢资源。

**B3**：适配器探测先看一眼 `os.networkInterfaces()`，看得见本名接口就直接判 present，省掉一次 PowerShell。只做肯定方向的短路（看不见不构成结论，仍回落 PowerShell）。

**B4**：就绪轮询 500ms → 50ms。判据是本地 loopback TCP connect，近乎免费，500ms 粒度带来的是纯空等。探活节拍单独拆出仍为 500ms——探活是子进程（Windows `tasklist`），跟着 50ms 走会把 spawn 次数放大 10 倍。同时把探活改为异步，不再阻塞 event loop。

**B5**：`sing-box version` 结果按二进制指纹（path|size|mtimeMs）缓存，核没换过就不重 spawn。指纹只在探测成功后写，换核后探测失败不会缓存旧版本。

**顺带修掉的一类系统性缺陷**：`waitForCoreReady` / `waitForAdapterReleased` / `waitForAdapterPresent` 三处都把 timeoutMs 实现成了「轮数封顶」（`maxPolls = ceil(timeoutMs/pollMs)`），假设每轮成本约等于 pollMs。但 isReady 是 TCP connect（自带 1000ms 上限）、isAlive 是子进程，单轮真实成本可以远超 pollMs。pollMs 越细这个假设错得越离谱：500ms→50ms 使单轮固定开销被摊 24 次变成摊 241 次，connect 打满时实测墙钟从 38.9s 膨胀到 254.9s。三处统一改为以单调时钟的 deadline 为主判据，maxPolls 退居为「时钟不前进时」的兜底。相应地 `TUN_ADAPTER_RELEASE_TIMEOUT_MS` 8000→24000、`TUN_READY_GRACE_TIMEOUT_MS` 8000→17000，是为了让 deadline 化之后的真实判定窗口与改动前等价——不提的话 #324 硬闸的窗口会被砍掉一半，导致更多「永久拒连」误报。

### 2. F1：PowerShell 探测改明文传参

`runPsProbe` 原用 `-EncodedCommand`（UTF-16LE base64）传脚本。真机实测发现 base64 编码的 PowerShell 会让杀软在进程创建回调里深扫，`execFile` 的 `CreateProcessW` 因此**同步阻塞主线程**。同一段脚本只换传参方式（每次插 nonce 保证内容都是冷的，排除按哈希缓存）：

| 变体 | 同步段（主进程冻结） | 总耗时 |
|---|---|---|
| `-EncodedCommand` | 2298 / 2328 / 2336 / 4729 ms | 3021–5467 ms |
| `-Command`（逐字同脚本） | 8.2 / 8.3 / 8.5 / 9.9 ms | 713–1005 ms |

这不是延迟而是主进程冻结：起核路径上地址冲突预检与适配器释放门各付一次，合计约 7.2s，占一次 TUN 冷启的六成，期间 UI 完全无响应，且任何并行预热都吃不掉它。

编码传参消掉的只有命令行层的转义面，而 `execFile` 不过 shell 本就没有那一层，故换回明文**不放宽任何输入约束**：脚本仍作为单个 argv 元素传入，IP 正则（`^\d{1,3}(\.\d{1,3}){3}$`）、网卡名字符集（`^[A-Za-z0-9_-]{1,32}$`）与单引号转义逻辑一字未动。

判据同步改写：原门断言的是机制（「必须走 `-EncodedCommand`」），现改为断言性质——脚本是单个 argv 元素、恶意别名不改变 argv 形态且引号正确转义，另加一条防回退门（守的是性能性质，单测测不出耗时故按形态钉）。新旧判据的输入对差表写在测试头注里。

## 真机验证

Windows 11 26200，TUN + 全局直连，经交互会话走 helper 路径（`schtasks` + XML 的 `InteractiveToken`——经 SSH 直起的进程令牌不带 Interactive SID，helper 命名管道会拒）。

- 三次连续启动全部 `outcome=ok`，`flowz-tun0` Up
- `L1.coreReady:ready` = 2098 / 1996 / 1990 ms；其中两个落在 2000 以下且非 500 的整数倍，可推断 50ms 节拍确在跑
- `L1.tunAdapter:present` = 3 / 10 / 7 ms（改动前 PowerShell 单次约 950ms）
- issue #324 正向就绪门四次全部拿到 `present`，无一次 `absent-timeout`
- issue #159 回归：硬杀 sing-box 后自动重启 1/3、2s 退避 → `total=4874ms outcome=ok`、`L1.adapterRelease=68ms`、适配器 Up。未复现适配器名冲突，无重试风暴，首腿即成功

## 测试

新增 4 个测试文件、扩充 5 个，共 +1591 / −35。

本轮新增的门全部经变异证明有牙，包括：回退 `-EncodedCommand` → 9 红；脚本被拆成多个 argv 元素 → 8 红；去掉网卡名单引号转义 → 2 红；`alivePollMs` 被当成 `pollMs` → 红；换核后探测失败仍缓存旧版本 → 红；接管方的收集器被旧腿收尾清掉 → 红。

`npm run build:main` 0 error；`npx jest` 3933 passed / 0 failed（251 suites）。

## 影响面

改动集中在 Windows TUN 起核路径与诊断报告。macOS / Linux 侧只受 B4（就绪轮询节拍）与 B5（版本指纹缓存）影响，两者跨平台语义一致。埋点本身全平台生效。
