### PR TITLE
perf(win-tun): Windows TUN 起核 5.2s → 4.4s（netsh 探测 + 解析器并行 + 地址预检改懒执行）

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -1030,6 +1030,9 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     //   open 不了 root 600 的 tailscaled.* → endpoint post-start `permission denied` → 拖垮**整个**启动
     //   （即便没选 tailscale 节点，它在 endpoints[] 里也会被 post-start；系统代理模式同样中招）。
     this.reconcileRuntimeOwnershipBeforeStart();
+    // 真机实测 lanResolver 一格 874–2460ms（波动 3 倍）。那一格里同时装着本行的同步 fs 归一和下面按接口
+    // 逐个跑 netsh 读解析器，合成一格看不出是谁在波动，故拆开——与 seedRules/customRules 同一处置。
+    this.markStart('reconcileOwnership');
 
     // 3.8 方案B：DNS 接管激活时,先读接管前的内网 LAN 解析器(私网 IPv4),供 generateDnsConfig 把内网/captive 域名
     //     重定向到它(takeover 把系统 DNS 改公网 8.8.8.8 后 dns-local 解不了内网/可能环)。必须在 generateSingBoxConfig

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -661,6 +661,18 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // issue #324 P0-2：本次起核经冲突预检选定的 TUN IPv4 裸地址（掩码由 buildInbounds 按平台拼）。null=未预检
   //   （非 TUN / 用户已显式配置 / 预检未跑）→ 沿用平台默认，行为零变化。每次 startInternal 重算。
   private effectiveTunInet4Address: string | null = null;
+  /**
+   * issue #324 P0-2 的「懒预检」开关（start-scoped，由 startWithTunAddressAvoidance 管）。
+   *
+   * 为什么改懒：预检是一次 PowerShell `Get-NetIPAddress`，真机实测 681–760ms，**每台机每次起核都付**，
+   *   而它要躲的地址冲突只发生在装了残留 TAP/TUN 网卡的少数机器上。B0 埋点把这笔账摆到台面上后
+   *   （`tunAddrPreflightWait` 0–954ms，且它 ≈ 探测耗时 − 并行窗口，前面的准备步骤被优化得越快它越显形），
+   *   正确的形状是**倒过来**：默认乐观起核，撞了才避。
+   * 撞了怎么办：核 FATAL 被 classifySingBoxFatal 判成 `tun-address-conflict`（#324 真机实证过的分类）→
+   *   本字段置真 → 整个 startInternal 重跑一遍，那一遍才付探测的钱并换地址。代价落在**确有冲突的机器**上
+   *   （多一遍起核），而不是所有人身上。
+   */
+  private tunAddressAvoidanceArmed = false;
   // issue #176 诊断计数：本次启动经几次「就绪重试」才成功（runStartWithRetry 累计）。>0 = 起核慢（多因 Windows
   // 重启争用下 wintun 适配器未及时释放），与「核崩溃自动重启」（restartCount/AUTO_RESTARTING）是不同轴，纳入诊断
   // 区分「核崩」vs「争用慢起」。每次 startInternal 复位。
@@ -743,7 +755,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     this.startTimeline = timeline;
     let outcome = 'failed';
     try {
-      await this.startInternal(config, options);
+      await this.startWithTunAddressAvoidance(config, options);
       outcome = 'ok';
     } catch (e) {
       // issue #176：本腿在就绪等待期被更新的 start/stop 接管 → 静默让位，**绝不 cleanup**（接管方已拥有/正在
@@ -4911,6 +4923,43 @@ rm -f "$STOPFLAG"
   }
 
   /**
+   * issue #324 P0-2「懒预检」的重跑腿：默认乐观起核；**只有**本次 start 因 TUN 地址冲突终态失败时，
+   * 才武装预检并把整个 startInternal 重跑一遍（那一遍才付 PowerShell 探测的钱、才可能换地址）。
+   *
+   * 为什么重跑整个 startInternal 而不是只重跑起核腿：地址要随配置下发给核，换地址就得重生成配置；而
+   * `singboxConfig` 在 startInternal 里还经过了 `checkAndPruneConfig` 的**就地剔除**（坏节点已被摘掉）。
+   * 在失败分支里单独重生成配置会把那些坏节点放回来（T9 已踩过同一个坑），单独就地改 TUN 地址又要复刻
+   * buildInbounds 的平台掩码逻辑——两条都是重复实现。重入 startInternal 走的是用户手动重连的同一条路径，
+   * 零新增分支、零重复。
+   *
+   * 只重跑一次：`tunAddressAvoidanceArmed` 在本方法入口复位、命中后置真，第二遍再撞就照常上抛终态错误
+   * （占用方不挪走，第三遍也不会好）。
+   */
+  private async startWithTunAddressAvoidance(
+    config: UserConfig,
+    options: { interactive?: boolean }
+  ): Promise<void> {
+    this.tunAddressAvoidanceArmed = false;
+    try {
+      await this.startInternal(config, options);
+    } catch (e) {
+      // 判据取 `lastStartupFatal.kind`（核自己写的失败原因）而不是错误文案：文案会随 i18n/措辞变，
+      // kind 是 classifySingBoxFatal 的结构化结论，#324 真机实证过。终态类型也要对上——瞬态族
+      // （CoreStartRetryError）本来就还在重试预算里，不该被这条腿抢走。
+      if (
+        !(e instanceof CoreStartTunPersistentError) ||
+        this.lastStartupFatal?.kind !== 'tun-address-conflict'
+      ) {
+        throw e;
+      }
+      this.tunAddressAvoidanceArmed = true;
+      this.logToManager('warn', 'TUN 地址冲突：正在探测可用地址并重试一次...');
+      this.markStart('tunAddrConflictRetry');
+      await this.startInternal(config, options);
+    }
+  }
+
+  /**
    * issue #324 P0-2：发起 TUN 地址冲突预检（不阻塞，结果由 applyTunAddressPreflight 收）。
    *
    * 硬编码的 `172.19.0.1` 撞上本机已有的同址接口时，sing-box 在 `configure tun interface: set ipv4 address`
@@ -4918,9 +4967,11 @@ rm -f "$STOPFLAG"
    * 重试、用户无从得知。起核前探一次，**确证冲突**才换到备选；探不了或无冲突一律沿用默认（fail-open——
    * 换地址本身有代价：用户钉着旧地址的路由/防火墙规则会失效，不能因一次探测失败就乱换）。
    *
-   * 不预检的两种情况都返回 null（沿用平台默认，行为零变化）：
+   * 不预检的三种情况都返回 null（沿用平台默认，行为零变化）：
    *  - 非 TUN 模式；
-   *  - 用户显式配置了 `tunConfig.inet4Address` —— 用户显式约束优先于「更优解」，照办不避让。
+   *  - 用户显式配置了 `tunConfig.inet4Address` —— 用户显式约束优先于「更优解」，照办不避让；
+   *  - **本次 start 尚未撞过地址冲突**（懒预检，见 `tunAddressAvoidanceArmed`）。默认乐观起核，
+   *    把这 681–760ms 从所有人的关键路径上拿掉；撞了才由 startWithTunAddressAvoidance 武装并重跑一遍。
    */
   private async startTunAddressPreflight(
     config: UserConfig,
@@ -4932,6 +4983,9 @@ rm -f "$STOPFLAG"
     const prevAddress = this.effectiveTunInet4Address;
     this.effectiveTunInet4Address = null;
     if (!isTunMode || config.tunConfig?.inet4Address) return null;
+    // 懒预检：没撞过就不探。**必须放在上面两行之后**——`effectiveTunInet4Address` 的复位是每次起核都要做的
+    // （否则上一次避让选的地址会粘到这一次），只有「探不探」这件事才受本闸门控。
+    if (!this.tunAddressAvoidanceArmed) return null;
     // 旧核仍在跑（#176 supersede 交错：用户连点连接）→ **跳过探测**。此刻本机接口上挂着的 `172.19.0.1` 是
     // **我们自己**的 TUN，探成 in-use 会让新腿静默切到备选、下次正常重启又切回——地址乒乓。Windows 侧已由
     // InterfaceAlias 过滤挡住（自家网卡名固定），但 macOS 的 utun 名由内核分配、无法按名排除，只能从状态侧堵。

--- a/src/main/services/SystemDnsManager.ts
+++ b/src/main/services/SystemDnsManager.ts
@@ -475,19 +475,29 @@ export class WindowsSystemDns extends SystemDnsBase {
     // 逐**已连接**接口读 DNS（与 listTargets 同口径，避免 VMware/Hyper-V/VPN 虚拟网卡的私网 DNS 抢先被选）。
     // 单接口 show dnsservers 同时含 static 与 dhcp 行 → extractIpv4s 两者都取；输出本地化不影响 IPv4 提取。
     // 仅 READ（show，非提权可跑），供 getLanResolverForDns(方案B) 用——SET(setDns) 已收敛为 no-op，见下。
+    // 起核关键路径上的耗时（真机埋点 `lanResolver` 一格 391–873ms，且拆格后已证明**全部**在这里——
+    //   同格里那步同步 fs 归一恒 0ms）。两处改动，都不改结论：
+    //   ① 逐接口的读**并行**跑。它们互不依赖，串行只是把 N 次进程启动的墙钟叠起来。
+    //   ② `execFile` 而非 `exec`：`exec` 每条命令都要先起一个 cmd.exe 来解析命令行，等于每个接口付两次进程
+    //      创建；顺带消掉接口名进 shell 命令行的拼接面（名字可含空格/`&`，本来就是靠引号硬扛的）。
+    //   **顺序仍按接口顺序去重**：pickLanResolverIp 取第一个私网地址，乱序会让它在多网卡机器上选到别的网卡
+    //   的解析器——那是行为变化，不是性能优化，故 Promise.all 后按 ifaces 原序合并。
     const ifaces = await this.listTargets();
-    const all: string[] = [];
-    for (const iface of ifaces) {
-      try {
-        const { stdout } = await execAsync(
-          `"${this.netshExe}" interface ipv4 show dnsservers name="${iface}"`,
+    const perIface = await Promise.all(
+      ifaces.map((iface) =>
+        execFileAsync(
+          this.netshExe,
+          ['interface', 'ipv4', 'show', 'dnsservers', `name=${iface}`],
           { timeout: DNS_CMD_TIMEOUT_MS }
-        );
-        for (const ip of extractIpv4s(stdout)) {
-          if (!all.includes(ip)) all.push(ip);
-        }
-      } catch {
-        /* 单接口读失败跳过 */
+        )
+          .then(({ stdout }) => extractIpv4s(String(stdout)))
+          .catch((): string[] => []) // 单接口读失败跳过
+      )
+    );
+    const all: string[] = [];
+    for (const ips of perIface) {
+      for (const ip of ips) {
+        if (!all.includes(ip)) all.push(ip);
       }
     }
     return all;

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -848,13 +848,24 @@ describe('issue #324 M-2 — performHealthCheck 的世代守卫', () => {
   });
 });
 
+/**
+ * 懒预检（`tunAddressAvoidanceArmed`）落地后，`startTunAddressPreflight` 默认直接返回 null。
+ * 下面两组验的是**预检自身的语义**（旧核在跑就沿用上次 / prev 的捕获与复位顺序），故一律先武装；
+ * 「默认不探」这条闸门本身由后面独立一组守，两者不混。
+ */
+function armedSvc(): any {
+  const svc = makeSvc();
+  svc.tunAddressAvoidanceArmed = true;
+  return svc;
+}
+
 describe('issue #324 M-1 — 旧核仍在跑时跳过地址探测（防 mac/linux 地址漂移）', () => {
   const tunCfg = { proxyModeType: 'tun', servers: [], tunConfig: {} };
 
   it('旧核在跑 → 跳过探测（不让自家 TUN 地址被探成冲突）', async () => {
     // 变异守卫：去掉这道闸 → supersede 交错（用户连点连接）时自家 utun 上的 172.19.0.1 被探成 in-use →
     // 新腿静默切备选、下次正常重启又切回，R1-H1 的地址乒乓在 mac/linux 复活。
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.activeCorePid = () => 4321;
     const probe = jest.fn();
     svc.probeIpv4AddressUsage = probe;
@@ -867,7 +878,7 @@ describe('issue #324 M-1 — 旧核仍在跑时跳过地址探测（防 mac/linu
     // 变异守卫：闸中 return null（回落平台默认）→ 在默认地址真冲突的机器上（#324 报告者型），用户连点重连
     // 就会把已经工作着的避让扔掉、再撞一次同一条 FATAL，还给出「请禁用网卡」的假终态。这是 R2→R3 之间
     // 被 review 抓出的真回归。
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.activeCorePid = () => 4321;
     svc.probeIpv4AddressUsage = jest.fn();
 
@@ -878,7 +889,7 @@ describe('issue #324 M-1 — 旧核仍在跑时跳过地址探测（防 mac/linu
   });
 
   it('旧核在跑但从未避让过 → null（回落平台默认，行为零变化）', async () => {
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.activeCorePid = () => 4321;
     svc.probeIpv4AddressUsage = jest.fn();
 
@@ -886,7 +897,7 @@ describe('issue #324 M-1 — 旧核仍在跑时跳过地址探测（防 mac/linu
   });
 
   it('无旧核 → 正常探测（prev 不干扰重新决策）', async () => {
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.activeCorePid = () => null;
     svc.probeIpv4AddressUsage = async () => 'free';
 
@@ -896,7 +907,7 @@ describe('issue #324 M-1 — 旧核仍在跑时跳过地址探测（防 mac/linu
   });
 
   it('非 TUN / 用户已显式配地址 → 不探测', async () => {
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.activeCorePid = () => null;
     const probe = jest.fn();
     svc.probeIpv4AddressUsage = probe;
@@ -913,7 +924,7 @@ describe('issue #324 M-1 — prev 的捕获与复位归属预检方法本身（�
   const tunCfg = { proxyModeType: 'tun', servers: [], tunConfig: {} };
 
   it('方法内复位 effectiveTunInet4Address（调用方不必也不该再 reset）', async () => {
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.effectiveTunInet4Address = '172.20.0.1';
     svc.activeCorePid = () => null;
     svc.probeIpv4AddressUsage = async () => 'free';
@@ -926,7 +937,7 @@ describe('issue #324 M-1 — prev 的捕获与复位归属预检方法本身（�
   it('捕获发生在复位之前 —— 旧核在跑时才能沿用上次地址', async () => {
     // 变异守卫：把捕获挪到复位之后（或写死 null）→ prev 恒 null → 真冲突机器上 supersede 重连回落默认。
     // 这条逃逸在 prev 由调用方传参时无门可拦（测试直调方法体会绕过捕获），故把两步收进本方法。
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.effectiveTunInet4Address = '172.31.0.1';
     svc.activeCorePid = () => 4321;
     svc.probeIpv4AddressUsage = jest.fn();
@@ -943,7 +954,7 @@ describe('issue #324 M-1 — prev 的捕获与复位归属预检方法本身（�
  */
 describe('B4 接线 — 就绪门必须按这三个值调用（复审 High）', () => {
   it('waitForCoreReadyOrThrow 传给 waitForCoreReady 的 opts 恒为 {12000, 50, 500}', async () => {
-    const svc = makeSvc();
+    const svc = armedSvc();
     svc.coreReadyProbe = async () => true; // 首轮即就绪，尽快收束
     const mod = require('../core-readiness');
     const spy = jest.spyOn(mod, 'waitForCoreReady');
@@ -963,7 +974,7 @@ describe('B4 接线 — 就绪门必须按这三个值调用（复审 High）', 
   });
 
   it('探活腿必须走异步版 isProcessAliveAsync（同步版会用 execSync 堵住 event loop）', async () => {
-    const svc = makeSvc();
+    const svc = armedSvc();
     const asyncProbe = jest.fn(async () => true);
     svc.isProcessAliveAsync = asyncProbe;
     svc.isProcessAlive = jest.fn(() => {
@@ -979,5 +990,134 @@ describe('B4 接线 — 就绪门必须按这三个值调用（复审 High）', 
     // 变异守卫：接线换回 `this.isProcessAlive(pid)` → 同步桩抛错 → 红
     expect(asyncProbe).toHaveBeenCalled();
     expect(svc.isProcessAlive).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * issue #324 P0-2「懒预检」：默认乐观起核不探测，撞了地址冲突才武装并重跑一遍。
+ *
+ * 为什么要有这组门：改动把一笔**每台机每次起核都付**的 681–760ms（真机实测的 PowerShell `Get-NetIPAddress`）
+ * 换成了「少数机器多起一遍核」。这笔交换只有在**撞了真的会重跑、且只重跑一次**时才成立——两条都失守的话，
+ * 表现分别是「#324 的 FATAL 直接回归成终态、避让机制等于删了」和「无限重起循环」，都比原来糟。
+ */
+describe('issue #324 P0-2 — 懒预检闸门（默认不探）', () => {
+  const tunCfg = { proxyModeType: 'tun', servers: [], tunConfig: {} };
+
+  it('未武装 → 不探测、返回 null（这才是省下那 681–760ms 的地方）', async () => {
+    const svc = makeSvc();
+    svc.activeCorePid = () => null;
+    const probe = jest.fn();
+    svc.probeIpv4AddressUsage = probe;
+
+    await expect(svc.startTunAddressPreflight(tunCfg, true)).resolves.toBeNull();
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('武装后 → 正常探测（闸门只挡「探不探」，不改探测语义）', async () => {
+    const svc = makeSvc();
+    svc.activeCorePid = () => null;
+    svc.tunAddressAvoidanceArmed = true;
+    const probe = jest.fn(async () => 'free');
+    svc.probeIpv4AddressUsage = probe;
+
+    const pick = await svc.startTunAddressPreflight(tunCfg, true);
+    expect(pick?.address).toBe('172.19.0.1');
+    expect(probe).toHaveBeenCalled();
+  });
+
+  it('闸门在 effectiveTunInet4Address 复位**之后**——上次避让的地址绝不粘到这次', async () => {
+    // 变异守卫：把 `if (!armed) return null` 提到复位之前 → 未武装的那一遍会带着上次选的 172.20.0.1 起核。
+    // 那不是「行为零变化」，而是把一次性的避让变成了永久粘滞，且没有任何一遍会重新验证它还对不对。
+    const svc = makeSvc();
+    svc.activeCorePid = () => null;
+    svc.probeIpv4AddressUsage = jest.fn();
+    svc.effectiveTunInet4Address = '172.20.0.1';
+
+    await svc.startTunAddressPreflight(tunCfg, true);
+    expect(svc.effectiveTunInet4Address).toBeNull();
+  });
+});
+
+describe('issue #324 P0-2 — 撞了才避：startWithTunAddressAvoidance', () => {
+  const cfg: any = { proxyModeType: 'tun', servers: [], selectedServerId: '__direct__' };
+
+  /** 让 startInternal 变成可编排的桩：按次序抛/返回，并记录每次进入时的武装状态。 */
+  function stubStarts(
+    svc: any,
+    plan: Array<Error | null>
+  ): { armedAt: boolean[]; calls: () => number } {
+    const armedAt: boolean[] = [];
+    svc.startInternal = jest.fn(async () => {
+      const step = plan[armedAt.length];
+      armedAt.push(svc.tunAddressAvoidanceArmed);
+      if (step) throw step;
+    });
+    return { armedAt, calls: () => armedAt.length };
+  }
+
+  const conflictErr = (): Error => new CoreStartTunPersistentError('TUN 地址已被占用');
+
+  it('地址冲突终态 → 武装后重跑一遍 startInternal，第二遍成功即整体成功', async () => {
+    const svc = makeSvc();
+    svc.lastStartupFatal = { kind: 'tun-address-conflict', raw: 'set ipv4 address', message: 'x' };
+    const h = stubStarts(svc, [conflictErr(), null]);
+
+    await expect(svc.startWithTunAddressAvoidance(cfg, {})).resolves.toBeUndefined();
+    expect(h.calls()).toBe(2);
+    // 第一遍必须**未**武装（否则那 681–760ms 又回到所有人身上），第二遍必须已武装（否则重跑毫无意义）
+    expect(h.armedAt).toEqual([false, true]);
+  });
+
+  it('只重跑一次：第二遍再撞照常上抛，不无限重起', async () => {
+    const svc = makeSvc();
+    svc.lastStartupFatal = { kind: 'tun-address-conflict', raw: 'set ipv4 address', message: 'x' };
+    const h = stubStarts(svc, [conflictErr(), conflictErr()]);
+
+    await expect(svc.startWithTunAddressAvoidance(cfg, {})).rejects.toBeInstanceOf(
+      CoreStartTunPersistentError
+    );
+    expect(h.calls()).toBe(2);
+  });
+
+  it('同为终态但**不是**地址冲突（如 wintun 创建失败）→ 不重跑', async () => {
+    const svc = makeSvc();
+    svc.lastStartupFatal = { kind: 'tun-adapter-create', raw: 'create adapter', message: 'x' };
+    const h = stubStarts(svc, [new CoreStartTunPersistentError('适配器创建失败'), null]);
+
+    await expect(svc.startWithTunAddressAvoidance(cfg, {})).rejects.toBeInstanceOf(
+      CoreStartTunPersistentError
+    );
+    expect(h.calls()).toBe(1);
+  });
+
+  it('瞬态族（CoreStartRetryError）→ 不重跑（它还在起核重试预算里，不该被这条腿抢走）', async () => {
+    const svc = makeSvc();
+    svc.lastStartupFatal = { kind: 'tun-address-conflict', raw: 'set ipv4 address', message: 'x' };
+    const h = stubStarts(svc, [new CoreStartRetryError('起核较慢'), null]);
+
+    await expect(svc.startWithTunAddressAvoidance(cfg, {})).rejects.toBeInstanceOf(
+      CoreStartRetryError
+    );
+    expect(h.calls()).toBe(1);
+  });
+
+  it('让位（superseded）→ 不重跑（接管方拥有状态，重入会与它抢适配器/端口）', async () => {
+    const svc = makeSvc();
+    svc.lastStartupFatal = { kind: 'tun-address-conflict', raw: 'set ipv4 address', message: 'x' };
+    const h = stubStarts(svc, [new CoreStartSupersededError(), null]);
+
+    await expect(svc.startWithTunAddressAvoidance(cfg, {})).rejects.toBeInstanceOf(
+      CoreStartSupersededError
+    );
+    expect(h.calls()).toBe(1);
+  });
+
+  it('入口复位武装位：上一次 start 遗留的 true 不得让这一次首遍就付探测的钱', async () => {
+    const svc = makeSvc();
+    svc.tunAddressAvoidanceArmed = true; // 上一次 start 留下的
+    const h = stubStarts(svc, [null]);
+
+    await svc.startWithTunAddressAvoidance(cfg, {});
+    expect(h.armedAt).toEqual([false]);
   });
 });

--- a/src/main/services/__tests__/system-dns-read-resolvers.test.ts
+++ b/src/main/services/__tests__/system-dns-read-resolvers.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Windows 侧「读接管前 LAN 解析器」（方案B，`getLanResolverForDns` 的取数腿）单测。
+ *
+ * 为什么单开一组：这段跑在**起核关键路径**上——真机埋点 `lanResolver` 一格 391–873ms，拆格后已证明成本
+ * 全在这里（同格里的同步 fs 归一恒 0ms）。它被改成「并行 + execFile」，而这两点都有**只在真机才显形**的
+ * 退化方式：改回串行只是变慢（测不出耗时，得按发起形态钉）；改回 `exec` 会多起一个 cmd.exe 且把接口名
+ * 重新塞进 shell 命令行（名字可含空格/`&`）。另外并行最容易顺手带进来的错误是**结果乱序**——
+ * `pickLanResolverIp` 取第一个私网地址，乱序会让多网卡机器选到别的网卡的解析器，那是行为变化不是提速。
+ */
+jest.mock('child_process', () => {
+  const actual = jest.requireActual('child_process');
+  const util = jest.requireActual('util');
+  const execFile = jest.fn();
+  // promisify 认 fn[util.promisify.custom]；真 execFile 自带，jest.fn 不带 → 不补的话 promisify 会退回
+  // 「回调首值」语义，`{ stdout }` 解构直接拿到 undefined，测出来的是夹具的毛病而不是被测代码的。
+  Object.defineProperty(execFile, util.promisify.custom, {
+    value: (...args: unknown[]) =>
+      new Promise((resolve, reject) => {
+        execFile(...args, (err: unknown, stdout: string, stderr: string) =>
+          err ? reject(err) : resolve({ stdout, stderr })
+        );
+      }),
+  });
+  return { ...actual, execFile, exec: jest.fn() };
+});
+
+import { execFile, exec } from 'child_process';
+import { WindowsSystemDns } from '../SystemDnsManager';
+
+/** 只替换 listTargets（protected），其余走真实实现——被测的正是 readEffectiveResolvers 本身。 */
+class TestWinDns extends WindowsSystemDns {
+  constructor(private readonly ifaces: string[]) {
+    super();
+  }
+  protected async listTargets(): Promise<string[]> {
+    return this.ifaces;
+  }
+  public read(): Promise<string[]> {
+    return this.readEffectiveResolvers();
+  }
+}
+
+type Cb = (e: Error | null, stdout: string, stderr: string) => void;
+
+/** 让出到宏任务，等被测代码把 `await listTargets()` 之后的同步发起跑完。 */
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+/** 按接口名给定「netsh 输出 或 抛错」，并记录每次调用的 argv；返回可手动放行的 resolver。 */
+function stubExecFile(plan: Record<string, string | Error>): {
+  argv: string[][];
+  release: () => void;
+  pending: () => number;
+} {
+  const argv: string[][] = [];
+  const queued: Array<() => void> = [];
+  (execFile as unknown as jest.Mock).mockImplementation(
+    (_bin: string, args: string[], _opts: unknown, cb: Cb) => {
+      argv.push(args);
+      const iface = String(args[args.length - 1]).replace(/^name=/, '');
+      const v = plan[iface];
+      // 不立即回调：攒住，由用例决定放行时机 → 可据此断言「所有调用在任一结果返回前就已发出」（= 并行）。
+      queued.push(() => (v instanceof Error ? cb(v, '', '') : cb(null, String(v ?? ''), '')));
+      return undefined as never;
+    }
+  );
+  return {
+    argv,
+    release: () => {
+      // 逆序放行：后发起的先返回，制造「完成顺序 ≠ 发起顺序」，专打乱序合并那条变异。
+      const all = queued.splice(0).reverse();
+      for (const f of all) f();
+    },
+    pending: () => queued.length,
+  };
+}
+
+/** netsh `show dnsservers` 的真机输出形态（本地化文案不影响 IPv4 提取）。 */
+function dnsOut(iface: string, ...ips: string[]): string {
+  const head = `接口 "${iface}" 的配置`;
+  const body = ips.length
+    ? [`    静态配置的 DNS 服务器:            ${ips[0]}`, ...ips.slice(1).map((i) => `                                      ${i}`)]
+    : ['    静态配置的 DNS 服务器:            无'];
+  return [head, ...body, ''].join('\r\n');
+}
+
+beforeEach(() => {
+  (execFile as unknown as jest.Mock).mockReset();
+  (exec as unknown as jest.Mock).mockReset();
+});
+
+describe('WindowsSystemDns.readEffectiveResolvers', () => {
+  it('逐接口读取并按**接口原序**合并去重（完成顺序不得影响结果顺序）', async () => {
+    const h = stubExecFile({
+      以太网: dnsOut('以太网', '192.168.10.1', '223.5.5.5'),
+      'Wi-Fi': dnsOut('Wi-Fi', '10.0.0.1', '223.5.5.5'),
+    });
+    const p = new TestWinDns(['以太网', 'Wi-Fi']).read();
+    await flush();
+    h.release(); // 逆序放行：Wi-Fi 先返回
+    // 变异守卫：改成「按完成顺序 push」→ 这里会变成 10.0.0.1 打头，
+    // 于是 pickLanResolverIp 在多网卡机器上选到另一张网卡的解析器。
+    await expect(p).resolves.toEqual(['192.168.10.1', '223.5.5.5', '10.0.0.1']);
+  });
+
+  it('所有接口的查询在任一结果返回前就已发出（并行，不是串行）', async () => {
+    const h = stubExecFile({
+      a: dnsOut('a', '192.168.1.1'),
+      b: dnsOut('b', '192.168.2.1'),
+      c: dnsOut('c', '192.168.3.1'),
+    });
+    const p = new TestWinDns(['a', 'b', 'c']).read();
+    await flush(); // 让 map 里的同步发起跑完
+    // 变异守卫：改回 `for … await` 串行 → 此刻只会有 1 条在飞
+    expect(h.pending()).toBe(3);
+    expect(h.argv).toHaveLength(3);
+    h.release();
+    await p;
+  });
+
+  it('走 execFile 且 argv 形态固定；接口名不带引号（无 shell，引号会被 netsh 当字面量）', async () => {
+    const h = stubExecFile({ 'Wi-Fi 2': dnsOut('Wi-Fi 2', '192.168.5.1') });
+    const p = new TestWinDns(['Wi-Fi 2']).read();
+    await flush();
+    h.release();
+    await p;
+    expect(h.argv[0]).toEqual(['interface', 'ipv4', 'show', 'dnsservers', 'name=Wi-Fi 2']);
+    // 变异守卫：改回 `exec`（cmd.exe 解析命令行）→ 每接口多一次进程创建，且接口名重回 shell 拼接面
+    expect(exec as unknown as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('单接口读失败不影响其余接口（fail-soft，不整体抛）', async () => {
+    const h = stubExecFile({
+      坏网卡: new Error('netsh 超时'),
+      以太网: dnsOut('以太网', '192.168.10.1'),
+    });
+    const p = new TestWinDns(['坏网卡', '以太网']).read();
+    await flush();
+    h.release();
+    await expect(p).resolves.toEqual(['192.168.10.1']);
+  });
+
+  it('全部接口都失败 → 空数组（调用方据此回落 dns-local，不是抛穿到起核流程）', async () => {
+    const h = stubExecFile({ a: new Error('x'), b: new Error('y') });
+    const p = new TestWinDns(['a', 'b']).read();
+    await flush();
+    h.release();
+    await expect(p).resolves.toEqual([]);
+  });
+});

--- a/src/main/services/__tests__/win-tun-adapter.test.ts
+++ b/src/main/services/__tests__/win-tun-adapter.test.ts
@@ -29,7 +29,7 @@ import {
   type AdapterPresence,
   type TunAdapterObservation,
 } from '../win-tun-adapter';
-import { powershellPath } from '../../utils/win-system32';
+import { powershellPath, system32 } from '../../utils/win-system32';
 import { resolveWinTunInterfaceName, FLOWZ_WIN_TUN_INTERFACE } from '../../../shared/tun-interface';
 import type { UserConfig } from '../../../shared/types';
 
@@ -332,6 +332,22 @@ function okStdout(...lines: string[]): string {
   return ['PROBE_OK', ...lines].join('\r\n') + '\r\n';
 }
 
+/** F2：netsh 存在性探测走的绝对路径（与产出侧同一口径，杜绝两处漂移）。 */
+function netshPath(): string {
+  return system32('netsh.exe');
+}
+
+/**
+ * `netsh interface show interface` 的真机输出形态（2026-08-26 实测抄回）：本地化表头 + 一整行连续 `-`
+ * 分隔线（哨兵，与语言无关）+ 每行四列、列间空白对齐、接口名在最后一列。
+ */
+function netshStdout(...names: string[]): string {
+  const head = '管理员状态    状态           类型             接口名称';
+  const sep = '-------------------------------------------------------------------------';
+  const rows = names.map((n) => `已启用           已连接           专用               ${n}`);
+  return [head, sep, ...rows].join('\r\n') + '\r\n';
+}
+
 /**
  * 真机实证过的脚本原文（逐字，issue #324）。
  *
@@ -371,17 +387,6 @@ try {
 } catch { }
 exit 0`;
 
-const SCRIPT_ADAPTER = `$ErrorActionPreference = 'SilentlyContinue'
-$Error.Clear()
-try {
-  $r = @(Get-NetAdapter -Name 'flowz-tun0' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name)
-  if (@($Error | Where-Object { $_.CategoryInfo.Category -ne 'ObjectNotFound' }).Count -eq 0) {
-    Write-Output 'PROBE_OK'
-    foreach ($x in $r) { Write-Output $x }
-  }
-} catch { }
-exit 0`;
-
 describe('PowerShell 探测脚本形态（#324 真机契约）', () => {
   // 姊妹腿：与 `describe('probeWinTunAdapterPresence')` 同一条理由——本组守的是**外部进程契约文本**
   // （PowerShell 全文 `toBe`），被 B3 快检短路掉的话连脚本都不会生成，失效代价比那组更高。
@@ -401,10 +406,13 @@ describe('PowerShell 探测脚本形态（#324 真机契约）', () => {
     expect(h.lastCommand()).toBe(SCRIPT_IP_WITH_ALIAS);
   });
 
-  it('网卡探测生成的脚本逐字等于真机实证过的原文', async () => {
-    const h = stubExecFile(null, okStdout());
+  it('存在性探测不得回退 PowerShell（F2：真机 netsh 66–71ms vs PowerShell 713–1005ms）', async () => {
+    // 原本这里断言的是「网卡探测脚本逐字等于真机原文」。F2 把这条腿整个换成了 netsh，脚本不复存在，
+    // 故判据改为「spawn 的不是 powershell」——守的仍是同一件事：这条腿的外部进程契约没被人悄悄改回去。
+    const h = stubExecFile(null, netshStdout('flowz-tun0'));
     await probeWinTunAdapterPresence('flowz-tun0');
-    expect(h.lastCommand()).toBe(SCRIPT_ADAPTER);
+    expect(h.lastBin()).not.toBe(powershellPath());
+    expect(h.lastBin()).toBe(netshPath());
   });
 
   /**
@@ -442,9 +450,9 @@ describe('PowerShell 探测脚本形态（#324 真机契约）', () => {
   it('恶意别名：引号被转义、其余字符原样落在单引号串内，且 argv 仍是一个元素', async () => {
     const h = stubExecFile(null, okStdout());
     // 同时含单引号、双引号、空格、换行——覆盖上表「别名含 `"` / 空格 / 换行」与「含 `'`」两行。
-    await probeWinTunAdapterPresence('a\'b"c d\ne');
+    await probeWinIpv4AddressUsage('172.19.0.1', 'a\'b"c d\ne');
     expect(h.lastArgs()).toHaveLength(4);
-    expect(h.lastCommand()).toContain(`Get-NetAdapter -Name 'a''b"c d\ne'`);
+    expect(h.lastCommand()).toContain(`$_.InterfaceAlias -ne 'a''b"c d\ne'`);
   });
 
   it('spawn 的是 powershellPath() 的绝对路径，且带 timeout / windowsHide', async () => {
@@ -539,52 +547,81 @@ describe('probeWinIpv4AddressUsage', () => {
  * `probeWinTunAdapterPresence` 的 execFile 级契约（此前只有注入桩的 waitForAdapterPresent 用例，
  * 这一层从未被覆盖——#324 的同源缺陷正是从这个缺口漏出去的）。
  */
-describe('probeWinTunAdapterPresence', () => {
+describe('probeWinTunAdapterPresence（F2：netsh 契约）', () => {
   beforeEach(() => (execFile as unknown as jest.Mock).mockReset());
-  // 本组验的是 **PowerShell 契约**（哨兵/退出码/三态），必须让 B3 快检恒不命中，否则判据会被短路吃掉。
+  // 本组验的是 **netsh 契约**（分隔线哨兵/列切分/三态），必须让 B3 快检恒不命中，否则判据会被短路吃掉。
   // 不加这行的话：本机 Linux 无 `flowz-tun0` 恰好全绿，但在真跑着 FlowZ 的 Windows 开发机上（那里确实存在
-  // 同名接口）这 8 条会集体短路成 present —— 一个只在特定机器上失效的门，比没有门更坏。
+  // 同名接口）这几条会集体短路成 present —— 一个只在特定机器上失效的门，比没有门更坏。
   beforeEach(() => mockIfaces(() => ({})));
 
-  it('哨兵在、命中本名 → present', async () => {
-    stubExecFile(null, okStdout('flowz-tun0'));
+  it('表里有本名 → present', async () => {
+    stubExecFile(null, netshStdout('flowz-tun0'));
     await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('present');
   });
 
-  it('哨兵在、无结果行 → absent（据此可判「从未创建」→ 硬闸失败本腿）', async () => {
-    // 真机上这正是「网卡不存在」的场景，旧实现因退出码 1 落 unknown → waitForAdapterPresent 的 sawAbsent
-    // 恒 false → outcome 恒 'unknown' → 硬闸永远 fail-open，#327 的就绪验证形同虚设。
-    stubExecFile(null, okStdout());
+  it('表里无本名 → absent（据此可判「从未创建」→ 硬闸失败本腿）', async () => {
+    // 真机上这正是「网卡不存在」的场景。absent 必须真的能产出，否则 waitForAdapterPresent 的 sawAbsent
+    // 恒 false → outcome 恒 'unknown' → #324 硬闸永远 fail-open，就绪验证形同虚设。
+    stubExecFile(null, netshStdout('以太网'));
     await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('absent');
   });
 
-  it('无哨兵 → unknown，绝不是 absent（不把「查不了」误判成「确实没有」）', async () => {
+  it('无表头分隔线 → unknown，绝不是 absent（不把「查不了」误判成「确实没有」）', async () => {
     stubExecFile(null, '');
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
+    // 有输出但不是那张表（被拦/换了形态）同样不作数
+    stubExecFile(null, '拒绝访问。\n');
     await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
   });
 
-  it('PowerShell 失败/超时 → unknown（fail-open，绝不据此判终态失败）', async () => {
+  it('netsh 失败/超时 → unknown（fail-open，绝不据此判终态失败）', async () => {
     stubExecFile(new Error('spawn ENOENT'), '');
     await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
   });
 
-  it('按整行精确匹配，同前缀网卡名不误判', async () => {
-    stubExecFile(null, okStdout('flowz-tun00', 'flowz-tun0-old'));
-    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('absent');
+  it('同前缀网卡名不误判（按列切分取全称，不做子串匹配）', async () => {
+    stubExecFile(null, netshStdout('flowz-tun00', 'flowz-tun0-old'));
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
   });
 
-  it('网卡名里的单引号被转义（PowerShell 字面量闭合）', async () => {
-    const h = stubExecFile(null, okStdout());
-    await probeWinTunAdapterPresence("it's");
-    expect(h.lastCommand()).toContain("-Name 'it''s'");
+  it('名字里带空格的**别的**网卡不误判成本名命中（「取最后一个空白 token」会栽在这里）', async () => {
+    // `VPN flowz-tun0` 的最后一个空白分隔 token 正好是 `flowz-tun0`；按 `\s{2,}` 切列则拿到全称，不命中。
+    stubExecFile(null, netshStdout('VPN flowz-tun0'));
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.not.toBe('present');
+  });
+
+  it('含糊（本名以子串出现但切不出干净字段）→ unknown 而非 absent', async () => {
+    // 这是新判据的安全阀：对 #324 正向门，假 absent 会走到 absent-timeout → 硬闸 → 永久拒连，
+    // 是最贵的误判方向；含糊时必须 fail-open。
+    stubExecFile(null, netshStdout('VPN flowz-tun0'));
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('unknown');
+  });
+
+  it('表头本地化/OEM 乱码不影响判定（哨兵与比对对象都是 ASCII）', async () => {
+    // 中文 Windows 的 netsh 按 OEM codepage(936) 写 stdout，Node 按 utf8 解码必成乱码——真机实测形态。
+    const garbled = `管理员状�?    状�?          类型             接口名称
+-------------------------------------------------------------------------
+已启�?           已连�?           专用               flowz-tun0
+`;
+    stubExecFile(null, garbled);
+    await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('present');
+  });
+
+  it('spawn 的是 netsh 绝对路径，argv 形态固定，且带 timeout / windowsHide', async () => {
+    // 变异守卫：删 `timeout: 4000` → 被拦住的 netsh 永不回调，起核卡死无兜底；bin 换裸名 → PATH 劫持面。
+    const h = stubExecFile(null, netshStdout('flowz-tun0'));
+    await probeWinTunAdapterPresence('flowz-tun0');
+    expect(h.lastBin()).toBe(netshPath());
+    expect(h.lastArgs()).toEqual(['interface', 'show', 'interface']);
+    expect(h.lastOpts()).toMatchObject({ timeout: 4000, windowsHide: true });
   });
 
   it('布尔版 probeWinTunAdapterPresent：absent/unknown 均塌成 false（#159 反向门 fail-open）', async () => {
-    stubExecFile(null, okStdout());
+    stubExecFile(null, netshStdout('以太网'));
     await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(false);
     stubExecFile(null, '');
     await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(false);
-    stubExecFile(null, okStdout('flowz-tun0'));
+    stubExecFile(null, netshStdout('flowz-tun0'));
     await expect(probeWinTunAdapterPresent('flowz-tun0')).resolves.toBe(true);
   });
 });
@@ -638,7 +675,7 @@ describe('nodeSeesInterface（B3 快检）', () => {
 describe('probeWinTunAdapterPresence — B3 短路接线', () => {
   afterEach(restoreIfaces);
 
-  it('Node 看得见 → 直接 present，且**零 spawn**（省掉真机实测 ~950ms 的那次 PowerShell）', async () => {
+  it('Node 看得见 → 直接 present，且**零 spawn**（省掉真机实测 ~70ms 的那次 netsh）', async () => {
     (execFile as unknown as jest.Mock).mockClear();
     mockIfaces(() => ({ 'flowz-tun0': [{ address: '172.19.0.1' }] }));
 
@@ -646,12 +683,12 @@ describe('probeWinTunAdapterPresence — B3 短路接线', () => {
     expect(execFile as unknown as jest.Mock).not.toHaveBeenCalled();
   });
 
-  it('Node 看不见 → 仍回落 PowerShell 由它给权威结论（absent 只能来自 PS）', async () => {
+  it('Node 看不见 → 仍回落 netsh 由它给权威结论（absent 只能来自外部查询）', async () => {
     (execFile as unknown as jest.Mock).mockClear();
     mockIfaces(() => ({}));
     (execFile as unknown as jest.Mock).mockImplementation(
       (_c: string, _a: string[], _o: unknown, cb: (e: unknown, out: string) => void) =>
-        cb(null, 'PROBE_OK\n')
+        cb(null, netshStdout('以太网'))
     );
 
     await expect(probeWinTunAdapterPresence('flowz-tun0')).resolves.toBe('absent');

--- a/src/main/services/win-tun-adapter.ts
+++ b/src/main/services/win-tun-adapter.ts
@@ -6,13 +6,13 @@
  *
  * 设计要点：
  *  - 设备级、按名匹配（非按地址）：杜绝与外部 sing-box / 用户手动核 / 自家孤儿核的同址网卡混淆。
- *  - 零提权：Get-NetAdapter 普通用户即可查。
+ *  - 零提权：netsh 只读查询（存在性）与 Get-NetIPAddress（地址占用）普通用户即可跑。
  *  - fail-open：探测失败 / 超时仍在 → 放行启动（绝不卡死代理），残留由启动 retry 兜底。
  *  - 纯逻辑 waitForAdapterReleased 注入 probe/sleep，便于无真实计时器/无真实网卡的单测。
  */
 import { execFile } from 'child_process';
 import * as os from 'os';
-import { powershellPath } from '../utils/win-system32';
+import { powershellPath, system32 } from '../utils/win-system32';
 import type { AddressUsage } from '../../shared/tun-address';
 
 /** 哨兵首行：脚本跑到这一行 == 探测链路可用（cmdlet 存在、模块加载成功、PS 未被拦）。 */
@@ -96,6 +96,58 @@ function runPsProbe(pipeline: string): Promise<PsProbeResult> {
       }
     );
   });
+}
+
+/**
+ * F2：跑一条 netsh 只读查询。**只用于设备级存在性**，不用于地址占用（理由见 probeWinIpv4AddressUsage 头注）。
+ *
+ * 为什么值得单开一条路：netsh 是原生工具，不过 PowerShell、不进 AMSI，真机实测 66–71ms，而同结论的
+ * PowerShell 探测要 713–1005ms（`-Command` 明文；`-EncodedCommand` 更是每次 2.3–4.7s 的主进程同步冻结）。
+ * #159 释放门在**真正需要等**的时候是每秒一探、最多 24 轮——那正是这条路差价最大的场景。
+ *
+ * 「查询确实跑过」的哨兵：netsh 的表头分隔线（一整行连续 `-`）。它**与语言无关**——中文 Windows 上表头
+ * 文字是本地化的，这行不是。exit code 只用来兜真正的执行失败（netsh 缺失 / 被拦 / 超时）。
+ *
+ * **stdout 只可用来比对 ASCII**：中文 Windows 的 netsh 按 OEM codepage(936) 写 stdout，Node 按 utf8 解码
+ * 必成乱码。本函数的比对对象只有分隔线与受 `^[A-Za-z0-9_-]{1,32}$` 约束的自家网卡名，二者皆 ASCII。
+ */
+function runNetshProbe(args: string[]): Promise<PsProbeResult> {
+  return new Promise((resolve) => {
+    execFile(system32('netsh.exe'), args, { timeout: 4000, windowsHide: true }, (err, stdout) => {
+      if (err) return resolve({ ok: false, lines: [] });
+      const lines = String(stdout)
+        .split(/\r?\n/)
+        .map((l) => l.trimEnd())
+        .filter((l) => l.trim().length > 0);
+      // 无分隔线 = 表根本没产出（被拦 / 输出截断 / 换了输出形态）→ 按探测失败处理，绝不当成「查询为空」。
+      if (!lines.some((l) => /^-{10,}$/.test(l.trim()))) return resolve({ ok: false, lines: [] });
+      resolve({ ok: true, lines });
+    });
+  });
+}
+
+/**
+ * 从 `netsh interface show interface` 的表里判断本名接口在不在。
+ *
+ * 判据：netsh 的列是**空白对齐**的，接口名在最后一列，故按 `\s{2,}` 切出的最后一个字段即接口名全称。
+ * 这一点比「最后一个空白分隔 token」强：后者会把名为 `VPN flowz-tun0` 的**别的**网卡误判成本名命中
+ * （`Get-NetAdapter -Name` 是精确匹配，不会）。
+ *
+ * **含糊时降级为 unknown，绝不降级为 absent**：若某行以子串形式含本名、却切不出干净字段（列间只隔了
+ * 一个空格等没吃准的排版），返回 `unknown`。因为对 issue #324 的正向就绪门来说，假 `absent` 会走到
+ * `absent-timeout` → 硬闸 → 「持续性 TUN 失败」永久拒连，是**最贵**的误判方向；`unknown` 则 fail-open。
+ */
+function matchNetshInterfaceName(lines: string[], name: string): AdapterPresence {
+  let ambiguous = false;
+  for (const line of lines) {
+    const fields = line
+      .trim()
+      .split(/\s{2,}/)
+      .filter((f) => f.length > 0);
+    if (fields.length > 0 && fields[fields.length - 1] === name) return 'present';
+    if (line.includes(name)) ambiguous = true;
+  }
+  return ambiguous ? 'unknown' : 'absent';
 }
 
 /**
@@ -199,16 +251,13 @@ export function nodeSeesInterface(
  * 仅返回值语义更细：err（spawn/执行失败）→ 'unknown'；命中本名 → 'present'；查询成功但空 → 'absent'。
  */
 export function probeWinTunAdapterPresence(name: string): Promise<AdapterPresence> {
-  // B3 快路径：Node 看得见本名接口 → 直接 'present'，省掉一次 PowerShell（真机实测单次 ~950ms）。
+  // B3 快路径：Node 看得见本名接口 → 直接 'present'，省掉一次外部进程。
   if (nodeSeesInterface(name)) return Promise.resolve('present');
-  const psName = name.replace(/'/g, "''");
-  // 哨兵在、命中本名 → present；哨兵在、无命中 → absent（查询确实跑过，可据此判「从未创建」）；
-  // 哨兵不在 → unknown（fail-open）。见 runPsProbe 头注：退出码不再参与「空结果」判定。
-  return runPsProbe(
-    `Get-NetAdapter -Name '${psName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name`
-  ).then((r) => {
+  // F2：设备级存在性改走 netsh（真机实测 66–71ms，PowerShell 同结论要 713–1005ms）。三态语义与
+  //   `Get-NetAdapter -Name <名>` 在真机上逐态对齐过（未起=absent / 已起=present / 停止后=absent）。
+  return runNetshProbe(['interface', 'show', 'interface']).then((r) => {
     if (!r.ok) return 'unknown';
-    return r.lines.some((line) => line === name) ? 'present' : 'absent';
+    return matchNetshInterfaceName(r.lines, name);
   });
 }
 
@@ -335,6 +384,12 @@ export function probeWinIpv4AddressUsage(
   ip: string,
   excludeInterfaceAlias?: string
 ): Promise<AddressUsage> {
+  // F2 **不覆盖本函数**（存在性探测已改 netsh，地址占用留在 PowerShell）。理由：`Get-NetIPAddress` 被选中
+  //   正是因为它看得见 **Disconnected 适配器**上的地址——#324 的冲突源就是那种。netsh 的
+  //   `interface ipv4 show ipaddresses` 默认只列活动接口，`store=persistent` 又是另一套语义（持久配置，
+  //   漏 DHCP 下发），两者都不等价。而「等价」这件事在手上这台真机**无法取证**：它只有一张网卡，
+  //   造一张 Disconnected 适配器就得动网卡=动控制通道。没有取证就不换判据——省下的那几百毫秒
+  //   （且不在关键路径上，实测 `tunAddrPreflightWait` 多数轮为 0）不值这个风险。
   // 纵深防御：调用方只传候选池常量，但仍拒绝非法字面量（PowerShell 命令拼接面）。
   if (!/^[0-9]{1,3}(\.[0-9]{1,3}){3}$/.test(ip)) return Promise.resolve('unknown');
   // **必须排除自家 TUN 接口**：预检跑在 startInternal，**早于** #159 的适配器释放门（在 startSingBoxProcess


### PR DESCRIPTION
接 #370。那批把 Windows TUN 起核从 12.1s 压到 5.2s 之后，B0 埋点又暴露出三处新的大头，本 PR 逐一处理。

真机（Windows 11 26200，TUN + 全局直连，经交互会话走 helper 路径，三次连续启动）：**5.2s → 4.4 / 4.0 / 4.7s**。

## 1. 网卡存在性探测改 netsh

`probeWinTunAdapterPresence`（#159 释放门与 #324 正向就绪门共用）由 PowerShell `Get-NetAdapter` 改 `netsh interface show interface`。netsh 是原生工具，不过 PowerShell、不进 AMSI，真机实测 66–71ms，同结论的明文 PowerShell 要 713–1005ms。释放门在真正需要等的时候是每秒一探、最多 24 轮，那正是差价最大的场景。

**只换这一支。** `probeWinIpv4AddressUsage` 不动——`Get-NetIPAddress` 被选中正是因为它看得见 Disconnected 适配器上的地址，而 #324 的冲突源就是那种；netsh 的 `show ipaddresses` 默认只列活动接口，`store=persistent` 又是另一套语义。这条等价性在手上的真机无法取证（只有一张物理网卡，造 Disconnected 适配器要动网卡），没有取证就不换判据。

判据设计（三条都是断言性质，不是断言机制）：

- 「查询确实跑过」的哨兵用 netsh 表头**分隔线**（一整行连续 `-`）。中文 Windows 上表头文字是本地化的，这行不是。
- 接口名按 `\s{2,}` 切列取最后一个字段（netsh 的列空白对齐）。比「取最后一个空白 token」强：后者会把名为 `VPN flowz-tun0` 的**别的**网卡误判成本名命中。
- **含糊时降级 unknown，绝不降级 absent**。对 #324 正向门，假 `absent` 会走到 `absent-timeout` → 硬闸 → 永久拒连，是最贵的误判方向。

真机三态对齐：`Get-NetAdapter` 与 netsh 在 TUN 未起 / 已起 / 停止后三态结论一致。另补**正向对照**——起核成功本身证明不了 netsh 在工作（`absent` 与 fail-open 的 `unknown` 在释放门里表现相同），故把 `os.networkInterfaces` 打瞎逼快检失效、直接调探测：未起 `absent`×3 / 已起 `present`×3 / 停止后 `absent`×3 / 不存在的名字三态全 `absent`，全程无 `unknown`。

## 2. 接管前读 LAN 解析器改并行 + execFile

`lanResolver` 一格真机实测 391–873ms。拆格后确认成本全在这里（同格里那步同步 fs 归一恒 0ms）。逐接口的 `show dnsservers` 由串行改 `Promise.all`；`exec` 改 `execFile`——`exec` 每条命令都要先起一个 cmd.exe 解析命令行，等于每个接口付两次进程创建，顺带消掉接口名进 shell 命令行的拼接面。

**合并顺序仍按接口原序**：`pickLanResolverIp` 取第一个私网地址，按完成顺序合并会让多网卡机器选到别的网卡的解析器——那是行为变化，不是提速。

## 3. TUN 地址预检改懒执行

预检是一次 PowerShell `Get-NetIPAddress`，真机实测 681–760ms，**每台机每次起核都付**；而它要躲的地址冲突只发生在装了残留 TAP/TUN 网卡的少数机器上。

埋点把这笔账摆出来后可以看清：`tunAddrPreflightWait` ≈ 探测耗时 − 并行窗口，前面的准备步骤被优化得越快它越显形（同一批数据里 `lanResolver=412` 时它是 787/954ms，`lanResolver=1455` 时它是 0）。正确的形状是倒过来：默认乐观起核，撞了才避。

撞了怎么办：核 FATAL 被 `classifySingBoxFatal` 判成 `tun-address-conflict`（#324 真机实证过的分类）→ 武装预检 → 整个 `startInternal` 重跑一遍，那一遍才付探测的钱并换地址。

- **为什么重跑整个 `startInternal`**：地址要随配置下发给核，换地址就得重生成配置；而 `singboxConfig` 还经过 `checkAndPruneConfig` 的就地剔除，在失败分支里单独重生成会把坏节点放回来（T9 踩过同一个坑），单独就地改地址又要复刻 `buildInbounds` 的平台掩码逻辑。重入走的是用户手动重连的同一条路径。
- **只重跑一次**：武装位在入口复位、命中后置真，第二遍再撞照常上抛终态错误。
- **判据取 `lastStartupFatal.kind` 且要求终态类型是 `CoreStartTunPersistentError`**：不取错误文案（会随措辞变）；瞬态族还在起核重试预算里、让位必须静默退场，两者都不该被这条腿抢走。
- **懒闸放在 `effectiveTunInet4Address` 复位之后**：复位是每次起核都要做的，提到前面会让上次避让的地址永久粘滞，且再没有一遍会重新验证它。

## 真机实测

| 批次 | 三次连续启动 |
|---|---|
| #370 之后 | 5004 / 5715 / 5378 ms |
| 本 PR 之后 | **4366 / 3969 / 4713 ms** |

- `tunAddrPreflightWait` 0–954ms → **0 / 0 / 0**
- `lanResolver` 391–1455ms → **250 / 261 / 326**（并行化的收益在预检不再抢主线程后才兑现）
- `L1.tunAdapter:present` 3–7ms，`L1.adapterRelease` 0
- issue #159 硬杀回归重跑仍过：杀 sing-box → 自动重启 1/3 → `total=3204ms outcome=ok`，适配器 Up

**未在真机走到的路径**：避让重跑腿本身没跑过——这台机不存在地址冲突，构造冲突要动真机网卡配置。该路径由 9 条单测 + 5 条变异覆盖。

## 测试

新增 1 个测试文件、扩充 2 个，共 +521 / −73。本轮新增的门全部经变异证明有牙：

| 变异 | 结果 |
|---|---|
| 含糊降级为 absent（拆掉安全阀） | 2 红 |
| 按单个空白切列（取最后 token） | 2 红 |
| 去掉 netsh 分隔线哨兵 | 1 红 |
| 存在性探测回退 PowerShell | 7 红 |
| 解析器读取改回串行 | 4 红 |
| 合并顺序按完成顺序 | 1 红 |
| 解析器读取回退 exec（shell） | 5 红 |
| 懒闸提到地址复位之前 | 1 红 |
| 拆掉懒闸（恒预检） | 1 红 |
| 重跑入口不复位武装位 | 1 红 |
| 重跑判据放宽成「任何终态」 | 1 红 |
| 去掉终态类型检查 | 2 红 |

`npm run build:main` 0 error；`npx jest` 3950 passed / 0 failed（252 suites）。

## 影响面

全部集中在 Windows 起核路径。macOS / Linux 不受影响：netsh 探测本就只在 win32 分支，`readEffectiveResolvers` 改的是 `WindowsSystemDns` 自己的实现，地址预检的懒闸对非 TUN / 非 win32 是既有的早退分支。
