### PR TITLE
fix(macos): follow active VPN routes in proxy and TUN modes

### DIFF
--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -57,9 +57,11 @@ import { localProxyPort, controlApiPort } from '../../shared/proxy-ports';
 import { effectiveBypassLan } from '../../shared/system-proxy-bypass';
 import { isDirectSelection, resolveGlobalExitTag } from '../../shared/direct-selection';
 import { parseDefaultGateway, parseScutilRouter } from '../../shared/default-route';
+import { parseMacRouteInterface } from '../../shared/mac-route-interface';
 import {
   isIpv4Host,
   isIpv6Host,
+  effectiveCustomRules,
   effectiveAppRules,
   applyRuleSetPrune,
   buildIdToTagMap,
@@ -347,6 +349,12 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   // 供 generateDnsConfig 把内网/captive 域名重定向到它（takeover 后 dns-local=公网解不了内网）+ rule C 直连放行防环。
   // null=无可用 LAN 解析器（非 TUN/关/DHCP 读不到/仅公网）→ 退回 dns-local。每次 start 入口重置重读。
   private lanResolverForDns: string | null = null;
+  // macOS TUN 的实际上游接口。启动前按所有会拨号的节点逐一执行 `route -n get <target>`；仅结果一致时设置，
+  // 供 route.default_interface 防自身回环并兼容 OpenVPN/EasyConnect 的 utun 路由。每次 start 重新探测。
+  private tunDefaultInterface: string | null = null;
+  // 与 tunDefaultInterface 同一启动世代的节点目标 IP。macOS 域名节点先解析为 IP 并进入 route_exclude，
+  // route monitor 触发后继续查询这些稳定目标，避免运行中域名 route get 被 FlowZ 自家 TUN 路由截获。
+  private macTunRouteTargets: string[] = [];
   // issue #147：本地节点域名 race DNS server（多上游并发 race）+ 其监听端口。start 路径（race on）起；
   // raceServerPort>0 = race 就绪 → getNodeResolverTag on→dns-node-race + buildDnsConfig 生成该 server；
   // =0（off / 起失败 / snapshot/preflight/未启动路径）→ 降级单上游（生成物逐字节回现状，快照零变化）。
@@ -997,18 +1005,20 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     await this.writeCustomRuleFiles(config);
     this.markStart('customRules');
 
-    // 3.5. 预解析所有节点的域名为 IP（仅针对 TUN 模式），防止 Windows 下回流死循环
+    // 3.5. 预解析所有节点的域名为 IP（仅针对 TUN 模式）。Windows 用于防回流；macOS 还用于
+    // route_exclude + VPN 路由热切检测，确保 OpenVPN 重连后查询的是节点 IP 而非被自家 TUN 捕获的域名路由。
     // 【待真机验证 / CDN 风险】：对"域名节点"预解析得到的 IP 会进 route_exclude_address，若节点在
     //   共享 CDN(如 Cloudflare) 后，等于把共享 IP 加直连 → 误伤同 IP 的被墙站点、且抗不住 IP 轮换。
     //   现已在 generateRouteConfig 用"全节点域名 → direct"的纯域名规则(sniff SNI)做 CDN 安全豁免；
     //   此处 Windows IP 预解析是否仍为断环所必需，需 Wintun 真机验证：若域名规则+sniff 足够 → 删除本块；
     //   若 Windows 确需 IP 级兜底 → 应仅对 IP-literal 节点保留、域名节点不预解析。无 Windows 环境暂不擅改。
     const resolvedServerIps: Record<string, string> = {};
-    if (isTunMode && process.platform === 'win32') {
-      this.logToManager('info', '正在预解析节点域名以防止 TUN 回流...');
+    if (isTunMode && (process.platform === 'win32' || process.platform === 'darwin')) {
+      this.logToManager('info', '正在预解析节点域名用于 TUN 防回流与 VPN 路由跟踪...');
       const dns = require('dns').promises;
       const allServerIds = new Set([
         config.selectedServerId as string,
+        ...effectiveCustomRules(config).map((r) => r.targetServerId),
         ...effectiveAppRules(config).map((r) => r.targetServerId),
       ]);
 
@@ -1032,7 +1042,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       });
       await Promise.all(resolvePromises);
     }
-    // 仅 win32+TUN 非零：全节点域名并行 dns.lookup。系统 DNS 此刻可能仍是上一会话 TUN 拆完的残态，慢在意料内 → 必须量。
+    // 仅 Windows/macOS + TUN 可能非零：全节点域名并行 dns.lookup。保留时间轴键名兼容现有诊断数据。
     this.markStart('winDnsPreresolve');
 
     // 3.6. 为出口 IP 探针分配端口（失败不阻断启动，仅探针不可用）
@@ -1081,6 +1091,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     // （或候选连撞导致多次 PowerShell 串行），并行化的收益名存实亡。
     await this.applyTunAddressPreflight(tunAddressPick);
     this.markStart('tunAddrPreflightWait');
+
+    // 3.9.6 macOS TUN：在自家 TUN 创建前按节点目标解析真实上游接口。OpenVPN 常用 0/1+128/1，
+    // 此时系统 default 仍是 en0，sing-box 的 auto detect 会误绑 en0；route get 目标地址才能得到 utun。
+    this.tunDefaultInterface = await this.resolveMacTunDefaultInterface(config, resolvedServerIps);
 
     // 4. 生成 sing-box 配置文件
     const singboxConfig = this.generateSingBoxConfig(config, resolvedServerIps);
@@ -3746,6 +3760,71 @@ done
   }
 
   /**
+   * macOS TUN 的上游接口不能只看 `route get default`：OpenVPN/EasyConnect 常用更具体路由接管目标，
+   * 同时保留 en0 default。逐节点查询实际路由，只有所有待拨号节点结果一致才显式绑定；混合出口或探测失败
+   * 回退 auto_detect_interface，避免把部分节点错误钉到另一张网卡。
+   */
+  private async resolveMacTunDefaultInterface(
+    config: UserConfig,
+    resolvedIps?: Record<string, string>
+  ): Promise<string | null> {
+    if (process.platform !== 'darwin' || config.proxyModeType !== 'tun') {
+      this.macTunRouteTargets = [];
+      return null;
+    }
+
+    const ids = new Set<string>();
+    if (config.selectedServerId && !isDirectSelection(config.selectedServerId)) {
+      ids.add(config.selectedServerId);
+    }
+    for (const rule of effectiveCustomRules(config)) {
+      if (rule.targetServerId) ids.add(rule.targetServerId);
+    }
+    for (const rule of effectiveAppRules(config)) {
+      if (rule.targetServerId) ids.add(rule.targetServerId);
+    }
+
+    const targets = Array.from(ids)
+      .map(
+        (id) =>
+          resolvedIps?.[id] ?? config.servers.find((server) => server.id === id)?.address?.trim()
+      )
+      .filter((target): target is string => Boolean(target));
+    if (resolvedIps) this.macTunRouteTargets = Array.from(new Set(targets));
+    const routeTargets = this.macTunRouteTargets;
+    if (routeTargets.length === 0) return null;
+
+    const interfaces = new Set<string>();
+    for (const target of routeTargets) {
+      try {
+        const { stdout } = await healthProbeExecFile('route', ['-n', 'get', target], {
+          timeout: 4000,
+        });
+        const iface = parseMacRouteInterface(stdout);
+        if (!iface) return null;
+        interfaces.add(iface);
+      } catch (error) {
+        this.logToManager(
+          'warn',
+          `macOS TUN 上游接口探测失败(${target})，回退自动检测: ${(error as Error)?.message ?? error}`
+        );
+        return null;
+      }
+    }
+
+    if (interfaces.size !== 1) {
+      this.logToManager(
+        'warn',
+        `macOS TUN 节点分属多个出口接口(${Array.from(interfaces).join(', ')})，回退自动检测`
+      );
+      return null;
+    }
+    const iface = interfaces.values().next().value as string;
+    this.logToManager('info', `macOS TUN 上游接口按节点实际路由选择: ${iface}`);
+    return iface;
+  }
+
+  /**
    * 生成 sing-box 配置（sing-box 1.12.x / 1.13.x 兼容格式）
    */
   generateSingBoxConfig(config: UserConfig, resolvedIps?: Record<string, string>): SingBoxConfig {
@@ -3837,6 +3916,7 @@ done
         },
         // §E.1：race 就绪时把上游 IP 传给 route 做直连放行（防 TUN 回环）；未就绪路径恒 []（零变化）。
         raceUpstreamIps: this.raceServerPort > 0 ? this.raceUpstreamIps : [],
+        defaultInterface: this.tunDefaultInterface ?? undefined,
       }),
       experimental: {
         cache_file: {
@@ -7124,7 +7204,8 @@ rm -f "$STOPFLAG"
   /**
    * 起链路变化 watcher（薄接线，三平台；issue #368 从「仅 darwin」放宽）。
    * 唤醒源（平台对应的链路监听命令 / 指纹轮询 / powerMonitor resume）→ 去抖 → onTrigger：
-   *   · macOS：经门控 shouldReconcileDns（TUN + 未关接管 + marker 在）重灌系统 DNS 接管——**门控与行为一字未变**；
+   *   · macOS：经门控 shouldReconcileDns（TUN + 未关接管 + marker 在）重灌系统 DNS；
+   *     TUN 下同时复查节点实际上游接口，VPN 路由变化时受控重连。
    *   · 三平台恒：**指纹对差后**补刷 OS DNS 缓存（issue #363 的持续失败即「两次启停之间的缓存污染无人清理」）。
    * Windows 无等价的链路监听命令 → 走指纹轮询（resume 只覆盖睡眠唤醒，覆盖不到换网/插拔）。
    * 幂等（DnsInterfaceWatcher.start 内部 started 守卫）。best-effort：构造/起失败仅 warn，绝不抛、不阻断启动。
@@ -7144,9 +7225,20 @@ rm -f "$STOPFLAG"
         // 状态变化；manager 若在某次核 start 之后才注入，构造时捕获会让这一代 watcher 的 reconcile 腿永久为 null。
         reconcile: async () => {
           const mgr = this.systemDnsManager;
-          if (!mgr) return;
-          if (!shouldReconcileDns(this.currentConfig, mgr.hasMarker())) return;
-          await mgr.reconcileDns();
+          if (mgr && shouldReconcileDns(this.currentConfig, mgr.hasMarker())) {
+            await mgr.reconcileDns();
+          }
+
+          const config = this.currentConfig;
+          if (!config || config.proxyModeType !== 'tun') return;
+          const actualInterface = await this.resolveMacTunDefaultInterface(config);
+          if (!actualInterface || actualInterface === this.tunDefaultInterface) return;
+
+          this.logToManager(
+            'info',
+            `检测到 VPN 上游接口变化: ${this.tunDefaultInterface ?? 'auto'} → ${actualInterface}，自动重连 FlowZ`
+          );
+          this.scheduleDebouncedRestart();
         },
         readFingerprint: () => this.readNetworkFingerprint(),
         getLastFingerprint: () => this.lastNetworkFingerprint,
@@ -7175,7 +7267,7 @@ rm -f "$STOPFLAG"
       this.dnsInterfaceWatcher.start();
       this.logToManager(
         'info',
-        '链路变化 watcher 已启动（热插/换网/唤醒 → 重灌 DNS 接管 + 刷缓存）'
+        '链路变化 watcher 已启动（热插/换网/唤醒 → 重灌 DNS + 复查 VPN 路由 + 刷缓存）'
       );
     } catch (e) {
       this.dnsInterfaceWatcher = null;

--- a/src/main/services/SpeedTestService.ts
+++ b/src/main/services/SpeedTestService.ts
@@ -907,7 +907,9 @@ export class SpeedTestService {
       outbounds,
       route: {
         rules: routeRules,
-        auto_detect_interface: true,
+        // 独立测速核没有 TUN inbound，不存在 outbound 回灌自身的问题。关闭接口自动绑定，让 OS
+        // 正确遵循 OpenVPN/EasyConnect 等通过更具体路由（macOS 常见 0/1 + 128/1）选出的出口。
+        auto_detect_interface: false,
         default_domain_resolver: 'dns-direct',
       },
     };

--- a/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/main/services/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -1490,7 +1490,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -2718,7 +2718,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -3303,7 +3303,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -3838,7 +3838,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "direct",
       "rule_set": [
@@ -4373,7 +4373,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -4915,7 +4915,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -7400,7 +7400,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -8002,7 +8002,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -8654,7 +8654,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -9222,7 +9222,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -9806,7 +9806,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -10376,7 +10376,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -10976,7 +10976,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -11602,7 +11602,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -12218,7 +12218,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -12832,7 +12832,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -13443,7 +13443,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -14056,7 +14056,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -14648,7 +14648,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -15268,7 +15268,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -15844,7 +15844,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "direct",
       "rules": [
@@ -16271,7 +16271,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -16917,7 +16917,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -18749,7 +18749,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "direct",
       "rule_set": [
@@ -19341,7 +19341,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -19940,7 +19940,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -20531,7 +20531,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -21226,7 +21226,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -21838,7 +21838,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [
@@ -22458,7 +22458,7 @@ exports[`generateSingBoxConfig — characterization 快照（抽取前锁基线�
       },
     ],
     "route": {
-      "auto_detect_interface": true,
+      "auto_detect_interface": false,
       "default_domain_resolver": "dns-bootstrap",
       "final": "proxy-selector",
       "rule_set": [

--- a/src/main/services/__tests__/singbox-route-builder.test.ts
+++ b/src/main/services/__tests__/singbox-route-builder.test.ts
@@ -74,6 +74,37 @@ const meshRule = (rc: any, tag: string): any =>
     (r: any) => r.outbound === tag && r.action === 'route' && Array.isArray(r.ip_cidr)
   );
 
+describe('buildRouteConfig — 出口接口自动检测', () => {
+  it.each([
+    ['tun', true],
+    ['systemProxy', false],
+    ['manual', false],
+  ] as const)('%s 模式 → auto_detect_interface=%s', (proxyModeType, expected) => {
+    const rc = buildRouteConfig(cfg([], { proxyModeType }), new Map(), deps([]));
+    expect(rc.auto_detect_interface).toBe(expected);
+  });
+
+  it('macOS TUN 已解析实际上游时改用 default_interface，且两种绑定方式不同时开启', () => {
+    const rc = buildRouteConfig(
+      cfg([], { proxyModeType: 'tun' }),
+      new Map(),
+      deps([], { defaultInterface: 'utun4' })
+    );
+    expect(rc.auto_detect_interface).toBe(false);
+    expect(rc.default_interface).toBe('utun4');
+  });
+
+  it('非 TUN 不接受 default_interface，继续服从系统逐目标路由', () => {
+    const rc = buildRouteConfig(
+      cfg([], { proxyModeType: 'systemProxy' }),
+      new Map(),
+      deps([], { defaultInterface: 'utun4' })
+    );
+    expect(rc.auto_detect_interface).toBe(false);
+    expect(rc.default_interface).toBeUndefined();
+  });
+});
+
 describe('buildRouteConfig — D-direct 组网 force-route', () => {
   const node = wgNode('w1', 'WG', ['10.8.0.0/24']);
 

--- a/src/main/services/singbox-config-types.ts
+++ b/src/main/services/singbox-config-types.ts
@@ -379,6 +379,7 @@ export interface SingBoxRouteConfig {
   rules: SingBoxRouteRule[];
   default_domain_resolver?: string;
   auto_detect_interface?: boolean;
+  default_interface?: string;
   final?: string;
 }
 

--- a/src/main/services/singbox-route-builder.ts
+++ b/src/main/services/singbox-route-builder.ts
@@ -85,6 +85,8 @@ export interface RouteConfigDeps {
   // TUN 下主进程 race server 对这些 IP 的 DoH/UDP 查询若不直连放行 → 进 TUN → 经代理节点 → 节点解析又回 race server → 回环死锁。
   // 故在 hijack-dns 之前直连放行（:53/:443；DoT :853 二期未实现、不放行，见下方 port 注释）。缺省 [] = race off / 无自定义上游（零变化）。
   raceUpstreamIps?: string[];
+  /** macOS TUN 启动前按节点目标路由解析出的上游接口；仅在结果一致且可信时设置。 */
+  defaultInterface?: string;
 }
 
 export function buildRouteConfig(
@@ -304,7 +306,13 @@ export function buildRouteConfig(
     // 核心修复：default_domain_resolver 使用 IP-based DoH 引导解析器 (dns-bootstrap)，
     // 既避免解析 doh.pub 域名时的死循环，又免疫 UDP 53 限速/劫持（dns-bootstrap 同为 IP-based）。
     default_domain_resolver: 'dns-bootstrap',
-    auto_detect_interface: true,
+    // 非 TUN 没有 outbound 回灌风险，交给 OS 按目标地址选择 OpenVPN/EasyConnect 等更具体路由。
+    // TUN 必须绑定上游接口防回环：macOS 若启动前已按实际节点目标解析出一致接口，则显式绑定它；
+    // 否则保留 sing-box 自动检测，绝不以全局关闭换取偶然可用。
+    auto_detect_interface: config.proxyModeType === 'tun' && !deps.defaultInterface,
+    ...(config.proxyModeType === 'tun' && deps.defaultInterface
+      ? { default_interface: deps.defaultInterface }
+      : {}),
     // 如果模式是全局代理 (global/proxy)，则最终出口是所选节点（经 proxy-selector）；direct 模式或 D4/D7 兜底→direct。
     // 地区分流反向（仅 smart + enabled + reverse，如「回国」）：海外应直连 → final 兜底翻为 direct。
     final:

--- a/src/shared/__tests__/mac-route-interface.test.ts
+++ b/src/shared/__tests__/mac-route-interface.test.ts
@@ -1,0 +1,23 @@
+import { parseMacRouteInterface } from '../mac-route-interface';
+
+describe('parseMacRouteInterface', () => {
+  it('读取 OpenVPN 拆半默认路由选出的 utun 接口', () => {
+    expect(
+      parseMacRouteInterface(`
+   route to: 113.20.7.104
+destination: default
+    gateway: 10.8.0.1
+  interface: utun4
+`)
+    ).toBe('utun4');
+  });
+
+  it('读取普通物理接口', () => {
+    expect(parseMacRouteInterface('  interface: en0\n')).toBe('en0');
+  });
+
+  it('缺字段或异常接口名时返回 null', () => {
+    expect(parseMacRouteInterface('gateway: 10.8.0.1')).toBeNull();
+    expect(parseMacRouteInterface('interface: en0;rm')).toBeNull();
+  });
+});

--- a/src/shared/mac-route-interface.ts
+++ b/src/shared/mac-route-interface.ts
@@ -1,0 +1,7 @@
+/** 解析 macOS `route -n get <target>` 输出中的实际出口接口。 */
+export function parseMacRouteInterface(output: string): string | null {
+  const match = output.match(/^\s*interface:\s*([^\s]+)\s*$/m);
+  if (!match) return null;
+  const name = match[1];
+  return /^[A-Za-z][A-Za-z0-9_.-]*$/.test(name) ? name : null;
+}


### PR DESCRIPTION
## What changed

- Let system-proxy/manual configurations and the standalone speed-test core follow the OS route selected for each destination instead of pinning the global default interface.
- Before starting macOS TUN, pre-resolve the selected node plus enabled custom/app-rule targets and query `route -n get <target>`.
- Set `route.default_interface` only when every dial target resolves to the same interface; otherwise retain `auto_detect_interface` as the safe fallback.
- Preserve the existing TUN loop protections and node-IP route exclusions.
- Recheck the stored node targets when the link watcher fires and schedule a controlled FlowZ restart if the VPN upstream interface changes.
- Add parser, route-builder, type, and snapshot coverage.

## Why

OpenVPN and EasyConnect commonly install more-specific routes on macOS (for example, split default routes) while the system-wide default route still points to the physical interface. sing-box interface auto-detection can therefore bind outbound sockets to the physical interface even though the destination route points to a `utun` interface, resulting in `network is unreachable`.

## Safety and fallback

- The target-route probe is macOS TUN-only.
- Mixed interfaces, missing route output, command failures, or an empty target set all fall back to sing-box automatic detection.
- Non-TUN modes have no TUN self-capture loop, so they are left to normal per-destination OS routing.
- A detected interface change uses the existing debounced restart path; this is a short controlled reconnect, not a seamless handoff.

## Verification

- Full suite on current upstream `main`: 254 suites and 4,027 tests passed; 38 snapshots passed (1 suite / 9 tests remain skipped by the repository)
- Focused route/DNS/speed-test coverage: 5 suites, 129 tests passed
- TypeScript main build and Vite renderer production build passed
- ESLint passed for all changed files

## Live-test boundary

The original route-selection failure was reproduced with macOS VPN routing. CI cannot emulate a real OpenVPN/EasyConnect disconnect/reconnect cycle, so that transition still deserves maintainer/user verification on macOS; the implementation deliberately falls back to automatic detection when route agreement is not provable.
