### PR TITLE
fix(rules): preserve process selections and UTF-8 paths

### DIFF
--- a/src/main/services/ProcessEnumerator.ts
+++ b/src/main/services/ProcessEnumerator.ts
@@ -14,7 +14,12 @@ const EXEC_TIMEOUT_MS = 5000;
 function execFileP(
   cmd: string,
   args: string[],
-  opts: { timeout: number; maxBuffer: number; windowsHide?: boolean }
+  opts: {
+    timeout: number;
+    maxBuffer: number;
+    windowsHide?: boolean;
+    env?: NodeJS.ProcessEnv;
+  }
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(cmd, args, { ...opts, encoding: 'utf-8' }, (err, stdout) => {
@@ -49,10 +54,19 @@ function aggregate(
 }
 
 async function listMac(): Promise<SystemProcessInfo[]> {
-  // ps comm 即完整可执行路径；basename 为进程名
+  // ps comm 即完整可执行路径；basename 为进程名。
+  // macOS 从 Finder/LaunchServices 启动的 GUI 应用可能继承 C locale；此时 ps 会把 UTF-8
+  // 路径的每个非 ASCII 字节先转义成 `M-fM-...`，Node 之后再按 UTF-8 解码也无法恢复。
+  // 必须在启动 ps 时就强制 UTF-8 locale；LC_ALL 覆盖母进程残留的 LC_CTYPE=C，
+  // LANG 作为不识别 LC_ALL 时的同值兜底。en_US.UTF-8 是 macOS 系统内置 locale。
   const out = await execFileP('/bin/ps', ['-axo', 'comm='], {
     timeout: EXEC_TIMEOUT_MS,
     maxBuffer: 8 * 1024 * 1024,
+    env: {
+      ...process.env,
+      LANG: 'en_US.UTF-8',
+      LC_ALL: 'en_US.UTF-8',
+    },
   });
   const items = out
     .split('\n')

--- a/src/main/services/__tests__/process-enumerator.test.ts
+++ b/src/main/services/__tests__/process-enumerator.test.ts
@@ -1,0 +1,45 @@
+/**
+ * ProcessEnumerator 回归：macOS GUI 应用常以 C locale 启动，/bin/ps 会把中文路径
+ * 转义成 `M-fM-...`。锁定子进程必须收到 UTF-8 locale，并验证中文进程名/路径原样返回。
+ */
+import { execFile } from 'child_process';
+import { listSystemProcesses } from '../ProcessEnumerator';
+
+jest.mock('child_process', () => ({ execFile: jest.fn() }));
+
+const execFileMock = execFile as unknown as jest.Mock;
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+describe('ProcessEnumerator macOS UTF-8 paths', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+  });
+
+  afterAll(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
+  it('以 UTF-8 locale 运行 ps，保留中文可执行名和路径', async () => {
+    const processPath = '/Applications/汽水音乐.app/Contents/MacOS/汽水音乐';
+    execFileMock.mockImplementation(
+      (
+        cmd: string,
+        args: string[],
+        options: { env?: NodeJS.ProcessEnv },
+        callback: (error: Error | null, stdout: string) => void
+      ) => {
+        expect(cmd).toBe('/bin/ps');
+        expect(args).toEqual(['-axo', 'comm=']);
+        expect(options.env).toEqual(
+          expect.objectContaining({ LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8' })
+        );
+        callback(null, `${processPath}\n`);
+      }
+    );
+
+    await expect(listSystemProcesses()).resolves.toEqual([
+      { name: '汽水音乐', path: processPath, count: 1 },
+    ]);
+  });
+});

--- a/src/renderer/components/rules/add-custom-app-dialog.tsx
+++ b/src/renderer/components/rules/add-custom-app-dialog.tsx
@@ -132,15 +132,9 @@ export function AddCustomAppDialog({
     }
   };
 
-  // 「选择进程」复用规则页 ProcessPickerDialog（一键拉运行进程 + 搜索 + 多选 + 系统进程过滤），勾选回填。
-  // 合并进现有逗号串（去重、去空），保留手输作兜底（进程未运行时仍可手加）。
+  // ProcessPickerDialog 返回包含初始值在内的完整勾选集合；按集合回写，既保留未运行的手输项，也支持取消旧选择。
   const handlePickProcesses = (names: string[]) => {
-    const existing = newAppProcessNames
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    const merged = Array.from(new Set([...existing, ...names]));
-    setNewAppProcessNames(merged.join(', '));
+    setNewAppProcessNames(Array.from(new Set(names)).join(', '));
   };
 
   const handleAddCustomApp = async () => {
@@ -439,6 +433,10 @@ export function AddCustomAppDialog({
           open={processPickerOpen}
           onOpenChange={setProcessPickerOpen}
           mode="name"
+          initialSelected={newAppProcessNames
+            .split(',')
+            .map((name) => name.trim())
+            .filter(Boolean)}
           onAdd={handlePickProcesses}
         />
       </DialogContent>

--- a/src/renderer/components/rules/process-picker-dialog.tsx
+++ b/src/renderer/components/rules/process-picker-dialog.tsx
@@ -23,13 +23,21 @@ interface ProcessPickerDialogProps {
   onOpenChange: (open: boolean) => void;
   /** 'name' → 取进程名；'path' → 取进程完整路径（无路径项禁选） */
   mode: 'name' | 'path';
+  /** 当前条件中已保存的值；重新打开选择器时应保持勾选，包含当前未运行/未展示的进程。 */
+  initialSelected: string[];
   onAdd: (values: string[]) => void;
 }
 
 // 系统进程路径启发式（隐藏系统进程开关用）
 const SYSTEM_PATH_RE = /^(\/usr\/|\/System\/|\/sbin\/|\/bin\/|[A-Za-z]:\\Windows\\)/i;
 
-export function ProcessPickerDialog({ open, onOpenChange, mode, onAdd }: ProcessPickerDialogProps) {
+export function ProcessPickerDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialSelected,
+  onAdd,
+}: ProcessPickerDialogProps) {
   const { t } = useTranslation();
   const [processes, setProcesses] = useState<SystemProcessInfo[]>([]);
   const [loading, setLoading] = useState(false);
@@ -53,11 +61,14 @@ export function ProcessPickerDialog({ open, onOpenChange, mode, onAdd }: Process
 
   useEffect(() => {
     if (open) {
-      setSelected(new Set());
+      // 选择器是当前条件值的可视化编辑器，不是一次性的「追加器」。以已保存值初始化，才能在编辑规则时
+      // 正确回显；未运行/被隐藏的进程虽然不在列表中，仍留在 Set，确认时不会被意外丢弃。
+      setSelected(new Set(initialSelected));
       setSearch('');
       void load();
     }
-  }, [open]);
+    // 只在弹窗开启或选择模式变化时建立一次编辑快照；父表单的普通重渲染不能覆盖用户正在勾选的状态。
+  }, [open, mode]);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/src/renderer/components/rules/rule-dialog.tsx
+++ b/src/renderer/components/rules/rule-dialog.tsx
@@ -214,20 +214,10 @@ export function RuleDialog({ open, onOpenChange, mode, rule }: RuleDialogProps) 
     // 保留 valuesByType[ct] 桶（再次添加该类型可恢复，且不进入提交）
   };
 
-  // 函数式更新：从 prev 桶读最新值再回写，避免 render 捕获值的陈旧读。
+  // 选择器返回完整勾选集合（含初始化时带入的未运行进程），按结果替换当前桶：既保留历史选择，
+  // 也允许用户取消已保存项；去重由 Set 保证，顺序采用选择器的稳定插入顺序。
   const handleProcessPicked = (ct: RuleType, picked: string[]) => {
-    setValuesByType((prev) => {
-      const lines = parseLines(prev[ct] ?? '');
-      const existing = new Set(lines);
-      const merged = [...lines];
-      for (const p of picked) {
-        if (!existing.has(p)) {
-          merged.push(p);
-          existing.add(p);
-        }
-      }
-      return { ...prev, [ct]: merged.join('\n') };
-    });
+    setValuesByType((prev) => ({ ...prev, [ct]: Array.from(new Set(picked)).join('\n') }));
   };
 
   const toggleValue = (ct: RuleType, v: string) => {
@@ -640,6 +630,7 @@ export function RuleDialog({ open, onOpenChange, mode, rule }: RuleDialogProps) 
           open={pickerType !== null}
           onOpenChange={(o) => !o && setPickerType(null)}
           mode={pickerType === 'processPath' ? 'path' : 'name'}
+          initialSelected={pickerType ? parseLines(valuesOf(pickerType)) : []}
           onAdd={(picked) => {
             if (pickerType) handleProcessPicked(pickerType, picked);
           }}


### PR DESCRIPTION
## What changed

- Initialize the process picker with the process names or executable paths already saved in the rule.
- Treat the picker result as the complete selection, so users can deselect existing entries without losing saved processes that are currently stopped or hidden.
- Run macOS `ps -axo comm=` with an explicit UTF-8 locale so non-ASCII application names and `/Applications/...` executable paths are not converted to `M-fM-...` mojibake.
- Add a regression test covering an exact Chinese application path.

## Why

Two issues were reproducible in the process-rule editor:

1. Reopening “select from running processes” always started with an empty selection, even when the rule already contained process names or full paths.
2. Finder/LaunchServices may start GUI apps with a C locale. In that environment, macOS `ps` escapes each non-ASCII byte before Node receives stdout, so decoding stdout as UTF-8 cannot recover the original path.

## Verification

- 3 focused suites, 38 tests passed
- `npm run build` passed (TypeScript main + Vite renderer)
- ESLint passed for all changed TypeScript/TSX files
- Reproduced the locale behavior on macOS and verified the Chinese application name/path is preserved
