### PR TITLE
perf(win-tun): 起核就绪窗内零 spawn + coreReady 埋点细分

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -4670,15 +4670,20 @@ rm -f "$STOPFLAG"
     } catch {
       /* 忽略 */
     }
+    // B6：PID 文件写入单独一格。它与下面的探活原本合记一格，而那一格真机量到 2.0–2.6s——
+    //   不切开就只能靠推测说「多半是探活」，切开即自证。
+    this.markStartLeg(startGen, 'pidFile');
 
-    if (!this.isProcessAlive(res.pid)) {
+    if (!this.processExistsNoSpawn(res.pid)) {
       this.cleanup();
       throw new Error('helper 报告已启动但进程不存在');
     }
-    // B6：这一格 = 写 PID 文件 + 一次**同步**探活。原先它没有自己的格子，耗时被整片记进 `coreReady`，
-    //   于是那一格看起来像「核起得慢」，实则掺着主进程被 execSync 堵住的时间。真机实测该调用 81–160ms
-    //   （execSync 必过 cmd.exe + tasklist；对照 execFileSync 67–72ms、`process.kill(pid,0)` 0.1ms）。
-    //   B4 当初只把**就绪循环里**的探活换成异步版，漏了这个调用点——先量出来，再决定怎么改。
+    // B6：这一格 = 一次**零 spawn** 的存在性判定。
+    //   改前它是 `isProcessAlive`（execSync → cmd.exe + tasklist），真机实测**这一格 2018–2584ms**，
+    //   占当时整个起核（~4.7s）的一半以上。同批数据里 `L1.spawn` 也从平时 9–12ms 抖到 155–168ms、
+    //   `configGen` 从 12ms 抖到 25–59ms —— 这一刀恰好落在「82MB 的新核刚起来、杀软正在扫它」的窗口里，
+    //   此刻这台机上**任何**进程创建都被拖慢。故正确的修法不是「改成异步」（异步只是不堵 event loop，
+    //   钱照付），而是**根本不在这里起进程**：`process.kill(pid, 0)` 真机实测 0.1ms。
     this.markStartLeg(startGen, 'aliveCheck');
 
     // issue #159：等核真就绪（管理 API 绑定）再判成功，而非「spawn 即 started」。起核期内核死/超时 → 抛可重试
@@ -6315,6 +6320,31 @@ rm -f "$STOPFLAG"
    *
    * T16 子 commit 2：改 public 供 PlatformPrivilegeService.ctx 回调注入（killOrphans 复核存活用）。
    */
+  /**
+   * 零 spawn 的进程存在性判定（`process.kill(pid, 0)`：只做权限/存在性检查，不投递信号）。
+   *
+   * 为什么需要它：`isProcessAlive` 走 `execSync`（Windows 上必过 cmd.exe）+ `tasklist`，真机单独量是
+   * 81–160ms，但**落在起核路径上时量到 2018–2584ms**——那一刀紧跟着 82MB 的新核启动，杀软正在扫它，
+   * 此刻这台机上任何进程创建都被拖慢。零 spawn 版真机 0.1ms。
+   *
+   * **判据的三态，尤其是 EPERM**：
+   *  - 不抛 → 存在；
+   *  - `ESRCH` → **确证不存在**（唯一可以判「没有」的情形）；
+   *  - `EPERM` → **存在**。这不是模棱两可：内核先查到进程、再拒绝访问，才会给 EPERM。
+   *    helper 路径下核由 LocalSystem 起、FlowZ 非提权，**正是 EPERM 的常见产地**——判成「不存在」
+   *    会让每次 helper 起核都被自己这道检查判死。
+   *  - 其余错误码 → 说不了 → **fail-open 判存在**。这道检查只为抓「helper 报成功但进程压根没起来」，
+   *    抓不准时绝不能替代它下结论；真死了由就绪门（`waitForCoreReady` 的 dead 分支）兜住。
+   */
+  private processExistsNoSpawn(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (e) {
+      return (e as NodeJS.ErrnoException)?.code !== 'ESRCH';
+    }
+  }
+
   isProcessAlive(pid: number): boolean {
     try {
       const { execSync } = require('child_process');

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -146,6 +146,7 @@ import {
   type AdapterPresence,
   type TunAdapterObservation,
   probeWinIpv4AddressUsage,
+  nodeSeesInterface,
 } from './win-tun-adapter';
 import {
   probeTcpReachable,
@@ -640,8 +641,15 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   //   死后验尸不可靠（适配器随进程句柄消失），故必须窗口内观测。就绪后 grace 内仍未见 = 本腿失败（硬闸，拒假连接）。
   private adapterPresenceProbe: (name: string) => Promise<AdapterPresence> =
     probeWinTunAdapterPresence;
-  // 就绪窗/grace 内的适配器观测轮询间隔（1s）。就绪窗 ≤12s → ≤~12 次 PS spawn；见到即停观测省 spawn。真机项 #2 校准。
+  // B8：就绪窗内观测腿专用的**零 spawn** 快检（Node 接口枚举）。只产肯定结论——看不见 ≠ 不存在（见
+  //   nodeSeesInterface 头注），故窗内只据它记 present，absent 证据一律由完整探测（硬闸 / 失败出口补探）提供。
+  //   注入点供单测替换，生产恒为 nodeSeesInterface。
+  private adapterPresenceFastProbe: (name: string) => boolean = nodeSeesInterface;
+  // grace 硬闸的适配器轮询间隔（1s）。那一轮每次都是真 netsh，且此刻就绪窗已过、杀软扫核的风暴已散。
   private static readonly TUN_READY_OBSERVE_POLL_MS = 1000;
+  // B8：就绪窗内观测腿的节拍（200ms）。改零 spawn 后每轮成本 ≈ 一次 os.networkInterfaces()，
+  //   故节拍可比硬闸细 5 倍——adapterEverSeen 的时刻更准，且不再有任何进程创建落在起核关键路径上。
+  private static readonly TUN_READY_FAST_OBSERVE_POLL_MS = 200;
   // 就绪（API 绑定）后再给适配器出现的 grace 上限（8s）：适配器晚于 API bind 出现属正常时序，避免误杀 #159/#176 瞬态。真机项 #2 校准。
   //   同上（姊妹腿）：8000/1000 的真实墙钟是 ~16.6s，deadline 化后 8000 会把 #324 硬闸的判定窗口砍掉一半 →
   //   更早判 absent-timeout → 更多「永久拒连」误报。故提到 17000 保持等价。
@@ -4724,15 +4732,18 @@ rm -f "$STOPFLAG"
     const recordPresence = (p: AdapterPresence): void => {
       if (obs) recordAdapterPresence(obs, p); // sticky monotonic 累计（纯函数，单测覆盖）
     };
+    // B8：就绪窗内的观测腿改**零 spawn**。原先每轮走 `adapterPresenceProbe`（F2 之后是 netsh），而适配器要到
+    //   +660–997ms 才出现，窗口前段每轮都真的起进程——`execFile` 的异步只是回调异步，`uv_spawn` 在 event loop
+    //   线程上同步执行，CreateProcessW 多慢主线程就堵多久。真机实测这个窗口里一次 netsh 要 819ms（空载 50–80ms），
+    //   而同期 FlowZ 的首次就绪探测（一次 loopback connect，正常 <5ms）被拖到 2538–4036ms。
+    //   Node 枚举与 `Get-NetAdapter -Name` 同一个名字空间，只是**只产肯定结论**：故窗内只记 present、绝不记
+    //   absent（看不见 ≠ 不存在）；absent 证据改由成功路径的 grace 硬闸、失败出口的补探提供（见下）。
     const observerDone: Promise<void> = observing
       ? (async () => {
           while (observing && !obs!.adapterEverSeen) {
-            const p = await this.adapterPresenceProbe(adapterName).catch(
-              () => 'unknown' as AdapterPresence
-            );
-            recordPresence(p);
+            if (this.adapterPresenceFastProbe(adapterName)) recordPresence('present');
             if (!observing || obs!.adapterEverSeen) break;
-            await sleep(ProxyManager.TUN_READY_OBSERVE_POLL_MS);
+            await sleep(ProxyManager.TUN_READY_FAST_OBSERVE_POLL_MS);
           }
         })()
       : Promise.resolve();
@@ -4744,9 +4755,12 @@ rm -f "$STOPFLAG"
         alivePollMs: ProxyManager.CORE_READY_ALIVE_POLL_MS,
       },
       {
-        // B4：换异步探活——同步版是 execSync，起核窗内每轮阻塞主进程 50–100ms（拖拽/动画可感）。
-        //   判定逻辑与 isProcessAlive 严格一致（见其头注），仅是不再堵 event loop。
-        isAlive: () => this.isProcessAliveAsync(pid),
+        // B8：探活换零 spawn。B4 把这条腿从 execSync 换成 execFile，只解决了「回调不堵 event loop」，钱照付：
+        //   `uv_spawn` 本身在 event loop 线程上同步执行。而这条腿的射程正是起核窗（alivePollMs=500，且 i=0 必探），
+        //   与杀软扫 82MB 新核的窗口完全重合——真机实测同窗口一次 tasklist 要 150–673ms（空载 50–80ms）。
+        //   `process.kill(pid, 0)` 零 spawn（真机 0.1ms），且顺带把探测失败的语义从 fail-closed 修成 fail-open：
+        //   tasklist 版 catch 一律 false（spawn 失败/超时 = 判核已死 → stopCore + 重试），kill 版只有 ESRCH 判死。
+        isAlive: () => this.processExistsNoSpawn(pid),
         // B6：把**首次**就绪探测单独切一格。要回答的问题是「那两秒里，管理 API 到底是还没开，还是开了没被
         //   及时发现」——首探若已 true，说明门进来时端口早就通了，钱花在了门之前；首探 false 则 `coreReady`
         //   那一格量的才真是「等端口开」。标签带上首探结果，两种情形在汇总行里一眼可分。
@@ -4769,7 +4783,7 @@ rm -f "$STOPFLAG"
     //   让位腿不打点的不变量靠 `measured` 保住（原先靠「放在 superseded 出口之后」，现在出口在下面）。
     const measured = outcome !== 'superseded';
     if (measured) this.markStartLeg(startGen, `coreReady:${outcome}`);
-    observing = false; // 停就绪窗观测，等其 drain（在途 sleep 至多 1s；若卡在在途 probe，Get-NetAdapter 的 execFile timeout 4s 封顶）
+    observing = false; // 停就绪窗观测，等其 drain（B8 之后窗内已无 spawn，drain 至多一个 200ms 的在途 sleep）
     await observerDone.catch(() => {});
     if (measured) this.markStartLeg(startGen, 'observerDrain'); // drain 本身单独一格：它是真实成本，只是不该混进就绪耗时
 
@@ -4822,6 +4836,21 @@ rm -f "$STOPFLAG"
       throw new CoreStartRetryError(
         `sing-box 已就绪但 TUN 适配器 ${adapterName} 未建立，正在自动重试`
       );
+    }
+
+    // B8：失败出口（dead/timeout）补一次**完整**存在性探测。窗内观测腿改零 spawn 后只产 present，
+    //   于是失败路径上 `probeEverConclusive` 会恒 false，#324 的终态判据（!adapterEverSeen && probeEverConclusive）
+    //   随之恒不成立——「wintun 装不起来」的机器退回无限重试 + 全程「正在自动重试」，正是 #324 报告者的抱怨。
+    //   **必须在 stopCore 之前**：拆核后适配器随即释放，那时的 absent 说明不了本腿是否建起过。
+    //   仅在「从未见过适配器」时才探（见过即已有 present 结论，无需再花一次 spawn）；此刻就绪窗已结束、
+    //   风暴已散，且这条路径本来就要 stopCore + 重试，这次 spawn 不在任何人的等待路径上。
+    //   被接管则跳过（接管方正在拆核，本腿再探也只是给它的适配器计数，且不该为让位腿花 spawn）。
+    if (obs && !obs.adapterEverSeen && this.lifecycleGeneration === startGen) {
+      const post = await this.adapterPresenceProbe(adapterName).catch(
+        () => 'unknown' as AdapterPresence
+      );
+      recordPresence(post);
+      this.markStartLeg(startGen, `tunAdapterPostmortem:${post}`);
     }
 
     // 失败：尽力停掉这个起不来的核（best-effort，其 wintun 适配器随即开始释放，给 retry 让路），再抛 CoreStartRetryError

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -4675,6 +4675,11 @@ rm -f "$STOPFLAG"
       this.cleanup();
       throw new Error('helper 报告已启动但进程不存在');
     }
+    // B6：这一格 = 写 PID 文件 + 一次**同步**探活。原先它没有自己的格子，耗时被整片记进 `coreReady`，
+    //   于是那一格看起来像「核起得慢」，实则掺着主进程被 execSync 堵住的时间。真机实测该调用 81–160ms
+    //   （execSync 必过 cmd.exe + tasklist；对照 execFileSync 67–72ms、`process.kill(pid,0)` 0.1ms）。
+    //   B4 当初只把**就绪循环里**的探活换成异步版，漏了这个调用点——先量出来，再决定怎么改。
+    this.markStartLeg(startGen, 'aliveCheck');
 
     // issue #159：等核真就绪（管理 API 绑定）再判成功，而非「spawn 即 started」。起核期内核死/超时 → 抛可重试
     // 错误交 runStartWithRetry 快速重起（届时 wintun 适配器/端口已释放），替代「假成功 + 10s 健康检查兜底」。
@@ -4707,6 +4712,8 @@ rm -f "$STOPFLAG"
     //   在就绪等待窗内并行探自家 wintun 适配器是否出现，sticky 落 tracker——即便本腿随后进程死（验尸不可靠），也已知
     //   「本次 start 是否曾见适配器」。见到即停观测省 spawn。macOS/Linux/非 TUN：obs=null → 全程 no-op、零改动。
     const obs = this.tunReadyObservation;
+    // B6：首次就绪探测只打一次点（见下方 isReady 包装）。
+    let firstReadyProbeMarked = false;
     const adapterName = obs ? resolveWinTunInterfaceName(this.currentConfig as UserConfig) : '';
     let observing = obs !== null;
     const recordPresence = (p: AdapterPresence): void => {
@@ -4735,7 +4742,18 @@ rm -f "$STOPFLAG"
         // B4：换异步探活——同步版是 execSync，起核窗内每轮阻塞主进程 50–100ms（拖拽/动画可感）。
         //   判定逻辑与 isProcessAlive 严格一致（见其头注），仅是不再堵 event loop。
         isAlive: () => this.isProcessAliveAsync(pid),
-        isReady: () => this.coreReadyProbe('127.0.0.1', port),
+        // B6：把**首次**就绪探测单独切一格。要回答的问题是「那两秒里，管理 API 到底是还没开，还是开了没被
+        //   及时发现」——首探若已 true，说明门进来时端口早就通了，钱花在了门之前；首探 false 则 `coreReady`
+        //   那一格量的才真是「等端口开」。标签带上首探结果，两种情形在汇总行里一眼可分。
+        //   只标一次（`readyProbe0` 之后的轮次不再打点），故对起核路径零额外开销。
+        isReady: async () => {
+          const r = await this.coreReadyProbe('127.0.0.1', port);
+          if (!firstReadyProbeMarked) {
+            firstReadyProbeMarked = true;
+            this.markStartLeg(startGen, `readyProbe0:${r}`);
+          }
+          return r;
+        },
         sleep,
         isSuperseded: () => this.lifecycleGeneration !== startGen,
       }
@@ -5173,6 +5191,10 @@ rm -f "$STOPFLAG"
       this.startupLogOffset = 0; // 文件还不存在（首启）→ 整文件都是本次的
     }
 
+    // 核日志的清空必须发生在**起核之前**（见 truncateCoreLogFile 头注：原先长在 startLogFileWatcher 里，
+    //   而那是就绪之后才调的，等于每轮都把核自己的启动日志抹掉）。放在本方法顶部 → 三条支路与每条重试腿共用。
+    this.truncateCoreLogFile();
+
     // issue #159：起核前（win32&&TUN）等上一轮自家 wintun 适配器释放。置于本方法顶部（而非 startInternal）→ 每次
     //   runStartWithRetry 重启腿、以及下方 helper / UAC 两条启动支路都经此门控（不止首次），杜绝重试立刻再撞僵尸适配器。
     const launchCfg = this.currentConfig;
@@ -5486,7 +5508,8 @@ rm -f "$STOPFLAG"
         // 必须【在 spawn 后立即起 logFileWatcher】（而非等 1s 成功后）。否则启动失败路径（进程在 1s 内退出、
         // watcher 尚未起）下 singbox.log 里的 FATAL 配置错误/端口冲突无人读取 → lastErrorOutput 链路
         // （parseStartupError/classifyCoreError）拿不到具体错误，用户只得到通用退出码（H2 回归）。
-        // startLogFileWatcher 内部会清空日志文件（writeFileSync ''），sing-box 从空文件续写，时序正确。
+        // 日志文件已由 startSingBoxProcess 顶部的 truncateCoreLogFile() 在 spawn 之前清空，sing-box 从空文件
+        // 续写；watcher 从 0 读起，故本腿核写的启动日志会被完整投递，时序正确。
         // macOS/Windows 系统代理 + Linux 系统代理/manual：sing-box 仍走 stdout（上面已监听），不起 watcher。
         if (process.platform === 'linux' && this.isTunModeNow()) {
           this.startLogFileWatcher();
@@ -7247,21 +7270,37 @@ rm -f "$STOPFLAG"
     }
   }
 
+  /**
+   * 清空核日志文件（sing-box 配置里 `log.output` 指向的那个）。**必须在起核之前调用。**
+   *
+   * 原先这一步长在 `startLogFileWatcher()` 里，而那个方法在 **`waitForCoreReadyOrThrow()` 返回之后**才被调用
+   * ——于是 helper 路径上，核自己的启动日志刚写完就被抹掉，每一轮都如此（真机实证：`singbox.log` 里最早的一行
+   * 恒是就绪之后的运行期流量；`singbox_startup.log` 恒 0 字节，因为核走 `log.output` 不走 stdout）。
+   * 后果是「起核那两三秒里核在干什么」这个问题**在产品里根本不可观测**，只能靠外部高频快照去抢，
+   * 本轮就是这么抢到 `sing-box started (0.93s)` 的。
+   *
+   * 前移到 spawn 之前后：清空 → 核写启动日志 → 就绪 → watcher 从 0 读起，把这段启动日志一并投进 app.log 与
+   * 诊断报告。三条起核支路（helper / UAC 看护 / Linux 直起）与每条重试腿共用本方法，语义一致。
+   */
+  private truncateCoreLogFile(): void {
+    try {
+      require('fs').writeFileSync(this.getLogFilePath(), '');
+    } catch {
+      /* 清不掉只是日志里混入上一轮内容，绝不该阻断起核 */
+    }
+    this.lastLogFileSize = 0;
+  }
+
   private startLogFileWatcher(): void {
     if (this.logFileWatcher) {
       return;
     }
 
     const logFilePath = this.getLogFilePath();
+    // 从 0 起读：清空动作已前移到 `truncateCoreLogFile()`（起核之前），此刻文件里躺着的正是**本腿核自己的
+    //   启动日志**，要原样喂进 app.log。本方法进入即早退于 `logFileWatcher` 非空，故不存在「没清空又从 0 重读」
+    //   导致的重复投递。
     this.lastLogFileSize = 0;
-
-    // 清空旧的日志文件
-    const fsSync = require('fs');
-    try {
-      fsSync.writeFileSync(logFilePath, '');
-    } catch {
-      // 忽略错误
-    }
 
     // 每 500ms 检查一次日志文件
     this.logFileWatcher = setInterval(async () => {

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -32,6 +32,8 @@ import {
   CoreStartTunPersistentError,
 } from '../core-readiness';
 import type { AdapterPresence, TunAdapterObservation } from '../win-tun-adapter';
+import { StartTimeline } from '../start-timeline';
+import { withPlatformAsync } from './platform-test-utils';
 
 afterAll(() => {
   try {
@@ -1119,5 +1121,167 @@ describe('issue #324 P0-2 — 撞了才避：startWithTunAddressAvoidance', () =
 
     await svc.startWithTunAddressAvoidance(cfg, {});
     expect(h.armedAt).toEqual([false]);
+  });
+});
+
+/**
+ * B6：把 `coreReady` 那一格拆细 + 把核日志的清空前移到 spawn 之前。
+ *
+ * 两件事同一个由来。真机把起核压到 ~4.3s 之后，`L1.coreReady:ready` 剩 2.3–2.8s，占了一半以上；抢救出来的核
+ * 日志显示核自报 `sing-box started (0.93s)`，也就是说那一格里**大部分不是核在初始化**。而之所以要「抢救」，
+ * 是因为清空日志的动作长在 `startLogFileWatcher()` 里、那又是就绪之后才调的——核自己的启动日志每轮刚写完就被抹掉。
+ *
+ * 这一组守的就是这两条：新格子确实打得出来（否则下一轮又只能靠外部抢快照），以及清空确实发生在起核之前。
+ */
+describe('B6：核日志清空前移到 spawn 之前', () => {
+  const fsSync = require('fs');
+
+  it('truncateCoreLogFile 清空文件并把 watcher 读游标复位到 0', () => {
+    const svc = makeSvc();
+    const p = svc.getLogFilePath();
+    fsSync.mkdirSync(path.dirname(p), { recursive: true });
+    fsSync.writeFileSync(p, '上一轮的残留\n');
+    svc.lastLogFileSize = 12345;
+
+    svc.truncateCoreLogFile();
+
+    expect(fsSync.readFileSync(p, 'utf-8')).toBe('');
+    expect(svc.lastLogFileSize).toBe(0);
+  });
+
+  it('startLogFileWatcher **不再**清空文件——那正是核启动日志被抹掉的原因', async () => {
+    const svc = makeSvc();
+    const p = svc.getLogFilePath();
+    fsSync.mkdirSync(path.dirname(p), { recursive: true });
+    // 模拟「核已经把本腿的启动日志写进来了」，此刻 watcher 才启动（真实时序：就绪之后）
+    fsSync.writeFileSync(p, '+0800 INFO sing-box started (0.93s)\n');
+
+    svc.startLogFileWatcher();
+    try {
+      // 变异守卫：把 writeFileSync(logFilePath, '') 放回 startLogFileWatcher → 这里读到空串
+      expect(fsSync.readFileSync(p, 'utf-8')).toContain('sing-box started (0.93s)');
+      // 且游标从 0 起，本腿启动日志会被完整投递进 app.log（而不是被跳过）
+      expect(svc.lastLogFileSize).toBe(0);
+    } finally {
+      svc.stopLogFileWatcher();
+    }
+  });
+
+  it('startSingBoxProcess 在交给任何启动支路**之前**就已清空', async () => {
+    const order: string[] = [];
+    const svc = makeSvc();
+    svc.currentConfig = { proxyModeType: 'tun', servers: [], tunConfig: {} };
+    svc.truncateCoreLogFile = jest.fn(() => order.push('truncate'));
+    svc.waitForOwnTunAdapterReleased = jest.fn(async () => {});
+    svc.helperManager = { isReady: jest.fn(async () => true), stopCore: jest.fn() };
+    // 直接钉住分支判定，避免本用例依赖 needsRootPrivilege / needsLinuxTun 的内部条件——
+    // 它们各有各的门，混进来会让这条「顺序」判据在别人改那些门时莫名其妙地红。
+    svc.needsOsascript = () => false;
+    svc.needsWindowsUAC = () => true;
+    // 哨兵必须用 CoreStartRetryError：helper 分支的 catch 会**吞掉**普通错误并回落 UAC 路径，
+    // 用普通 Error 的话本用例会一路跑到后面的支路上去，测出来的就不是「顺序」而是别的东西。
+    svc.startViaHelper = jest.fn(async () => {
+      order.push('launch');
+      throw new CoreStartRetryError('停在这里即可，本用例只看顺序');
+    });
+
+    await withPlatformAsync('win32', async () => {
+      await expect(svc.startSingBoxProcess(svc.lifecycleGeneration)).rejects.toThrow('停在这里即可');
+    });
+
+    // 变异守卫：把 truncateCoreLogFile() 挪回就绪之后（或删掉）→ order 不再是 ['truncate','launch']
+    expect(order).toEqual(['truncate', 'launch']);
+  });
+});
+
+/**
+ * B6：`coreReady` 那一格的细分埋点。
+ * 要回答的问题是「那两秒里，管理 API 到底是还没开、还是开了没被及时发现」——首次就绪探测的结果就是判据。
+ */
+describe('B6：首次就绪探测单独一格（readyProbe0）', () => {
+  function withTimeline(svc: any): StartTimeline {
+    const tl = new StartTimeline();
+    svc.startTimeline = tl;
+    return tl;
+  }
+
+  it('首探即 true → 打 readyProbe0:true（说明门进来时端口早已通，钱花在门之前）', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    const tl = withTimeline(svc);
+    svc.coreReadyProbe = jest.fn(async () => true);
+    svc.adapterPresenceProbe = jest.fn(async () => 'present' as AdapterPresence);
+    svc.isProcessAliveAsync = async () => true;
+
+    await svc.waitForCoreReadyOrThrow(4321, svc.lifecycleGeneration);
+
+    const labels = tl.phases().map((p: { label: string }) => p.label);
+    expect(labels).toContain('readyProbe0:true');
+  });
+
+  it('首探 false → 打 readyProbe0:false（coreReady 那一格量的才真是「等端口开」）', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    const tl = withTimeline(svc);
+    let n = 0;
+    svc.coreReadyProbe = jest.fn(async () => ++n > 1); // 首探 false，第二探 true
+    svc.adapterPresenceProbe = jest.fn(async () => 'present' as AdapterPresence);
+    svc.isProcessAliveAsync = async () => true;
+
+    await svc.waitForCoreReadyOrThrow(4321, svc.lifecycleGeneration);
+
+    const labels = tl.phases().map((p: { label: string }) => p.label);
+    expect(labels).toContain('readyProbe0:false');
+  });
+
+  it('只打一次——后续轮次不再打点（否则病态路径下会把时间轴刷爆）', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    const tl = withTimeline(svc);
+    let n = 0;
+    svc.coreReadyProbe = jest.fn(async () => ++n > 5); // 前 5 探 false
+    svc.adapterPresenceProbe = jest.fn(async () => 'present' as AdapterPresence);
+    svc.isProcessAliveAsync = async () => true;
+
+    await svc.waitForCoreReadyOrThrow(4321, svc.lifecycleGeneration);
+
+    const marks = tl
+      .phases()
+      .map((p: { label: string }) => p.label)
+      .filter((l: string) => l.startsWith('readyProbe0'));
+    expect(marks).toEqual(['readyProbe0:false']);
+  });
+});
+
+/**
+ * B6：`aliveCheck` 格（写 PID 文件 + 一次同步探活）。
+ * 它原先没有自己的格子，耗时被整片记进 `coreReady` —— 于是那一格看起来像「核起得慢」，
+ * 实则掺着主进程被 `execSync`（cmd.exe + tasklist，真机 81–160ms）堵住的时间。
+ */
+describe('B6：aliveCheck 单独一格', () => {
+  it('startViaHelper 在探活之后、就绪门之前打 aliveCheck，且早于 coreReady 那一格', async () => {
+    const svc = makeSvc();
+    // singboxPath 必须真实存在：startViaHelper 顶部有 existsSync 早退
+    const realBin = path.join(TMP, 'fake-sing-box');
+    fsSync.writeFileSync(realBin, 'x');
+    svc.singboxPath = realBin;
+    svc.currentConfig = { proxyModeType: 'tun', servers: [], allowLan: false, tunConfig: {} };
+    svc.helperManager = { startCore: jest.fn(async () => ({ ok: true, pid: 4321 })) };
+    svc.isProcessAlive = jest.fn(() => true);
+    // 就绪门本身在别处测；这里只看它**之前**的那一格确实打了
+    svc.waitForCoreReadyOrThrow = jest.fn(async () => {});
+    svc.startLogFileWatcher = jest.fn();
+    svc.startHealthCheck = jest.fn();
+    svc.sendEventToRenderer = jest.fn();
+
+    const tl = new StartTimeline();
+    svc.startTimeline = tl;
+    await svc.startViaHelper(svc.lifecycleGeneration);
+
+    const labels = tl.phases().map((p: { label: string }) => p.label);
+    // 变异守卫：删掉 markStartLeg(startGen, 'aliveCheck') → 这条红
+    expect(labels).toContain('aliveCheck');
+    expect(labels.indexOf('spawn')).toBeLessThan(labels.indexOf('aliveCheck'));
+    expect(svc.isProcessAlive).toHaveBeenCalledWith(4321);
   });
 });

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -25,6 +25,7 @@ jest.mock('child_process', () => ({
   execFile: jest.fn(),
 }));
 
+import { execFile } from 'child_process';
 import { ProxyManager } from '../ProxyManager';
 import {
   CoreStartRetryError,
@@ -1254,34 +1255,104 @@ describe('B6：首次就绪探测单独一格（readyProbe0）', () => {
 });
 
 /**
- * B6：`aliveCheck` 格（写 PID 文件 + 一次同步探活）。
- * 它原先没有自己的格子，耗时被整片记进 `coreReady` —— 于是那一格看起来像「核起得慢」，
- * 实则掺着主进程被 `execSync`（cmd.exe + tasklist，真机 81–160ms）堵住的时间。
+ * B6：`pidFile` / `aliveCheck` 两格，以及那次探活**不得再起进程**。
+ *
+ * 由来：这两条语句原本合记一格，真机量到 2018–2584ms，占当时整个起核（~4.7s）的一半以上。切开之后
+ * 才能自证是谁；而探活那一刀之所以贵，是因为它紧跟在 82MB 的新核启动之后——杀软正在扫它，此刻这台机上
+ * **任何**进程创建都被拖慢（同批数据里 `L1.spawn` 也从 9–12ms 抖到 155–168ms）。故判据是「零 spawn」，
+ * 不是「改成异步」——异步只是不堵 event loop，钱照付。
  */
-describe('B6：aliveCheck 单独一格', () => {
-  it('startViaHelper 在探活之后、就绪门之前打 aliveCheck，且早于 coreReady 那一格', async () => {
+describe('B6：零 spawn 探活 + pidFile 单独一格', () => {
+  /** 让 startViaHelper 能一路跑到就绪门之前；返回时间轴与「是否起过进程」的观测点。 */
+  function makeHelperSvc(): { svc: any; tl: StartTimeline; execSyncSpy: jest.SpyInstance } {
     const svc = makeSvc();
-    // singboxPath 必须真实存在：startViaHelper 顶部有 existsSync 早退
     const realBin = path.join(TMP, 'fake-sing-box');
     fsSync.writeFileSync(realBin, 'x');
     svc.singboxPath = realBin;
     svc.currentConfig = { proxyModeType: 'tun', servers: [], allowLan: false, tunConfig: {} };
-    svc.helperManager = { startCore: jest.fn(async () => ({ ok: true, pid: 4321 })) };
-    svc.isProcessAlive = jest.fn(() => true);
-    // 就绪门本身在别处测；这里只看它**之前**的那一格确实打了
+    svc.helperManager = { startCore: jest.fn(async () => ({ ok: true, pid: process.pid })) };
     svc.waitForCoreReadyOrThrow = jest.fn(async () => {});
     svc.startLogFileWatcher = jest.fn();
     svc.startHealthCheck = jest.fn();
     svc.sendEventToRenderer = jest.fn();
-
+    // 变异守卫的观测点：改回 isProcessAlive（execSync 版）→ 这个 spy 会被调用
+    const execSyncSpy = jest.spyOn(svc, 'isProcessAlive');
     const tl = new StartTimeline();
     svc.startTimeline = tl;
+    return { svc, tl, execSyncSpy };
+  }
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('processExistsNoSpawn：不抛 → 存在，且**零 spawn**', () => {
+    const svc = makeSvc();
+    const kill = jest.spyOn(process, 'kill').mockImplementation(() => true as never);
+    const execFileMock = execFile as unknown as jest.Mock;
+    execFileMock.mockClear();
+
+    expect(svc.processExistsNoSpawn(4321)).toBe(true);
+    expect(kill).toHaveBeenCalledWith(4321, 0);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('processExistsNoSpawn：EPERM → **存在**（helper 起的核归 LocalSystem，这是常态而非例外）', () => {
+    // 变异守卫：把判据写成「抛了就是不存在」→ 每次 helper 起核都会被自己这道检查判死。
+    const svc = makeSvc();
+    jest.spyOn(process, 'kill').mockImplementation(() => {
+      const e: NodeJS.ErrnoException = new Error('operation not permitted');
+      e.code = 'EPERM';
+      throw e;
+    });
+    expect(svc.processExistsNoSpawn(4321)).toBe(true);
+  });
+
+  it('processExistsNoSpawn：ESRCH → 不存在（唯一可以判「没有」的情形）', () => {
+    const svc = makeSvc();
+    jest.spyOn(process, 'kill').mockImplementation(() => {
+      const e: NodeJS.ErrnoException = new Error('no such process');
+      e.code = 'ESRCH';
+      throw e;
+    });
+    expect(svc.processExistsNoSpawn(4321)).toBe(false);
+  });
+
+  it('processExistsNoSpawn：其余错误码 → fail-open 判存在（抓不准就不替就绪门下结论）', () => {
+    const svc = makeSvc();
+    jest.spyOn(process, 'kill').mockImplementation(() => {
+      const e: NodeJS.ErrnoException = new Error('weird');
+      e.code = 'EINVAL';
+      throw e;
+    });
+    expect(svc.processExistsNoSpawn(4321)).toBe(true);
+  });
+
+  it('startViaHelper 打出 spawn → pidFile → aliveCheck 三格，顺序固定', async () => {
+    const { svc, tl } = makeHelperSvc();
     await svc.startViaHelper(svc.lifecycleGeneration);
 
     const labels = tl.phases().map((p: { label: string }) => p.label);
-    // 变异守卫：删掉 markStartLeg(startGen, 'aliveCheck') → 这条红
+    expect(labels).toContain('pidFile');
     expect(labels).toContain('aliveCheck');
-    expect(labels.indexOf('spawn')).toBeLessThan(labels.indexOf('aliveCheck'));
-    expect(svc.isProcessAlive).toHaveBeenCalledWith(4321);
+    expect(labels.indexOf('spawn')).toBeLessThan(labels.indexOf('pidFile'));
+    expect(labels.indexOf('pidFile')).toBeLessThan(labels.indexOf('aliveCheck'));
+  });
+
+  it('探活不得回退到 execSync 版 isProcessAlive（真机实测该调用在此处 2.0–2.6s）', async () => {
+    const { svc, execSyncSpy } = makeHelperSvc();
+    await svc.startViaHelper(svc.lifecycleGeneration);
+    expect(execSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('确证不存在（ESRCH）→ 仍然抛「进程不存在」并 cleanup（这道检查没被削弱）', async () => {
+    const { svc } = makeHelperSvc();
+    svc.cleanup = jest.fn();
+    jest.spyOn(process, 'kill').mockImplementation(() => {
+      const e: NodeJS.ErrnoException = new Error('no such process');
+      e.code = 'ESRCH';
+      throw e;
+    });
+
+    await expect(svc.startViaHelper(svc.lifecycleGeneration)).rejects.toThrow('进程不存在');
+    expect(svc.cleanup).toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
+++ b/src/main/services/__tests__/proxy-manager-tun-ready-324.test.ts
@@ -53,6 +53,12 @@ function makeSvc(): any {
   // B4：就绪门的探活腿已从 isProcessAlive（execSync，阻塞 event loop）换成异步版。默认委托到同一个同步桩，
   //   使各用例既有的 `svc.isProcessAlive = …` 意图逐字保留；个别用例直接改 isProcessAliveAsync 的照旧覆盖本默认。
   svc.isProcessAliveAsync = async () => svc.isProcessAlive();
+  // B8：就绪门的探活腿再换一次——零 spawn 的 processExistsNoSpawn（`process.kill(pid, 0)`）。同样委托到
+  //   `svc.isProcessAlive` 桩，逐字保留各用例意图；不桩的话真实实现会对着假 pid 1234 判 ESRCH → 全线 'dead'。
+  svc.processExistsNoSpawn = () => svc.isProcessAlive();
+  // B8：就绪窗内的观测腿改零 spawn 快检（Node 接口枚举）。默认「窗内看不见」——要模拟窗内见到适配器的用例
+  //   显式置 true，免得桩默认值把「窗内见到」这个前提悄悄送给所有用例。
+  svc.adapterPresenceFastProbe = () => false;
   return svc;
 }
 
@@ -61,6 +67,16 @@ function armTun(svc: any): TunAdapterObservation {
   const obs: TunAdapterObservation = { adapterEverSeen: false, probeEverConclusive: false };
   svc.tunReadyObservation = obs;
   return obs;
+}
+
+/**
+ * B6 那组用例打的是 `processExistsNoSpawn` **真身**（零 spawn 判据），故撤掉 makeSvc 给就绪门装的桩——
+ * 留着桩的话「不起进程」这条门就是在验桩，恒绿且无信息量。
+ */
+function makeNoSpawnSvc(): any {
+  const svc = makeSvc();
+  delete svc.processExistsNoSpawn;
+  return svc;
 }
 
 /** 定序三态 probe（用尽后恒返回末值）。 */
@@ -96,6 +112,7 @@ describe('issue #324 — waitForCoreReadyOrThrow 正向 TUN 就绪门（win32+TU
     const obs = armTun(svc);
     svc.isProcessAlive = () => true;
     svc.coreReadyProbe = async () => true;
+    svc.adapterPresenceFastProbe = () => true; // B8：窗内的「看见」现在由零 spawn 快检给出
     svc.adapterPresenceProbe = seqProbe(['present']);
 
     const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
@@ -199,13 +216,160 @@ describe('issue #324 — waitForCoreReadyOrThrow 正向 TUN 就绪门（win32+TU
     const obs = armTun(svc);
     svc.isProcessAlive = () => false;
     svc.coreReadyProbe = async () => false;
-    svc.adapterPresenceProbe = seqProbe(['present']); // 观测窗曾见 → 瞬态族
+    svc.adapterPresenceFastProbe = () => true; // B8：观测窗曾见（零 spawn 快检）→ 瞬态族
+    svc.adapterPresenceProbe = seqProbe(['present']);
 
     const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
     const assertion = expect(p).rejects.toThrow(/TUN 初始化未完成/);
     await jest.advanceTimersByTimeAsync(20000);
     await assertion;
     expect(obs.adapterEverSeen).toBe(true);
+  });
+});
+
+describe('B8 — 就绪窗内零 spawn（起核关键路径上不得起进程）', () => {
+  /**
+   * 为什么这组门值一整个 describe：真机实测「杀软扫 82MB 新核」的窗口里，一次 netsh/tasklist 要 150–819ms
+   * （空载 50–80ms），而 `execFile` 的异步只是**回调**异步——`uv_spawn` 在 event loop 线程上同步跑，
+   * 起一次进程就把主线程堵那么久。同窗口 FlowZ 自己的首次就绪探测（一次 loopback connect，正常 <5ms）
+   * 被拖到 2538–4036ms，API 明明 1.2–1.6s 就已可连，就绪却要 3.0–4.4s 才宣布。
+   * 故「窗内不起进程」是这批改动的**判据本身**，不是实现细节——下面每条都钉一个会让它复活的变异。
+   */
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('成功路径：完整探测只在 grace 硬闸调一次，就绪窗内一次都不调', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    svc.isProcessAlive = () => true;
+    let left = 6; // 前几轮 not ready → 就绪窗真的转起来（否则窗内一轮都不转，门无信息量）
+    svc.coreReadyProbe = async () => --left <= 0;
+    const probe = jest.fn(async () => 'present' as AdapterPresence);
+    svc.adapterPresenceProbe = probe;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).resolves.toBeUndefined();
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    // 变异「观测腿改回 adapterPresenceProbe」→ 窗内每 200ms 一次 → 调用数 > 1 → 此断言爆
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('探活腿零 spawn：走 processExistsNoSpawn，绝不碰 isProcessAliveAsync（tasklist）', async () => {
+    const svc = makeSvc();
+    armTun(svc);
+    const tasklist = jest.fn(async () => true);
+    svc.isProcessAliveAsync = tasklist; // 起进程的那条腿：本门断言它在起核窗内根本不被调用
+    let noSpawnCalls = 0;
+    svc.processExistsNoSpawn = () => {
+      noSpawnCalls++;
+      return false; // 核已死 → 走 dead 出口
+    };
+    svc.coreReadyProbe = async () => false;
+    svc.adapterPresenceProbe = async () => 'absent' as AdapterPresence;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(noSpawnCalls).toBeGreaterThan(0);
+    // 变异「isAlive 改回 isProcessAliveAsync」→ 此断言爆（且那条腿在真机上每 500ms 起一次 tasklist）
+    expect(tasklist).not.toHaveBeenCalled();
+  });
+
+  it('窗内快检看不见 → 绝不据此记 absent（看不见 ≠ 不存在，sticky 不得被污染）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    svc.isProcessAlive = () => true; // 进程活但 API 始终不绑 → timeout 出口
+    svc.coreReadyProbe = async () => false;
+    svc.adapterPresenceProbe = async () => 'unknown' as AdapterPresence; // 补探也给不出 clean 结论
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    // 变异「快检 false 就 recordPresence('absent')」→ probeEverConclusive 变 true →
+    //   #324 终态判据（!adapterEverSeen && probeEverConclusive）在健康机器上误判「wintun 从未创建」的持续性失败。
+    expect(obs.probeEverConclusive).toBe(false);
+    expect(obs.adapterEverSeen).toBe(false);
+  });
+
+  it('失败出口补一次完整探测，且必须在 stopCore 之前（拆核后的 absent 说明不了本腿）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    const order: string[] = [];
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => false;
+    const probe = jest.fn(async () => {
+      order.push('probe');
+      return 'absent' as AdapterPresence;
+    });
+    svc.adapterPresenceProbe = probe;
+    svc.helperManager = {
+      stopCore: jest.fn(async () => {
+        order.push('stopCore');
+      }),
+    };
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(probe).toHaveBeenCalledTimes(1);
+    // 变异「补探挪到 stopCore 之后」→ order 反序 → 此断言爆（真机上那次探测会恒 absent，证据作废）
+    expect(order).toEqual(['probe', 'stopCore']);
+    // 变异「删掉补探」→ probeEverConclusive 恒 false → #324 的持续性终态永不成立、无限重试
+    expect(obs.probeEverConclusive).toBe(true);
+  });
+
+  it('失败出口：窗内已见适配器 → 不补探（已有 present 结论，不再花一次 spawn）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    svc.isProcessAlive = () => true;
+    svc.coreReadyProbe = async () => false;
+    svc.adapterPresenceFastProbe = () => true; // 窗内已确证 present
+    const probe = jest.fn(async () => 'absent' as AdapterPresence);
+    svc.adapterPresenceProbe = probe;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    expect(obs.adapterEverSeen).toBe(true);
+    // 变异「补探不看 adapterEverSeen」→ 多一次 spawn，且把 present 结论覆写成 absent（sticky 是 monotonic
+    //   救得回 adapterEverSeen，但 probeEverConclusive 的来源被换掉，分类证据变脏）
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('失败出口被接管 → 不补探（绝不为让位腿起进程）', async () => {
+    const svc = makeSvc();
+    const obs = armTun(svc);
+    const startGen = svc.lifecycleGeneration;
+    svc.isProcessAlive = () => true;
+    // 就绪窗内每轮开头都判 supersede，故只有在**循环跑完之后**的收尾判定里翻世代，才走得到失败出口的守卫。
+    // 轮数由常量算出（不写死）：loop 内 maxPolls 次，之后收尾再判一次 → 第 maxPolls+1 次调用即收尾那次。
+    const maxPolls = Math.ceil(
+      (ProxyManager as any).CORE_READY_TIMEOUT_MS / (ProxyManager as any).CORE_READY_POLL_MS
+    );
+    let readyCalls = 0;
+    svc.coreReadyProbe = async () => {
+      readyCalls++;
+      if (readyCalls >= maxPolls + 1) svc.lifecycleGeneration = startGen + 1; // 收尾判定时被接管
+      return false;
+    };
+    const probe = jest.fn(async () => 'absent' as AdapterPresence);
+    svc.adapterPresenceProbe = probe;
+
+    const p = svc.waitForCoreReadyOrThrow(1234, startGen);
+    const assertion = expect(p).rejects.toBeInstanceOf(CoreStartRetryError);
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+    // 变异「补探不判世代」→ 让位腿也起一次进程，并把结果写进（本腿自己的）tracker → 此断言爆
+    expect(probe).not.toHaveBeenCalled();
+    expect(obs.probeEverConclusive).toBe(false);
   });
 });
 
@@ -976,10 +1140,18 @@ describe('B4 接线 — 就绪门必须按这三个值调用（复审 High）', 
     }
   });
 
-  it('探活腿必须走异步版 isProcessAliveAsync（同步版会用 execSync 堵住 event loop）', async () => {
+  /**
+   * B8 更正：这条门原本钉的是「必须走**异步版** isProcessAliveAsync」。那个判据不够——异步只解决「回调不堵
+   * event loop」，而 `uv_spawn` 本身仍在 event loop 线程上同步执行，钱照付。真机实测起核窗（杀软扫 82MB 新核）
+   * 内一次 tasklist 要 150–673ms，空载只要 50–80ms。现在的契约更严：就绪门**一个进程都不许起**。
+   */
+  it('探活腿必须走零 spawn 的 processExistsNoSpawn（异步版 tasklist 同样不许碰）', async () => {
     const svc = armedSvc();
-    const asyncProbe = jest.fn(async () => true);
-    svc.isProcessAliveAsync = asyncProbe;
+    const noSpawn = jest.fn(() => true);
+    svc.processExistsNoSpawn = noSpawn;
+    svc.isProcessAliveAsync = jest.fn(async () => {
+      throw new Error('就绪门不得起 tasklist（异步版也不行）');
+    });
     svc.isProcessAlive = jest.fn(() => {
       throw new Error('就绪门不得触碰同步探活腿');
     });
@@ -990,8 +1162,9 @@ describe('B4 接线 — 就绪门必须按这三个值调用（复审 High）', 
 
     await svc.waitForCoreReadyOrThrow(1234, svc.lifecycleGeneration);
 
-    // 变异守卫：接线换回 `this.isProcessAlive(pid)` → 同步桩抛错 → 红
-    expect(asyncProbe).toHaveBeenCalled();
+    // 变异守卫：接线换回 isProcessAliveAsync / isProcessAlive → 桩抛错 → 红
+    expect(noSpawn).toHaveBeenCalled();
+    expect(svc.isProcessAliveAsync).not.toHaveBeenCalled();
     expect(svc.isProcessAlive).not.toHaveBeenCalled();
   });
 });
@@ -1227,7 +1400,7 @@ describe('B6：首次就绪探测单独一格（readyProbe0）', () => {
     let n = 0;
     svc.coreReadyProbe = jest.fn(async () => ++n > 1); // 首探 false，第二探 true
     svc.adapterPresenceProbe = jest.fn(async () => 'present' as AdapterPresence);
-    svc.isProcessAliveAsync = async () => true;
+    svc.isProcessAlive = () => true; // B8：就绪门的探活腿走零 spawn 版，桩在 makeSvc 里委托到这里
 
     await svc.waitForCoreReadyOrThrow(4321, svc.lifecycleGeneration);
 
@@ -1242,7 +1415,7 @@ describe('B6：首次就绪探测单独一格（readyProbe0）', () => {
     let n = 0;
     svc.coreReadyProbe = jest.fn(async () => ++n > 5); // 前 5 探 false
     svc.adapterPresenceProbe = jest.fn(async () => 'present' as AdapterPresence);
-    svc.isProcessAliveAsync = async () => true;
+    svc.isProcessAlive = () => true; // B8：同上
 
     await svc.waitForCoreReadyOrThrow(4321, svc.lifecycleGeneration);
 
@@ -1265,7 +1438,7 @@ describe('B6：首次就绪探测单独一格（readyProbe0）', () => {
 describe('B6：零 spawn 探活 + pidFile 单独一格', () => {
   /** 让 startViaHelper 能一路跑到就绪门之前；返回时间轴与「是否起过进程」的观测点。 */
   function makeHelperSvc(): { svc: any; tl: StartTimeline; execSyncSpy: jest.SpyInstance } {
-    const svc = makeSvc();
+    const svc = makeNoSpawnSvc();
     const realBin = path.join(TMP, 'fake-sing-box');
     fsSync.writeFileSync(realBin, 'x');
     svc.singboxPath = realBin;
@@ -1285,7 +1458,7 @@ describe('B6：零 spawn 探活 + pidFile 单独一格', () => {
   afterEach(() => jest.restoreAllMocks());
 
   it('processExistsNoSpawn：不抛 → 存在，且**零 spawn**', () => {
-    const svc = makeSvc();
+    const svc = makeNoSpawnSvc();
     const kill = jest.spyOn(process, 'kill').mockImplementation(() => true as never);
     const execFileMock = execFile as unknown as jest.Mock;
     execFileMock.mockClear();
@@ -1297,7 +1470,7 @@ describe('B6：零 spawn 探活 + pidFile 单独一格', () => {
 
   it('processExistsNoSpawn：EPERM → **存在**（helper 起的核归 LocalSystem，这是常态而非例外）', () => {
     // 变异守卫：把判据写成「抛了就是不存在」→ 每次 helper 起核都会被自己这道检查判死。
-    const svc = makeSvc();
+    const svc = makeNoSpawnSvc();
     jest.spyOn(process, 'kill').mockImplementation(() => {
       const e: NodeJS.ErrnoException = new Error('operation not permitted');
       e.code = 'EPERM';
@@ -1307,7 +1480,7 @@ describe('B6：零 spawn 探活 + pidFile 单独一格', () => {
   });
 
   it('processExistsNoSpawn：ESRCH → 不存在（唯一可以判「没有」的情形）', () => {
-    const svc = makeSvc();
+    const svc = makeNoSpawnSvc();
     jest.spyOn(process, 'kill').mockImplementation(() => {
       const e: NodeJS.ErrnoException = new Error('no such process');
       e.code = 'ESRCH';
@@ -1317,7 +1490,7 @@ describe('B6：零 spawn 探活 + pidFile 单独一格', () => {
   });
 
   it('processExistsNoSpawn：其余错误码 → fail-open 判存在（抓不准就不替就绪门下结论）', () => {
-    const svc = makeSvc();
+    const svc = makeNoSpawnSvc();
     jest.spyOn(process, 'kill').mockImplementation(() => {
       const e: NodeJS.ErrnoException = new Error('weird');
       e.code = 'EINVAL';


### PR DESCRIPTION
## 背景

上一批（#370 / #372 / #373）把 Windows TUN 起核从 12.1s 压到 4.4s 之后，`coreReady` 一格独占了剩余耗时的一半以上。本 PR 是继续往下查的结果：三个 commit，其中埋点与零 spawn 是**可以留的改进**，但**总起核耗时不变**——真正的瓶颈已定位在 FlowZ 的 JS 层之外，结论写在最后。

## 改动

**1. 拆细 coreReady 埋点，并把核日志清空前移到 spawn 之前（`c100d2e`）**

`coreReady` 原本是一整格，真机量到 2.4s 却无从判断是「核还没绑 API」还是「绑了没被及时发现」。切成 `pidFile` / `aliveCheck` / `readyProbe0:<首探结果>` / `coreReady` 四格，首次就绪探测的结果直接进标签，两种情形在汇总行里一眼可分。

同一个 commit 把核日志的清空从 `startLogFileWatcher()`（在就绪之后才调）前移到 `startSingBoxProcess` 顶部。原先起核期的核日志会被随后的清空抹掉，等于最需要它的那段窗口反而没有记录；前移之后才拿到了后面几节分析所依赖的核启动日志。

**2. 起核路径上的同步探活换成零 spawn，PID 写入单独一格（`5fe98c3`）**

helper 报告启动成功后的那次存在性检查原本是 `isProcessAlive`（`execSync` 起 `tasklist`），真机实测这一格 2018–2584ms，且全程同步阻塞主进程。换成 `process.kill(pid, 0)`（真机 0.1ms）。判定语义在头注里写明：EPERM 即存在（helper 起的核归 LocalSystem，这是常态）、ESRCH 才是不存在、其余错误码 fail-open。

**3. 起核就绪窗内不再创建任何进程（`5802f72`）**

就绪等待窗内原有两处进程创建：

- `waitForCoreReady` 的 `isAlive`（spawn `tasklist`，`alivePollMs=500` 且 `i=0` 必探）→ 改用 `processExistsNoSpawn`。顺带修了一个语义缺陷：`tasklist` 版一旦 spawn 失败或超时就返回 false，等于「探不到 = 判核已死 → 停核重试」；`kill` 版只有 ESRCH 才判死。
- issue #324 的适配器观测腿（F2 之后是 `netsh`）→ 改用 Node 接口枚举。它只产肯定结论，故窗内只记 present、绝不记 absent；免费之后节拍从 1000ms 细化到 200ms。

因为窗内不再产出 absent 证据，失败路径（dead/timeout）上 `probeEverConclusive` 会恒为 false，issue #324 的持续性失败终态判据随之失效（wintun 装不起来的机器会退回无限重试 + 全程「正在自动重试」，正是该 issue 报告者的抱怨）。故在失败出口补一次完整探测，**且必须在 `stopCore` 之前**——拆核后适配器随即释放，那时的 absent 说明不了本腿是否建起过。仅在从未见过适配器时才探，此刻就绪窗已结束、不在任何人的等待路径上。

## 门与变异收据

新增 6 条门。原「探活腿必须走异步版 `isProcessAliveAsync`」那条门已被本次契约取代（异步只解决回调不堵 event loop，`uv_spawn` 仍在 event loop 线程上同步执行），就地改写为「一个进程都不许起」。

7 条变异全部先证明能编译（含一条因 `noUnusedLocals` 需要连带删除死代码的真回退），全部见红：

| 变异 | 变红的门 |
|---|---|
| 观测腿改回完整探测 | 窗内零 spawn + 失败出口三条 |
| `isAlive` 改回 `isProcessAliveAsync` | 探活腿零 spawn + 接线门 |
| 快检看不见就记 absent | 「绝不据此记 absent」+ fail-open 门 |
| 删掉失败出口补探 | 补探门 + #324 A3 文案门 |
| 补探挪到 `stopCore` 之后 | 补探顺序门 |
| 补探不看 `adapterEverSeen` | 「已见则不补探」门 |
| 补探不判世代 | 「被接管不补探」门 |

`npm run build:main` 0 error；jest 4022 passed / 253 suites。

## 真机结果：首次就绪探测那一格砍掉了，总耗时不变

Windows 11 26200，TUN + 直连出站，走 helper 路径：

| | `readyProbe0` | 管理 API 实际可连（外部实测）| 宣布就绪 |
|---|---|---|---|
| 改前（5 轮）| 143 / 2538–4036 ms | 1200–1630 ms | 2993–4410 ms |
| 改后（4 轮）| 24 / 32 / 25 / 26 ms | 1181–1791 ms | 2466–3729 ms |

**总耗时没有改善，这一点必须说清楚。** 本 PR 的价值是：起核关键路径上不再有进程创建、探活腿从 fail-closed 修成 fail-open、issue #324 的证据链在改动后仍然成立且有门守着。

## 为什么总耗时不动：主进程在建 TUN 期间被拖住

在就绪窗内加了事件循环心跳（`setInterval(20ms)` 记 tick 数与最大滞后），并把「第一次触碰」整体推迟，窗口前段一个系统调用都不发：

```
hb2-lag2776-at2834-probes0-obs1-alive1-log1-logmax93
```

2.8 秒里心跳只跳了 2 次、最大滞后 2776ms，而这段时间 FlowZ 什么都没做。JS 定时器都排不上，说明不是「某个调用慢」，是主进程整个被拖住。同机同时刻，一个以 `ELECTRON_RUN_AS_NODE` 方式跑的纯 Node 观测进程（同一个 Electron 二进制）20ms 轮询毫无影响。

两组对照把触发源锁死：

| 配置 | helper | tun-in | `coreReady` | 主线程最大滞后 |
|---|---|---|---|---|
| TUN（产品路径）| 是 | 有 | 1814–3922 ms | 1197–1843 ms |
| systemProxy（产品路径）| 否 | 无 | 不走就绪门 | 231–353 ms |
| systemProxy + 诊断构建强制走 helper | 是 | 无 | 229 / 237 ms | 218 / 509 ms（且落在 `systemProxySync`，不在起核窗）|

同样经 helper 起核、同样等管理 API，只要不建 TUN，就绪只要 229/237ms 且窗内无冻结。**触发源是 wintun 设备创建，不是 helper 路径**；它发生在 Electron 主进程内、纯 Node 进程不受影响，FlowZ 的 JS 层无从消除。

这也解释了此前两次「砍掉窗内的活、总耗时却不动」：被砍掉的调用只是冻结解除那一刻恰好在飞的那个，账记在谁头上是随机的。

## 兼容性

macOS / Linux / 非 TUN 路径不受影响：观测腿与失败出口补探都在 `tunReadyObservation` 非 null（即 win32+TUN）时才生效，其余平台全程 no-op；探活腿的替换是跨平台的语义等价改进（`process.kill(pid, 0)` 与 `tasklist` / `ps` 的判定口径一致，且不再把探测失败当成核已死）。
